### PR TITLE
🏷️ #37 NijiDescriptor の tokenURI に attributes を追加

### DIFF
--- a/packages/nouns-contracts/contracts/NijiDescriptor.sol
+++ b/packages/nouns-contracts/contracts/NijiDescriptor.sol
@@ -103,6 +103,7 @@ contract NijiDescriptor is Ownable2Step {
         if (traitIndices.length == 0) revert EmptyTraitIndices();
 
         string memory svgBase64 = generateSVGBase64(traitIndices);
+        string memory attributes = _generateAttributes(traitIndices);
 
         return string(
             abi.encodePacked(
@@ -114,7 +115,9 @@ contract NijiDescriptor is Ownable2Step {
                             tokenId.toString(),
                             '", "description":"Niji is a fully on-chain generative art collection featuring high-quality PNG images.", "image": "data:image/svg+xml;base64,',
                             svgBase64,
-                            '"}'
+                            '", "attributes":',
+                            attributes,
+                            '}'
                         )
                     )
                 )
@@ -137,6 +140,7 @@ contract NijiDescriptor is Ownable2Step {
         if (traitIndices.length == 0) revert EmptyTraitIndices();
 
         string memory svgBase64 = generateSVGBase64(traitIndices);
+        string memory attributes = _generateAttributes(traitIndices);
 
         return string(
             abi.encodePacked(
@@ -152,12 +156,42 @@ contract NijiDescriptor is Ownable2Step {
                             description,
                             '", "image": "data:image/svg+xml;base64,',
                             svgBase64,
-                            '"}'
+                            '", "attributes":',
+                            attributes,
+                            '}'
                         )
                     )
                 )
             )
         );
+    }
+
+    // =============================================================
+    //                      ATTRIBUTES GENERATION
+    // =============================================================
+
+    /// @notice Generate JSON attributes array from trait indices
+    /// @param traitIndices Array of trait indices for each category
+    /// @return JSON attributes array string (e.g., [{"trait_type":"hair","value":"2"},…])
+    function _generateAttributes(uint256[] memory traitIndices) internal view returns (string memory) {
+        bytes memory attrs = bytes('[');
+        bool first = true;
+        for (uint256 i = 0; i < traitIndices.length; ) {
+            if (traitIndices[i] != SKIP_LAYER) {
+                if (!first) attrs = abi.encodePacked(attrs, ',');
+                attrs = abi.encodePacked(
+                    attrs,
+                    '{"trait_type":"',
+                    art.getTraitName(i),
+                    '","value":"',
+                    traitIndices[i].toString(),
+                    '"}'
+                );
+                first = false;
+            }
+            unchecked { ++i; }
+        }
+        return string(abi.encodePacked(attrs, ']'));
     }
 
     // =============================================================

--- a/packages/nouns-contracts/test/niji/NijiDescriptor.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiDescriptor.test.ts
@@ -135,6 +135,70 @@ describe('NijiDescriptor', () => {
     });
   });
 
