### PR TITLE
fix(eslint): tsconfigRootDir を絶対 path に強制 (sub PR 1-a.1 of 5)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,12 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import { defineConfig, globalIgnores } from 'eslint/config';
 import globals from 'globals';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // TypeScript plugins and parsers
 import typescriptEslintEslintPlugin from '@typescript-eslint/eslint-plugin';
@@ -65,7 +70,11 @@ export default defineConfig([
       parserOptions: {
         // Enable project service for better TypeScript integration
         projectService: true,
-        tsconfigRootDir: import.meta.dirname,
+        // Use fileURLToPath + dirname for a deterministically absolute
+        // root directory. `import.meta.dirname` works in most setups but
+        // some lint-staged invocations leave it resolving to a relative
+        // './' which the typescript-eslint parser rejects.
+        tsconfigRootDir: __dirname,
       },
     },
     plugins: {
@@ -279,12 +288,30 @@ export default defineConfig([
   },
 
   // nouns-api specific configuration (Ponder)
+  // eslint-config-ponder hard-codes `tsconfigRootDir: './'` and
+  // `project: true`. The former is rejected as a non-absolute path when
+  // lint-staged invokes eslint from the repo root with file arguments, and
+  // the latter conflicts with our base config's `projectService: true`.
+  // Patch both options on the extended configs before spreading.
+  ...compat.extends('ponder').map(cfg => {
+    const { project: _project, ...restParserOptions } = cfg.languageOptions?.parserOptions ?? {};
+    return {
+      ...cfg,
+      files: cfg.files ?? ['**/packages/nouns-api/**/*.{ts,tsx}'],
+      languageOptions: {
+        ...cfg.languageOptions,
+        parserOptions: {
+          ...restParserOptions,
+          tsconfigRootDir: __dirname,
+        },
+      },
+    };
+  }),
   {
     files: ['**/packages/nouns-api/**/*.{ts,tsx}'],
-    extends: [...compat.extends('ponder')],
     languageOptions: {
       parserOptions: {
-        project: ['packages/nouns-api/tsconfig.json'],
+        tsconfigRootDir: __dirname,
       },
     },
     settings: {


### PR DESCRIPTION
# 概要

Issue #104 の sub PR 1-a.1。
sub PR 1-b (dir rename) で `git mv` 後に lint-staged が大量 file (~300) を一括 lint する際、 ESLint config の 2 つの構造的な不整合で pre-commit hook が必ず失敗する事象が発生したため、 1-b に着手する前段 fix として独立 PR で対応する。

# 課題

PR #105 (sub PR 1-a) merge 後に sub PR 1-b の dir rename を進めようとしたところ、 lint-staged 経由の eslint が以下の 2 種類のエラーで止まった。

第 1 種類。

```
Parsing error: parserOptions.tsconfigRootDir must be an absolute path, but received: "./". This is a bug in your configuration; please supply an absolute path
```

`eslint-config-ponder` (`compat.extends('ponder')` 経由) が `parserOptions.tsconfigRootDir` に **相対 path `'./'` を hard-code** しており、 typescript-eslint parser が「absolute path でないと bug 扱い」 として弾く。 1-a では rename の commit 分割で lint-staged が触る file 数が少なく顕在化していなかったが、 dir rename で 300+ src file が一括 staged になると上記 deprecation が必ず発火する。

第 2 種類。

```
Parsing error: Enabling "project" does nothing when "projectService" is enabled. You can remove the "project" setting
```

base config で `projectService: true` を使っているのに対し `eslint-config-ponder` が `project: true` を hard-code、 typescript-eslint が「両方有効化は無効」 として弾く。

これらは sub PR 1-b の dir rename 自体とは無関係な ESLint 設定上の負債で、 1-b に混ぜると scope が膨らむため独立 PR にする。

# 詳細

```mermaid
graph LR
    A[lint-staged invokes eslint] --> B[eslint.config.mjs]
    B --> C[base: tsconfigRootDir = import.meta.dirname]
    B --> D[extends ponder]
    D --> E[ponder: tsconfigRootDir = './' ★]
    D --> F[ponder: project = true ★]
    E --> G[parser rejects: not absolute path]
    F --> H[parser rejects: conflicts with projectService]
```

`import.meta.dirname` 自体は Node v20.11+ で絶対 path を返すが、 lint-staged が file 引数付きで eslint を invoke する場合に **特定の resolve 経路で `./` に化ける** ケースが報告されている (本 PR の発端事象もこれ)。 確実に絶対 path を渡すには `fileURLToPath + dirname` を使う方が頑健。

# 解決方法

eslint.config.mjs に `fileURLToPath + dirname` 経由の `__dirname` 定数を導入し、 以下 3 箇所で絶対 path を強制する。

- base config の `tsconfigRootDir` を `import.meta.dirname` から `__dirname` に置換
- `compat.extends('ponder')` の戻り value を `.map` で patch して `tsconfigRootDir: './'` を `__dirname` に上書き、 `project: true` を `projectService` と競合しないよう削除
- nouns-api section の `parserOptions.project` も削除し `tsconfigRootDir` 1 本に統一

# 仕組み

```mermaid
graph LR
    A[eslint.config.mjs] --> B["__dirname = dirname(fileURLToPath(import.meta.url))"]
    B --> C[base parserOptions.tsconfigRootDir = __dirname]
    A --> D["compat.extends('ponder').map(cfg => patch(cfg))"]
    D --> E[ponder parserOptions.tsconfigRootDir = __dirname]
    D --> F[ponder parserOptions.project 削除]
    A --> G[nouns-api section parserOptions.tsconfigRootDir = __dirname]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `eslint.config.mjs` | `fileURLToPath` / `dirname` を import、 `__dirname` 定数を導入、 base + ponder + nouns-api の 3 箇所で `tsconfigRootDir` を絶対 path に統一、 `project: true` の override を撤去 |

# テストと確認

- [x] `pnpm exec eslint packages/nouns-webapp/src/App.tsx` で warning 1 件 (既存) / 0 errors
- [x] `pnpm exec eslint packages/nouns-api/src/NounsToken.ts` で 0 件 (clean)
- [x] config import 後の config tree 全 entry で `tsconfigRootDir = /Users/.../niji-monorepo` (絶対 path) を確認
- [x] 既存 eslint 動作に regression なし

レビューで見てほしいところ。

- `compat.extends('ponder').map(...)` での config patch が ponder plugin の他設定 (rules / plugins / settings) を壊していないか
- 本 PR は ESLint 設定だけの変更で動作影響は lint-staged hook 内に閉じる、 production runtime には触れない

# 関連

- Issue #104 (全面 rename、 本 PR は sub PR 1-a.1)
- 直前の PR #105 (sub PR 1-a npm package 名 rename、 merged)
- 後続 PR (sub PR 1-b dir rename、 本 PR merge 後に再開予定)

Refs #104
