### PR TITLE
✨ feat(niji-webapp): NetworkAlert を wagmi useSwitchChain でアクション化 + dev port 3000 → 2424 (Issue #156)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Pattern: Use `useQuery` with `execute()` function from GraphQL Codegen (see `src
 ```bash
 # From packages/niji-webapp directory
 cp .env.example.local .env    # Setup environment
-pnpm dev                      # Start dev server on port 3000
+pnpm dev                      # Start dev server on port 2424
 pnpm test:watch               # Run tests in watch mode
 pnpm test:coverage            # Run tests with coverage
 pnpm graphql-codegen          # Generate GraphQL types

--- a/packages/niji-webapp/src/components/NetworkAlert/index.tsx
+++ b/packages/niji-webapp/src/components/NetworkAlert/index.tsx
@@ -1,4 +1,5 @@
-import { Modal } from 'react-bootstrap';
+import { Button, Modal } from 'react-bootstrap';
+import { useAccount, useSwitchChain } from 'wagmi';
 
 import { CHAIN_ID } from '@/config';
 
@@ -8,6 +9,10 @@ const networkName = () => {
       return 'Ethereum Mainnet';
     case 4:
       return 'the Rinkeby network';
+    case 11155111:
+      return 'Sepolia Testnet';
+    case 31337:
+      return 'Hardhat / Anvil local network';
     default:
       return `Network ${CHAIN_ID}`;
   }
@@ -19,33 +24,62 @@ const metamaskNetworkName = () => {
       return 'Ethereum Mainnet';
     case 4:
       return 'Rinkeby Test Network';
+    case 11155111:
+      return 'Sepolia';
+    case 31337:
+      return 'Localhost 8545';
     default:
       return `Network ${CHAIN_ID}`;
   }
 };
 
 const NetworkAlert = () => {
+  const targetChainId = Number(CHAIN_ID);
+  const { isConnected } = useAccount();
+  const { switchChain, isPending, error } = useSwitchChain();
+
+  const handleSwitch = () => {
+    switchChain({ chainId: targetChainId });
+  };
+
   return (
-    <>
-      <Modal show={true} backdrop="static" keyboard={false}>
-        <Modal.Header>
-          <Modal.Title>Wrong Network Detected</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <p>
-            Niji DAO auctions require you to switch over {networkName()} to be able to participate.
-          </p>
-          <p>
-            <b>To get started, please switch your network by following the instructions below:</b>
-          </p>
-          <ol>
-            <li>Open Metamask</li>
-            <li>Click the network select dropdown</li>
-            <li>Click on "{metamaskNetworkName()}"</li>
-          </ol>
-        </Modal.Body>
-      </Modal>
-    </>
+    <Modal show={true} backdrop="static" keyboard={false}>
+      <Modal.Header>
+        <Modal.Title>Wrong Network Detected</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>
+          Niji DAO auctions require you to switch over {networkName()} to be able to participate.
+        </p>
+
+        {isConnected ? (
+          <>
+            <p>
+              <b>Click the button below to request a network switch from your wallet:</b>
+            </p>
+            <Button variant="primary" onClick={handleSwitch} disabled={isPending}>
+              {isPending ? 'Switching…' : `Switch to ${networkName()}`}
+            </Button>
+            {error && (
+              <p className="text-danger mb-0 mt-3">
+                Failed to switch: {error.message}. Please switch manually from your wallet.
+              </p>
+            )}
+          </>
+        ) : (
+          <>
+            <p>
+              <b>Please connect your wallet first, or switch your network manually:</b>
+            </p>
+            <ol>
+              <li>Open Metamask</li>
+              <li>Click the network select dropdown</li>
+              <li>Click on "{metamaskNetworkName()}"</li>
+            </ol>
+          </>
+        )}
+      </Modal.Body>
+    </Modal>
   );
 };
 export default NetworkAlert;

--- a/packages/niji-webapp/vite.config.ts
+++ b/packages/niji-webapp/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: 3000,
+    port: 2424,
     hmr: {
       overlay: true,
     },


### PR DESCRIPTION
# 概要

`NetworkAlert` を MetaMask 手順表示から wagmi の `useSwitchChain` ベースのアクション化 + dev port を `3000` → `2424` に変更した。

接続済 wallet (MetaMask / WalletConnect / Coinbase Wallet) に対し 1 click で chain 切替リクエストを直接送るようにし、 ユーザーが wallet UI で approve するだけで chain 切替が完了するようにした。

# 課題

現状の `packages/niji-webapp/src/components/NetworkAlert/index.tsx` は wallet が wrong chain の時 `Modal` で次の手順だけを表示していた。

```
Wrong Network Detected
Niji DAO auctions require you to switch over Network 31337 to be able to participate.
Open Metamask → dropdown → "Network 31337"
```

UX として手順が冗長、 wallet に切替依頼を直接送る方が早い。 wagmi v2 は `useSwitchChain` フックで `switchChain({ chainId })` を呼ぶことで wallet に EIP-3326 (`wallet_switchEthereumChain`) を発行できる。

加えて dev port `3000` は Next.js デフォルトと衝突する。 Niji 専用ポートとして `2424` (に・じ → ni-ji と Niji の数字 mnemonics) に変更する。

# 詳細

```mermaid
graph LR
    A[wallet on wrong chain] --> B[NetworkAlert 表示]
    B --> C[現状 手順表示のみ]
    C --> D[ユーザーが手動切替]
    E[useSwitchChain switchChain chainId] --> F[wallet に switchEthereumChain 発行]
    F --> G[ユーザーは Approve だけ]
    G --> H[chain 切替完了]
```

# 解決方法

`NetworkAlert/index.tsx` を以下の構成にした。

1. `useSwitchChain` フックで `switchChain` / `isPending` / `error` を取得
2. `useAccount` で wallet 接続状態判定 (`isConnected`)
3. **接続済 wallet** の時は「Switch to {chain name}」 ボタンを表示、 click で `switchChain({ chainId: Number(CHAIN_ID) })` を実行 (isPending 中は disabled、 error 時は失敗メッセージ + 手動切替案内)
4. **未接続 wallet** の時は従来通り手動切替手順を表示 (fallback、 wallet 接続前に chain 切替を促す経路として残す)
5. chain id `11155111` (Sepolia Testnet) / `31337` (Hardhat / Anvil local network) の表示名を追加

`vite.config.ts` で `server.port` を `2424` に変更、 `CLAUDE.md` の `pnpm dev` コメントも更新。

# 仕組み

```mermaid
graph LR
    A[NetworkAlert mount] --> B{wallet 接続?}
    B -->|No| C[従来通り手順表示]
    B -->|Yes| D[切替ボタン表示]
    D --> E[click → switchChain]
    E --> F[wallet UI で approve]
    F --> G[chainId 反映]
    G --> H[NetworkAlert unmount]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/components/NetworkAlert/index.tsx` | useSwitchChain + useAccount で切替アクション化、 接続済/未接続で UI 切替、 11155111 / 31337 の表示名追加 |
| `packages/niji-webapp/vite.config.ts` | server.port 3000 → 2424 |
| `CLAUDE.md` | pnpm dev のコメントを port 2424 に更新 |

# テストと確認

- [x] `pnpm tsc --noEmit` 通過
- [ ] `pnpm dev` で port 2424 起動確認 (本 PR では起動せず別タスクで)
- [ ] 接続済 wallet で wrong chain 状態 → 切替ボタン click で wallet UI が立ち上がる
- [ ] 切替成功で NetworkAlert が消える
- [ ] 切替失敗 (ユーザー reject 等) で error メッセージ表示
- [ ] 未接続 wallet で従来の手順表示が出る

# 関連

- Issue #156
- PR #146 (Issue #141 webapp wagmi.ts hardhat chain 追加、 本 PR の前提)
- PR #145 (Issue #140 sdk address map 31337、 本 PR の前提)

Closes #156
