### PR TITLE
test: Niji edge case + integration + fuzz tests (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### nouns-contracts
 
+#### 追加
+- **エッジケース + 統合 + ファジングテスト** (#77)
+  - `test/niji/NijiArt.edge.test.ts`: NijiArt 境界値・エラーパステスト 19 件
+  - `test/niji/NijiDescriptor.edge.test.ts`: NijiDescriptor 境界値・エラーパステスト 15 件
+  - `test/niji/NijiToken.edge.test.ts`: NijiToken 境界値・未テストカスタムエラーテスト 14 件
+  - `test/niji/NijiSeeder.edge.test.ts`: NijiSeeder 境界値テスト 5 件
+  - `test/niji/NijiIntegration.test.ts`: クロスコントラクト統合テスト 8 件（フルフロー、Descriptor/Seeder/Minter差し替え、Ownership移転等）
+  - `test/foundry/NijiFuzz.t.sol`: Foundry ファジングテスト 6 件（generateSeedFromSource, generateSVG, mintBatch, addTraitImage, modulo分布）
+  - テスト数: Hardhat 134 → 195 (+61), Foundry +6, 合計 +67 テスト
+
 #### 改善
 - **テスト共通ヘルパー抽出** (#75)
   - `test/niji/helpers/` モジュールを新規作成。5ファイルに散在していた重複コードを共通化

--- a/packages/nouns-contracts/README.md
+++ b/packages/nouns-contracts/README.md
@@ -63,6 +63,31 @@ forge install
 forge test -vvv
 ```
 
+### Test Structure
+
+#### Hardhat Tests (`test/niji/`)
+
+- **Unit Tests**: Basic functionality for each contract (`NijiArt.test.ts`, `NijiDescriptor.test.ts`, `NijiSeeder.test.ts`, `NijiToken.test.ts`)
+- **Edge Case Tests**: Boundary conditions and error paths (`*.edge.test.ts`)
+- **Integration Tests**: Cross-contract interactions and full workflows (`NijiIntegration.test.ts`)
+- **Gas Benchmarks**: Production-size PNG operation measurements (`NijiGas.test.ts`)
+
+#### Foundry Tests (`test/foundry/`)
+
+- **Fuzz Tests**: Property-based testing with randomized inputs (`NijiFuzz.t.sol`)
+  - Covers seed generation, SVG rendering, batch minting, trait image addition, modulo distribution
+  - 256 fuzz runs per test by default
+
+Run fuzz tests only:
+
+```sh
+forge test --match-contract NijiFuzz --fuzz-runs 256 -vv
+```
+
+#### Test Helpers (`test/niji/helpers/`)
+
+Shared test utilities: constants, deployers, fixtures, utils, behaviors (Ownable2Step).
+
 ### Environment Setup
 
 Copy `.env.example` to `.env` and fill in fields

--- a/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
+++ b/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
@@ -22,7 +22,6 @@ contract NijiFuzzTest is Test {
         hex'0a49444154789c63000100000500010d0a2db40000000049454e44ae426082';
 
     string[] traitNames;
-    uint256[] compositeOrder;
 
     function setUp() public {
         // Build trait names
@@ -41,7 +40,7 @@ contract NijiFuzzTest is Test {
         traitNames[11] = 'hair';
 
         // Composite order (bottom to top)
-        compositeOrder = new uint256[](TRAIT_COUNT);
+        uint256[] memory compositeOrder = new uint256[](TRAIT_COUNT);
         compositeOrder[0] = 10;
         compositeOrder[1] = 9;
         compositeOrder[2] = 8;

--- a/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
+++ b/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
@@ -8,7 +8,7 @@ import { NijiSeeder } from '../../contracts/NijiSeeder.sol';
 import { NijiToken } from '../../contracts/NijiToken.sol';
 import { INijiSeeder } from '../../contracts/interfaces/INijiSeeder.sol';
 
-contract NijiFuzzTest is Test {
+contract NijiFuzz is Test {
     NijiArt art;
     NijiDescriptor descriptor;
     NijiSeeder seeder;

--- a/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
+++ b/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
@@ -105,20 +105,12 @@ contract NijiFuzzTest is Test {
 
     function testFuzz_generateSeedFromSource_validTraits(uint256 source) public {
         INijiSeeder.Seed memory seed = seeder.generateSeedFromSource(source);
+        uint256[] memory indices = _seedToTraitIndices(seed);
 
         // All traits must be < IMAGES_PER_TRAIT
-        assertLt(seed.special, IMAGES_PER_TRAIT, 'special out of range');
-        assertLt(seed.choker, IMAGES_PER_TRAIT, 'choker out of range');
-        assertLt(seed.headphone, IMAGES_PER_TRAIT, 'headphone out of range');
-        assertLt(seed.leftHand, IMAGES_PER_TRAIT, 'leftHand out of range');
-        assertLt(seed.hat, IMAGES_PER_TRAIT, 'hat out of range');
-        assertLt(seed.clothing, IMAGES_PER_TRAIT, 'clothing out of range');
-        assertLt(seed.ear, IMAGES_PER_TRAIT, 'ear out of range');
-        assertLt(seed.back, IMAGES_PER_TRAIT, 'back out of range');
-        assertLt(seed.backDecoration, IMAGES_PER_TRAIT, 'backDecoration out of range');
-        assertLt(seed.background, IMAGES_PER_TRAIT, 'background out of range');
-        assertLt(seed.solidBackground, IMAGES_PER_TRAIT, 'solidBackground out of range');
-        assertLt(seed.hair, IMAGES_PER_TRAIT, 'hair out of range');
+        for (uint256 i = 0; i < TRAIT_COUNT; i++) {
+            assertLt(indices[i], IMAGES_PER_TRAIT, string(abi.encodePacked(traitNames[i], ' out of range')));
+        }
     }
 
     // =========================================================================

--- a/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
+++ b/packages/nouns-contracts/test/foundry/NijiFuzz.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.20;
+
+import 'forge-std/Test.sol';
+import { NijiArt } from '../../contracts/NijiArt.sol';
+import { NijiDescriptor } from '../../contracts/NijiDescriptor.sol';
+import { NijiSeeder } from '../../contracts/NijiSeeder.sol';
+import { NijiToken } from '../../contracts/NijiToken.sol';
+import { INijiSeeder } from '../../contracts/interfaces/INijiSeeder.sol';
+
+contract NijiFuzzTest is Test {
+    NijiArt art;
+    NijiDescriptor descriptor;
+    NijiSeeder seeder;
+    NijiToken token;
+
+    uint256 constant TRAIT_COUNT = 12;
+    uint256 constant IMAGES_PER_TRAIT = 10;
+
+    /// @dev Minimal valid PNG (1×1 transparent pixel)
+    bytes constant SAMPLE_PNG = hex'89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489000000'
+        hex'0a49444154789c63000100000500010d0a2db40000000049454e44ae426082';
+
+    string[] traitNames;
+    uint256[] compositeOrder;
+
+    function setUp() public {
+        // Build trait names
+        traitNames = new string[](TRAIT_COUNT);
+        traitNames[0] = 'special';
+        traitNames[1] = 'choker';
+        traitNames[2] = 'headphone';
+        traitNames[3] = 'leftHand';
+        traitNames[4] = 'hat';
+        traitNames[5] = 'clothing';
+        traitNames[6] = 'ear';
+        traitNames[7] = 'back';
+        traitNames[8] = 'backDecoration';
+        traitNames[9] = 'background';
+        traitNames[10] = 'solidBackground';
+        traitNames[11] = 'hair';
+
+        // Composite order (bottom to top)
+        compositeOrder = new uint256[](TRAIT_COUNT);
+        compositeOrder[0] = 10;
+        compositeOrder[1] = 9;
+        compositeOrder[2] = 8;
+        compositeOrder[3] = 0;
+        compositeOrder[4] = 3;
+        compositeOrder[5] = 7;
+        compositeOrder[6] = 5;
+        compositeOrder[7] = 1;
+        compositeOrder[8] = 6;
+        compositeOrder[9] = 11;
+        compositeOrder[10] = 4;
+        compositeOrder[11] = 2;
+
+        // Deploy contracts
+        art = new NijiArt(address(this), traitNames);
+        descriptor = new NijiDescriptor(address(art), 320, compositeOrder);
+        seeder = new NijiSeeder(address(art));
+        token = new NijiToken('Niji', 'NIJI', address(descriptor), address(seeder), 0);
+
+        // Set descriptor on art, then transfer to this contract for image management
+        art.setDescriptor(address(descriptor));
+        art.transferDescriptor(address(this));
+
+        // Populate images: IMAGES_PER_TRAIT per category
+        bytes[] memory images = new bytes[](IMAGES_PER_TRAIT);
+        for (uint256 j = 0; j < IMAGES_PER_TRAIT; j++) {
+            images[j] = SAMPLE_PNG;
+        }
+        for (uint256 i = 0; i < TRAIT_COUNT; i++) {
+            art.addTraitImages(i, images);
+        }
+
+        // Activate minting
+        token.toggleMinting();
+    }
+
+    // =========================================================================
+    //  Internal helper: seed → traitIndices
+    // =========================================================================
+
+    function _seedToTraitIndices(INijiSeeder.Seed memory seed) internal pure returns (uint256[] memory) {
+        uint256[] memory indices = new uint256[](TRAIT_COUNT);
+        indices[0] = seed.special;
+        indices[1] = seed.choker;
+        indices[2] = seed.headphone;
+        indices[3] = seed.leftHand;
+        indices[4] = seed.hat;
+        indices[5] = seed.clothing;
+        indices[6] = seed.ear;
+        indices[7] = seed.back;
+        indices[8] = seed.backDecoration;
+        indices[9] = seed.background;
+        indices[10] = seed.solidBackground;
+        indices[11] = seed.hair;
+        return indices;
+    }
+
+    // =========================================================================
+    //  Fuzz: generateSeedFromSource always produces valid trait indices
+    // =========================================================================
+
+    function testFuzz_generateSeedFromSource_validTraits(uint256 source) public {
+        INijiSeeder.Seed memory seed = seeder.generateSeedFromSource(source);
+
+        // All traits must be < IMAGES_PER_TRAIT
+        assertLt(seed.special, IMAGES_PER_TRAIT, 'special out of range');
+        assertLt(seed.choker, IMAGES_PER_TRAIT, 'choker out of range');
+        assertLt(seed.headphone, IMAGES_PER_TRAIT, 'headphone out of range');
+        assertLt(seed.leftHand, IMAGES_PER_TRAIT, 'leftHand out of range');
+        assertLt(seed.hat, IMAGES_PER_TRAIT, 'hat out of range');
+        assertLt(seed.clothing, IMAGES_PER_TRAIT, 'clothing out of range');
+        assertLt(seed.ear, IMAGES_PER_TRAIT, 'ear out of range');
+        assertLt(seed.back, IMAGES_PER_TRAIT, 'back out of range');
+        assertLt(seed.backDecoration, IMAGES_PER_TRAIT, 'backDecoration out of range');
+        assertLt(seed.background, IMAGES_PER_TRAIT, 'background out of range');
+        assertLt(seed.solidBackground, IMAGES_PER_TRAIT, 'solidBackground out of range');
+        assertLt(seed.hair, IMAGES_PER_TRAIT, 'hair out of range');
+    }
+
+    // =========================================================================
+    //  Fuzz: generateSVG with valid traitIndices never reverts
+    // =========================================================================
+
+    function testFuzz_generateSVG_noRevert(uint256 source) public {
+        uint256[] memory traitIndices = _seedToTraitIndices(seeder.generateSeedFromSource(source));
+
+        string memory svg = descriptor.generateSVG(traitIndices);
+        assertTrue(bytes(svg).length > 0, 'SVG should not be empty');
+    }
+
+    // =========================================================================
+    //  Fuzz: generateSVG with SKIP_LAYER mixing never reverts
+    // =========================================================================
+
+    function testFuzz_generateSVG_withSkipLayers(uint256 source, uint256 skipMask) public {
+        uint256[] memory traitIndices = _seedToTraitIndices(seeder.generateSeedFromSource(source));
+
+        // Use skipMask bits to randomly set some layers to SKIP_LAYER
+        for (uint256 i = 0; i < TRAIT_COUNT; i++) {
+            if ((skipMask >> i) & 1 == 1) {
+                traitIndices[i] = type(uint256).max;
+            }
+        }
+
+        string memory svg = descriptor.generateSVG(traitIndices);
+        assertTrue(bytes(svg).length > 0, 'SVG should not be empty');
+    }
+
+    // =========================================================================
+    //  Fuzz: mintBatch with bounded quantity succeeds
+    // =========================================================================
+
+    function testFuzz_mintBatch_bounded(uint8 rawQuantity) public {
+        // Bound to 1-50 to keep test fast
+        uint256 quantity = bound(rawQuantity, 1, 50);
+
+        uint256[] memory tokenIds = token.mintBatch(address(0xBEEF), quantity);
+        assertEq(tokenIds.length, quantity, 'wrong number of minted tokens');
+
+        // Verify all tokens exist
+        for (uint256 i = 0; i < quantity; i++) {
+            assertTrue(token.exists(tokenIds[i]), 'token should exist');
+        }
+    }
+
+    // =========================================================================
+    //  Fuzz: addTraitImage with valid traitId and non-empty data
+    // =========================================================================
+
+    function testFuzz_addTraitImage_validInput(uint8 rawTraitId) public {
+        uint256 traitId = bound(rawTraitId, 0, TRAIT_COUNT - 1);
+
+        uint256 countBefore = art.getTraitImageCount(traitId);
+        art.addTraitImage(traitId, SAMPLE_PNG);
+        assertEq(art.getTraitImageCount(traitId), countBefore + 1, 'image count should increase');
+    }
+
+    // =========================================================================
+    //  Fuzz: _pickTrait modulo distribution (statistical)
+    // =========================================================================
+
+    function testFuzz_pickTrait_moduloDistribution() public {
+        // Generate 1000 seeds and check trait 0 distribution across 10 buckets
+        uint256[10] memory buckets;
+
+        for (uint256 i = 0; i < 1000; i++) {
+            INijiSeeder.Seed memory seed = seeder.generateSeedFromSource(i);
+            buckets[seed.special]++;
+        }
+
+        // With 10 images, each bucket should get ~100 hits.
+        // Allow wide tolerance (20-200) to avoid flaky tests while catching severe bias.
+        for (uint256 i = 0; i < IMAGES_PER_TRAIT; i++) {
+            assertGt(buckets[i], 20, 'bucket underrepresented');
+            assertLt(buckets[i], 200, 'bucket overrepresented');
+        }
+    }
+}

--- a/packages/nouns-contracts/test/niji/NijiArt.edge.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiArt.edge.test.ts
@@ -1,0 +1,189 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { NijiArt } from '../../typechain';
+import {
+  TRAIT_NAMES,
+  TRAIT_COUNT,
+  SAMPLE_PNG,
+  deployNijiArt,
+} from './helpers';
+
+describe('NijiArt (edge cases)', () => {
+  let art: NijiArt;
+  let owner: SignerWithAddress;
+  let descriptor: SignerWithAddress;
+  let other: SignerWithAddress;
+
+  beforeEach(async () => {
+    [owner, descriptor, other] = await ethers.getSigners();
+    art = await deployNijiArt(descriptor.address);
+  });
+
+  // =========================================================================
+  //  addTraitImages — edge cases
+  // =========================================================================
+
+  describe('addTraitImages edge cases', () => {
+    it('should succeed with empty array (no-op)', async () => {
+      await art.connect(descriptor).addTraitImages(0, []);
+      expect(await art.getTraitImageCount(0)).to.equal(0);
+    });
+
+    it('should revert when called by non-descriptor', async () => {
+      await expect(
+        art.connect(other).addTraitImages(0, [SAMPLE_PNG]),
+      ).to.be.revertedWithCustomError(art, 'SenderIsNotDescriptor');
+    });
+
+    it('should revert if any element has empty PNG data', async () => {
+      await expect(
+        art.connect(descriptor).addTraitImages(0, [SAMPLE_PNG, '0x']),
+      ).to.be.revertedWithCustomError(art, 'EmptyPngData');
+    });
+  });
+
+  // =========================================================================
+  //  addTraitImage — boundary traitId
+  // =========================================================================
+
+  describe('addTraitImage boundary traitId', () => {
+    it('should succeed at last valid traitId (traitCount - 1)', async () => {
+      const lastTrait = TRAIT_COUNT - 1;
+      await art.connect(descriptor).addTraitImage(lastTrait, SAMPLE_PNG);
+      expect(await art.getTraitImageCount(lastTrait)).to.equal(1);
+    });
+
+    it('should revert at traitId = traitCount (just out of bounds)', async () => {
+      await expect(
+        art.connect(descriptor).addTraitImage(TRAIT_COUNT, SAMPLE_PNG),
+      ).to.be.revertedWithCustomError(art, 'InvalidTraitId');
+    });
+  });
+
+  // =========================================================================
+  //  getTraitImage — edge cases
+  // =========================================================================
+
+  describe('getTraitImage edge cases', () => {
+    it('should revert at index 0 when trait has no images', async () => {
+      await expect(art.getTraitImage(0, 0)).to.be.revertedWithCustomError(
+        art,
+        'InvalidImageIndex',
+      );
+    });
+
+    it('should succeed at last valid imageIndex', async () => {
+      // Add 3 images
+      await art.connect(descriptor).addTraitImages(0, [SAMPLE_PNG, SAMPLE_PNG, SAMPLE_PNG]);
+      const data = await art.getTraitImage(0, 2);
+      expect(data).to.equal('0x' + SAMPLE_PNG.toString('hex'));
+    });
+
+    it('should revert at imageIndex = imageCount (just out of bounds)', async () => {
+      await art.connect(descriptor).addTraitImage(0, SAMPLE_PNG);
+      await expect(art.getTraitImage(0, 1)).to.be.revertedWithCustomError(
+        art,
+        'InvalidImageIndex',
+      );
+    });
+  });
+
+  // =========================================================================
+  //  getTraitPointer / getTraitPointers — edge cases
+  // =========================================================================
+
+  describe('getTraitPointer edge cases', () => {
+    it('should revert for invalid traitId', async () => {
+      await expect(art.getTraitPointer(99, 0)).to.be.revertedWithCustomError(
+        art,
+        'InvalidTraitId',
+      );
+    });
+
+    it('should revert for out-of-bounds imageIndex', async () => {
+      await expect(art.getTraitPointer(0, 0)).to.be.revertedWithCustomError(
+        art,
+        'InvalidImageIndex',
+      );
+    });
+
+    it('should return valid pointer for existing image', async () => {
+      await art.connect(descriptor).addTraitImage(0, SAMPLE_PNG);
+      const pointer = await art.getTraitPointer(0, 0);
+      expect(pointer).to.not.equal(ethers.ZeroAddress);
+    });
+  });
+
+  describe('getTraitPointers edge cases', () => {
+    it('should revert for invalid traitId', async () => {
+      await expect(art.getTraitPointers(99)).to.be.revertedWithCustomError(
+        art,
+        'InvalidTraitId',
+      );
+    });
+
+    it('should return empty array when no images stored', async () => {
+      const pointers = await art.getTraitPointers(0);
+      expect(pointers.length).to.equal(0);
+    });
+  });
+
+  // =========================================================================
+  //  setDescriptor — edge cases
+  // =========================================================================
+
+  describe('setDescriptor edge cases', () => {
+    it('should revert when setting zero address', async () => {
+      await expect(
+        art.connect(descriptor).setDescriptor(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(art, 'EmptyDescriptorAddress');
+    });
+
+    it('should allow self-update (same address)', async () => {
+      await art.connect(descriptor).setDescriptor(descriptor.address);
+      expect(await art.descriptor()).to.equal(descriptor.address);
+    });
+
+    it('should prevent old descriptor from adding images after change', async () => {
+      await art.connect(descriptor).setDescriptor(other.address);
+
+      await expect(
+        art.connect(descriptor).addTraitImage(0, SAMPLE_PNG),
+      ).to.be.revertedWithCustomError(art, 'SenderIsNotDescriptor');
+
+      // New descriptor can add
+      await art.connect(other).addTraitImage(0, SAMPLE_PNG);
+      expect(await art.getTraitImageCount(0)).to.equal(1);
+    });
+  });
+
+  // =========================================================================
+  //  transferDescriptor — edge cases
+  // =========================================================================
+
+  describe('transferDescriptor edge cases', () => {
+    it('should revert when setting zero address', async () => {
+      await expect(
+        art.connect(owner).transferDescriptor(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(art, 'EmptyDescriptorAddress');
+    });
+  });
+
+  // =========================================================================
+  //  Constructor — edge cases
+  // =========================================================================
+
+  describe('constructor edge cases', () => {
+    it('should deploy with single trait name', async () => {
+      const singleArt = await deployNijiArt(descriptor.address, ['only']);
+      expect(await singleArt.traitCount()).to.equal(1);
+      expect(await singleArt.getTraitName(0)).to.equal('only');
+    });
+
+    it('should deploy with empty trait names array', async () => {
+      const emptyArt = await deployNijiArt(descriptor.address, []);
+      expect(await emptyArt.traitCount()).to.equal(0);
+    });
+  });
+});

--- a/packages/nouns-contracts/test/niji/NijiArt.edge.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiArt.edge.test.ts
@@ -3,7 +3,6 @@ import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { NijiArt } from '../../typechain';
 import {
-  TRAIT_NAMES,
   TRAIT_COUNT,
   SAMPLE_PNG,
   deployNijiArt,

--- a/packages/nouns-contracts/test/niji/NijiDescriptor.edge.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiDescriptor.edge.test.ts
@@ -1,0 +1,235 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { NijiArt, NijiDescriptor } from '../../typechain';
+import {
+  TRAIT_NAMES,
+  TRAIT_COUNT,
+  SAMPLE_PNG,
+  RESOLUTION,
+  COMPOSITE_ORDER,
+  deployNijiArt,
+  deployNijiDescriptor,
+  populateAllTraits,
+  buildTraitIndices,
+  decodeTokenURI,
+} from './helpers';
+
+describe('NijiDescriptor (edge cases)', () => {
+  let art: NijiArt;
+  let descriptor: NijiDescriptor;
+  let owner: SignerWithAddress;
+  let other: SignerWithAddress;
+
+  beforeEach(async () => {
+    [owner, other] = await ethers.getSigners();
+    art = await deployNijiArt(owner.address);
+    descriptor = await deployNijiDescriptor(await art.getAddress());
+    await art.setDescriptor(await descriptor.getAddress());
+    await art.transferDescriptor(owner.address);
+  });
+
+  // =========================================================================
+  //  Constructor — edge cases
+  // =========================================================================
+
+  describe('constructor edge cases', () => {
+    it('should deploy with resolution = 1 (minimum valid)', async () => {
+      const d = await deployNijiDescriptor(await art.getAddress(), 1);
+      expect(await d.resolution()).to.equal(1);
+    });
+
+    it('should deploy with empty compositeOrder', async () => {
+      const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+      const d = (await NijiDescriptorFactory.deploy(
+        await art.getAddress(),
+        RESOLUTION,
+        [],
+      )) as unknown as NijiDescriptor;
+
+      expect(await d.getCompositeOrderLength()).to.equal(0);
+    });
+
+    it('should deploy with compositeOrder containing out-of-range values', async () => {
+      // compositeOrder can contain values >= traitCount; they are silently skipped in generateSVG
+      const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+      const d = (await NijiDescriptorFactory.deploy(
+        await art.getAddress(),
+        RESOLUTION,
+        [99, 100],
+      )) as unknown as NijiDescriptor;
+
+      expect(await d.getCompositeOrderLength()).to.equal(2);
+    });
+  });
+
+  // =========================================================================
+  //  tokenURIWithMetadata — edge cases
+  // =========================================================================
+
+  describe('tokenURIWithMetadata edge cases', () => {
+    beforeEach(async () => {
+      await art.addTraitImage(10, SAMPLE_PNG);
+    });
+
+    it('should revert for empty traitIndices', async () => {
+      await expect(
+        descriptor.tokenURIWithMetadata(0, [], 'Name', 'Desc'),
+      ).to.be.revertedWithCustomError(descriptor, 'EmptyTraitIndices');
+    });
+  });
+
+  // =========================================================================
+  //  generateSVG — all SKIP_LAYER
+  // =========================================================================
+
+  describe('generateSVG with all SKIP_LAYER', () => {
+    it('should generate valid SVG with no image tags', async () => {
+      const allSkip = Array(TRAIT_COUNT).fill(ethers.MaxUint256);
+      const svg = await descriptor.generateSVG(allSkip);
+
+      expect(svg).to.include('<svg xmlns="http://www.w3.org/2000/svg"');
+      expect(svg).to.include('</svg>');
+      // No <image> tags since all are SKIP_LAYER
+      expect(svg).to.not.include('<image');
+    });
+  });
+
+  // =========================================================================
+  //  generateSVG — compositeOrder with out-of-range traitId
+  // =========================================================================
+
+  describe('generateSVG with out-of-range compositeOrder', () => {
+    it('should skip layers whose traitId exceeds traitIndices length', async () => {
+      // Deploy descriptor with compositeOrder containing out-of-range value
+      const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+      const d = (await NijiDescriptorFactory.deploy(
+        await art.getAddress(),
+        RESOLUTION,
+        [99], // traitId 99 > traitIndices.length
+      )) as unknown as NijiDescriptor;
+
+      const traitIndices = [0n]; // only 1 element
+      const svg = await d.generateSVG(traitIndices);
+
+      expect(svg).to.include('<svg');
+      expect(svg).to.not.include('<image');
+    });
+  });
+
+  // =========================================================================
+  //  setArt — edge cases
+  // =========================================================================
+
+  describe('setArt edge cases', () => {
+    it('should revert for zero address', async () => {
+      await expect(
+        descriptor.setArt(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(descriptor, 'EmptyArtAddress');
+    });
+
+    it('should use new art for SVG generation after setArt', async () => {
+      // Create new art with images
+      const newArt = await deployNijiArt(owner.address);
+      await newArt.addTraitImage(0, SAMPLE_PNG);
+
+      await descriptor.setArt(await newArt.getAddress());
+
+      // Generate SVG using trait 0 image 0
+      const traitIndices = buildTraitIndices({ 0: 0 });
+      const svg = await descriptor.generateSVG(traitIndices);
+
+      expect(svg).to.include('<image');
+    });
+  });
+
+  // =========================================================================
+  //  generateDataURI
+  // =========================================================================
+
+  describe('generateDataURI', () => {
+    beforeEach(async () => {
+      await art.addTraitImage(10, SAMPLE_PNG);
+    });
+
+    it('should return valid data URI', async () => {
+      const traitIndices = buildTraitIndices({ 10: 0 });
+      const dataURI = await descriptor.generateDataURI(traitIndices);
+
+      expect(dataURI).to.include('data:image/svg+xml;base64,');
+    });
+
+    it('should return data URI with all SKIP_LAYER', async () => {
+      const allSkip = Array(TRAIT_COUNT).fill(ethers.MaxUint256);
+      const dataURI = await descriptor.generateDataURI(allSkip);
+
+      expect(dataURI).to.include('data:image/svg+xml;base64,');
+    });
+  });
+
+  // =========================================================================
+  //  getCompositeOrderLength
+  // =========================================================================
+
+  describe('getCompositeOrderLength', () => {
+    it('should return correct length', async () => {
+      expect(await descriptor.getCompositeOrderLength()).to.equal(COMPOSITE_ORDER.length);
+    });
+  });
+
+  // =========================================================================
+  //  isConfigured — edge cases
+  // =========================================================================
+
+  describe('isConfigured edge cases', () => {
+    it('should return false when compositeOrder is empty', async () => {
+      const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+      const d = (await NijiDescriptorFactory.deploy(
+        await art.getAddress(),
+        RESOLUTION,
+        [],
+      )) as unknown as NijiDescriptor;
+
+      expect(await d.isConfigured()).to.be.false;
+    });
+  });
+
+  // =========================================================================
+  //  setCompositeOrder — edge cases
+  // =========================================================================
+
+  describe('setCompositeOrder edge cases', () => {
+    it('should allow setting empty composite order', async () => {
+      await descriptor.setCompositeOrder([]);
+      expect(await descriptor.getCompositeOrderLength()).to.equal(0);
+    });
+
+    it('should revert if non-owner calls', async () => {
+      await expect(
+        descriptor.connect(other).setCompositeOrder([0, 1]),
+      ).to.be.revertedWithCustomError(descriptor, 'OwnableUnauthorizedAccount');
+    });
+  });
+
+  // =========================================================================
+  //  setResolution — edge cases
+  // =========================================================================
+
+  describe('setResolution edge cases', () => {
+    it('should allow setting resolution = 1', async () => {
+      await descriptor.setResolution(1);
+      expect(await descriptor.resolution()).to.equal(1);
+    });
+
+    it('should reflect new resolution in generated SVG', async () => {
+      await art.addTraitImage(10, SAMPLE_PNG);
+      await descriptor.setResolution(999);
+
+      const traitIndices = buildTraitIndices({ 10: 0 });
+      const svg = await descriptor.generateSVG(traitIndices);
+
+      expect(svg).to.include('width="999"');
+      expect(svg).to.include('height="999"');
+    });
+  });
+});

--- a/packages/nouns-contracts/test/niji/NijiDescriptor.edge.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiDescriptor.edge.test.ts
@@ -3,16 +3,13 @@ import { ethers } from 'hardhat';
 import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
 import { NijiArt, NijiDescriptor } from '../../typechain';
 import {
-  TRAIT_NAMES,
   TRAIT_COUNT,
   SAMPLE_PNG,
   RESOLUTION,
   COMPOSITE_ORDER,
   deployNijiArt,
   deployNijiDescriptor,
-  populateAllTraits,
   buildTraitIndices,
-  decodeTokenURI,
 } from './helpers';
 
 describe('NijiDescriptor (edge cases)', () => {

--- a/packages/nouns-contracts/test/niji/NijiIntegration.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiIntegration.test.ts
@@ -13,6 +13,33 @@ import {
   decodeTokenURI,
 } from './helpers';
 
+/** Hash a seed struct into a single keccak256 digest for comparison. */
+function hashSeed(seed: {
+  special: bigint;
+  choker: bigint;
+  headphone: bigint;
+  leftHand: bigint;
+  hat: bigint;
+  clothing: bigint;
+  ear: bigint;
+  back: bigint;
+  backDecoration: bigint;
+  background: bigint;
+  solidBackground: bigint;
+  hair: bigint;
+}): string {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      Array(TRAIT_COUNT).fill('uint48'),
+      [
+        seed.special, seed.choker, seed.headphone, seed.leftHand,
+        seed.hat, seed.clothing, seed.ear, seed.back,
+        seed.backDecoration, seed.background, seed.solidBackground, seed.hair,
+      ],
+    ),
+  );
+}
+
 describe('NijiIntegration', () => {
   let art: NijiArt;
   let descriptor: NijiDescriptor;
@@ -150,27 +177,7 @@ describe('NijiIntegration', () => {
 
       const seedHashes = new Set<string>();
       for (let i = 0; i < 10; i++) {
-        const seed = await token.getSeed(i);
-        const hash = ethers.keccak256(
-          ethers.AbiCoder.defaultAbiCoder().encode(
-            Array(TRAIT_COUNT).fill('uint48'),
-            [
-              seed.special,
-              seed.choker,
-              seed.headphone,
-              seed.leftHand,
-              seed.hat,
-              seed.clothing,
-              seed.ear,
-              seed.back,
-              seed.backDecoration,
-              seed.background,
-              seed.solidBackground,
-              seed.hair,
-            ],
-          ),
-        );
-        seedHashes.add(hash);
+        seedHashes.add(hashSeed(await token.getSeed(i)));
       }
 
       // With 3 images per trait and pseudo-random seeds, all 10 should be different

--- a/packages/nouns-contracts/test/niji/NijiIntegration.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiIntegration.test.ts
@@ -1,0 +1,252 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { NijiArt, NijiDescriptor, NijiSeeder, NijiToken } from '../../typechain';
+import {
+  TRAIT_COUNT,
+  SAMPLE_PNG,
+  deployNijiArt,
+  deployNijiDescriptor,
+  deployNijiSeeder,
+  deployNijiToken,
+  populateAllTraits,
+  decodeTokenURI,
+} from './helpers';
+
+describe('NijiIntegration', () => {
+  let art: NijiArt;
+  let descriptor: NijiDescriptor;
+  let seeder: NijiSeeder;
+  let token: NijiToken;
+  let owner: SignerWithAddress;
+  let minter: SignerWithAddress;
+  let newOwner: SignerWithAddress;
+
+  beforeEach(async () => {
+    [owner, minter, newOwner] = await ethers.getSigners();
+
+    // Full deployment flow
+    art = await deployNijiArt(owner.address);
+    descriptor = await deployNijiDescriptor(await art.getAddress());
+    seeder = await deployNijiSeeder(await art.getAddress());
+    token = await deployNijiToken(
+      'Niji',
+      'NIJI',
+      await descriptor.getAddress(),
+      await seeder.getAddress(),
+      100,
+    );
+
+    // Wire up: set descriptor on art, then transfer descriptor to owner
+    await art.setDescriptor(await descriptor.getAddress());
+    await art.transferDescriptor(owner.address);
+
+    // Populate traits
+    await populateAllTraits(art, SAMPLE_PNG);
+
+    // Activate minting
+    await token.toggleMinting();
+  });
+
+  // =========================================================================
+  //  Full flow: deploy → trait registration → mint → tokenURI → attributes
+  // =========================================================================
+
+  describe('full flow: mint → tokenURI → attributes', () => {
+    it('should produce valid tokenURI with attributes after mint', async () => {
+      await token.mint(minter.address);
+
+      const uri = await token.tokenURI(0);
+      const json = decodeTokenURI(uri);
+
+      expect(json.name).to.equal('Niji #0');
+      expect(json.image).to.include('data:image/svg+xml;base64,');
+      expect(json.attributes).to.be.an('array');
+      expect(json.attributes.length).to.be.greaterThan(0);
+
+      // Verify each attribute has valid structure
+      for (const attr of json.attributes) {
+        expect(attr.trait_type).to.be.a('string');
+        expect(attr.value).to.be.a('string');
+      }
+    });
+  });
+
+  // =========================================================================
+  //  Descriptor swap: mint → change descriptor → tokenURI uses new descriptor
+  // =========================================================================
+
+  describe('descriptor swap after mint', () => {
+    it('should use new descriptor for tokenURI', async () => {
+      await token.mint(minter.address);
+
+      // Deploy new descriptor with different resolution
+      const newArt = await deployNijiArt(owner.address);
+      await populateAllTraits(newArt, SAMPLE_PNG);
+
+      const newDescriptor = await deployNijiDescriptor(
+        await newArt.getAddress(),
+        999, // different resolution
+      );
+
+      await token.setDescriptor(await newDescriptor.getAddress());
+
+      const uri = await token.tokenURI(0);
+      const json = decodeTokenURI(uri);
+
+      // SVG should use the new resolution
+      const svgBase64 = json.image.replace('data:image/svg+xml;base64,', '');
+      const svg = Buffer.from(svgBase64, 'base64').toString();
+      expect(svg).to.include('width="999"');
+    });
+  });
+
+  // =========================================================================
+  //  Seeder swap: seed is immutable after mint
+  // =========================================================================
+
+  describe('seeder swap: existing seeds unchanged', () => {
+    it('should preserve seed of already-minted tokens after seeder change', async () => {
+      await token.mint(minter.address);
+      const seedBefore = await token.getSeed(0);
+
+      // Swap seeder
+      const newSeeder = await deployNijiSeeder(await art.getAddress());
+      await token.setSeeder(await newSeeder.getAddress());
+
+      // Existing seed should be unchanged (stored in mapping)
+      const seedAfter = await token.getSeed(0);
+      expect(seedAfter.special).to.equal(seedBefore.special);
+      expect(seedAfter.hair).to.equal(seedBefore.hair);
+    });
+  });
+
+  // =========================================================================
+  //  Minter delegation flow
+  // =========================================================================
+
+  describe('minter delegation flow', () => {
+    it('should allow new minter and reject old minter', async () => {
+      await token.setMinter(minter.address);
+
+      // Old minter (owner) should fail
+      await expect(
+        token.mint(newOwner.address),
+      ).to.be.revertedWithCustomError(token, 'OnlyMinter');
+
+      // New minter should succeed
+      await token.connect(minter).mint(newOwner.address);
+      expect(await token.ownerOf(0)).to.equal(newOwner.address);
+    });
+  });
+
+  // =========================================================================
+  //  Batch mint: 10 tokens with all different seeds
+  // =========================================================================
+
+  describe('batch mint: unique seeds', () => {
+    it('should generate 10 tokens with all-different seeds', async () => {
+      await token.mintBatch(minter.address, 10);
+
+      const seedHashes = new Set<string>();
+      for (let i = 0; i < 10; i++) {
+        const seed = await token.getSeed(i);
+        const hash = ethers.keccak256(
+          ethers.AbiCoder.defaultAbiCoder().encode(
+            Array(TRAIT_COUNT).fill('uint48'),
+            [
+              seed.special,
+              seed.choker,
+              seed.headphone,
+              seed.leftHand,
+              seed.hat,
+              seed.clothing,
+              seed.ear,
+              seed.back,
+              seed.backDecoration,
+              seed.background,
+              seed.solidBackground,
+              seed.hair,
+            ],
+          ),
+        );
+        seedHashes.add(hash);
+      }
+
+      // With 3 images per trait and pseudo-random seeds, all 10 should be different
+      // (collision probability is negligibly low)
+      expect(seedHashes.size).to.equal(10);
+    });
+  });
+
+  // =========================================================================
+  //  Supply limit flow
+  // =========================================================================
+
+  describe('supply limit flow', () => {
+    it('should allow minting up to maxSupply then revert', async () => {
+      const limitedToken = await deployNijiToken(
+        'Niji',
+        'NIJI',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        5,
+      );
+      await limitedToken.toggleMinting();
+
+      // Mint 5
+      await limitedToken.mintBatch(minter.address, 5);
+      expect(await limitedToken.remainingSupply()).to.equal(0);
+
+      // 6th should revert
+      await expect(
+        limitedToken.mint(minter.address),
+      ).to.be.revertedWithCustomError(limitedToken, 'MaxSupplyReached');
+    });
+  });
+
+  // =========================================================================
+  //  Ownership transfer flow
+  // =========================================================================
+
+  describe('ownership transfer flow', () => {
+    it('should allow new owner to perform admin actions after transfer', async () => {
+      // Transfer ownership
+      await token.transferOwnership(newOwner.address);
+      await token.connect(newOwner).acceptOwnership();
+
+      expect(await token.owner()).to.equal(newOwner.address);
+
+      // New owner can set minter
+      await token.connect(newOwner).setMinter(minter.address);
+      expect(await token.minter()).to.equal(minter.address);
+
+      // Old owner cannot
+      await expect(
+        token.setMinter(owner.address),
+      ).to.be.revertedWithCustomError(token, 'OwnableUnauthorizedAccount');
+    });
+  });
+
+  // =========================================================================
+  //  Art descriptor change: controls image access
+  // =========================================================================
+
+  describe('art descriptor change controls image access', () => {
+    it('should allow new descriptor to add images after descriptor change on art', async () => {
+      // Currently owner is descriptor on art
+      // Set art's descriptor to a new address
+      await art.transferDescriptor(minter.address);
+
+      // Owner can no longer add images
+      await expect(
+        art.addTraitImage(0, SAMPLE_PNG),
+      ).to.be.revertedWithCustomError(art, 'SenderIsNotDescriptor');
+
+      // New descriptor (minter) can add images
+      const countBefore = await art.getTraitImageCount(0);
+      await art.connect(minter).addTraitImage(0, SAMPLE_PNG);
+      expect(await art.getTraitImageCount(0)).to.equal(countBefore + 1n);
+    });
+  });
+});

--- a/packages/nouns-contracts/test/niji/NijiSeeder.edge.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiSeeder.edge.test.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { NijiArt, NijiSeeder } from '../../typechain';
+import {
+  TRAIT_COUNT,
+  SAMPLE_PNG,
+  deployNijiArt,
+  deployNijiSeeder,
+  populateAllTraits,
+} from './helpers';
+
+describe('NijiSeeder (edge cases)', () => {
+  let art: NijiArt;
+  let seeder: NijiSeeder;
+  let owner: SignerWithAddress;
+  let other: SignerWithAddress;
+
+  beforeEach(async () => {
+    [owner, other] = await ethers.getSigners();
+    art = await deployNijiArt(owner.address);
+    seeder = await deployNijiSeeder(await art.getAddress());
+  });
+
+  // =========================================================================
+  //  generateSeed with 0 images — SKIP_LAYER
+  // =========================================================================
+
+  describe('generateSeed with no images', () => {
+    it('should return SKIP_LAYER (MaxUint256) for traits with 0 images', async () => {
+      // No images added — all traits have 0 count
+      const seed = await seeder.generateSeedFromSource(12345n);
+
+      // When traitCount == 0, _pickTrait returns type(uint256).max
+      // But seed fields are uint48, so MaxUint256 truncates to 2^48 - 1 = 281474976710655
+      const UINT48_MAX = (1n << 48n) - 1n;
+      expect(seed.special).to.equal(UINT48_MAX);
+      expect(seed.choker).to.equal(UINT48_MAX);
+      expect(seed.hair).to.equal(UINT48_MAX);
+    });
+  });
+
+  // =========================================================================
+  //  generateSeedFromSource — boundary values
+  // =========================================================================
+
+  describe('generateSeedFromSource boundary values', () => {
+    beforeEach(async () => {
+      await populateAllTraits(art);
+    });
+
+    it('should handle source = 0', async () => {
+      const seed = await seeder.generateSeedFromSource(0n);
+      // With 3 images per trait: 0 % 3 = 0 for all traits
+      expect(seed.special).to.equal(0);
+      expect(seed.choker).to.equal(0);
+      expect(seed.hair).to.equal(0);
+    });
+
+    it('should handle source = MaxUint256', async () => {
+      const seed = await seeder.generateSeedFromSource(ethers.MaxUint256);
+      // Should not revert; all values should be valid (0-2)
+      for (const field of [
+        seed.special, seed.choker, seed.headphone, seed.leftHand,
+        seed.hat, seed.clothing, seed.ear, seed.back,
+        seed.backDecoration, seed.background, seed.solidBackground, seed.hair,
+      ]) {
+        expect(field).to.be.at.least(0);
+        expect(field).to.be.at.most(2);
+      }
+    });
+  });
+
+  // =========================================================================
+  //  getTraitCount with out-of-range traitId
+  // =========================================================================
+
+  describe('getTraitCount out-of-range', () => {
+    it('should return 0 for traitId beyond art.traitCount', async () => {
+      // art.getTraitImageCount for non-existing traitId returns 0 (empty mapping)
+      const count = await seeder.getTraitCount(99);
+      expect(count).to.equal(0);
+    });
+  });
+
+  // =========================================================================
+  //  setArt — seed generation after art change
+  // =========================================================================
+
+  describe('generateSeed after art change', () => {
+    it('should use new art for trait counts', async () => {
+      await populateAllTraits(art);
+
+      // Verify current state works
+      const seed1 = await seeder.generateSeedFromSource(42n);
+      expect(seed1.special).to.be.at.most(2);
+
+      // Deploy new art with only 1 image per trait
+      const newArt = await deployNijiArt(owner.address);
+      await populateAllTraits(newArt, SAMPLE_PNG, 1);
+
+      await seeder.setArt(await newArt.getAddress());
+
+      // Now all traits have exactly 1 image → all values should be 0
+      const seed2 = await seeder.generateSeedFromSource(42n);
+      expect(seed2.special).to.equal(0);
+      expect(seed2.hair).to.equal(0);
+    });
+  });
+});

--- a/packages/nouns-contracts/test/niji/NijiToken.edge.test.ts
+++ b/packages/nouns-contracts/test/niji/NijiToken.edge.test.ts
@@ -1,0 +1,236 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { SignerWithAddress } from '@nomicfoundation/hardhat-ethers/signers';
+import { NijiArt, NijiDescriptor, NijiSeeder, NijiToken } from '../../typechain';
+import {
+  TRAIT_COUNT,
+  SAMPLE_PNG,
+  deployNijiArt,
+  deployNijiDescriptor,
+  deployNijiSeeder,
+  deployNijiToken,
+  populateAllTraits,
+} from './helpers';
+
+describe('NijiToken (edge cases)', () => {
+  let art: NijiArt;
+  let descriptor: NijiDescriptor;
+  let seeder: NijiSeeder;
+  let token: NijiToken;
+  let owner: SignerWithAddress;
+  let minter: SignerWithAddress;
+  let other: SignerWithAddress;
+
+  const MAX_SUPPLY = 100;
+
+  beforeEach(async () => {
+    [owner, minter, other] = await ethers.getSigners();
+
+    art = await deployNijiArt(owner.address);
+    descriptor = await deployNijiDescriptor(await art.getAddress());
+    seeder = await deployNijiSeeder(await art.getAddress());
+    token = await deployNijiToken(
+      'Niji',
+      'NIJI',
+      await descriptor.getAddress(),
+      await seeder.getAddress(),
+      MAX_SUPPLY,
+    );
+
+    await art.setDescriptor(await descriptor.getAddress());
+    await art.transferDescriptor(owner.address);
+    await populateAllTraits(art, SAMPLE_PNG);
+  });
+
+  // =========================================================================
+  //  Constructor — zero address errors
+  // =========================================================================
+
+  describe('constructor zero-address errors', () => {
+    it('should revert with DescriptorNotSet if descriptor is zero', async () => {
+      const NijiTokenFactory = await ethers.getContractFactory('NijiToken');
+      await expect(
+        NijiTokenFactory.deploy('Niji', 'NIJI', ethers.ZeroAddress, await seeder.getAddress(), 100),
+      ).to.be.revertedWithCustomError(NijiTokenFactory, 'DescriptorNotSet');
+    });
+
+    it('should revert with SeederNotSet if seeder is zero', async () => {
+      const NijiTokenFactory = await ethers.getContractFactory('NijiToken');
+      await expect(
+        NijiTokenFactory.deploy(
+          'Niji',
+          'NIJI',
+          await descriptor.getAddress(),
+          ethers.ZeroAddress,
+          100,
+        ),
+      ).to.be.revertedWithCustomError(NijiTokenFactory, 'SeederNotSet');
+    });
+  });
+
+  // =========================================================================
+  //  mintBatch — edge cases
+  // =========================================================================
+
+  describe('mintBatch edge cases', () => {
+    beforeEach(async () => {
+      await token.toggleMinting();
+    });
+
+    it('should succeed with quantity = 0 (empty array returned)', async () => {
+      const tokenIds = await token.mintBatch.staticCall(other.address, 0);
+      expect(tokenIds.length).to.equal(0);
+    });
+
+    it('should revert when quantity exceeds remaining supply', async () => {
+      // Deploy with maxSupply = 3
+      const limitedToken = await deployNijiToken(
+        'Niji',
+        'NIJI',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        3,
+      );
+      await limitedToken.toggleMinting();
+
+      // Mint 2 first
+      await limitedToken.mintBatch(other.address, 2);
+
+      // Trying to mint 2 more should revert (only 1 remaining)
+      await expect(
+        limitedToken.mintBatch(other.address, 2),
+      ).to.be.revertedWithCustomError(limitedToken, 'MaxSupplyReached');
+    });
+
+    it('should succeed when minting exactly up to maxSupply', async () => {
+      const limitedToken = await deployNijiToken(
+        'Niji',
+        'NIJI',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        5,
+      );
+      await limitedToken.toggleMinting();
+
+      await limitedToken.mintBatch(other.address, 5);
+      expect(await limitedToken.currentTokenId()).to.equal(5);
+      expect(await limitedToken.remainingSupply()).to.equal(0);
+    });
+  });
+
+  // =========================================================================
+  //  maxSupply = 0 (unlimited)
+  // =========================================================================
+
+  describe('unlimited supply (maxSupply = 0)', () => {
+    it('should allow minting without limit', async () => {
+      const unlimitedToken = await deployNijiToken(
+        'Niji',
+        'NIJI',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        0,
+      );
+      await unlimitedToken.toggleMinting();
+
+      // Mint 10 tokens
+      await unlimitedToken.mintBatch(other.address, 10);
+      expect(await unlimitedToken.currentTokenId()).to.equal(10);
+      expect(await unlimitedToken.remainingSupply()).to.equal(ethers.MaxUint256);
+    });
+  });
+
+  // =========================================================================
+  //  setDescriptor / setSeeder / setMinter — zero address
+  // =========================================================================
+
+  describe('set* with zero address', () => {
+    it('should revert setDescriptor with EmptyAddress', async () => {
+      await expect(
+        token.setDescriptor(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(token, 'EmptyAddress');
+    });
+
+    it('should revert setSeeder with EmptyAddress', async () => {
+      await expect(
+        token.setSeeder(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(token, 'EmptyAddress');
+    });
+
+    it('should revert setMinter with EmptyAddress', async () => {
+      await expect(
+        token.setMinter(ethers.ZeroAddress),
+      ).to.be.revertedWithCustomError(token, 'EmptyAddress');
+    });
+  });
+
+  // =========================================================================
+  //  lockProvenanceHash — edge cases
+  // =========================================================================
+
+  describe('lockProvenanceHash edge cases', () => {
+    it('should revert when locking twice', async () => {
+      await token.lockProvenanceHash();
+
+      await expect(token.lockProvenanceHash()).to.be.revertedWithCustomError(
+        token,
+        'ProvenanceHashLocked',
+      );
+    });
+
+    it('should allow locking with empty provenance hash', async () => {
+      // provenanceHash defaults to empty
+      await token.lockProvenanceHash();
+      expect(await token.isProvenanceHashLocked()).to.be.true;
+      expect(await token.provenanceHash()).to.equal('');
+    });
+  });
+
+  // =========================================================================
+  //  getTraitIndices — full verification
+  // =========================================================================
+
+  describe('getTraitIndices full verification', () => {
+    it('should return 12-element array matching seed fields', async () => {
+      await token.toggleMinting();
+      await token.mint(other.address);
+
+      const seed = await token.getSeed(0);
+      const indices = await token.getTraitIndices(0);
+
+      expect(indices.length).to.equal(TRAIT_COUNT);
+      expect(indices[0]).to.equal(seed.special);
+      expect(indices[1]).to.equal(seed.choker);
+      expect(indices[2]).to.equal(seed.headphone);
+      expect(indices[3]).to.equal(seed.leftHand);
+      expect(indices[4]).to.equal(seed.hat);
+      expect(indices[5]).to.equal(seed.clothing);
+      expect(indices[6]).to.equal(seed.ear);
+      expect(indices[7]).to.equal(seed.back);
+      expect(indices[8]).to.equal(seed.backDecoration);
+      expect(indices[9]).to.equal(seed.background);
+      expect(indices[10]).to.equal(seed.solidBackground);
+      expect(indices[11]).to.equal(seed.hair);
+    });
+  });
+
+  // =========================================================================
+  //  Minter delegation
+  // =========================================================================
+
+  describe('minter delegation', () => {
+    it('should prevent old minter from minting after setMinter', async () => {
+      await token.toggleMinting();
+      await token.setMinter(minter.address);
+
+      // Old minter (owner) should fail
+      await expect(
+        token.mint(other.address),
+      ).to.be.revertedWithCustomError(token, 'OnlyMinter');
+
+      // New minter should succeed
+      await token.connect(minter).mint(other.address);
+      expect(await token.ownerOf(0)).to.equal(other.address);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add edge case tests for NijiArt, NijiDescriptor, NijiToken, NijiSeeder (53 tests)
- Add cross-contract integration tests covering full mint flow, descriptor/seeder/minter swaps, ownership transfer (8 tests)
- Add Foundry fuzz tests for seed generation, SVG rendering, batch minting, and modulo distribution (6 tests, 256 runs)
- Total: **+67 tests** (Hardhat 134 → 195, Foundry +6)

## Test plan
- [x] `npx hardhat test --grep "Niji"` — 195 passing
- [x] `forge test --match-contract NijiFuzz --fuzz-runs 256` — 6 passing
- [x] Code review: 0 Critical, Medium/Low issues fixed

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)