### PR TITLE
⚙️ #73 本番サイズ PNG ガスベンチマーク

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 ### nouns-contracts
 
 #### 追加
+- **NijiGas: 本番サイズ PNG ガスベンチマーク** (#73)
+  - `test/niji/NijiGas.test.ts` を新規作成。5KB/10KB/15KB/20KB の合成 PNG データを使用したガス計測テスト 12 件
+  - tokenURI ガス計測: 5KB×12layers (26.1M, 30M以内) / 10KB (59.9M) / 15KB (102.0M) / 20KB (152.4M)
+  - ストレージ ガス計測: addTraitImage (1.2M〜4.6M) / addTraitImages バッチ (7.0M)
+  - サブオペレーション: generateSVG 10KB×12 (19.2M, 30M以内) / generateSVGBase64 (33.6M)
+  - 主要発見: 5KB×12layers のみが Ethereum 30M ブロックガスリミット以内。Base64 エンコードとメモリ拡張がボトルネック
+  - hardhat.config.ts: hardfork を `cancun` に固定、blockGasLimit を 300M に引き上げ（Fusaka EIP-7825 ガスキャップ回避）
+
 - **NijiDescriptor: JSON エスケープ処理追加** (#33)
   - `JsonEscape` ライブラリを新規作成（`contracts/libs/JsonEscape.sol`）。JSON 文字列内の特殊文字を安全にエスケープ
   - 対象文字: `"` → `\"`, `\` → `\\`, `\n` → `\n`, `\r` → `\r`, `\t` → `\t`, 制御文字 (0x00-0x1F) → `\uXXXX`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,11 @@ Located in `packages/nouns-contracts/`:
 - **@nomicfoundation/hardhat-ethers v3**: Hardhat plugin for ethers v6
 - **TypeChain ethers-v6**: TypeChain type generation target
 
+### Hardhat Network Configuration (Gas Benchmarking)
+- **hardfork**: Pinned to `cancun` to avoid Fusaka's 16M tx gas cap (EIP-7825)
+- **blockGasLimit**: Set to 300M (elevated from default 30M) to support large view-function gas benchmarks
+- Gas benchmark tests in `test/niji/NijiGas.test.ts` measure production-size PNG operations (5-20KB per layer)
+
 Key contracts:
 - `NounsToken` - ERC721 for Noun NFTs
 - `NounsAuctionHouse` - Auction mechanism

--- a/packages/nouns-contracts/hardhat.config.ts
+++ b/packages/nouns-contracts/hardhat.config.ts
@@ -54,6 +54,8 @@ const config: HardhatUserConfig = {
     },
     hardhat: {
       initialBaseFeePerGas: 0,
+      hardfork: 'cancun', // Pin to Cancun — Hardhat 2.28+ defaults to Fusaka which caps tx gas at 16M (EIP-7825)
+      blockGasLimit: 300_000_000, // 300M — elevated for gas benchmarking (NijiGas.test.ts)
     },
   },
   etherscan: {

--- a/packages/nouns-contracts/test/niji/NijiGas.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiGas.test.ts
@@ -1,0 +1,238 @@
+/**
+ * NijiGas – Production-size PNG gas benchmarks
+ *
+ * Measures gas consumption for core Niji operations using production-scale
+ * PNG data (5-20KB per layer) instead of the minimal 67-byte test PNG.
+ *
+ * Gas bottlenecks:
+ *   1. art.getTraitImage()  — SSTORE2 read (EXTCODECOPY)
+ *   2. Base64.encode(png)   — per-layer Base64 encoding
+ *   3. Base64.encode(svg)   — full SVG Base64 encoding
+ *   4. abi.encodePacked()   — JSON/SVG string concatenation + memory expansion
+ *
+ * Measurement approach:
+ *   View functions are called as transactions (sendTransaction with explicit
+ *   gasLimit) to bypass Hardhat's eth_estimateGas cap. The actual gas
+ *   consumption is read from the transaction receipt.
+ *
+ * Requirements:
+ *   - hardhat.config.ts: hardfork = "cancun" (Fusaka default caps tx gas at 16M via EIP-7825)
+ *   - hardhat.config.ts: blockGasLimit = 300_000_000 (elevated for large view calls)
+ *
+ * This is a benchmark suite — all tests pass and report gas values.
+ * Results exceeding the Ethereum mainnet block gas limit (30M) are
+ * flagged with [OVER 30M LIMIT].
+ */
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { NijiArt, NijiDescriptor } from '../../typechain';
+import crypto from 'crypto';
+
+describe('NijiGas – production-size PNG gas benchmarks', function () {
+  this.timeout(180_000); // 3 minutes — large images need longer setup
+
+  let owner: SignerWithAddress;
+
+  const traitNames = [
+    'special',
+    'choker',
+    'headphone',
+    'leftHand',
+    'hat',
+    'clothing',
+    'ear',
+    'back',
+    'backDecoration',
+    'background',
+    'solidBackground',
+    'hair',
+  ];
+  const RESOLUTION = 320;
+  const COMPOSITE_ORDER = [10, 9, 8, 0, 3, 7, 5, 1, 6, 11, 4, 2];
+  const BLOCK_GAS_LIMIT = 30_000_000n;
+  const TRAIT_COUNT = 12;
+
+  /**
+   * Gas limit for view-function transactions.
+   * Must be below blockGasLimit (300M in hardhat.config.ts).
+   */
+  const VIEW_TX_GAS_LIMIT = 200_000_000n;
+
+  /** PNG file signature (8 bytes) */
+  const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  /**
+   * Generate synthetic PNG data of the specified size.
+   * Starts with a valid PNG signature followed by random bytes.
+   * The contract does not validate PNG format — only size matters for gas.
+   */
+  function generateSyntheticPng(sizeInBytes: number): Buffer {
+    const body = crypto.randomBytes(sizeInBytes - PNG_HEADER.length);
+    return Buffer.concat([PNG_HEADER, body]);
+  }
+
+  /**
+   * Measure gas for a view function by sending it as a transaction
+   * with an explicit gas limit, bypassing Hardhat's estimateGas cap.
+   *
+   * Returns gasUsed from the transaction receipt.
+   */
+  async function measureViewGas(
+    contractAddress: string,
+    callData: string,
+  ): Promise<bigint> {
+    const tx = await owner.sendTransaction({
+      to: contractAddress,
+      data: callData,
+      gasLimit: VIEW_TX_GAS_LIMIT,
+    });
+    const receipt = await tx.wait();
+    return receipt!.gasUsed;
+  }
+
+  /**
+   * Deploy NijiArt + NijiDescriptor and populate traits with synthetic PNG data.
+   *
+   * @param png         - synthetic PNG buffer to use for every trait
+   * @param activeLayers - number of active layers (rest are SKIP_LAYER)
+   */
+  async function deployWithImages(
+    png: Buffer,
+    activeLayers: number = TRAIT_COUNT,
+  ): Promise<{ art: NijiArt; descriptor: NijiDescriptor; traitIndices: bigint[] }> {
+    const NijiArtFactory = await ethers.getContractFactory('NijiArt');
+    const art = (await NijiArtFactory.deploy(owner.address, traitNames)) as unknown as NijiArt;
+
+    const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+    const descriptor = (await NijiDescriptorFactory.deploy(
+      await art.getAddress(),
+      RESOLUTION,
+      COMPOSITE_ORDER,
+    )) as unknown as NijiDescriptor;
+
+    // owner is already the descriptor (set in NijiArt constructor)
+    for (let i = 0; i < TRAIT_COUNT; i++) {
+      await art.addTraitImage(i, png);
+    }
+
+    // Build trait indices: first `activeLayers` use index 0, rest are SKIP_LAYER
+    const traitIndices: bigint[] = Array.from({ length: TRAIT_COUNT }, (_, i) =>
+      i < activeLayers ? 0n : ethers.MaxUint256,
+    );
+
+    return { art, descriptor, traitIndices };
+  }
+
+  /** Format gas value with comma separators and over-limit marker */
+  function fmtGas(gas: bigint): string {
+    const formatted = gas.toLocaleString();
+    return gas > BLOCK_GAS_LIMIT ? `${formatted} [OVER 30M LIMIT]` : `${formatted}`;
+  }
+
+  before(async () => {
+    [owner] = await ethers.getSigners();
+  });
+
+  // =========================================================================
+  //  Gas measurement – tokenURI
+  // =========================================================================
+
+  describe('Gas measurement – tokenURI', () => {
+    const sizes = [
+      { label: ' 5KB', bytes: 5_120 },
+      { label: '10KB', bytes: 10_240 },
+      { label: '15KB', bytes: 15_360 },
+      { label: '20KB', bytes: 20_480 },
+    ];
+
+    for (const { label, bytes } of sizes) {
+      it(`${label.trim()} PNG x 12 layers`, async () => {
+        const png = generateSyntheticPng(bytes);
+        const { descriptor, traitIndices } = await deployWithImages(png, TRAIT_COUNT);
+
+        const descriptorAddr = await descriptor.getAddress();
+        const callData = descriptor.interface.encodeFunctionData('tokenURI', [0, traitIndices]);
+        const gas = await measureViewGas(descriptorAddr, callData);
+
+        console.log(`        tokenURI          | ${label} x 12 layers | ${fmtGas(gas)} gas`);
+      });
+    }
+
+    it('10KB PNG x 8 layers (4 SKIP)', async () => {
+      const png = generateSyntheticPng(10_240);
+      const { descriptor, traitIndices } = await deployWithImages(png, 8);
+
+      const descriptorAddr = await descriptor.getAddress();
+      const callData = descriptor.interface.encodeFunctionData('tokenURI', [0, traitIndices]);
+      const gas = await measureViewGas(descriptorAddr, callData);
+
+      console.log(`        tokenURI          | 10KB x  8 layers | ${fmtGas(gas)} gas`);
+    });
+  });
+
+  // =========================================================================
+  //  Gas measurement – storage (addTraitImage / addTraitImages)
+  // =========================================================================
+
+  describe('Gas measurement – storage', () => {
+    let art: NijiArt;
+
+    beforeEach(async () => {
+      const NijiArtFactory = await ethers.getContractFactory('NijiArt');
+      art = (await NijiArtFactory.deploy(owner.address, traitNames)) as unknown as NijiArt;
+    });
+
+    const sizes = [
+      { label: ' 5KB', bytes: 5_120 },
+      { label: '10KB', bytes: 10_240 },
+      { label: '15KB', bytes: 15_360 },
+      { label: '20KB', bytes: 20_480 },
+    ];
+
+    for (const { label, bytes } of sizes) {
+      it(`addTraitImage – ${label.trim()}`, async () => {
+        const png = generateSyntheticPng(bytes);
+        const tx = await art.addTraitImage(0, png);
+        const receipt = await tx.wait();
+
+        console.log(`        addTraitImage     | ${label}            | ${receipt!.gasUsed.toLocaleString()} gas`);
+      });
+    }
+
+    it('addTraitImages – batch 3 x 10KB', async () => {
+      const png = generateSyntheticPng(10_240);
+      const tx = await art.addTraitImages(0, [png, png, png]);
+      const receipt = await tx.wait();
+
+      console.log(`        addTraitImages    | 3 x 10KB          | ${receipt!.gasUsed.toLocaleString()} gas`);
+    });
+  });
+
+  // =========================================================================
+  //  Gas measurement – sub-operations
+  // =========================================================================
+
+  describe('Gas measurement – sub-operations', () => {
+    it('generateSVG – 10KB x 12 layers', async () => {
+      const png = generateSyntheticPng(10_240);
+      const { descriptor, traitIndices } = await deployWithImages(png, TRAIT_COUNT);
+
+      const descriptorAddr = await descriptor.getAddress();
+      const callData = descriptor.interface.encodeFunctionData('generateSVG', [traitIndices]);
+      const gas = await measureViewGas(descriptorAddr, callData);
+
+      console.log(`        generateSVG       | 10KB x 12 layers | ${fmtGas(gas)} gas`);
+    });
+
+    it('generateSVGBase64 – 10KB x 12 layers', async () => {
+      const png = generateSyntheticPng(10_240);
+      const { descriptor, traitIndices } = await deployWithImages(png, TRAIT_COUNT);
+
+      const descriptorAddr = await descriptor.getAddress();
+      const callData = descriptor.interface.encodeFunctionData('generateSVGBase64', [traitIndices]);
+      const gas = await measureViewGas(descriptorAddr, callData);
+
+      console.log(`        generateSVGBase64  | 10KB x 12 layers | ${fmtGas(gas)} gas`);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- 本番サイズ PNG（5-20KB）でのガス消費量を計測するベンチマークテストスイートを追加
- Hardhat 設定を Cancun hardfork に固定し、blockGasLimit を 300M に引き上げ（Fusaka EIP-7825 の 16M tx ガスキャップ回避）
- 12 テストケースで tokenURI / addTraitImage / generateSVG 等のガス消費を計測

### ガス計測結果

| 構成 | ガス消費量 | 30M リミット |
|------|-----------|-------------|
| 5KB × 12 layers | 26.1M | ✅ OK |
| 10KB × 12 layers | 59.9M | ❌ OVER |
| 15KB × 12 layers | 102.0M | ❌ OVER |
| 20KB × 12 layers | 152.4M | ❌ OVER |
| 10KB × 8 layers (4 SKIP) | 34.1M | ❌ OVER |

### 主要発見

- **5KB × 12 layers が 30M 以内に収まる唯一の tokenURI 構成**
- ガスは PNG サイズに対して二次的にスケール（Base64 エンコード + メモリ拡張が原因）
- generateSVG 自体は 10KB × 12 で 19.2M（30M 以内）だが、Base64 エンコードで +14.3M
- Hardhat 2.28+ のデフォルト Fusaka hardfork で 16M tx ガスキャップ（EIP-7825）が問題に

## Test plan

- [x] `npx hardhat test test/niji/NijiGas.test.ts` — 12/12 全パス
- [x] `npx hardhat test --grep "Niji"` — 134/134 全パス（リグレッションなし）

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)