### PR TITLE
🗑️ refactor(niji-webapp): @fortawesome/* (3 package) 削除 + lucide-react に統一 (Issue #152)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -27,9 +27,6 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.7.0",
-    "@fortawesome/free-solid-svg-icons": "^6.7.0",
-    "@fortawesome/react-fontawesome": "^0.2.2",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@heroicons/react": "^1.0.6",
     "@lingui/core": "^5.9.0",
@@ -121,7 +118,6 @@
     "@types/pngjs": "^6.0.1",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@types/react-fontawesome": "^1.6.5",
     "@types/react-transition-group": "^4.4.5",
     "@types/redux-logger": "^3.0.13",
     "@vitejs/plugin-react": "^5.0.0",

--- a/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
+++ b/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
@@ -1,10 +1,9 @@
 import React, { ReactNode, useCallback, useEffect, useState, useMemo } from 'react';
 
-import { faCircleCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MinusCircleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
+import { CircleCheckIcon, XIcon } from 'lucide-react';
 import { FormControl, FormSelect, FormText, InputGroup, Spinner } from 'react-bootstrap';
 import { map } from 'remeda';
 
@@ -513,11 +512,9 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
                     </span>
                   )}
                   {isApprovalTxSuccessful && (
-                    <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
+                    <CircleCheckIcon height={20} width={20} color="green" />
                   )}
-                  {approvalErrorMessage && (
-                    <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
-                  )}
+                  {approvalErrorMessage && <XIcon height={20} width={20} color="red" />}
                 </strong>
                 <Trans>Set approval</Trans>
               </li>
@@ -528,11 +525,9 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
                       <Spinner animation="border" />
                     </span>
                   )}
-                  {isTxSuccessful && (
-                    <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
-                  )}
+                  {isTxSuccessful && <CircleCheckIcon height={20} width={20} color="green" />}
                   {(errorMessage || approvalErrorMessage) && (
-                    <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
+                    <XIcon height={20} width={20} color="red" />
                   )}
                   {!(
                     isWaiting ||

--- a/packages/niji-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { nijiAuctionHouseAddress } from '@niji/sdk/react';
+import { InfoIcon } from 'lucide-react';
 import { Col, Row } from 'react-bootstrap';
 
 import AuctionActivityDateHeadline from '@/components/AuctionActivityDateHeadline';
@@ -138,7 +137,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
         {auctionEnded && (
           <Row className={classes.activityRow}>
             <Col lg={12} className={classes.nextNounLink}>
-              <FontAwesomeIcon icon={faInfoCircle} />
+              <InfoIcon />
               <a href={'https://www.nouns.game/crystal-ball'} target={'_blank'} rel="noreferrer">
                 <Trans>Help mint the next Niji</Trans>
               </a>

--- a/packages/niji-webapp/src/components/CandidateSponsors/Signature.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/Signature.tsx
@@ -2,12 +2,11 @@ import type { Address } from '@/utils/types';
 
 import React, { useEffect } from 'react';
 
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { CircleCheckIcon } from 'lucide-react';
 
 import ShortAddress from '@/components/ShortAddress';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
@@ -158,7 +157,7 @@ const Signature: React.FC<CandidateSignatureProps> = props => {
         {props.isUpdateToProposal && !props.isAccountSigner && (
           <p className={classes.sigStatus}>
             <span>
-              <FontAwesomeIcon icon={faCircleCheck} />
+              <CircleCheckIcon />
             </span>
             <Trans>Re-signed</Trans>
           </p>

--- a/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx
@@ -1,11 +1,10 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 
-import { faCircleCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { nijiGovernorAddress } from '@niji/sdk/react';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
+import { CircleCheckIcon, XIcon } from 'lucide-react';
 import { Spinner } from 'react-bootstrap';
 import {
   encodeAbiParameters,
@@ -428,11 +427,9 @@ const SignatureForm = (props: Readonly<SignatureFormProps>) => {
                       </span>
                     )}
                     {isGetSignatureTxSuccessful && (
-                      <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
+                      <CircleCheckIcon height={20} width={20} color="green" />
                     )}
-                    {getSignatureErrorMessage && (
-                      <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
-                    )}
+                    {getSignatureErrorMessage && <XIcon height={20} width={20} color="red" />}
                   </strong>
                   <Trans>Signature request</Trans>
                 </li>
@@ -443,11 +440,9 @@ const SignatureForm = (props: Readonly<SignatureFormProps>) => {
                         <Spinner animation="border" />
                       </span>
                     )}
-                    {isTxSuccessful && (
-                      <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
-                    )}
+                    {isTxSuccessful && <CircleCheckIcon height={20} width={20} color="green" />}
                     {(getSignatureErrorMessage || errorMessage) && (
-                      <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
+                      <XIcon height={20} width={20} color="red" />
                     )}
                     {!(
                       isWaiting ||

--- a/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
+import { CircleCheckIcon } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { Link } from 'react-router';
 import { useAccount } from 'wagmi';
@@ -134,7 +133,7 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
       <div className={classes.wrapper}>
         {isThresholdMet && (
           <p className={classes.thresholdMet}>
-            <FontAwesomeIcon icon={faCircleCheck} /> Sponsor threshold met
+            <CircleCheckIcon /> Sponsor threshold met
           </p>
         )}
         <div

--- a/packages/niji-webapp/src/components/LanguageSelectionModal/index.tsx
+++ b/packages/niji-webapp/src/components/LanguageSelectionModal/index.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
 
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { useAtom } from 'jotai/react';
+import { CheckIcon } from 'lucide-react';
 
 import Modal from '@/components/Modal';
 import { activeLocaleAtom } from '@/i18n/activeLocaleAtom';
@@ -35,7 +34,7 @@ const LanguageSelectionModal: FC<LanguageSelectionModalProps> = ({ onDismiss }) 
           >
             {LOCALE_LABEL[locale]}
             {locale === activeLocale && (
-              <FontAwesomeIcon icon={faCheck} height={24} width={24} className={classes.icon} />
+              <CheckIcon height={24} width={24} className={classes.icon} />
             )}
           </div>
         );

--- a/packages/niji-webapp/src/components/NavBar/index.tsx
+++ b/packages/niji-webapp/src/components/NavBar/index.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
 
-import { faFile, faPenToSquare, faPlay, faUsers } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { nijiTreasuryAddress, useReadNijiTreasuryBalancesInEth } from '@niji/sdk/react';
 import clsx from 'clsx';
 import { ConnectKitButton } from 'connectkit';
+import { FileIcon, PlayIcon, SquarePenIcon, UsersIcon } from 'lucide-react';
 import { Container, Dropdown, Nav, Navbar } from 'react-bootstrap';
 import { Link, useLocation } from 'react-router';
 import { formatEther } from 'viem';
@@ -69,11 +68,7 @@ const NavBar = () => {
   ) : null;
 
   const v3DaoNavItem = (
-    <NavDropdown
-      buttonText="DAO"
-      buttonIcon={<FontAwesomeIcon icon={faUsers} />}
-      buttonStyle={nonWalletButtonStyle}
-    >
+    <NavDropdown buttonText="DAO" buttonIcon={<UsersIcon />} buttonStyle={nonWalletButtonStyle}>
       <Dropdown.Item
         className={clsx(
           usePickByState(
@@ -135,7 +130,7 @@ const NavBar = () => {
               <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink} onClick={closeNav}>
                 <NavBarButton
                   buttonText={isDaoGteV3 ? <Trans>Proposals</Trans> : <Trans>DAO</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faFile} />}
+                  buttonIcon={<FileIcon />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>
@@ -150,7 +145,7 @@ const NavBar = () => {
                     >
                       <NavBarButton
                         buttonText={<Trans>Candidates</Trans>}
-                        buttonIcon={<FontAwesomeIcon icon={faPenToSquare} />}
+                        buttonIcon={<SquarePenIcon />}
                         buttonStyle={nonWalletButtonStyle}
                       />
                     </Nav.Link>
@@ -165,7 +160,7 @@ const NavBar = () => {
                 <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink} onClick={closeNav}>
                   <NavBarButton
                     buttonText={<Trans>DAO</Trans>}
-                    buttonIcon={<FontAwesomeIcon icon={faUsers} />}
+                    buttonIcon={<UsersIcon />}
                     buttonStyle={nonWalletButtonStyle}
                   />
                 </Nav.Link>
@@ -180,7 +175,7 @@ const NavBar = () => {
               >
                 <NavBarButton
                   buttonText={<Trans>Playground</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faPlay} />}
+                  buttonIcon={<PlayIcon />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>

--- a/packages/niji-webapp/src/components/NavBarButton/index.tsx
+++ b/packages/niji-webapp/src/components/NavBarButton/index.tsx
@@ -1,8 +1,7 @@
 import { FC, HTMLAttributes } from 'react';
 
-import { faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
+import { ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
 
 import navDropdownClasses from '../NavBar/NavBarDropdown.module.css';
 
@@ -125,7 +124,7 @@ const NavBarButton: FC<NavBarButtonProps> = ({
                 isButtonUp === true ? navDropdownClasses.arrowUp : navDropdownClasses.arrowDown
               }
             >
-              <FontAwesomeIcon icon={isButtonUp === true ? faSortUp : faSortDown} />{' '}
+              {isButtonUp === true ? <ChevronUpIcon /> : <ChevronDownIcon />}{' '}
             </div>
           )}
         </div>

--- a/packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx
+++ b/packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx
@@ -1,10 +1,9 @@
 import React, { HTMLAttributes, useState } from 'react';
 
-import { faCheck, faGlobe, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import { useAtom } from 'jotai/react';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon, GlobeIcon } from 'lucide-react';
 import { Dropdown } from 'react-bootstrap';
 
 import LanguageSelectionModal from '@/components/LanguageSelectionModal';
@@ -93,11 +92,9 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
         }}
       >
         <div className={navDropdownClasses.button}>
-          <div className={navDropdownClasses.dropdownBtnContent}>
-            {<FontAwesomeIcon icon={faGlobe} />}
-          </div>
+          <div className={navDropdownClasses.dropdownBtnContent}>{<GlobeIcon />}</div>
           <div className={buttonUp ? navDropdownClasses.arrowUp : navDropdownClasses.arrowDown}>
-            <FontAwesomeIcon icon={buttonUp ? faSortUp : faSortDown} />{' '}
+            {buttonUp ? <ChevronUpIcon /> : <ChevronDownIcon />}{' '}
           </div>
         </div>
       </div>
@@ -118,7 +115,7 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
       >
         <NavBarButton
           buttonText={<Trans>Language</Trans>}
-          buttonIcon={<FontAwesomeIcon icon={faGlobe} />}
+          buttonIcon={<GlobeIcon />}
           buttonStyle={buttonStyle}
         />
       </div>
@@ -161,9 +158,7 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
                 onClick={() => setActiveLocale(locale)}
               >
                 {LOCALE_LABEL[locale]}
-                {activeLocale === locale && (
-                  <FontAwesomeIcon icon={faCheck} height={24} width={24} />
-                )}
+                {activeLocale === locale && <CheckIcon height={24} width={24} />}
               </div>
             );
           })}

--- a/packages/niji-webapp/src/components/SettleManuallyBtn/index.tsx
+++ b/packages/niji-webapp/src/components/SettleManuallyBtn/index.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import dayjs from 'dayjs';
+import { InfoIcon } from 'lucide-react';
 
 import { CHAIN_ID } from '@/config';
 import { Auction } from '@/wrappers/nijiAuction';
@@ -68,7 +67,7 @@ const SettleManuallyBtn: React.FC<{
           </>
         ) : (
           <>
-            <FontAwesomeIcon icon={faInfoCircle} />
+            <InfoIcon />
             {mins !== 0 ? (
               <Trans>You can settle manually in {mins + 1} minutes</Trans>
             ) : (

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalGroup.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalGroup.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 
-import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
+import { ChevronDownIcon } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 import { VoteSignalDetail } from '@/wrappers/nijiData';
@@ -58,7 +57,7 @@ const VoteSignalGroup = (props: Props) => {
               ease: 'easeInOut',
             }}
           >
-            <FontAwesomeIcon icon={faChevronDown} />
+            <ChevronDownIcon />
           </motion.div>
         )}
       </button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,15 +493,6 @@ importers:
 
   packages/niji-webapp:
     dependencies:
-      '@fortawesome/fontawesome-svg-core':
-        specifier: ^6.7.0
-        version: 6.7.2
-      '@fortawesome/free-solid-svg-icons':
-        specifier: ^6.7.0
-        version: 6.7.2
-      '@fortawesome/react-fontawesome':
-        specifier: ^0.2.2
-        version: 0.2.2(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.1.0)
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.11.0)
@@ -767,9 +758,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.1.6(@types/react@19.1.8)
-      '@types/react-fontawesome':
-        specifier: ^1.6.5
-        version: 1.6.8
       '@types/react-transition-group':
         specifier: ^4.4.5
         version: 4.4.12(@types/react@19.1.8)
@@ -782,9 +770,6 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.0.0
         version: 4.0.18(bufferutil@4.0.9)(playwright@1.54.1)(utf-8-validate@5.0.7)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@4.0.18)
-      '@wagmi/cli':
-        specifier: 'catalog:'
-        version: 2.3.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -2183,28 +2168,9 @@ packages:
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
-  '@fortawesome/fontawesome-common-types@6.7.2':
-    resolution: {integrity: sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==}
-    engines: {node: '>=6'}
-
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
-
-  '@fortawesome/fontawesome-svg-core@6.7.2':
-    resolution: {integrity: sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    resolution: {integrity: sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/react-fontawesome@0.2.2':
-    resolution: {integrity: sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==}
-    deprecated: v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.
-    peerDependencies:
-      '@fortawesome/fontawesome-svg-core': ~1 || ~6
-      react: '>=16.3'
 
   '@gql.tada/internal@1.0.8':
     resolution: {integrity: sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==}
@@ -5319,9 +5285,6 @@ packages:
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
       '@types/react': ^19.0.0
-
-  '@types/react-fontawesome@1.6.8':
-    resolution: {integrity: sha512-+dQ+4jccHraCd/FI4uSeY/O7c1RZ+wVASTgpCgbC6ijh1zSDsr0cb9XU3Dbfy5eJPyXq5QPp9W9RJTVRf+5+pA==}
 
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
@@ -17553,23 +17516,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@fortawesome/fontawesome-common-types@6.7.2': {}
-
   '@fortawesome/fontawesome-free@6.7.2': {}
-
-  '@fortawesome/fontawesome-svg-core@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
-
-  '@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.1.0)':
-    dependencies:
-      '@fortawesome/fontawesome-svg-core': 6.7.2
-      prop-types: 15.8.1
-      react: 19.1.0
 
   '@gql.tada/internal@1.0.8(graphql@16.11.0)(typescript@5.9.2)':
     dependencies:
@@ -21752,10 +21699,6 @@ snapshots:
   '@types/range-parser@1.2.4': {}
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
-    dependencies:
-      '@types/react': 19.1.8
-
-  '@types/react-fontawesome@1.6.8':
     dependencies:
       '@types/react': 19.1.8
 


### PR DESCRIPTION
# 概要

webapp で利用していた 12 種類の fontawesome icon を全て lucide-react (既存依存) に置換し、 `@fortawesome/*` 3 package + `@types/react-fontawesome` を削除した。 webapp は shadcn/ui の default icon library として lucide-react を既に採用済で、 fontawesome と icon library が二重化していた。

# 課題

`@fortawesome/fontawesome-svg-core` + `@fortawesome/free-solid-svg-icons` + `@fortawesome/react-fontawesome` + `@types/react-fontawesome` の 4 package が webapp に依存され、 lucide-react との icon library 重複によりバンドル size を増やしていた (~50KB+ minified)。

# 詳細

11 file で `FontAwesomeIcon` + 12 icon が利用されていた。

| FontAwesome | Lucide (Icon suffix) |
|---|---|
| faCheck | CheckIcon |
| faChevronDown | ChevronDownIcon |
| faCircleCheck | CircleCheckIcon |
| faFile | FileIcon |
| faGlobe | GlobeIcon |
| faInfoCircle | InfoIcon |
| faPenToSquare | SquarePenIcon |
| faPlay | PlayIcon |
| faUsers | UsersIcon |
| faXmark | XIcon |
| faSortUp / faSortDown | ChevronUpIcon / ChevronDownIcon (三項演算子) |

# 解決方法

各 file で。
1. fontawesome の import 行を削除
2. lucide-react から `XxxIcon` 形式で import (eslint no-restricted-imports rule `/^.+Icon$/` に合わせる)
3. JSX usage を `<FontAwesomeIcon icon={faXxx} />` → `<XxxIcon />` に置換
4. NavBarButton / NavLocaleSwitcher の三項演算子 (`faSortUp` / `faSortDown`) は `{condition ? <ChevronUpIcon /> : <ChevronDownIcon />}` に書き換え

package.json から 4 package を削除、 pnpm install で lockfile 更新。

# 仕組み

```mermaid
graph LR
    A[FontAwesomeIcon + faXxx] --> B[icon library 二重化]
    B --> C[bundle size 増]
    D[lucide-react XxxIcon] --> E[icon library 統一]
    E --> F[bundle size 50KB+ 削減]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/package.json` | fontawesome 4 package 削除 |
| `pnpm-lock.yaml` | lockfile 自動更新 |
| `src/components/CandidateSponsors/SignatureForm.tsx` | CircleCheckIcon / XIcon (4 ヶ所) |
| `src/components/NavBar/index.tsx` | UsersIcon / FileIcon / SquarePenIcon / PlayIcon (4 ヶ所) |
| `src/components/VoteSignals/VoteSignalGroup.tsx` | ChevronDownIcon (1 ヶ所) |
| `src/components/CandidateSponsors/Signature.tsx` | CircleCheckIcon (1 ヶ所) |
| `src/components/CandidateSponsors/index.tsx` | CircleCheckIcon (1 ヶ所) |
| `src/components/LanguageSelectionModal/index.tsx` | CheckIcon (1 ヶ所) |
| `src/components/NavBarButton/index.tsx` | ChevronUpIcon / ChevronDownIcon (三項演算子) |
| `src/components/AuctionActivity/index.tsx` | InfoIcon (1 ヶ所) |
| `src/components/NavLocaleSwitcher/index.tsx` | CheckIcon / GlobeIcon / ChevronUpIcon / ChevronDownIcon |
| `src/components/AddNijisToForkModal/index.tsx` | CircleCheckIcon / XIcon (4 ヶ所) |
| `src/components/SettleManuallyBtn/index.tsx` | InfoIcon (1 ヶ所) |

# テストと確認

- [x] `pnpm install` exit 0 (lockfile 更新)
- [x] `pnpm tsc --noEmit` exit 0 (型エラー 0 件)
- [x] lint-staged (prettier + eslint) pass (`*Icon` suffix で no-restricted-imports rule 満たす)
- [ ] icon 視覚 regression なし確認 (手動、 NavBar / Modal / Sponsor 画面等)

# 関連

- Issue #152
- Issue #25 (不要依存削除、 同方向)
- PR #161 (Issue #154 react-transition-group → motion、 同 audit 由来)
- PR #160 (Issue #148 axios 削除)
- PR #159 (Issue #151 react-diff-viewer → continued)

Closes #152
