### PR TITLE
🔧 #52 Unify TypeScript config to ES2022/ESNext

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ The monorepo uses a unified TypeScript configuration with package-specific overr
   - `packages/nouns-contracts`: Uses `module: "CommonJS"` for Hardhat compatibility
   - `packages/nouns-subgraph`: Uses `module: "CommonJS"` for Graph TS compatibility
 
-All other packages inherit the base configuration for consistency.
+Packages extending the base: `nouns-contracts`, `nouns-subgraph`, `nouns-webapp`. Standalone configs: `nouns-assets`, `nouns-sdk`, `nouns-docs` (aligned to the same ES2022/ESNext standard).
 
 ## Package Structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,14 +168,14 @@ Optional:
 ## Testing
 
 Each package has its own test setup:
-- **Assets/SDK**: Node.js with standard test runners (ES2022 target)
-- **Contracts**: Hardhat (TypeScript with CommonJS) + Foundry (Solidity)
-- **Webapp**: Vitest + React Testing Library (ES2022 target)
-- **Subgraph**: Matchstick framework (CommonJS)
+- **Assets/SDK**: Node.js with standard test runners
+- **Contracts**: Hardhat (TypeScript) + Foundry (Solidity)
+- **Webapp**: Vitest + React Testing Library
+- **Subgraph**: Matchstick framework
 
 Run `pnpm test` from root to test all packages, or `cd` into specific package for targeted testing.
 
-Note: Contracts and subgraph packages use CommonJS for compatibility with their respective frameworks, while other packages use ESNext modules.
+Note: All packages target ES2022. Contracts and subgraph use CommonJS modules for framework compatibility; other packages use ESNext.
 
 ## Active Migrations (nouns-webapp)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,21 @@ This is a monorepo for Nouns DAO, a generative avatar art collective run by cryp
 - **TypeScript** throughout the codebase
 - **Node.js** 16.x or higher
 
+### TypeScript Configuration
+
+The monorepo uses a unified TypeScript configuration with package-specific overrides:
+
+- **Base configuration** (`tsconfig.base.json`):
+  - `target: ES2022` (Node.js 16+ and all modern browsers)
+  - `module: ESNext` (optimized for bundlers and tree-shaking)
+  - `lib: ["ES2022"]` (modern JavaScript features)
+
+- **CommonJS overrides** (for compatibility):
+  - `packages/nouns-contracts`: Uses `module: "CommonJS"` for Hardhat compatibility
+  - `packages/nouns-subgraph`: Uses `module: "CommonJS"` for Graph TS compatibility
+
+All other packages inherit the base configuration for consistency.
+
 ## Package Structure
 
 Six main packages with interdependencies:
@@ -55,6 +70,7 @@ Located in `packages/nouns-contracts/`:
 - Tests in `test/` (TypeScript) and `test/foundry/` (Solidity)
 - Deployment scripts in `script/`
 - Generated TypeChain types in `typechain/`
+- **TypeScript**: Uses CommonJS module format for Hardhat compatibility
 
 ### Contract Testing Stack
 - **ethers v6**: JavaScript/TypeScript Ethereum library (uses native `bigint`, not `BigNumber`)
@@ -152,12 +168,14 @@ Optional:
 ## Testing
 
 Each package has its own test setup:
-- **Assets/SDK**: Node.js with standard test runners
-- **Contracts**: Hardhat (TypeScript) + Foundry (Solidity)
-- **Webapp**: Vitest + React Testing Library
-- **Subgraph**: Matchstick framework
+- **Assets/SDK**: Node.js with standard test runners (ES2022 target)
+- **Contracts**: Hardhat (TypeScript with CommonJS) + Foundry (Solidity)
+- **Webapp**: Vitest + React Testing Library (ES2022 target)
+- **Subgraph**: Matchstick framework (CommonJS)
 
 Run `pnpm test` from root to test all packages, or `cd` into specific package for targeted testing.
+
+Note: Contracts and subgraph packages use CommonJS for compatibility with their respective frameworks, while other packages use ESNext modules.
 
 ## Active Migrations (nouns-webapp)
 
