### PR TITLE
chore(niji-webapp): NijiInfoCardProps + nijiAssetsLink + NijisPage comment Niji 統一 (Issue #125)

### DIFF
--- a/packages/niji-webapp/src/components/NijiInfoCard.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoCard.tsx
@@ -11,12 +11,12 @@ import { useAppSelector } from '@/hooks';
 import { buildEtherscanTokenLink } from '@/utils/etherscan';
 import { defaultChain } from '@/wagmi';
 
-interface NounInfoCardProps {
+interface NijiInfoCardProps {
   nounId: bigint;
   bidHistoryOnClickHandler: () => void;
 }
 
-const NijiInfoCard: React.FC<NounInfoCardProps> = props => {
+const NijiInfoCard: React.FC<NijiInfoCardProps> = props => {
   const { nounId, bidHistoryOnClickHandler } = props;
   const chainId = defaultChain.id;
 

--- a/packages/niji-webapp/src/pages/NijisPage.tsx
+++ b/packages/niji-webapp/src/pages/NijisPage.tsx
@@ -212,14 +212,14 @@ const NijisPage: React.FC<NijisPageProps> = () => {
       {/* Selected Noun Details */}
       <motion.div layout className="border-border flex h-full flex-col border-l">
         <div className="bg-muted/40 flex h-full flex-col">
-          {/* Noun Image */}
+          {/* Niji Image */}
           <Niji
             nounId={selectedNijiId != undefined ? BigInt(selectedNijiId) : undefined}
             loadingNounFallback
             className="mx-auto size-[288px] object-cover"
           />
 
-          {/* Noun Info Header */}
+          {/* Niji Info Header */}
           <div className="bg-muted mx-2 flex items-center justify-between rounded-t-2xl px-3 py-2 shadow-sm">
             <Button
               variant="ghost"

--- a/packages/niji-webapp/src/pages/Playground/index.tsx
+++ b/packages/niji-webapp/src/pages/Playground/index.tsx
@@ -54,7 +54,7 @@ const nounsProtocolLink = (
   />
 );
 
-const nounsAssetsLink = (
+const nijiAssetsLink = (
   <Link
     text="nouns-assets"
     url="https://github.com/Niji-DAO/niji-monorepo/tree/develop/packages/niji-assets"
@@ -278,7 +278,7 @@ const Playground: FC = () => {
             <p>
               <Trans>
                 The playground was built using the {nounsProtocolLink}. Niji&apos;s traits are
-                determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and
+                determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and
                 rendered using the {nounsSDKLink}.
               </Trans>
             </p>


### PR DESCRIPTION
# 概要

PR #120 review で発見した minor 残置を修正。 build / runtime 影響なし、 code consistency のみ。

# 詳細

| file | 変更 |
|---|---|
| `components/NijiInfoCard.tsx` | interface `NounInfoCardProps` → `NijiInfoCardProps` |
| `pages/Playground/index.tsx` | identifier `nounsAssetsLink` → `nijiAssetsLink` |
| `pages/NijisPage.tsx` | JSX comment `/* Noun Image */` / `/* Noun Info Header */` を Niji |

判断 — `<Trans>Nounspot</Trans>` は外部 site (https://nounspot.com) link text で固有名詞のため維持 (Issue body 推奨と異なる判断)。

# テストと確認

- [x] `pnpm --filter @niji/webapp build` pass (exit 0)

Closes #125