### PR TITLE
✨ #36 NijiToken に contractURI を実装

### DIFF
--- a/packages/nouns-contracts/contracts/NijiToken.sol
+++ b/packages/nouns-contracts/contracts/NijiToken.sol
@@ -69,6 +69,10 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
     /// @param isActive Whether minting is now active
     event MintingToggled(bool isActive);
 
+    /// @notice Emitted when the contract URI hash is updated
+    /// @param newContractURIHash The new IPFS hash for contract metadata
+    event ContractURIHashUpdated(string newContractURIHash);
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -93,6 +97,9 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
 
     /// @notice Mapping from token ID to seed
     mapping(uint256 => INijiSeeder.Seed) public seeds;
+
+    /// @notice The IPFS hash for the contract-level metadata
+    string private _contractURIHash;
 
     // =============================================================
     //                           MODIFIERS
@@ -286,9 +293,23 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
         emit MintingToggled(_isActive);
     }
 
+    /// @notice Set the contract-level metadata IPFS hash
+    /// @param newContractURIHash The new IPFS hash
+    function setContractURIHash(string memory newContractURIHash) external onlyOwner {
+        _contractURIHash = newContractURIHash;
+        emit ContractURIHashUpdated(newContractURIHash);
+    }
+
     // =============================================================
     //                      VIEW FUNCTIONS
     // =============================================================
+
+    /// @notice The IPFS URI of contract-level metadata (used by marketplaces)
+    /// @return The contract URI
+    function contractURI() public view returns (string memory) {
+        return string(abi.encodePacked('ipfs://', _contractURIHash));
+    }
+
 
     /// @notice Get the current token ID counter
     /// @return Current token ID

--- a/packages/nouns-contracts/test/niji/NijiToken.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiToken.test.ts
@@ -336,6 +336,42 @@ describe('NijiToken', () => {
     });
   });
 
+  describe('contractURI', () => {
+    it('should return ipfs:// with empty hash by default', async () => {
+      expect(await token.contractURI()).to.equal('ipfs://');
+    });
+
+    it('should allow owner to set contract URI hash', async () => {
+      const hash = 'QmTest1234567890abcdef';
+      await token.setContractURIHash(hash);
+      expect(await token.contractURI()).to.equal(`ipfs://${hash}`);
+    });
+
+    it('should emit ContractURIHashUpdated event', async () => {
+      const hash = 'QmTest1234567890abcdef';
+      await expect(token.setContractURIHash(hash))
+        .to.emit(token, 'ContractURIHashUpdated')
+        .withArgs(hash);
+    });
+
+    it('should allow updating hash multiple times', async () => {
+      const hash1 = 'QmFirst';
+      const hash2 = 'QmSecond';
+
+      await token.setContractURIHash(hash1);
+      expect(await token.contractURI()).to.equal(`ipfs://${hash1}`);
+
+      await token.setContractURIHash(hash2);
+      expect(await token.contractURI()).to.equal(`ipfs://${hash2}`);
+    });
+
+    it('should revert if caller is not owner', async () => {
+      await expect(
+        token.connect(other).setContractURIHash('QmTest')
+      ).to.be.revertedWithCustomError(token, 'OwnableUnauthorizedAccount');
+    });
+  });
+
   describe('exists', () => {
     beforeEach(async () => {
       await token.toggleMinting();


### PR DESCRIPTION
## Summary
- NijiToken に `contractURI()` を実装し、OpenSea 等のマーケットプレイスがコレクションメタデータを取得できるようにした
- `setContractURIHash()` で owner が IPFS ハッシュを設定・更新可能
- `ContractURIHashUpdated` イベントを追加（Nouns にはないベストプラクティス）

## Changes
- `NijiToken.sol`: ストレージ `_contractURIHash`、イベント `ContractURIHashUpdated`、view 関数 `contractURI()`、admin 関数 `setContractURIHash()` を追加
- `NijiToken.test.ts`: 5 件のテストを追加

## Test plan
- [x] デフォルトで `ipfs://` を返す
- [x] owner が hash を設定できる
- [x] `ContractURIHashUpdated` イベント発行
- [x] 複数回更新可能
- [x] 非 owner は revert（`OwnableUnauthorizedAccount`）
- [x] Niji テスト 104/104 パス（リグレッションなし）

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)