@@ -209,6 +227,7 @@ Located in `packages/nouns-docs/` - Next.js 15 documentation site built with Nex
 - **nextra-theme-docs** for the documentation theme
 - **Pagefind** for search functionality
 - **Lucide Icons** for UI components
+- **TypeScript**: ES2022 target with ESNext modules (bundler module resolution)
 
 ### File Structure
 - `app/layout.tsx` - Root layout with Nextra theme configuration

--- a/packages/nouns-assets/tsconfig.json
+++ b/packages/nouns-assets/tsconfig.json
@@ -3,7 +3,7 @@
     "composite": true,
     /* → Basic ESM setup */
     "module": "ESNext",
-    "target": "ES2020",
+    "target": "ES2022",
 
     /* → Tell TS how to resolve “./foo” imports */
     "moduleResolution": "node",

--- a/packages/nouns-contracts/tsconfig.json
+++ b/packages/nouns-contracts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "composite": true
+    "composite": true,
+    "module": "CommonJS"
   },
   "extends": "../../tsconfig.base.json",
   "include": [

--- a/packages/nouns-docs/tsconfig.json
+++ b/packages/nouns-docs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "ESNext"],
+    "lib": ["dom", "dom.iterable", "ES2022"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,

--- a/packages/nouns-docs/tsconfig.json
+++ b/packages/nouns-docs/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2024",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ESNext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -18,7 +18,7 @@
         "name": "next"
       }
     ],
-    "module": "esnext",
+    "module": "ESNext",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]

--- a/packages/nouns-sdk/tsconfig.json
+++ b/packages/nouns-sdk/tsconfig.json
@@ -4,7 +4,7 @@
     "strict": true,
     /* → Basic ESM setup */
     "module": "ESNext",
-    "target": "ES2021",
+    "target": "ES2022",
     "lib": ["ES2022", "DOM"],
 
     /* → Tell TS how to resolve “./foo” imports */

--- a/packages/nouns-subgraph/tsconfig.json
+++ b/packages/nouns-subgraph/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
+    "module": "CommonJS",
     "rootDir": "src",
     "outDir": "dist"
   }

--- a/packages/nouns-webapp/tsconfig.json
+++ b/packages/nouns-webapp/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "es2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "composite": false,
     "declaration": false,
     "forceConsistentCasingInFileNames": true,
-    "module": "esnext",
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",

--- a/packages/nouns-webapp/tsconfig.json
+++ b/packages/nouns-webapp/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "ESNext"],
     "allowJs": true,
     "composite": false,
     "declaration": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,15 +13,15 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "composite": true,
-    "lib": ["esnext"],
-    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "module": "ESNext",
     "moduleResolution": "node",
     "noImplicitThis":true,
     "outDir": "dist",
     "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
-    "target": "es6",
+    "target": "ES2022",
   },
   "exclude": ["**/dist"]
 }


### PR DESCRIPTION
## Summary

- Unify `target` to `ES2022` and `module` to `ESNext` across the monorepo base config
- Add explicit `module: "CommonJS"` overrides for Hardhat (contracts) and Graph TS (subgraph) compatibility
- Remove redundant `target`/`module` from webapp (now inherits from base)
- Normalize casing in docs tsconfig (`esnext` → `ESNext`)
- Update CLAUDE.md with TypeScript configuration documentation

## Changes

| File | Change |
|------|--------|
| `tsconfig.base.json` | `target: es6→ES2022`, `module: CJS→ESNext`, `lib: esnext→ES2022` |
| `packages/nouns-assets/tsconfig.json` | `target: ES2020→ES2022` |
| `packages/nouns-contracts/tsconfig.json` | `module: "CommonJS"` added |
| `packages/nouns-sdk/tsconfig.json` | `target: ES2021→ES2022` |
| `packages/nouns-subgraph/tsconfig.json` | `module: "CommonJS"` added |
| `packages/nouns-webapp/tsconfig.json` | `target`, `module` removed (inherited) |
| `packages/nouns-docs/tsconfig.json` | `target: es2024→ES2022`, casing normalized |

## Test plan

- [x] `pnpm build` — sdk, contracts, assets, subgraph, docs all pass
- [x] `pnpm check` (webapp) — type check passes
- [x] contracts tests — 280 passing
- [x] webapp tests — 30 passed

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)