### PR TITLE
🛡️ #33 Add JSON escape to NijiDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 ### nouns-contracts
 
 #### 追加
+- **NijiDescriptor: JSON エスケープ処理追加** (#33)
+  - `JsonEscape` ライブラリを新規作成（`contracts/libs/JsonEscape.sol`）。JSON 文字列内の特殊文字を安全にエスケープ
+  - 対象文字: `"` → `\"`, `\` → `\\`, `\n` → `\n`, `\r` → `\r`, `\t` → `\t`, 制御文字 (0x00-0x1F) → `\uXXXX`
+  - 2-pass アルゴリズム（長さ計算 + 書き込み）でメモリ効率を最大化。エスケープ不要な文字列は即リターンでガス最小化
+  - `tokenURIWithMetadata()` の `name`, `description` パラメータにエスケープを適用（ユーザー制御可能な入力）
+  - `_generateAttributes()` の `traitName` にエスケープを適用（防御的対応）
+  - `tokenURI()` は固定文字列のみのためエスケープ不適用（ガスコスト追加なし）
+  - テスト 7 件追加（合計 122 Niji テストすべてパス）
+
 - **NijiToken: Provenance Hash 機能追加** (#38)
   - `string public provenanceHash` ストレージを追加。全画像データの結合ハッシュを保持し、NFTコレクションの公平性証明に使用
   - `bool public isProvenanceHashLocked` ストレージを追加。ハッシュのロック状態を管理

--- a/packages/nouns-contracts/contracts/NijiDescriptor.sol
+++ b/packages/nouns-contracts/contracts/NijiDescriptor.sol
@@ -9,11 +9,13 @@ pragma solidity ^0.8.20;
 
 import { Base64 } from 'base64-sol/base64.sol';
 import { NijiArt } from './NijiArt.sol';
+import { JsonEscape } from './libs/JsonEscape.sol';
 import { Strings } from '@openzeppelin/contracts-v5/utils/Strings.sol';
 import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 
 contract NijiDescriptor is Ownable2Step {
     using Strings for uint256;
+    using JsonEscape for string;
 
     // =============================================================
     //                           ERRORS
@@ -149,11 +151,11 @@ contract NijiDescriptor is Ownable2Step {
                     bytes(
                         abi.encodePacked(
                             '{"name":"',
-                            name,
+                            name.escape(),
                             ' #',
                             tokenId.toString(),
                             '", "description":"',
-                            description,
+                            description.escape(),
                             '", "image": "data:image/svg+xml;base64,',
                             svgBase64,
                             '", "attributes":',
@@ -179,10 +181,11 @@ contract NijiDescriptor is Ownable2Step {
         for (uint256 i = 0; i < traitIndices.length; ) {
             if (traitIndices[i] != SKIP_LAYER) {
                 if (!first) attrs = abi.encodePacked(attrs, ',');
+                string memory traitName = art.getTraitName(i).escape();
                 attrs = abi.encodePacked(
                     attrs,
                     '{"trait_type":"',
-                    art.getTraitName(i),
+                    traitName,
                     '","value":"',
                     traitIndices[i].toString(),
                     '"}'

--- a/packages/nouns-contracts/contracts/libs/JsonEscape.sol
+++ b/packages/nouns-contracts/contracts/libs/JsonEscape.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0
+
+/// @title JsonEscape - JSON string escape library
+/// @author Niji DAO
+/// @notice Escapes special characters in strings for safe JSON embedding
+/// @dev Uses a 2-pass algorithm (length calculation + write) for memory efficiency
+
+pragma solidity ^0.8.20;
+
+library JsonEscape {
+    /// @notice Escape a string for safe use inside a JSON string value
+    /// @dev Handles: " → \", \ → \\, \n → \n, \r → \r, \t → \t, 0x00-0x1F → \uXXXX
+    /// @param input The raw string to escape
+    /// @return The escaped string safe for JSON embedding
+    function escape(string memory input) internal pure returns (string memory) {
+        bytes memory b = bytes(input);
+        uint256 len = b.length;
+        if (len == 0) return input;
+
+        // --- Pass 1: calculate output length & check if escaping is needed ---
+        uint256 outLen;
+        bool needsEscape;
+        for (uint256 i; i < len; ) {
+            uint8 c = uint8(b[i]);
+            if (c == 0x22 || c == 0x5C) {
+                // " or \ → 2 chars
+                outLen += 2;
+                needsEscape = true;
+            } else if (c == 0x0A || c == 0x0D || c == 0x09) {
+                // \n, \r, \t → 2 chars
+                outLen += 2;
+                needsEscape = true;
+            } else if (c < 0x20) {
+                // other control chars → \uXXXX (6 chars)
+                outLen += 6;
+                needsEscape = true;
+            } else {
+                outLen += 1;
+            }
+            unchecked { ++i; }
+        }
+
+        // Short-circuit: no escaping needed
+        if (!needsEscape) return input;
+
+        // --- Pass 2: write escaped output ---
+        bytes memory out = new bytes(outLen);
+        uint256 j;
+        for (uint256 i; i < len; ) {
+            uint8 c = uint8(b[i]);
+            if (c == 0x22) {
+                // "
+                out[j++] = 0x5C; // backslash
+                out[j++] = 0x22; // "
+            } else if (c == 0x5C) {
+                // backslash
+                out[j++] = 0x5C;
+                out[j++] = 0x5C;
+            } else if (c == 0x0A) {
+                // \n
+                out[j++] = 0x5C;
+                out[j++] = 0x6E; // n
+            } else if (c == 0x0D) {
+                // \r
+                out[j++] = 0x5C;
+                out[j++] = 0x72; // r
+            } else if (c == 0x09) {
+                // \t
+                out[j++] = 0x5C;
+                out[j++] = 0x74; // t
+            } else if (c < 0x20) {
+                // other control chars → \uXXXX
+                out[j++] = 0x5C; // backslash
+                out[j++] = 0x75; // u
+                out[j++] = 0x30; // 0
+                out[j++] = 0x30; // 0
+                out[j++] = _hexChar(c >> 4);
+                out[j++] = _hexChar(c & 0x0F);
+            } else {
+                out[j++] = b[i];
+            }
+            unchecked { ++i; }
+        }
+        return string(out);
+    }
+
+    /// @dev Convert a nibble (0-15) to its hex ASCII character
+    function _hexChar(uint8 nibble) private pure returns (bytes1) {
+        return nibble < 10
+            ? bytes1(nibble + 0x30)       // '0'-'9'
+            : bytes1(nibble - 10 + 0x61); // 'a'-'f'
+    }
+}

--- a/packages/nouns-contracts/test/niji/NijiDescriptor.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiDescriptor.test.ts
@@ -291,4 +291,108 @@ describe('NijiDescriptor', () => {
       expect(skipLayer).to.equal(ethers.MaxUint256);
     });
   });
+
+  // =========================================================================
+  //  JSON Escape Tests (#33)
+  // =========================================================================
+
+  /** Helper: decode data-URI → parsed JSON */
+  function decodeTokenURI(uri: string): any {
+    const jsonB64 = uri.replace('data:application/json;base64,', '');
+    return JSON.parse(Buffer.from(jsonB64, 'base64').toString());
+  }
+
+  describe('JSON escape – tokenURIWithMetadata', () => {
+    beforeEach(async () => {
+      await art.transferDescriptor(owner.address);
+      await art.addTraitImage(10, samplePng);
+    });
+
+    const traitIndices = () => {
+      const t = Array(12).fill(ethers.MaxUint256);
+      t[10] = 0;
+      return t;
+    };
+
+    it('should escape double quotes in name and JSON.parse succeeds', async () => {
+      const uri = await descriptor.tokenURIWithMetadata(
+        0, traitIndices(), 'My "Cool" Art', 'A description'
+      );
+      // JSON.parse succeeds = escaping is correct (would throw on unescaped ")
+      const json = decodeTokenURI(uri);
+      expect(json.name).to.equal('My "Cool" Art #0');
+      expect(json.description).to.equal('A description');
+    });
+
+    it('should escape backslash in name and JSON.parse succeeds', async () => {
+      const uri = await descriptor.tokenURIWithMetadata(
+        0, traitIndices(), 'path\\to\\art', 'A description'
+      );
+      const json = decodeTokenURI(uri);
+      expect(json.name).to.equal('path\\to\\art #0');
+    });
+
+    it('should escape newline in description and JSON.parse succeeds', async () => {
+      const uri = await descriptor.tokenURIWithMetadata(
+        0, traitIndices(), 'Art', 'Line1\nLine2'
+      );
+      const json = decodeTokenURI(uri);
+      // JSON.parse converts \n back to actual newline
+      expect(json.description).to.equal('Line1\nLine2');
+    });
+
+    it('should escape control characters in description and JSON.parse succeeds', async () => {
+      const uri = await descriptor.tokenURIWithMetadata(
+        0, traitIndices(), 'Art', 'before\x01after'
+      );
+      const json = decodeTokenURI(uri);
+      // JSON.parse converts \u0001 back to actual control char
+      expect(json.description).to.equal('before\x01after');
+    });
+
+    it('should handle mixed special characters', async () => {
+      const uri = await descriptor.tokenURIWithMetadata(
+        0, traitIndices(), 'He said "hi"\\wow', 'tab\there\nnewline'
+      );
+      const json = decodeTokenURI(uri);
+      expect(json.name).to.equal('He said "hi"\\wow #0');
+      expect(json.description).to.equal('tab\there\nnewline');
+    });
+
+    it('should not alter safe strings', async () => {
+      const uri = await descriptor.tokenURIWithMetadata(
+        0, traitIndices(), 'SafeName', 'Safe description with spaces and 123'
+      );
+      const json = decodeTokenURI(uri);
+      expect(json.name).to.equal('SafeName #0');
+      expect(json.description).to.equal('Safe description with spaces and 123');
+    });
+  });
+
+  describe('JSON escape – attributes with special trait names', () => {
+    it('should escape double quote in trait name', async () => {
+      const [signer] = await ethers.getSigners();
+
+      // Deploy new art with a trait name containing a double quote
+      const specialTraitNames = ['my"trait'];
+      const NijiArtFactory = await ethers.getContractFactory('NijiArt');
+      const specialArt = (await NijiArtFactory.deploy(signer.address, specialTraitNames)) as unknown as NijiArt;
+
+      const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+      const specialDescriptor = (await NijiDescriptorFactory.deploy(
+        await specialArt.getAddress(), RESOLUTION, [0]
+      )) as unknown as NijiDescriptor;
+
+      await specialArt.setDescriptor(await specialDescriptor.getAddress());
+      await specialArt.transferDescriptor(signer.address);
+      await specialArt.addTraitImage(0, samplePng);
+
+      const uri = await specialDescriptor.tokenURI(0, [0]);
+      const json = decodeTokenURI(uri);
+
+      expect(json.attributes).to.be.an('array');
+      expect(json.attributes.length).to.equal(1);
+      expect(json.attributes[0].trait_type).to.equal('my"trait');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Add `JsonEscape` library (`contracts/libs/JsonEscape.sol`) for safe JSON string encoding with 2-pass algorithm
- Apply escape to `tokenURIWithMetadata()` (name, description) and `_generateAttributes()` (traitName) in NijiDescriptor
- `tokenURI()` uses only fixed strings so no escape needed (gas optimization)

## Escaped Characters
| Character | Escape |
|-----------|--------|
| `"` (0x22) | `\"` |
| `\` (0x5C) | `\\` |
| `\n` (0x0A) | `\n` |
| `\r` (0x0D) | `\r` |
| `\t` (0x09) | `\t` |
| 0x00-0x1F | `\uXXXX` |

## Test plan
- [x] 7 new JSON escape tests added (double quote, backslash, newline, control chars, mixed, safe strings, trait names)
- [x] All 122 Niji tests passing
- [x] No regressions

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)