### PR TITLE
refactor(niji-webapp): StandaloneNoun → StandaloneNiji rename (Issue #123)

### DIFF
--- a/packages/niji-webapp/src/components/Auction/index.tsx
+++ b/packages/niji-webapp/src/components/Auction/index.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router';
 import AuctionActivity from '@/components/AuctionActivity';
 import { LoadingNoun } from '@/components/LegacyNoun';
 import NijiContent from '@/components/NijiContent';
-import { StandaloneNounWithSeed } from '@/components/StandaloneNoun';
+import { StandaloneNijiWithSeed } from '@/components/StandaloneNiji';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 import { setStateBackgroundColor } from '@/state/slices/application';
 import { RootState } from '@/store';
@@ -47,7 +47,7 @@ const Auction: React.FC<AuctionProps> = props => {
 
   const nounContent = currentAuction && (
     <div className={classes.nounWrapper}>
-      <StandaloneNounWithSeed
+      <StandaloneNijiWithSeed
         nounId={BigInt(currentAuction.nounId)}
         onLoadSeed={loadedNounHandler}
         shouldLinkToProfile={false}

--- a/packages/niji-webapp/src/components/BidHistoryModal/index.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModal/index.tsx
@@ -5,7 +5,7 @@ import { Trans } from '@lingui/react/macro';
 import ReactDOM from 'react-dom';
 
 import BidHistoryModalRow from '@/components/BidHistoryModalRow';
-import { StandaloneNounRoundedCorners } from '@/components/StandaloneNoun';
+import { StandaloneNijiRoundedCorners } from '@/components/StandaloneNiji';
 import { Bid } from '@/utils/types';
 import { Auction } from '@/wrappers/nijiAuction';
 import { useAuctionBids } from '@/wrappers/onDisplayAuction';
@@ -40,7 +40,7 @@ const BidHistoryModalOverlay: React.FC<BidHistoryModalOverlayProps> = ({ auction
         <div className={classes.content}>
           <div className={classes.header}>
             <div className={classes.nounWrapper}>
-              <StandaloneNounRoundedCorners nounId={BigInt(auction && auction.nounId)} />
+              <StandaloneNijiRoundedCorners nounId={BigInt(auction && auction.nounId)} />
             </div>
 
             <div className={classes.title}>

--- a/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.tsx
@@ -1,4 +1,4 @@
-import { StandaloneNounImage } from '@/components/StandaloneNoun';
+import { StandaloneNijiImage } from '@/components/StandaloneNiji';
 
 import classes from './CandidateSponsors.module.css';
 
@@ -8,7 +8,7 @@ type CandidateSponsorImageProps = {
 
 const CandidateSponsorImage = ({ nounId }: CandidateSponsorImageProps) => (
   <div className={classes.sponsorAvatar}>
-    <StandaloneNounImage nounId={nounId} />
+    <StandaloneNijiImage nounId={nounId} />
   </div>
 );
 

--- a/packages/niji-webapp/src/components/HorizontalStackedNijis/index.tsx
+++ b/packages/niji-webapp/src/components/HorizontalStackedNijis/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { StandaloneNounCircular } from '@/components/StandaloneNoun';
+import { StandaloneNijiCircular } from '@/components/StandaloneNiji';
 
 import classes from './HorizontalStackedNijis.module.css';
 
@@ -23,7 +23,7 @@ const HorizontalStackedNijis: React.FC<HorizontalStackedNounsProps> = ({ nounIds
               }}
               className={classes.nounWrapper}
             >
-              <StandaloneNounCircular nounId={BigInt(nounId)} border={true} />
+              <StandaloneNijiCircular nounId={BigInt(nounId)} border={true} />
             </div>
           );
         })

--- a/packages/niji-webapp/src/components/StandaloneNiji/StandaloneNiji.module.css
+++ b/packages/niji-webapp/src/components/StandaloneNiji/StandaloneNiji.module.css
@@ -1,3 +1,3 @@
-.clickableNoun {
+.clickableNiji {
   cursor: pointer;
 }

--- a/packages/niji-webapp/src/components/StandaloneNiji/index.tsx
+++ b/packages/niji-webapp/src/components/StandaloneNiji/index.tsx
@@ -10,25 +10,25 @@ import { getNijiData, NijiImageData } from '@/lib/nijiAssets';
 import { setOnDisplayAuctionNounId } from '@/state/slices/onDisplayAuction';
 import { INounSeed, useNounSeed } from '@/wrappers/nijiToken';
 
-import classes from './StandaloneNoun.module.css';
+import classes from './StandaloneNiji.module.css';
 
 import nounClasses from '@/components/LegacyNoun/Noun.module.css';
 
-interface StandaloneNounProps {
+interface StandaloneNijiProps {
   nounId: bigint;
 }
-interface StandaloneCircularNounProps {
+interface StandaloneCircularNijiProps {
   nounId: bigint;
   border?: boolean;
 }
 
-interface StandaloneNounWithSeedProps {
+interface StandaloneNijiWithSeedProps {
   nounId: bigint;
   onLoadSeed?: (seed: INounSeed) => void;
   shouldLinkToProfile: boolean;
 }
 
-export const getNoun = (nounId: string | bigint, seed: INounSeed) => {
+export const getNiji = (nounId: string | bigint, seed: INounSeed) => {
   const id = nounId.toString();
   const name = `Niji ${id}`;
   const description = `Niji ${id} is a member of the Niji DAO`;
@@ -45,21 +45,21 @@ export const getNoun = (nounId: string | bigint, seed: INounSeed) => {
 /**
  * @deprecated Use [Noun](../Noun.tsx) instead
  */
-export const StandaloneNounImage: FC<StandaloneNounProps> = (props: StandaloneNounProps) => {
+export const StandaloneNijiImage: FC<StandaloneNijiProps> = (props: StandaloneNijiProps) => {
   const { nounId } = props;
   const seed = useNounSeed(nounId);
-  const noun = seed && getNoun(nounId, seed);
+  const niji = seed && getNiji(nounId, seed);
 
-  return <Image src={noun ? noun.image : ''} fluid />;
+  return <Image src={niji ? niji.image : ''} fluid />;
 };
 
 /**
  * @deprecated Use [Noun](../Noun.tsx) instead
  */
-const StandaloneNoun: FC<StandaloneNounProps> = (props: StandaloneNounProps) => {
+const StandaloneNiji: FC<StandaloneNijiProps> = (props: StandaloneNijiProps) => {
   const { nounId } = props;
   const seed = useNounSeed(nounId);
-  const noun = seed && getNoun(nounId, seed);
+  const niji = seed && getNiji(nounId, seed);
 
   const dispatch = useDispatch();
 
@@ -70,10 +70,10 @@ const StandaloneNoun: FC<StandaloneNounProps> = (props: StandaloneNounProps) => 
   return (
     <Link
       to={'/niji/' + nounId.toString()}
-      className={classes.clickableNoun}
+      className={classes.clickableNiji}
       onClick={onClickHandler}
     >
-      <LegacyNoun imgPath={noun ? noun.image : ''} alt={noun ? noun.description : 'Noun'} />
+      <LegacyNoun imgPath={niji ? niji.image : ''} alt={niji ? niji.description : 'Niji'} />
     </Link>
   );
 };
@@ -81,12 +81,12 @@ const StandaloneNoun: FC<StandaloneNounProps> = (props: StandaloneNounProps) => 
 /**
  * @deprecated Use [Noun](../Noun.tsx) instead
  */
-export const StandaloneNounCircular: FC<StandaloneCircularNounProps> = (
-  props: StandaloneCircularNounProps,
+export const StandaloneNijiCircular: FC<StandaloneCircularNijiProps> = (
+  props: StandaloneCircularNijiProps,
 ) => {
   const { nounId, border } = props;
   const seed = useNounSeed(nounId);
-  const noun = seed && getNoun(nounId, seed);
+  const niji = seed && getNiji(nounId, seed);
 
   const dispatch = useDispatch();
   const onClickHandler = () => {
@@ -94,17 +94,17 @@ export const StandaloneNounCircular: FC<StandaloneCircularNounProps> = (
   };
 
   if (!seed || nounId == undefined)
-    return <LegacyNoun imgPath="" alt="Noun" wrapperClassName={nounClasses.circularNounWrapper} />;
+    return <LegacyNoun imgPath="" alt="Niji" wrapperClassName={nounClasses.circularNounWrapper} />;
 
   return (
     <Link
       to={'/niji/' + nounId.toString()}
-      className={classes.clickableNoun}
+      className={classes.clickableNiji}
       onClick={onClickHandler}
     >
       <LegacyNoun
-        imgPath={noun ? noun.image : ''}
-        alt={noun ? noun.description : 'Noun'}
+        imgPath={niji ? niji.image : ''}
+        alt={niji ? niji.description : 'Niji'}
         wrapperClassName={nounClasses.circularNounWrapper}
         className={border === true ? nounClasses.circleWithBorder : nounClasses.circular}
       />
@@ -115,12 +115,12 @@ export const StandaloneNounCircular: FC<StandaloneCircularNounProps> = (
 /**
  * @deprecated Use [Noun](../Noun.tsx) instead
  */
-export const StandaloneNounRoundedCorners: FC<StandaloneNounProps> = (
-  props: StandaloneNounProps,
+export const StandaloneNijiRoundedCorners: FC<StandaloneNijiProps> = (
+  props: StandaloneNijiProps,
 ) => {
   const { nounId } = props;
   const seed = useNounSeed(nounId);
-  const noun = seed && getNoun(nounId, seed);
+  const niji = seed && getNiji(nounId, seed);
 
   const dispatch = useDispatch();
   const onClickHandler = () => {
@@ -130,12 +130,12 @@ export const StandaloneNounRoundedCorners: FC<StandaloneNounProps> = (
   return (
     <Link
       to={'/niji/' + nounId.toString()}
-      className={classes.clickableNoun}
+      className={classes.clickableNiji}
       onClick={onClickHandler}
     >
       <LegacyNoun
-        imgPath={noun ? noun.image : ''}
-        alt={noun ? noun.description : 'Noun'}
+        imgPath={niji ? niji.image : ''}
+        alt={niji ? niji.description : 'Niji'}
         className={nounClasses.rounded}
       />
     </Link>
@@ -145,11 +145,11 @@ export const StandaloneNounRoundedCorners: FC<StandaloneNounProps> = (
 /**
  * @deprecated Use [Noun](../Noun.tsx) instead
  */
-export const StandaloneNounWithSeed: FC<StandaloneNounWithSeedProps> = ({
+export const StandaloneNijiWithSeed: FC<StandaloneNijiWithSeedProps> = ({
   nounId,
   onLoadSeed,
   shouldLinkToProfile,
-}: StandaloneNounWithSeedProps) => {
+}: StandaloneNijiWithSeedProps) => {
   const dispatch = useDispatch();
   const seed = useNounSeed(nounId);
   const seedIsInvalid = Object.values(seed || {}).every(v => v === 0);
@@ -161,25 +161,25 @@ export const StandaloneNounWithSeed: FC<StandaloneNounWithSeedProps> = ({
   }, [seed, seedIsInvalid, onLoadSeed]);
 
   if (!seed || seedIsInvalid || nounId == undefined || !onLoadSeed)
-    return <LegacyNoun imgPath="" alt="Noun" />;
+    return <LegacyNoun imgPath="" alt="Niji" />;
 
   const onClickHandler = () => {
     dispatch(setOnDisplayAuctionNounId(Number(nounId)));
   };
 
-  const { image, description } = getNoun(nounId, seed);
+  const { image, description } = getNiji(nounId, seed);
 
-  const noun = <LegacyNoun imgPath={image} alt={description} />;
-  const nounWithLink = (
+  const niji = <LegacyNoun imgPath={image} alt={description} />;
+  const nijiWithLink = (
     <Link
       to={'/niji/' + nounId.toString()}
-      className={classes.clickableNoun}
+      className={classes.clickableNiji}
       onClick={onClickHandler}
     >
-      {noun}
+      {niji}
     </Link>
   );
-  return shouldLinkToProfile ? nounWithLink : noun;
+  return shouldLinkToProfile ? nijiWithLink : niji;
 };
 
-export default StandaloneNoun;
+export default StandaloneNiji;

--- a/packages/niji-webapp/src/components/TightStackedCircleNiji/index.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNiji/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { LoadingNoun } from '@/components/LegacyNoun';
-import { getNoun } from '@/components/StandaloneNoun';
+import { getNiji } from '@/components/StandaloneNiji';
 import { useNounSeed } from '@/wrappers/nijiToken';
 
 interface TightStackedCircleNounProps {
@@ -23,8 +23,8 @@ const TightStackedCircleNiji: React.FC<TightStackedCircleNounProps> = ({
     return <LoadingNoun />;
   }
 
-  const nounData = getNoun(BigInt(nounId), seed);
-  const image = nounData.image;
+  const nijiData = getNiji(BigInt(nounId), seed);
+  const image = nijiData.image;
 
   return (
     <g key={index}>


### PR DESCRIPTION
# 概要

PR #120 review で発見した StandaloneNoun component の rename 漏れを解消。 PR #120 で他 component を全 Niji 統一したが本 dir のみ漏れていた。

# 詳細

| 区分 | 変更 |
|---|---|
| dir | components/StandaloneNoun/ → StandaloneNiji/ (git mv) |
| 5 export rename | StandaloneNoun{Circular/RoundedCorners/WithSeed/Image} + getNoun → 全 Niji* |
| 5 利用 component の import + identifier | BidHistoryModal / Auction / HorizontalStackedNijis / TightStackedCircleNiji / CandidateSponsorImage |
| props | alt="Noun" → alt="Niji" |

7 file changed, +47/-47。

# テストと確認

- [x] `pnpm --filter @niji/webapp build` pass (exit 0)
- [x] grep -rn 'StandaloneNoun|getNoun' src で hit 0

Closes #123