### PR TITLE
♻️ #87 Migrate component/page Apollo useQuery to useSubgraphQuery

### DIFF
--- a/packages/nouns-webapp/src/components/ByLineHoverCard/index.tsx
+++ b/packages/nouns-webapp/src/components/ByLineHoverCard/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useQuery } from '@apollo/client';
 import { ScaleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import { Spinner } from 'react-bootstrap';
@@ -8,9 +7,9 @@ import { map } from 'remeda';
 
 import HorizontalStackedNouns from '@/components/HorizontalStackedNouns';
 import ShortAddress from '@/components/ShortAddress';
-import { Delegate, Maybe } from '@/subgraphs/graphql';
+import { useSubgraphQuery } from '@/hooks/useSubgraphQuery';
 import { Address } from '@/utils/types';
-import { currentlyDelegatedNouns } from '@/wrappers/subgraph';
+import { currentlyDelegatedNounsDocument } from '@/wrappers/subgraph';
 
 import classes from './ByLineHoverCard.module.css';
 
@@ -23,8 +22,11 @@ const MAX_NOUN_IDS_SHOWN = 12;
 const ByLineHoverCard: React.FC<ByLineHoverCardProps> = props => {
   const { proposerAddress } = props;
 
-  const { query, variables } = currentlyDelegatedNouns(proposerAddress);
-  const { data, loading, error } = useQuery<{ delegates: Maybe<Delegate[]> }>(query, { variables });
+  const { data, loading, error } = useSubgraphQuery({
+    document: currentlyDelegatedNounsDocument,
+    variables: { delegate: proposerAddress },
+    queryKey: ['currentlyDelegatedNouns', proposerAddress],
+  });
 
   if (loading || (data && data?.delegates?.length === 0)) {
     return (

--- a/packages/nouns-webapp/src/components/CandidateCard/CandidateSponsors.tsx
+++ b/packages/nouns-webapp/src/components/CandidateCard/CandidateSponsors.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
 
-import { useQuery } from '@apollo/client';
 import clsx from 'clsx';
 
 import { CandidateSignature } from '@/wrappers/nounsData';
-import { delegateNounsAtBlockQuery, Delegates } from '@/wrappers/subgraph';
+import { useDelegateNounsAtBlockQuery } from '@/wrappers/nounToken';
 
 import CandidateSponsorImage from './CandidateSponsorImage';
 import classes from './CandidateSponsors.module.css';
@@ -25,11 +24,10 @@ const CandidateSponsors = ({
   const maxVisibleSpots = 5;
   const [signerCountOverflow, setSignerCountOverflow] = useState(0);
   const activeSigners =
-    signers?.filter(s => s.signer.activeOrPendingProposal === false && s.signer.id) ?? [];
+    signers?.filter(s => s.signer.activeOrPendingProposal === false && s.signer.id !== '') ?? [];
   const signerIds = activeSigners?.map(s => s.signer.id) ?? [];
-  const { query, variables } = delegateNounsAtBlockQuery(signerIds ?? [], currentBlock ?? 0n);
-  const { data: delegateSnapshot } = useQuery<Delegates>(query, { variables });
-  const { delegates } = delegateSnapshot || {};
+  const { data: delegateSnapshot } = useDelegateNounsAtBlockQuery(signerIds, currentBlock ?? 0n);
+  const delegates = delegateSnapshot?.delegates;
   const delegateToNounIds = delegates?.reduce<Record<string, string[]>>((acc, curr) => {
     acc[curr.id] = curr?.nounsRepresented?.map(nr => nr.id) ?? [];
     return acc;
@@ -39,7 +37,7 @@ const CandidateSponsors = ({
     setSignerCountOverflow(signers.length - maxVisibleSpots);
   }
   const placeholderCount =
-    isThresholdMetByProposer && nounIds.length === 0 ? 1 : nounsRequired - nounIds.length;
+    isThresholdMetByProposer === true && nounIds.length === 0 ? 1 : nounsRequired - nounIds.length;
   const placeholderArray = Array(placeholderCount >= 1 ? placeholderCount : 0).fill(0);
 
   return (

--- a/packages/nouns-webapp/src/components/DelegateHoverCard/index.tsx
+++ b/packages/nouns-webapp/src/components/DelegateHoverCard/index.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 
-import { useQuery } from '@apollo/client';
 import { ScaleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import { Spinner } from 'react-bootstrap';
 
 import HorizontalStackedNouns from '@/components/HorizontalStackedNouns';
 import ShortAddress from '@/components/ShortAddress';
-import { delegateNounsAtBlockQuery } from '@/wrappers/subgraph';
+import { useDelegateNounsAtBlockQuery } from '@/wrappers/nounToken';
 
 import classes from './DelegateHoverCard.module.css';
 
@@ -21,11 +20,10 @@ const DelegateHoverCard: React.FC<DelegateHoverCardProps> = props => {
 
   const unwrappedDelegateId = delegateId ? delegateId.replace('delegate-', '') : '';
 
-  const { query, variables } = delegateNounsAtBlockQuery(
+  const { data, loading, error } = useDelegateNounsAtBlockQuery(
     [unwrappedDelegateId],
     proposalCreationBlock,
   );
-  const { data, loading, error } = useQuery(query, { variables });
 
   if (loading || !data || data === undefined || data.delegates.length === 0) {
     return (
@@ -52,7 +50,7 @@ const DelegateHoverCard: React.FC<DelegateHoverCardProps> = props => {
       </div>
 
       <div className={classes.address}>
-        <ShortAddress address={data ? data.delegates[0].id : ''} />
+        <ShortAddress address={(data?.delegates[0]?.id ?? '') as `0x${string}`} />
       </div>
 
       <div className={classes.nounInfoWrapper}>

--- a/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/nouns-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-import { useQuery } from '@apollo/client';
 import { XIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import ReactDOM from 'react-dom';
 
 import { Backdrop } from '@/components/Modal';
+import { useSubgraphQuery } from '@/hooks/useSubgraphQuery';
 import { Proposal, useDynamicQuorumProps } from '@/wrappers/nounsDao';
-import { adjustedNounSupplyAtPropSnapshot } from '@/wrappers/subgraph';
+import { adjustedNounSupplyAtPropSnapshotDocument } from '@/wrappers/subgraph';
 
 import classes from './DynamicQuorumInfoModal.module.css';
 
@@ -293,10 +293,12 @@ const DynamicQuorumInfoModal: React.FC<{
 }> = props => {
   const { onDismiss, proposal, againstVotesAbsolute, currentQuorum } = props;
 
-  const { query,variables } = adjustedNounSupplyAtPropSnapshot(proposal && proposal.id ? proposal.id : '0');
-  const { data, loading, error } = useQuery(
-    query,{variables}
-  );
+  const proposalId = proposal.id ?? '0';
+  const { data, loading, error } = useSubgraphQuery({
+    document: adjustedNounSupplyAtPropSnapshotDocument,
+    variables: { proposalId },
+    queryKey: ['adjustedNounSupplyAtPropSnapshot', proposalId],
+  });
 
   const dynamicQuorumProps = useDynamicQuorumProps(BigInt(proposal.startBlock));
 
@@ -325,8 +327,9 @@ const DynamicQuorumInfoModal: React.FC<{
           minQuorumBps={dynamicQuorumProps?.minQuorumVotesBPS ?? 0}
           maxQuorumBps={dynamicQuorumProps?.maxQuorumVotesBPS ?? 0}
           quorumCoefficent={
-            dynamicQuorumProps?.quorumCoefficient
-              ? dynamicQuorumProps?.quorumCoefficient / scalingFactor
+            dynamicQuorumProps?.quorumCoefficient != null &&
+            dynamicQuorumProps.quorumCoefficient !== 0
+              ? dynamicQuorumProps.quorumCoefficient / scalingFactor
               : 0
           }
           onDismiss={onDismiss}

--- a/packages/nouns-webapp/src/components/Holder/index.tsx
+++ b/packages/nouns-webapp/src/components/Holder/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useQuery } from '@apollo/client';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import { Col, Row } from 'react-bootstrap';
@@ -8,8 +7,9 @@ import { Col, Row } from 'react-bootstrap';
 import ShortAddress from '@/components/ShortAddress';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useAppSelector } from '@/hooks';
+import { useSubgraphQuery } from '@/hooks/useSubgraphQuery';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
-import { nounQuery } from '@/wrappers/subgraph';
+import { nounDocument } from '@/wrappers/subgraph';
 
 import classes from './Holder.module.css';
 
@@ -23,8 +23,12 @@ const Holder: React.FC<HolderProps> = props => {
 
   const isCool = useAppSelector(state => state.application.isCoolBackground);
 
-  const { query, variables } = nounQuery(nounId.toString());
-  const { loading, error, data } = useQuery(query, { variables });
+  const id = nounId.toString();
+  const { loading, error, data } = useSubgraphQuery({
+    document: nounDocument,
+    variables: { id },
+    queryKey: ['noun', id],
+  });
 
   if (loading) {
     return <></>;
@@ -36,11 +40,11 @@ const Holder: React.FC<HolderProps> = props => {
     );
   }
 
-  const holder = data && data.noun.owner.id;
+  const holder = data?.noun?.owner.id;
 
   const nonNounderNounContent = (
     <a
-      href={buildEtherscanAddressLink(holder)}
+      href={buildEtherscanAddressLink(holder ?? '')}
       target={'_blank'}
       rel="noreferrer"
       className={classes.link}
@@ -50,7 +54,7 @@ const Holder: React.FC<HolderProps> = props => {
           <Trans>View on Etherscan</Trans>
         </TooltipContent>
         <TooltipTrigger>
-          <ShortAddress size={40} address={holder} avatar={true} />
+          <ShortAddress size={40} address={(holder ?? '') as `0x${string}`} avatar={true} />
         </TooltipTrigger>
       </Tooltip>
     </a>
@@ -78,7 +82,7 @@ const Holder: React.FC<HolderProps> = props => {
               color: isCool ? 'var(--brand-cool-dark-text)' : 'var(--brand-warm-dark-text)',
             }}
           >
-            {isNounders ? nounderNounContent : nonNounderNounContent}
+            {isNounders === true ? nounderNounContent : nonNounderNounContent}
           </h2>
         </Col>
       </Row>

--- a/packages/nouns-webapp/src/pages/Vote/index.tsx
+++ b/packages/nouns-webapp/src/pages/Vote/index.tsx
@@ -2,7 +2,6 @@ import type { Address } from '@/utils/types';
 
 import { Fragment, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { useQuery } from '@apollo/client';
 import { SearchIcon } from '@heroicons/react/solid';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/core/macro';
@@ -33,6 +32,7 @@ import VoteSignals from '@/components/VoteSignals/VoteSignals';
 import { useReadNounsGovernorQuorumVotes } from '@/contracts';
 import { useAppSelector } from '@/hooks';
 import { useActiveLocale } from '@/hooks/useActivateLocale';
+import { useSubgraphQuery } from '@/hooks/useSubgraphQuery';
 import { SUPPORTED_LOCALE_TO_DAYSJS_LOCALE, SupportedLocale } from '@/i18n/locales';
 import Section from '@/layout/Section';
 import { cn } from '@/lib/utils';
@@ -56,11 +56,9 @@ import {
 import { useProposalFeedback } from '@/wrappers/nounsData';
 import { useUserVotes, useUserVotesAsOfBlock } from '@/wrappers/nounToken';
 import {
-  delegateNounsAtBlockQuery,
-  Delegates,
-  ProposalVotes,
-  proposalVotesQuery,
-  propUsingDynamicQuorum,
+  delegateNounsAtBlockDocument,
+  proposalVotesDocument,
+  propUsingDynamicQuorumDocument,
 } from '@/wrappers/subgraph';
 
 import classes from './Vote.module.css';
@@ -117,8 +115,16 @@ const VotePage = () => {
   const activeLocale = useActiveLocale();
   const { _ } = useLingui();
   const { address: account } = useAccount();
-  const { query, variables } = propUsingDynamicQuorum(id ?? '0');
-  const { data: dqInfo, loading: loadingDQInfo, error: dqError } = useQuery(query, { variables });
+  const proposalId = id ?? '0';
+  const {
+    data: dqInfo,
+    loading: loadingDQInfo,
+    error: dqError,
+  } = useSubgraphQuery({
+    document: propUsingDynamicQuorumDocument,
+    variables: { proposalId },
+    queryKey: ['propUsingDynamicQuorum', proposalId],
+  });
   const { queueProposal, queueProposalState } = useQueueProposal();
   const { executeProposal, executeProposalState } = useExecuteProposal();
   const { cancelProposal, cancelProposalState } = useCancelProposal();
@@ -194,8 +200,8 @@ const VotePage = () => {
     args: [proposal !== undefined && proposal.id !== undefined ? BigInt(proposal.id) : 0n],
     query: {
       enabled:
-        dqInfo !== undefined && dqInfo.proposal !== undefined
-          ? dqInfo.proposal.quorumCoefficient === '0'
+        dqInfo !== undefined && dqInfo.proposal != null
+          ? dqInfo.proposal.quorumCoefficient === 0n
           : true,
     },
   });
@@ -400,27 +406,27 @@ const VotePage = () => {
   }, [forkActiveState.data, setIsForkActive]);
 
   const activeAccount = useAppSelector(state => state.account.activeAccount);
-  const { query: votesQuery, variables: votesVariables } = proposalVotesQuery(proposal?.id ?? '0');
   const {
     loading,
     error,
     data: voters,
-  } = useQuery<ProposalVotes>(votesQuery, {
-    skip: !proposal,
-    variables: votesVariables,
+  } = useSubgraphQuery({
+    document: proposalVotesDocument,
+    variables: { proposalId: proposal?.id ?? '0' },
+    queryKey: ['proposalVotes', proposal?.id ?? '0'],
+    enabled: !!proposal,
   });
 
   const voterIds = voters?.votes?.map(v => v.voter.id);
-  const { query: voteSnapshotQuery, variables: voteSnapshotVariables } = delegateNounsAtBlockQuery(
-    voterIds ?? [],
-    BigInt(proposal?.voteSnapshotBlock ?? 0),
-  );
-  const { data: delegateSnapshot } = useQuery<Delegates>(voteSnapshotQuery, {
-    skip: (voters?.votes?.length ?? 0) === 0,
-    variables: voteSnapshotVariables,
+  const snapshotBlock = Number(BigInt(proposal?.voteSnapshotBlock ?? 0));
+  const { data: delegateSnapshot } = useSubgraphQuery({
+    document: delegateNounsAtBlockDocument,
+    variables: { delegates: voterIds ?? [], block: snapshotBlock },
+    queryKey: ['delegateNounsAtBlock', voterIds ?? [], snapshotBlock],
+    enabled: (voters?.votes?.length ?? 0) > 0,
   });
 
-  const { delegates } = delegateSnapshot || {};
+  const delegates = delegateSnapshot?.delegates;
   const delegateToNounIds = delegates?.reduce<Record<string, string[]>>((acc, curr) => {
     acc[curr.id] = curr?.nounsRepresented?.map(nr => nr.id) ?? [];
     return acc;
@@ -428,7 +434,7 @@ const VotePage = () => {
 
   const data = voters?.votes?.map(v => ({
     delegate: v.voter.id as Address,
-    supportDetailed: v.supportDetailed,
+    supportDetailed: v.supportDetailed as 0 | 1 | 2,
     nounsRepresented: delegateToNounIds?.[v.voter.id] ?? [],
   }));
 
@@ -488,7 +494,7 @@ const VotePage = () => {
     return <Trans>Failed to fetch</Trans>;
   }
   const againstNouns = getNounVotes(data, 0);
-  const isV2Prop = dqInfo.proposal.quorumCoefficient > 0;
+  const isV2Prop = (dqInfo.proposal?.quorumCoefficient ?? 0n) > 0n;
 
   return (
     <Section fullWidth={false} className={classes.votePage}>


### PR DESCRIPTION
## Summary
- Replace direct Apollo Client `useQuery` calls in 6 component/page files with `useSubgraphQuery` (TanStack Query) and codegen typed documents
- DelegateHoverCard and CandidateSponsors unified to use `useDelegateNounsAtBlockQuery` hook
- Vote page: 3 Apollo calls migrated (propUsingDynamicQuorum, proposalVotes, delegateNounsAtBlock)
- Fix pre-existing strict-boolean-expression lint errors in touched files

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [x] `vite build` succeeds
- [ ] Manual verification: Vote page loads proposal details
- [ ] Manual verification: DynamicQuorumInfoModal displays correctly
- [ ] Manual verification: Candidate sponsors display correctly

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)