### PR TITLE
♻️ #98 ESLint flat config の冗長性解消

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,9 @@ import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 
+// Config
+import prettierConfig from 'eslint-config-prettier';
+
 // Other plugins
 import importXPlugin from 'eslint-plugin-import-x';
 import linguiPlugin from 'eslint-plugin-lingui';
@@ -77,13 +80,9 @@ export default defineConfig([
     },
     extends: [
       ...tseslint.configs.recommended,
-      ...compat.extends(
-        'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
-        'prettier',
-      ),
       importXPlugin.flatConfigs.recommended,
       importXPlugin.flatConfigs.typescript,
+      prettierConfig,
     ],
     rules: {
       '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -197,8 +196,9 @@ export default defineConfig([
       prettier: prettierPlugin,
     },
     extends: [
-      ...compat.extends('plugin:react/recommended', 'plugin:prettier/recommended'),
+      ...compat.extends('plugin:react/recommended'),
       eslintReactPlugin.configs['recommended-typescript'],
+      prettierConfig,
     ],
     rules: {
       // React hooks rules
@@ -255,7 +255,7 @@ export default defineConfig([
   // Base JS configuration
   {
     files: ['**/*.js', '**/*.mjs'],
-    extends: [js.configs.recommended, ...compat.extends('plugin:prettier/recommended')],
+    extends: [js.configs.recommended, prettierConfig],
     languageOptions: {
       ecmaVersion: 2020,
       globals: {


### PR DESCRIPTION
## What

ESLint flat config から冗長な `compat.extends` 呼び出しを削除し、ネイティブ flat config に統一。

## Why

#93（ESLint 10 アップグレード）で Gemini Code Assist から指摘された冗長性を解消。`compat.extends` はレガシー eslintrc 形式の互換レイヤーであり、flat config 対応済みのプラグインでは不要。

## How

| 箇所 | Before | After |
|------|--------|-------|
| TS セクション | `compat.extends('plugin:@typescript-eslint/recommended', 'plugin:prettier/recommended', 'prettier')` | 削除（`tseslint.configs.recommended` で既にカバー + `prettierConfig` 直接利用） |
| Webapp セクション | `compat.extends('plugin:react/recommended', 'plugin:prettier/recommended')` | `compat.extends('plugin:react/recommended')` + `prettierConfig` |
| JS セクション | `compat.extends('plugin:prettier/recommended')` | `prettierConfig` 直接利用 |

`compat.extends` の残存箇所は flat config 未対応の2プラグインのみ:
- `eslint-plugin-react`（`plugin:react/recommended`）
- `eslint-config-ponder`（`ponder`）

## Test

- [x] `pnpm -w lint` — エラー数に変化なし（652 errors, 928 warnings — 全て既存コード起因）
- [x] 設定の意味的等価性を確認

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)