### PR TITLE
feat(NijiToken): Add provenance hash (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 ### nouns-contracts
 
+#### 追加
+- **NijiToken: Provenance Hash 機能追加** (#38)
+  - `string public provenanceHash` ストレージを追加。全画像データの結合ハッシュを保持し、NFTコレクションの公平性証明に使用
+  - `bool public isProvenanceHashLocked` ストレージを追加。ハッシュのロック状態を管理
+  - `setProvenanceHash(string)` 関数を追加（onlyOwner）。ロック後に呼び出すと `ProvenanceHashLocked` エラーをrevert
+  - `lockProvenanceHash()` 関数を追加（onlyOwner）。一度ロックすると以降の変更を永久に禁止
+  - `ProvenanceHashLocked()` カスタムエラーを追加
+  - `ProvenanceHashSet(string provenanceHash)` イベントを追加
+  - テスト6件追加（デフォルト空文字・設定・イベント発行・ロック前更新可・ロック後revert・非ownerrevert）
+
+- **NijiDescriptor: OpenSea メタデータ標準対応（attributes 追加）** (#37)
+  - `_generateAttributes(uint256[] traitIndices)` internal 関数を追加。トレイトインデックスから OpenSea 標準の `attributes` 配列 JSON を生成
+  - `tokenURI()` および `tokenURIWithMetadata()` の JSON 出力に `"attributes":[…]` フィールドを追加
+  - `SKIP_LAYER`（`type(uint256).max`）のトレイトは attributes に含まれない
+  - トレイト名は `NijiArt.getTraitName(i)` から取得し、値はインデックスの数値文字列で表現
+  - テスト4件追加（`NijiDescriptor.test.ts`）、統合テスト1件追加（`NijiToken.test.ts`）
+
+- **NijiToken: contractURI サポート** (#36)
+  - `contractURI()` メソッドを追加。OpenSea 等のマーケットプレイスがコレクションレベルのメタデータを取得できるように対応
+  - `setContractURIHash(string)` メソッドを追加。オーナーが IPFS ハッシュを設定することで `ipfs://{hash}` 形式の URI を返却
+  - `ContractURIHashUpdated(string newContractURIHash)` イベントを追加
+  - デフォルト値は空文字列（`ipfs://` を返却）
+  - テスト5件追加（合計 189 テストすべてパス）
+
 #### 変更
 - **Ownable → Ownable2Step 移行** (#66)
   - `NijiToken`, `NijiArt`, `NijiDescriptor`, `NijiSeeder` の4コントラクトで `Ownable` → `Ownable2Step`（OZ v5）へ継承変更

--- a/packages/nouns-contracts/contracts/NijiToken.sol
+++ b/packages/nouns-contracts/contracts/NijiToken.sol
@@ -40,6 +40,9 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
     /// @notice Thrown when token does not exist
     error TokenDoesNotExist();
 
+    /// @notice Thrown when provenance hash is already locked
+    error ProvenanceHashLocked();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -73,6 +76,10 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
     /// @param newContractURIHash The new IPFS hash for contract metadata
     event ContractURIHashUpdated(string newContractURIHash);
 
+    /// @notice Emitted when the provenance hash is set
+    /// @param provenanceHash The provenance hash value
+    event ProvenanceHashSet(string provenanceHash);
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -100,6 +107,12 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
 
     /// @notice The IPFS hash for the contract-level metadata
     string private _contractURIHash;
+
+    /// @notice The provenance hash for verifying image integrity
+    string public provenanceHash;
+
+    /// @notice Whether the provenance hash is locked
+    bool public isProvenanceHashLocked;
 
     // =============================================================
     //                           MODIFIERS
@@ -298,6 +311,20 @@ contract NijiToken is ERC721Enumerable, Ownable2Step, ReentrancyGuard {
     function setContractURIHash(string memory newContractURIHash) external onlyOwner {
         _contractURIHash = newContractURIHash;
         emit ContractURIHashUpdated(newContractURIHash);
+    }
+
+    /// @notice Set the provenance hash (can only be set before locking)
+    /// @param _provenanceHash The provenance hash value
+    function setProvenanceHash(string memory _provenanceHash) external onlyOwner {
+        if (isProvenanceHashLocked) revert ProvenanceHashLocked();
+        provenanceHash = _provenanceHash;
+        emit ProvenanceHashSet(_provenanceHash);
+    }
+
+    /// @notice Lock the provenance hash permanently
+    function lockProvenanceHash() external onlyOwner {
+        if (isProvenanceHashLocked) revert ProvenanceHashLocked();
+        isProvenanceHashLocked = true;
     }
 
     // =============================================================

--- a/packages/nouns-contracts/test/niji/NijiToken.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiToken.test.ts
@@ -387,6 +387,47 @@ describe('NijiToken', () => {
     });
   });
 
+  describe('provenanceHash', () => {
+    const SAMPLE_HASH = 'abc123def456789';
+
+    it('should default to empty string', async () => {
+      expect(await token.provenanceHash()).to.equal('');
+    });
+
+    it('should allow owner to set provenance hash', async () => {
+      await token.setProvenanceHash(SAMPLE_HASH);
+      expect(await token.provenanceHash()).to.equal(SAMPLE_HASH);
+    });
+
+    it('should emit ProvenanceHashSet event', async () => {
+      await expect(token.setProvenanceHash(SAMPLE_HASH))
+        .to.emit(token, 'ProvenanceHashSet')
+        .withArgs(SAMPLE_HASH);
+    });
+
+    it('should allow updating before lock', async () => {
+      await token.setProvenanceHash(SAMPLE_HASH);
+      const updatedHash = 'updated_hash_value';
+      await token.setProvenanceHash(updatedHash);
+      expect(await token.provenanceHash()).to.equal(updatedHash);
+    });
+
+    it('should revert setProvenanceHash after lock', async () => {
+      await token.setProvenanceHash(SAMPLE_HASH);
+      await token.lockProvenanceHash();
+
+      await expect(
+        token.setProvenanceHash('new_hash')
+      ).to.be.revertedWithCustomError(token, 'ProvenanceHashLocked');
+    });
+
+    it('should revert if non-owner calls setProvenanceHash', async () => {
+      await expect(
+        token.connect(other).setProvenanceHash(SAMPLE_HASH)
+      ).to.be.revertedWithCustomError(token, 'OwnableUnauthorizedAccount');
+    });
+  });
+
   describe('exists', () => {
     beforeEach(async () => {
       await token.toggleMinting();


### PR DESCRIPTION
## Summary
- NijiToken に Provenance Hash 機能を追加
- 全画像データの結合ハッシュをオンチェーンにコミットし、NFTコレクションの公平性を証明

## Changes
- `string public provenanceHash` — 全画像データの結合ハッシュを保持
- `bool public isProvenanceHashLocked` — 一度ロックすると変更不可
- `setProvenanceHash(string)` — owner がハッシュを設定（ロック前のみ）
- `lockProvenanceHash()` — owner がハッシュを永久ロック
- `ProvenanceHashLocked()` カスタムエラー
- `ProvenanceHashSet(string)` イベント

## Test plan
- [x] Niji 全テスト 115/115 パス
- [x] provenance hash テスト 6件追加
- [x] リグレッションなし

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)