### PR TITLE
🗑️ refactor(niji-webapp): react-tooltip v4 削除 + @radix-ui/react-tooltip に統一 (Issue #149)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -82,7 +82,6 @@
     "react-router-dom": "^7.6.0",
     "react-stepz": "^1.0.2",
     "react-swipeable": "^7.0.0",
-    "react-tooltip": "^4.5.1",
     "react-transition-group": "^4.4.5",
     "redux": "^5.0.1",
     "redux-devtools-extension": "^2.13.9",

--- a/packages/niji-webapp/src/components/HoverCard.tsx
+++ b/packages/niji-webapp/src/components/HoverCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import ReactTooltip from 'react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface HoverCardProps {
   hoverCardContent: (dataTip: string) => React.ReactNode;
@@ -10,21 +10,18 @@ interface HoverCardProps {
 }
 
 const HoverCard: React.FC<HoverCardProps> = props => {
-  const { hoverCardContent, tip, id } = props;
+  const { hoverCardContent, tip } = props;
 
   return (
-    <>
-      <ReactTooltip
-        id={id}
-        arrowColor={'rgba(0,0,0,0)'}
+    <Tooltip>
+      <TooltipTrigger asChild>{props.children}</TooltipTrigger>
+      <TooltipContent
+        sideOffset={4}
         className="!box-border !h-fit !w-max !min-w-[217px] !rounded-xl !border !border-gray-200 !bg-white !text-black !shadow-sm"
-        effect={'solid'}
-        getContent={hoverCardContent}
-      />
-      <div data-tip={tip} data-for={id}>
-        {props.children}
-      </div>
-    </>
+      >
+        {hoverCardContent(tip)}
+      </TooltipContent>
+    </Tooltip>
   );
 };
 

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
@@ -5,13 +5,13 @@ import React from 'react';
 
 import { Trans } from '@lingui/react/macro';
 import { nijiGovernorAddress } from '@niji/sdk/react';
-import ReactTooltip from 'react-tooltip';
 
 import ModalBottomButtonRow from '@/components/ModalBottomButtonRow';
 import ModalLabel from '@/components/ModalLabel';
 import ModalTextPrimary from '@/components/ModalTextPrimary';
 import ModalTitle from '@/components/ModalTitle';
 import ShortAddress from '@/components/ShortAddress';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import useStreamPaymentTransactions from '@/hooks/useStreamPaymentTransactions';
 import {
   formatTokenAmount,
@@ -45,14 +45,6 @@ const StreamPaymentsReviewStep: React.FC<FinalProposalActionStepProps> = props =
 
   return (
     <>
-      <ReactTooltip
-        id={'address-tooltip'}
-        effect={'solid'}
-        className={classes.hover}
-        getContent={() => {
-          return state.address;
-        }}
-      />
       <ModalTitle>
         <Trans>Review Streaming Payment Action</Trans>
       </ModalTitle>
@@ -70,9 +62,14 @@ const StreamPaymentsReviewStep: React.FC<FinalProposalActionStepProps> = props =
         <Trans>To</Trans>
       </ModalLabel>
       <ModalTextPrimary>
-        <span data-for="address-tooltip" data-tip="address">
-          <ShortAddress address={state.address} />
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <ShortAddress address={state.address} />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className={classes.hover}>{state.address}</TooltipContent>
+        </Tooltip>
       </ModalTextPrimary>
 
       <ModalLabel>

--- a/packages/niji-webapp/src/pages/Vote/index.tsx
+++ b/packages/niji-webapp/src/pages/Vote/index.tsx
@@ -16,7 +16,6 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import { Button, Card, Col, Row, Spinner } from 'react-bootstrap';
 import { Link, useParams } from 'react-router';
-import ReactTooltip from 'react-tooltip';
 import { isNonNullish } from 'remeda';
 import { toast } from 'sonner';
 import { zeroAddress } from 'viem';
@@ -27,6 +26,7 @@ import ProposalContent from '@/components/ProposalContent';
 import ProposalHeader from '@/components/ProposalHeader';
 import ShortAddress from '@/components/ShortAddress';
 import StreamWithdrawModal from '@/components/StreamWithdrawModal';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import VoteCard, { VoteCardVariant } from '@/components/VoteCard';
 import VoteModal from '@/components/VoteModal';
 import VoteSignals from '@/components/VoteSignals/VoteSignals';
@@ -710,32 +710,36 @@ const VotePage = () => {
                       <Trans>Threshold</Trans>
                     </h1>
                   </div>
-                  {isV2Prop && (
-                    <ReactTooltip
-                      id={'view-dq-info'}
-                      className={classes.delegateHover}
-                      getContent={() => {
-                        return <Trans>View Threshold Info</Trans>;
-                      }}
-                    />
+                  {isV2Prop ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div
+                          onClick={() => setShowDynamicQuorumInfoModal(isV2Prop)}
+                          className={clsx(classes.thresholdInfo, classes.cursorPointer)}
+                        >
+                          <span>
+                            <Trans>Current Threshold</Trans>
+                          </span>
+                          <h3>
+                            <Trans>{i18n.number(Number(currentQuorum ?? 0))} votes</Trans>
+                            <SearchIcon className={cn(classes.dqIcon, 'inline-block')} />
+                          </h3>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent className={classes.delegateHover}>
+                        <Trans>View Threshold Info</Trans>
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <div className={classes.thresholdInfo}>
+                      <span>
+                        <Trans>Threshold</Trans>
+                      </span>
+                      <h3>
+                        <Trans>{proposal.quorumVotes} votes</Trans>
+                      </h3>
+                    </div>
                   )}
-                  <div
-                    data-for="view-dq-info"
-                    data-tip="View Dynamic Quorum Info"
-                    onClick={() => setShowDynamicQuorumInfoModal(isV2Prop)}
-                    className={clsx(classes.thresholdInfo, isV2Prop ? classes.cursorPointer : '')}
-                  >
-                    <span>
-                      {isV2Prop ? <Trans>Current Threshold</Trans> : <Trans>Threshold</Trans>}
-                    </span>
-                    <h3>
-                      <Trans>
-                        {isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes}{' '}
-                        votes
-                      </Trans>
-                      {isV2Prop && <SearchIcon className={cn(classes.dqIcon, 'inline-block')} />}
-                    </h3>
-                  </div>
                 </div>
               </Card.Body>
             </Card>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,9 +658,6 @@ importers:
       react-swipeable:
         specifier: ^7.0.0
         version: 7.0.2(react@19.1.0)
-      react-tooltip:
-        specifier: ^4.5.1
-        version: 4.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -782,9 +779,6 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.0.0
         version: 4.0.18(bufferutil@4.0.9)(playwright@1.54.1)(utf-8-validate@5.0.7)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@4.0.18)
-      '@wagmi/cli':
-        specifier: 'catalog:'
-        version: 2.3.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -12881,13 +12875,6 @@ packages:
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
 
-  react-tooltip@4.5.1:
-    resolution: {integrity: sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==}
-    engines: {npm: '>=6.13'}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -14900,11 +14887,6 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -31407,13 +31389,6 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  react-tooltip@4.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      uuid: 7.0.3
-
   react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.4
@@ -33778,8 +33753,6 @@ snapshots:
   uuid@2.0.1: {}
 
   uuid@3.4.0: {}
-
-  uuid@7.0.3: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
# 概要

`react-tooltip: ^4.5.1` を削除し、 既存依存の `@radix-ui/react-tooltip` (shadcn ベースの `components/ui/tooltip.tsx` 経由) に統一した。

webapp は shadcn/ui の default tooltip として既に Radix tooltip を採用済 (`Winner` / `Holder` 等) で、 react-tooltip と二重化していた。

# 課題

`react-tooltip: ^4.5.1` は React 17 想定で最終 release が 2021 年。 React 18/19 では peer dep warning が出ており、 v5 (現行) は大幅な API 変更で工数が大きい。 webapp は既に `@radix-ui/react-tooltip: ^1.2.7` + `components/ui/tooltip.tsx` (shadcn) を持つため、 Radix 統一が綺麗。

# 詳細

3 file で `ReactTooltip` の `data-tip` + `data-for={id}` pattern が利用されていた。

```mermaid
graph LR
    A[react-tooltip v4] --> B[data-tip / data-for / getContent パターン]
    B --> C[React 17 想定]
    C --> D[React 18/19 で warning]
    E[Radix Tooltip] --> F[Trigger + Content + Provider 構造]
    F --> G[React 18/19 native]
```

# 解決方法

各 file で `ReactTooltip` を `Tooltip` + `TooltipTrigger asChild` + `TooltipContent` に書き換え。

1. `components/HoverCard.tsx` ... ReactTooltip + `data-tip` / `data-for` を Radix tooltip wrapper に置換 (props API 維持)
2. `components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx` ... `ShortAddress` 上の address-tooltip を Tooltip wrapper に置換
3. `pages/Vote/index.tsx` ... view-dq-info threshold tooltip を Tooltip + 条件分岐 (`isV2Prop`) に整理

`TooltipProvider` は既に `src/index.tsx` でアプリ全体を wrap 済のため、 追加 setup 不要。

# 仕組み

```mermaid
graph LR
    A[<HoverCard tip id>] --> B[Tooltip wrapper]
    B --> C[TooltipTrigger asChild children]
    B --> D[TooltipContent hoverCardContent tip]
    D --> E[Radix Portal で render]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/package.json` | `react-tooltip` 削除 |
| `pnpm-lock.yaml` | lockfile 自動更新 |
| `components/HoverCard.tsx` | ReactTooltip wrapper → Radix Tooltip wrapper |
| `components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx` | address-tooltip を Radix Tooltip 化 |
| `pages/Vote/index.tsx` | view-dq-info を Radix Tooltip + 条件分岐に整理 |

# テストと確認

- [x] `pnpm install` exit 0 (lockfile 更新)
- [x] `pnpm tsc --noEmit` exit 0 (型エラー 0 件)
- [ ] HoverCard 経由の各画面で tooltip 動作確認 (手動)
- [ ] StreamPayments review modal で ShortAddress hover 時に full address 表示確認
- [ ] Vote ページの Threshold info hover で Threshold Info メッセージ表示確認

# 関連

- Issue #149
- Issue #25 (不要依存削除、 同方向)
- PR #162 (Issue #152 fontawesome → lucide、 同 audit 由来)
- PR #161 (Issue #154 react-transition-group → motion)

Closes #149
