### PR TITLE
Apollo → TanStack Query: useSubgraphQuery インフラフック作成 (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ The webapp is undergoing modernization efforts:
 **From**: Apollo Client with manual queries  
 **To**: TanStack Query + GraphQL Codegen with typed `execute()` function  
 **Guidance**: New GraphQL queries should use the codegen'd `execute()` pattern
-**Helper**: Use `useSubgraphQuery` hook (`src/hooks/useSubgraphQuery.ts`) for Apollo-compatible `{ loading, data, error, refetch }` interface
+**Helper**: Use `useSubgraphQuery` hook (`packages/nouns-webapp/src/hooks/useSubgraphQuery.ts`) for Apollo-compatible `{ loading, data, error, refetch }` interface
 
 ## Code Generation Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ The webapp is undergoing modernization efforts:
 **From**: Apollo Client with manual queries  
 **To**: TanStack Query + GraphQL Codegen with typed `execute()` function  
 **Guidance**: New GraphQL queries should use the codegen'd `execute()` pattern
+**Helper**: Use `useSubgraphQuery` hook (`src/hooks/useSubgraphQuery.ts`) for Apollo-compatible `{ loading, data, error, refetch }` interface
 
 ## Code Generation Dependencies
 

--- a/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
+++ b/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
@@ -35,7 +35,7 @@ export function useSubgraphQuery<TResult, TVariables>({
   return {
     loading: result.isLoading,
     data: result.data,
-    error: result.error ?? undefined,
+    error: result.error || undefined,
     refetch: result.refetch,
   };
 }

--- a/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
+++ b/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
@@ -1,0 +1,41 @@
+import type { TypedDocumentString } from '@/subgraphs/graphql';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { execute } from '@/subgraphs/execute';
+
+interface UseSubgraphQueryOptions<TResult, TVariables> {
+  document: TypedDocumentString<TResult, TVariables>;
+  variables?: TVariables;
+  queryKey: unknown[];
+  enabled?: boolean;
+  refetchInterval?: number;
+}
+
+export function useSubgraphQuery<TResult, TVariables>({
+  document,
+  variables,
+  queryKey,
+  enabled = true,
+  refetchInterval,
+}: UseSubgraphQueryOptions<TResult, TVariables>) {
+  const result = useQuery({
+    queryKey,
+    queryFn: () => {
+      const exec = execute as (
+        query: TypedDocumentString<TResult, TVariables>,
+        variables?: TVariables,
+      ) => Promise<TResult>;
+      return exec(document, variables);
+    },
+    enabled,
+    refetchInterval: refetchInterval ?? false,
+  });
+
+  return {
+    loading: result.isLoading,
+    data: result.data,
+    error: result.error ?? undefined,
+    refetch: result.refetch,
+  };
+}


### PR DESCRIPTION
## Summary
- Apollo Client → TanStack Query 移行の基盤となる `useSubgraphQuery` ラッパーフックを作成
- Apollo `useQuery` と同じ `{ loading, data, error, refetch }` インターフェースを返す
- `pollInterval` → `refetchInterval`、`skip` → `enabled` マッピングをサポート
- CLAUDE.md の GraphQL Migration セクションに Helper 行を追記

## Test plan
- [x] `tsc --noEmit` 型チェック通過
- [x] ESLint パス
- [ ] 後続 Issue (B〜E) で実際の使用箇所に適用して動作確認

Closes #79
Part of #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)