### PR TITLE
Ownable2Step マイグレーション（Niji コントラクト4つ）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### nouns-contracts
 
 #### 変更
+- **Ownable → Ownable2Step 移行** (#66)
+  - `NijiToken`, `NijiArt`, `NijiDescriptor`, `NijiSeeder` の4コントラクトで `Ownable` → `Ownable2Step`（OZ v5）へ継承変更
+  - オーナーシップ移転が2段階（`transferOwnership` → `acceptOwnership`）になり、誤送信による喪失リスクを排除
+  - 既存の `Ownable(msg.sender)` コンストラクタ引数および `onlyOwner` 修飾子はそのまま維持
+  - 各コントラクトに Ownable2Step テスト 5 件ずつ追加（計 20 件追加、合計 184 テストすべてパス）
+
 - **ethers v5 → v6 移行** (#64)
   - `ethers` を `^5.x` から `^6.14.0` へアップグレード
   - `@nomiclabs/hardhat-ethers` → `@nomicfoundation/hardhat-ethers@^3.1.3`

--- a/packages/nouns-contracts/contracts/NijiArt.sol
+++ b/packages/nouns-contracts/contracts/NijiArt.sol
@@ -8,9 +8,9 @@
 pragma solidity ^0.8.20;
 
 import { SSTORE2 } from './libs/SSTORE2.sol';
-import { Ownable } from '@openzeppelin/contracts-v5/access/Ownable.sol';
+import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 
-contract NijiArt is Ownable {
+contract NijiArt is Ownable2Step {
     // =============================================================
     //                           ERRORS
     // =============================================================

--- a/packages/nouns-contracts/contracts/NijiDescriptor.sol
+++ b/packages/nouns-contracts/contracts/NijiDescriptor.sol
@@ -10,9 +10,9 @@ pragma solidity ^0.8.20;
 import { Base64 } from 'base64-sol/base64.sol';
 import { NijiArt } from './NijiArt.sol';
 import { Strings } from '@openzeppelin/contracts-v5/utils/Strings.sol';
-import { Ownable } from '@openzeppelin/contracts-v5/access/Ownable.sol';
+import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 
-contract NijiDescriptor is Ownable {
+contract NijiDescriptor is Ownable2Step {
     using Strings for uint256;
 
     // =============================================================

--- a/packages/nouns-contracts/contracts/NijiSeeder.sol
+++ b/packages/nouns-contracts/contracts/NijiSeeder.sol
@@ -9,9 +9,9 @@ pragma solidity ^0.8.20;
 
 import { INijiSeeder } from './interfaces/INijiSeeder.sol';
 import { NijiArt } from './NijiArt.sol';
-import { Ownable } from '@openzeppelin/contracts-v5/access/Ownable.sol';
+import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 
-contract NijiSeeder is INijiSeeder, Ownable {
+contract NijiSeeder is INijiSeeder, Ownable2Step {
     // =============================================================
     //                           ERRORS
     // =============================================================

--- a/packages/nouns-contracts/contracts/NijiToken.sol
+++ b/packages/nouns-contracts/contracts/NijiToken.sol
@@ -9,12 +9,12 @@ pragma solidity ^0.8.20;
 
 import { ERC721 } from '@openzeppelin/contracts-v5/token/ERC721/ERC721.sol';
 import { ERC721Enumerable } from '@openzeppelin/contracts-v5/token/ERC721/extensions/ERC721Enumerable.sol';
-import { Ownable } from '@openzeppelin/contracts-v5/access/Ownable.sol';
+import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 import { ReentrancyGuard } from '@openzeppelin/contracts-v5/utils/ReentrancyGuard.sol';
 import { NijiDescriptor } from './NijiDescriptor.sol';
 import { INijiSeeder } from './interfaces/INijiSeeder.sol';
 
-contract NijiToken is ERC721Enumerable, Ownable, ReentrancyGuard {
+contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
     // =============================================================
     //                           ERRORS
     // =============================================================

--- a/packages/nouns-contracts/test/niji/NijiArt.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiArt.test.ts
@@ -148,6 +148,37 @@ describe('NijiArt', () => {
     });
   });
 
+  describe('Ownable2Step', () => {
+    it('transferOwnership should not change owner immediately', async () => {
+      await art.transferOwnership(other.address);
+      expect(await art.owner()).to.equal(owner.address);
+    });
+
+    it('transferOwnership should set pendingOwner', async () => {
+      await art.transferOwnership(other.address);
+      expect(await art.pendingOwner()).to.equal(other.address);
+    });
+
+    it('transferOwnership should emit OwnershipTransferStarted', async () => {
+      await expect(art.transferOwnership(other.address))
+        .to.emit(art, 'OwnershipTransferStarted')
+        .withArgs(owner.address, other.address);
+    });
+
+    it('acceptOwnership should transfer ownership to pendingOwner', async () => {
+      await art.transferOwnership(other.address);
+      await art.connect(other).acceptOwnership();
+      expect(await art.owner()).to.equal(other.address);
+    });
+
+    it('acceptOwnership should revert if caller is not pendingOwner', async () => {
+      await art.transferOwnership(other.address);
+      await expect(
+        art.connect(descriptor).acceptOwnership()
+      ).to.be.revertedWithCustomError(art, 'OwnableUnauthorizedAccount');
+    });
+  });
+
   describe('getTraitNames', () => {
     it('should return all trait names', async () => {
       const names = await art.getTraitNames();

--- a/packages/nouns-contracts/test/niji/NijiDescriptor.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiDescriptor.test.ts
@@ -183,6 +183,38 @@ describe('NijiDescriptor', () => {
     });
   });
 
+  describe('Ownable2Step', () => {
+    it('transferOwnership should not change owner immediately', async () => {
+      await descriptor.transferOwnership(other.address);
+      expect(await descriptor.owner()).to.equal(owner.address);
+    });
+
+    it('transferOwnership should set pendingOwner', async () => {
+      await descriptor.transferOwnership(other.address);
+      expect(await descriptor.pendingOwner()).to.equal(other.address);
+    });
+
+    it('transferOwnership should emit OwnershipTransferStarted', async () => {
+      await expect(descriptor.transferOwnership(other.address))
+        .to.emit(descriptor, 'OwnershipTransferStarted')
+        .withArgs(owner.address, other.address);
+    });
+
+    it('acceptOwnership should transfer ownership to pendingOwner', async () => {
+      await descriptor.transferOwnership(other.address);
+      await descriptor.connect(other).acceptOwnership();
+      expect(await descriptor.owner()).to.equal(other.address);
+    });
+
+    it('acceptOwnership should revert if caller is not pendingOwner', async () => {
+      await descriptor.transferOwnership(other.address);
+      // owner is not the pendingOwner, so this should revert
+      await expect(
+        descriptor.acceptOwnership()
+      ).to.be.revertedWithCustomError(descriptor, 'OwnableUnauthorizedAccount');
+    });
+  });
+
   describe('isConfigured', () => {
     it('should return true when properly configured', async () => {
       expect(await descriptor.isConfigured()).to.be.true;

--- a/packages/nouns-contracts/test/niji/NijiSeeder.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiSeeder.test.ts
@@ -185,4 +185,36 @@ describe('NijiSeeder', () => {
       ).to.be.revertedWithCustomError(seeder, 'InvalidArtAddress');
     });
   });
+
+  describe('Ownable2Step', () => {
+    it('transferOwnership should not change owner immediately', async () => {
+      await seeder.transferOwnership(other.address);
+      expect(await seeder.owner()).to.equal(owner.address);
+    });
+
+    it('transferOwnership should set pendingOwner', async () => {
+      await seeder.transferOwnership(other.address);
+      expect(await seeder.pendingOwner()).to.equal(other.address);
+    });
+
+    it('transferOwnership should emit OwnershipTransferStarted', async () => {
+      await expect(seeder.transferOwnership(other.address))
+        .to.emit(seeder, 'OwnershipTransferStarted')
+        .withArgs(owner.address, other.address);
+    });
+
+    it('acceptOwnership should transfer ownership to pendingOwner', async () => {
+      await seeder.transferOwnership(other.address);
+      await seeder.connect(other).acceptOwnership();
+      expect(await seeder.owner()).to.equal(other.address);
+    });
+
+    it('acceptOwnership should revert if caller is not pendingOwner', async () => {
+      await seeder.transferOwnership(other.address);
+      // owner is not the pendingOwner, so this should revert
+      await expect(
+        seeder.acceptOwnership()
+      ).to.be.revertedWithCustomError(seeder, 'OwnableUnauthorizedAccount');
+    });
+  });
 });

--- a/packages/nouns-contracts/test/niji/NijiToken.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiToken.test.ts
@@ -305,6 +305,37 @@ describe('NijiToken', () => {
     });
   });
 
+  describe('Ownable2Step', () => {
+    it('transferOwnership should not change owner immediately', async () => {
+      await token.transferOwnership(other.address);
+      expect(await token.owner()).to.equal(owner.address);
+    });
+
+    it('transferOwnership should set pendingOwner', async () => {
+      await token.transferOwnership(other.address);
+      expect(await token.pendingOwner()).to.equal(other.address);
+    });
+
+    it('transferOwnership should emit OwnershipTransferStarted', async () => {
+      await expect(token.transferOwnership(other.address))
+        .to.emit(token, 'OwnershipTransferStarted')
+        .withArgs(owner.address, other.address);
+    });
+
+    it('acceptOwnership should transfer ownership to pendingOwner', async () => {
+      await token.transferOwnership(other.address);
+      await token.connect(other).acceptOwnership();
+      expect(await token.owner()).to.equal(other.address);
+    });
+
+    it('acceptOwnership should revert if caller is not pendingOwner', async () => {
+      await token.transferOwnership(other.address);
+      await expect(
+        token.connect(minter).acceptOwnership()
+      ).to.be.revertedWithCustomError(token, 'OwnableUnauthorizedAccount');
+    });
+  });
+
   describe('exists', () => {
     beforeEach(async () => {
       await token.toggleMinting();


### PR DESCRIPTION
## Summary
- NijiToken, NijiArt, NijiDescriptor, NijiSeeder の4コントラクトで `Ownable` → `Ownable2Step`（OZ v5）へ継承変更
- 2段階オーナーシップ移転（`transferOwnership` → `acceptOwnership`）で誤送信リスクを排除
- 各コントラクトに Ownable2Step テスト5件ずつ追加（計20件、全184テストパス）

## Test plan
- [x] `npx hardhat compile` — コンパイル成功
- [x] Niji テスト 99/99 全パス（79既存 + 20新規）
- [x] 全テスト 184/184 全パス（リグレッションなし）

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)