### PR TITLE
♻️ #98 ESLint flat config の冗長性解消（compat.extends 削減）

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,6 +14,9 @@ import reactPlugin from 'eslint-plugin-react';
 import reactHooksPlugin from 'eslint-plugin-react-hooks';
 import reactRefreshPlugin from 'eslint-plugin-react-refresh';
 
+// Config
+import prettierConfig from 'eslint-config-prettier';
+
 // Other plugins
 import importXPlugin from 'eslint-plugin-import-x';
 import linguiPlugin from 'eslint-plugin-lingui';
@@ -77,13 +80,9 @@ export default defineConfig([
     },
     extends: [
       ...tseslint.configs.recommended,
-      ...compat.extends(
-        'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
-        'prettier',
-      ),
       importXPlugin.flatConfigs.recommended,
       importXPlugin.flatConfigs.typescript,
+      prettierConfig,
     ],
     rules: {
       '@typescript-eslint/explicit-module-boundary-types': 'off',
@@ -197,8 +196,9 @@ export default defineConfig([
       prettier: prettierPlugin,
     },
     extends: [
-      ...compat.extends('plugin:react/recommended', 'plugin:prettier/recommended'),
+      ...compat.extends('plugin:react/recommended'),
       eslintReactPlugin.configs['recommended-typescript'],
+      prettierConfig,
     ],
     rules: {
       // React hooks rules
@@ -255,7 +255,7 @@ export default defineConfig([
   // Base JS configuration
   {
     files: ['**/*.js', '**/*.mjs'],
-    extends: [js.configs.recommended, ...compat.extends('plugin:prettier/recommended')],
+    extends: [js.configs.recommended, prettierConfig],
     languageOptions: {
       ecmaVersion: 2020,
       globals: {


### PR DESCRIPTION
## What

ESLint flat config から冗長な `compat.extends` 呼び出しを削減し、ネイティブ flat config に置き換えた。

## Why

PR #97（ESLint 10 アップグレード）で Gemini Code Assist から指摘された3点の冗長性を解消するため。`compat.extends` はレガシー互換レイヤーであり、flat config ネイティブの設定が存在する場合はそちらを優先すべき。

## How

- `compat.extends('plugin:@typescript-eslint/recommended')` を削除（`tseslint.configs.recommended` と重複）
- `compat.extends('plugin:prettier/recommended')` → `prettierConfig`（eslint-config-prettier の flat config エクスポート）に置き換え（3箇所）
- `eslint-config-prettier` を直接 import して使用

## Test

- `pnpm -w lint "packages/**/*.{ts,tsx}"` — lint パス確認済み

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)