### PR TITLE
Apollo → TanStack Query: nounToken.ts 移行 (#81)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,7 +177,7 @@ The webapp is undergoing modernization efforts:
 **From**: Apollo Client with manual queries  
 **To**: TanStack Query + GraphQL Codegen with typed `execute()` function  
 **Guidance**: New GraphQL queries should use the codegen'd `execute()` pattern
-**Helper**: Use `useSubgraphQuery` hook (`src/hooks/useSubgraphQuery.ts`) for Apollo-compatible `{ loading, data, error, refetch }` interface
+**Helper**: Use `useSubgraphQuery` hook (`packages/nouns-webapp/src/hooks/useSubgraphQuery.ts`) for Apollo-compatible `{ loading, data, error, refetch }` interface
 
 ## Code Generation Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,6 +177,7 @@ The webapp is undergoing modernization efforts:
 **From**: Apollo Client with manual queries  
 **To**: TanStack Query + GraphQL Codegen with typed `execute()` function  
 **Guidance**: New GraphQL queries should use the codegen'd `execute()` pattern
+**Helper**: Use `useSubgraphQuery` hook (`src/hooks/useSubgraphQuery.ts`) for Apollo-compatible `{ loading, data, error, refetch }` interface
 
 ## Code Generation Dependencies
 

--- a/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
+++ b/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
@@ -35,7 +35,7 @@ export function useSubgraphQuery<TResult, TVariables>({
   return {
     loading: result.isLoading,
     data: result.data,
-    error: result.error ?? undefined,
+    error: result.error || undefined,
     refetch: result.refetch,
   };
 }

--- a/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
+++ b/packages/nouns-webapp/src/hooks/useSubgraphQuery.ts
@@ -1,0 +1,41 @@
+import type { TypedDocumentString } from '@/subgraphs/graphql';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { execute } from '@/subgraphs/execute';
+
+interface UseSubgraphQueryOptions<TResult, TVariables> {
+  document: TypedDocumentString<TResult, TVariables>;
+  variables?: TVariables;
+  queryKey: unknown[];
+  enabled?: boolean;
+  refetchInterval?: number;
+}
+
+export function useSubgraphQuery<TResult, TVariables>({
+  document,
+  variables,
+  queryKey,
+  enabled = true,
+  refetchInterval,
+}: UseSubgraphQueryOptions<TResult, TVariables>) {
+  const result = useQuery({
+    queryKey,
+    queryFn: () => {
+      const exec = execute as (
+        query: TypedDocumentString<TResult, TVariables>,
+        variables?: TVariables,
+      ) => Promise<TResult>;
+      return exec(document, variables);
+    },
+    enabled,
+    refetchInterval: refetchInterval ?? false,
+  });
+
+  return {
+    loading: result.isLoading,
+    data: result.data,
+    error: result.error ?? undefined,
+    refetch: result.refetch,
+  };
+}

--- a/packages/nouns-webapp/src/wrappers/nounToken.ts
+++ b/packages/nouns-webapp/src/wrappers/nounToken.ts
@@ -1,9 +1,8 @@
-import type { Delegate, EscrowedNoun, Noun, Seed } from '@/subgraphs/graphql';
+import type { Seed } from '@/subgraphs/graphql';
 import type { Address } from '@/utils/types';
 
 import { useEffect } from 'react';
 
-import { useQuery } from '@apollo/client';
 import { zeroAddress } from 'viem';
 import { useAccount } from 'wagmi';
 
@@ -19,15 +18,16 @@ import {
   useWriteNounsTokenDelegate,
   useWriteNounsTokenSetApprovalForAll,
 } from '@/contracts';
+import { useSubgraphQuery } from '@/hooks/useSubgraphQuery';
 import { defaultChain } from '@/wagmi';
 
 import { cache, cacheKey, CHAIN_ID } from '../config';
 
 import {
-  accountEscrowedNounsQuery,
-  delegateNounsAtBlockQuery,
-  ownedNounsQuery,
-  seedsQuery,
+  accountEscrowedNounsDocument,
+  delegateNounsAtBlockDocument,
+  ownedNounsDocument,
+  seedsDocument,
 } from './subgraph';
 
 export interface INounSeed {
@@ -63,10 +63,11 @@ const seedArrayToObject = (seeds: (INounSeed & { id: string })[]) => {
 const useNounSeeds = () => {
   const cache = localStorage.getItem(seedCacheKey);
   const cachedSeeds = cache ? (JSON.parse(cache) as Seed[]) : undefined;
-  const { query, variables } = seedsQuery();
-  const { data } = useQuery<{ seeds: Seed[] }>(query, {
-    skip: !!cachedSeeds,
-    variables,
+  const { data } = useSubgraphQuery({
+    document: seedsDocument,
+    variables: { first: 1000 },
+    queryKey: ['seeds', 1000],
+    enabled: !cachedSeeds,
   });
 
   useEffect(() => {
@@ -200,32 +201,37 @@ export const useNounTokenBalance = (address: Address): number | undefined => {
 };
 export const useUserOwnedNounIds = (pollInterval: number) => {
   const { address } = useAccount();
-  const { query, variables } = ownedNounsQuery(address?.toLowerCase() ?? '');
-  const { loading, data, error, refetch } = useQuery<{ nouns: Noun[] }>(query, {
-    pollInterval,
-    variables,
+  const owner = address?.toLowerCase() ?? '';
+  const { loading, data, error, refetch } = useSubgraphQuery({
+    document: ownedNounsDocument,
+    variables: { owner },
+    queryKey: ['ownedNouns', owner],
+    refetchInterval: pollInterval,
   });
-  const userOwnedNouns: number[] = data?.nouns?.map(noun => Number(noun.id)) || [];
+  const userOwnedNouns: number[] = data?.nouns?.map(noun => Number(noun.id)) ?? [];
   return { loading, data: userOwnedNouns, error, refetch };
 };
 
 export const useUserEscrowedNounIds = (pollInterval: number, forkId: string) => {
   const { address } = useAccount();
-  const { query, variables } = accountEscrowedNounsQuery(address?.toLowerCase() ?? '');
-  const { loading, data, error, refetch } = useQuery<{
-    escrowedNouns: Array<EscrowedNoun>;
-  }>(query, {
-    pollInterval,
-    variables,
+  const owner = address?.toLowerCase() ?? '';
+  const { loading, data, error, refetch } = useSubgraphQuery({
+    document: accountEscrowedNounsDocument,
+    variables: { owner },
+    queryKey: ['accountEscrowedNouns', owner],
+    refetchInterval: pollInterval,
   });
   // filter escrowed nouns to just this fork
   const userEscrowedNounIds: number[] =
-    data?.escrowedNouns?.reduce((acc: number[], escrowedNoun: EscrowedNoun) => {
-      if (escrowedNoun.fork.id === forkId) {
-        acc.push(+escrowedNoun.noun.id);
-      }
-      return acc;
-    }, []) || [];
+    data?.escrowedNouns?.reduce(
+      (acc: number[], escrowedNoun: { noun: { id: string }; fork: { id: string } }) => {
+        if (escrowedNoun.fork.id === forkId) {
+          acc.push(+escrowedNoun.noun.id);
+        }
+        return acc;
+      },
+      [],
+    ) ?? [];
   return { loading, data: userEscrowedNounIds, error, refetch };
 };
 
@@ -270,7 +276,10 @@ export const useIsApprovedForAll = () => {
   return (data as boolean) || false;
 };
 export const useDelegateNounsAtBlockQuery = (signers: string[], block: bigint) => {
-  const { query, variables } = delegateNounsAtBlockQuery(signers, block);
-  const { loading, data, error } = useQuery<{ delegates: Delegate[] }>(query, { variables });
+  const { loading, data, error } = useSubgraphQuery({
+    document: delegateNounsAtBlockDocument,
+    variables: { delegates: signers, block: Number(block) },
+    queryKey: ['delegateNounsAtBlock', signers, Number(block)],
+  });
   return { loading, data, error };
 };

--- a/packages/nouns-webapp/src/wrappers/nounToken.ts
+++ b/packages/nouns-webapp/src/wrappers/nounToken.ts
@@ -223,15 +223,12 @@ export const useUserEscrowedNounIds = (pollInterval: number, forkId: string) => 
   });
   // filter escrowed nouns to just this fork
   const userEscrowedNounIds: number[] =
-    data?.escrowedNouns?.reduce(
-      (acc: number[], escrowedNoun: { noun: { id: string }; fork: { id: string } }) => {
-        if (escrowedNoun.fork.id === forkId) {
-          acc.push(+escrowedNoun.noun.id);
-        }
-        return acc;
-      },
-      [],
-    ) ?? [];
+    data?.escrowedNouns?.reduce((acc: number[], escrowedNoun) => {
+      if (escrowedNoun.fork.id === forkId) {
+        acc.push(+escrowedNoun.noun.id);
+      }
+      return acc;
+    }, []) ?? [];
   return { loading, data: userEscrowedNounIds, error, refetch };
 };
 

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -3,6 +3,13 @@ import { ApolloClient, ApolloLink, gql, HttpLink, InMemoryCache } from '@apollo/
 import { graphql } from '@/subgraphs';
 import { BigNumberish } from '@/utils/types';
 
+export {
+  GetSeedsDocument as seedsDocument,
+  GetOwnedNounsDocument as ownedNounsDocument,
+  GetAccountEscrowedNounsDocument as accountEscrowedNounsDocument,
+  GetDelegateNounsAtBlockDocument as delegateNounsAtBlockDocument,
+} from '@/subgraphs/graphql';
+
 export const clientFactory = (uri: string) => {
   // patch BigInt JSON serialization (runs once)
   if (
@@ -66,19 +73,6 @@ export interface Delegate {
 export interface Delegates {
   delegates: Delegate[];
 }
-
-export const seedsDocument = graphql(`
-  query GetSeeds($first: Int!) {
-    seeds(first: $first) {
-      id
-      background
-      body
-      accessory
-      head
-      glasses
-    }
-  }
-`);
 
 export const seedsQuery = (first = 1_000) => ({
   query: gql`
@@ -582,17 +576,6 @@ export const proposalVotesQuery = (proposalId: string) => ({
   variables: { proposalId },
 });
 
-export const delegateNounsAtBlockDocument = graphql(`
-  query GetDelegateNounsAtBlock($delegates: [ID!]!, $block: Int!) {
-    delegates(where: { id_in: $delegates }, block: { number: $block }) {
-      id
-      nounsRepresented {
-        id
-      }
-    }
-  }
-`);
-
 export const delegateNounsAtBlockQuery = (delegates: string[], block: bigint) => ({
   query: gql`
     query GetDelegateNounsAtBlock($delegates: [ID!]!, $block: Int!) {
@@ -682,14 +665,6 @@ export const candidateFeedbacksQuery = (candidateId: string) => ({
   variables: { candidateId },
 });
 
-export const ownedNounsDocument = graphql(`
-  query GetOwnedNouns($owner: ID!) {
-    nouns(where: { owner_: { id: $owner } }) {
-      id
-    }
-  }
-`);
-
 export const ownedNounsQuery = (owner: string) => ({
   query: gql`
     query GetOwnedNouns($owner: ID!) {
@@ -700,19 +675,6 @@ export const ownedNounsQuery = (owner: string) => ({
   `,
   variables: { owner },
 });
-
-export const accountEscrowedNounsDocument = graphql(`
-  query GetAccountEscrowedNouns($owner: ID!) {
-    escrowedNouns(where: { owner_: { id: $owner } }, first: 1000) {
-      noun {
-        id
-      }
-      fork {
-        id
-      }
-    }
-  }
-`);
 
 export const accountEscrowedNounsQuery = (owner: string) => ({
   query: gql`

--- a/packages/nouns-webapp/src/wrappers/subgraph.ts
+++ b/packages/nouns-webapp/src/wrappers/subgraph.ts
@@ -67,6 +67,19 @@ export interface Delegates {
   delegates: Delegate[];
 }
 
+export const seedsDocument = graphql(`
+  query GetSeeds($first: Int!) {
+    seeds(first: $first) {
+      id
+      background
+      body
+      accessory
+      head
+      glasses
+    }
+  }
+`);
+
 export const seedsQuery = (first = 1_000) => ({
   query: gql`
     query GetSeeds($first: Int!) {
@@ -569,6 +582,17 @@ export const proposalVotesQuery = (proposalId: string) => ({
   variables: { proposalId },
 });
 
+export const delegateNounsAtBlockDocument = graphql(`
+  query GetDelegateNounsAtBlock($delegates: [ID!]!, $block: Int!) {
+    delegates(where: { id_in: $delegates }, block: { number: $block }) {
+      id
+      nounsRepresented {
+        id
+      }
+    }
+  }
+`);
+
 export const delegateNounsAtBlockQuery = (delegates: string[], block: bigint) => ({
   query: gql`
     query GetDelegateNounsAtBlock($delegates: [ID!]!, $block: Int!) {
@@ -658,6 +682,14 @@ export const candidateFeedbacksQuery = (candidateId: string) => ({
   variables: { candidateId },
 });
 
+export const ownedNounsDocument = graphql(`
+  query GetOwnedNouns($owner: ID!) {
+    nouns(where: { owner_: { id: $owner } }) {
+      id
+    }
+  }
+`);
+
 export const ownedNounsQuery = (owner: string) => ({
   query: gql`
     query GetOwnedNouns($owner: ID!) {
@@ -668,6 +700,19 @@ export const ownedNounsQuery = (owner: string) => ({
   `,
   variables: { owner },
 });
+
+export const accountEscrowedNounsDocument = graphql(`
+  query GetAccountEscrowedNouns($owner: ID!) {
+    escrowedNouns(where: { owner_: { id: $owner } }, first: 1000) {
+      noun {
+        id
+      }
+      fork {
+        id
+      }
+    }
+  }
+`);
 
 export const accountEscrowedNounsQuery = (owner: string) => ({
   query: gql`


### PR DESCRIPTION
## Summary
- `nounToken.ts` の 4 つの Apollo `useQuery` を `useSubgraphQuery` に移行
- `subgraph.ts` に 4 つの型安全な `graphql()` document を追加 (`seedsDocument`, `ownedNounsDocument`, `accountEscrowedNounsDocument`, `delegateNounsAtBlockDocument`)
- Apollo `@apollo/client` の `useQuery` import を `nounToken.ts` から完全除去

## Test plan
- [x] `tsc --noEmit` 型チェック通過
- [x] ESLint パス
- [ ] ブラウザで Noun 表示・delegate 機能の動作確認

Closes #81
Depends on #80
Part of #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)