+  describe('tokenURI attributes', () => {
+    beforeEach(async () => {
+      await art.transferDescriptor(owner.address);
+      for (let i = 0; i < 12; i++) {
+        await art.addTraitImages(i, [samplePng, samplePng, samplePng]);
+      }
+    });
+
+    it('should include attributes array in JSON', async () => {
+      const traitIndices = Array(12).fill(ethers.MaxUint256);
+      traitIndices[0] = 0; // special
+      traitIndices[11] = 2; // hair
+
+      const uri = await descriptor.tokenURI(0, traitIndices);
+      const jsonB64 = uri.replace('data:application/json;base64,', '');
+      const json = JSON.parse(Buffer.from(jsonB64, 'base64').toString());
+
+      expect(json.attributes).to.be.an('array');
+      expect(json.attributes.length).to.equal(2);
+    });
+
+    it('should have trait_type matching art.getTraitName', async () => {
+      const traitIndices = Array(12).fill(ethers.MaxUint256);
+      traitIndices[0] = 0; // special
+      traitIndices[11] = 2; // hair
+
+      const uri = await descriptor.tokenURI(0, traitIndices);
+      const jsonB64 = uri.replace('data:application/json;base64,', '');
+      const json = JSON.parse(Buffer.from(jsonB64, 'base64').toString());
+
+      const specialAttr = json.attributes.find((a: any) => a.trait_type === 'special');
+      const hairAttr = json.attributes.find((a: any) => a.trait_type === 'hair');
+
+      expect(specialAttr).to.exist;
+      expect(specialAttr.value).to.equal('0');
+      expect(hairAttr).to.exist;
+      expect(hairAttr.value).to.equal('2');
+    });
+
+    it('should exclude SKIP_LAYER traits from attributes', async () => {
+      const traitIndices = Array(12).fill(ethers.MaxUint256);
+      traitIndices[0] = 1; // only special is set
+
+      const uri = await descriptor.tokenURI(0, traitIndices);
+      const jsonB64 = uri.replace('data:application/json;base64,', '');
+      const json = JSON.parse(Buffer.from(jsonB64, 'base64').toString());
+
+      expect(json.attributes.length).to.equal(1);
+      expect(json.attributes[0].trait_type).to.equal('special');
+      expect(json.attributes[0].value).to.equal('1');
+    });
+
+    it('should return empty array when all traits are SKIP_LAYER', async () => {
+      const traitIndices = Array(12).fill(ethers.MaxUint256);
+
+      const uri = await descriptor.tokenURI(0, traitIndices);
+      const jsonB64 = uri.replace('data:application/json;base64,', '');
+      const json = JSON.parse(Buffer.from(jsonB64, 'base64').toString());
+
+      expect(json.attributes).to.be.an('array');
+      expect(json.attributes.length).to.equal(0);
+    });
+  });
+
   describe('setArt', () => {
     it('should allow owner to update art', async () => {
       const NijiArtFactory = await ethers.getContractFactory('NijiArt');

--- a/packages/nouns-contracts/test/niji/NijiToken.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiToken.test.ts
@@ -190,6 +190,21 @@ describe('NijiToken', () => {
     it('should revert for non-existent token', async () => {
       await expect(token.tokenURI(999)).to.be.revertedWithCustomError(token, 'TokenDoesNotExist');
     });
+
+    it('should include attributes in tokenURI', async () => {
+      const uri = await token.tokenURI(0);
+      const jsonB64 = uri.replace('data:application/json;base64,', '');
+      const json = JSON.parse(Buffer.from(jsonB64, 'base64').toString());
+
+      expect(json.attributes).to.be.an('array');
+      expect(json.attributes.length).to.be.greaterThan(0);
+
+      // Each attribute should have trait_type and value
+      for (const attr of json.attributes) {
+        expect(attr.trait_type).to.be.a('string');
+        expect(attr.value).to.be.a('string');
+      }
+    });
   });
 
   describe('getSeed', () => {


### PR DESCRIPTION
## Summary
- NijiDescriptor の `tokenURI()` と `tokenURIWithMetadata()` に OpenSea メタデータ標準準拠の `attributes` 配列を追加
- `_generateAttributes()` internal 関数でトレイトインデックスから JSON attributes を生成
- `SKIP_LAYER` のトレイトは attributes から自動除外

## Changes
- `NijiDescriptor.sol`: `_generateAttributes()` 追加、`tokenURI()` / `tokenURIWithMetadata()` 更新
- `NijiDescriptor.test.ts`: 4 件のテスト追加
- `NijiToken.test.ts`: 統合テスト 1 件追加

## Output example
```json
{
  "name": "Niji #0",
  "description": "...",
  "image": "data:image/svg+xml;base64,...",
  "attributes": [
    {"trait_type": "special", "value": "0"},
    {"trait_type": "hair", "value": "2"}
  ]
}
```

## Test plan
- [x] attributes 配列が JSON に含まれること
- [x] trait_type が art.getTraitName と一致すること
- [x] SKIP_LAYER のトレイトが除外されること
- [x] 全トレイト SKIP 時に空配列を返すこと
- [x] NijiToken.tokenURI 経由で attributes が取得できること（統合テスト）
- [x] Niji テスト 104/104 パス（リグレッションなし）

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)