### PR TITLE
🔧 refactor(webapp): usePickByState 命名衝突解消 + placeholder no-op button fix

### DIFF
--- a/packages/niji-webapp/src/components/NavBar/index.tsx
+++ b/packages/niji-webapp/src/components/NavBar/index.tsx
@@ -26,7 +26,7 @@ import NavLocaleSwitcher from '@/components/NavLocaleSwitcher';
 import ShortAddress from '@/components/ShortAddress';
 import config, { CHAIN_ID } from '@/config';
 import { useAppSelector } from '@/hooks';
-import { usePickByState } from '@/utils/colorResponsiveUIUtils';
+import { usePickByStateColor } from '@/utils/colorResponsiveUIUtils';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
 import { defaultChain } from '@/wagmi';
 import { useIsDaoGteV3 } from '@/wrappers/nijiDao';
@@ -60,7 +60,7 @@ const NavBar = () => {
   const nonWalletButtonStyle = !useStateBg ? NavBarButtonStyle.WHITE_INFO : stateBasedButtonStyle;
 
   const closeNav = () => setIsNavExpanded(false);
-  const buttonClasses = usePickByState(
+  const buttonClasses = usePickByStateColor(
     navDropdownClasses.whiteInfoSelectedBottom,
     navDropdownClasses.coolInfoSelected,
     navDropdownClasses.warmInfoSelected,
@@ -79,7 +79,7 @@ const NavBar = () => {
     >
       <Dropdown.Item
         className={clsx(
-          usePickByState(
+          usePickByStateColor(
             navDropdownClasses.whiteInfoSelectedBottom,
             navDropdownClasses.coolInfoSelected,
             navDropdownClasses.warmInfoSelected,
@@ -277,7 +277,7 @@ const NavBar = () => {
               >
                 <Dropdown.Item
                   className={clsx(
-                    usePickByState(
+                    usePickByStateColor(
                       navDropdownClasses.whiteInfoSelectedBottom,
                       navDropdownClasses.coolInfoSelected,
                       navDropdownClasses.warmInfoSelected,
@@ -289,7 +289,7 @@ const NavBar = () => {
                 </Dropdown.Item>
                 <Dropdown.Item
                   className={clsx(
-                    usePickByState(
+                    usePickByStateColor(
                       navDropdownClasses.whiteInfoSelectedBottom,
                       navDropdownClasses.coolInfoSelected,
                       navDropdownClasses.warmInfoSelected,
@@ -301,7 +301,7 @@ const NavBar = () => {
                 </Dropdown.Item>
                 <Dropdown.Item
                   className={clsx(
-                    usePickByState(
+                    usePickByStateColor(
                       navDropdownClasses.whiteInfoSelectedBottom,
                       navDropdownClasses.coolInfoSelected,
                       navDropdownClasses.warmInfoSelected,
@@ -313,7 +313,7 @@ const NavBar = () => {
                 </Dropdown.Item>
                 <Dropdown.Item
                   className={clsx(
-                    usePickByState(
+                    usePickByStateColor(
                       navDropdownClasses.whiteInfoSelectedBottom,
                       navDropdownClasses.coolInfoSelected,
                       navDropdownClasses.warmInfoSelected,

--- a/packages/niji-webapp/src/components/NavDropdown/index.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { Dropdown } from 'react-bootstrap';
 
 import NavBarButton, { NavBarButtonStyle } from '@/components/NavBarButton';
-import { usePickByState } from '@/utils/colorResponsiveUIUtils';
+import { usePickByStateColor } from '@/utils/colorResponsiveUIUtils';
 
 import classes from './NavDropdown.module.css';
 
@@ -23,13 +23,13 @@ const NavDropDown: React.FC<NavDropDownProps> = props => {
 
   const [buttonUp, setButtonUp] = useState(false);
 
-  const statePrimaryButtonClass = usePickByState(
+  const statePrimaryButtonClass = usePickByStateColor(
     navDropdownClasses.whiteInfo,
     navDropdownClasses.coolInfo,
     navDropdownClasses.warmInfo,
   );
 
-  const stateSelectedDropdownClass = usePickByState(
+  const stateSelectedDropdownClass = usePickByStateColor(
     navDropdownClasses.whiteInfoSelected,
     navDropdownClasses.dropdownActive,
     navDropdownClasses.dropdownActive,

--- a/packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx
+++ b/packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx
@@ -11,7 +11,7 @@ import LanguageSelectionModal from '@/components/LanguageSelectionModal';
 import NavBarButton, { NavBarButtonStyle } from '@/components/NavBarButton';
 import { activeLocaleAtom } from '@/i18n/activeLocaleAtom';
 import { LOCALE_LABEL, SUPPORTED_LOCALES, SupportedLocale } from '@/i18n/locales';
-import { usePickByState } from '@/utils/colorResponsiveUIUtils';
+import { usePickByStateColor } from '@/utils/colorResponsiveUIUtils';
 
 import classes from './NavLocalSwitcher.module.css';
 
@@ -52,25 +52,25 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
   const [showLanguagePickerModal, setShowLanguagePickerModal] = useState(false);
   const [activeLocale, setActiveLocale] = useAtom(activeLocaleAtom);
 
-  const statePrimaryButtonClass = usePickByState(
+  const statePrimaryButtonClass = usePickByStateColor(
     navDropdownClasses.whiteInfo,
     navDropdownClasses.coolInfo,
     navDropdownClasses.warmInfo,
   );
 
-  const stateSelectedDropdownClass = usePickByState(
+  const stateSelectedDropdownClass = usePickByStateColor(
     navDropdownClasses.whiteInfoSelected,
     navDropdownClasses.dropdownActive,
     navDropdownClasses.dropdownActive,
   );
 
-  const buttonStyleTop = usePickByState(
+  const buttonStyleTop = usePickByStateColor(
     navDropdownClasses.whiteInfoSelectedTop,
     navDropdownClasses.coolInfoSelected,
     navDropdownClasses.warmInfoSelected,
   );
 
-  const buttonStyleBottom = usePickByState(
+  const buttonStyleBottom = usePickByStateColor(
     navDropdownClasses.whiteInfoSelectedBottom,
     navDropdownClasses.coolInfoSelected,
     navDropdownClasses.warmInfoSelected,

--- a/packages/niji-webapp/src/components/ProposalActionsModal/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/index.tsx
@@ -194,10 +194,19 @@ const ModalContent: React.FC<{
         />
       );
     default:
+      // 想定外 step (state machine 漏れ) は SELECT_ACTION_TYPE と同じ起点 step に
+      // フォールバック。 placeholder no-op handler だと button が動かないため
+      // case SELECT_ACTION_TYPE と同じ valid handler を渡す (Issue #169 F-6)。
       return (
         <SelectProposalActionStep
-          onNextBtnClick={() => console.log('')}
-          onPrevBtnClick={() => console.log('')}
+          onNextBtnClick={(
+            e?: React.MouseEvent | ProposalActionCreationStep | ProposalTransaction,
+          ) => {
+            if (e && typeof e !== 'object') {
+              setStep(e);
+            }
+          }}
+          onPrevBtnClick={onDismiss}
           state={state}
           setState={setState}
         />

--- a/packages/niji-webapp/src/utils/colorResponsiveUIUtils.ts
+++ b/packages/niji-webapp/src/utils/colorResponsiveUIUtils.ts
@@ -11,14 +11,14 @@ export const shouldUseStateBg = (location: { pathname: string }) => {
 };
 
 /**
- * Utility function that takes three items and returns whichever one corresponds to the current
- * page state (white, cool, warm)
- * @param whiteState  What to return if the state is white
- * @param coolState  What to return if the state is cool
- * @param warmState  What to return is the state is warm
- * @returns item corresponding to current state
+ * Color-aware state picker — current page background (white / cool / warm) に応じて
+ * 3 引数のうち 1 つを返す。 `utils/pickByState.ts` の generic 版 `usePickByState`
+ * と名前衝突しないよう ColorState 接尾辞を付けて区別する (rename Issue #169 R-1)。
+ * @param whiteState white page state で返す値
+ * @param coolState  cool 背景時に返す値
+ * @param warmState  warm 背景時に返す値
  */
-export const usePickByState = (whiteState: any, coolState: any, warmState: any) => {
+export const usePickByStateColor = (whiteState: any, coolState: any, warmState: any) => {
   const location = useLocation();
   const useStateBg = shouldUseStateBg(location);
   const isCoolState = useAppSelector(state => state.application.isCoolBackground);


### PR DESCRIPTION
# 概要

PR #168 の code-review-router sweep で検出した Minor refactor 4 件のうち、 命名衝突 R-1 と placeholder no-op button F-6 を fix する小規模 PR です。
外部動作は変わりません (rename + dead handler 整理のみ)。
残り F-4 / F-5 (`as any` / `: any`) はコメント済の意図的妥協なので scope-out しました (Issue 末尾に追記)。

# 課題

- `usePickByState` が 2 file に同名 export されており、 IDE 補完で紛らわしく誤 import の原因になる
  - `utils/pickByState.ts` ... generic state pick (引数 `(state, states[], stateResults[])`)
  - `utils/colorResponsiveUIUtils.ts` ... white/cool/warm の color state pick (引数 `(whiteState, coolState, warmState)`)
- `ProposalActionsModal/index.tsx` の default case で `SelectProposalActionStep` を `onNextBtnClick={() => console.log('')}` の no-op handler で呼んでおり、 想定外 step に落ちた瞬間に button が無反応になる

# 詳細

```mermaid
graph LR
    A[usePickByState 重複 export] --> B[誤 import / IDE 候補が紛らわしい]
    C[default no-op handler] --> D[想定外 step で button 無反応]
```

# 解決方法

- R-1 ... `utils/colorResponsiveUIUtils.ts` の `usePickByState` を `usePickByStateColor` に rename、 generic 版と分離。 call site 3 file (NavBar / NavDropdown / NavLocaleSwitcher) を一括更新
- F-6 ... default case の handler を case `SELECT_ACTION_TYPE` と同一に統合 (想定外 step も SELECT_ACTION_TYPE 起点へフォールバック)

# 仕組み

```mermaid
graph LR
    A[usePickByStateColor] --> B[color picker 専用と明示]
    C[usePickByState] --> D[generic state picker のまま]
    E[default fallback] --> F[SELECT_ACTION_TYPE と同一 handler でユーザーが復帰可能]
```

| 変更したファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/utils/colorResponsiveUIUtils.ts` | `usePickByState` → `usePickByStateColor` rename + JSDoc 強化 |
| `packages/niji-webapp/src/components/NavBar/index.tsx` | import + 全 call (6 箇所) を `usePickByStateColor` に |
| `packages/niji-webapp/src/components/NavDropdown/index.tsx` | import + 全 call (2 箇所) を `usePickByStateColor` に |
| `packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx` | import + 全 call (4 箇所) を `usePickByStateColor` に |
| `packages/niji-webapp/src/components/ProposalActionsModal/index.tsx` | default case の no-op handler を SELECT_ACTION_TYPE と同一に統合 |

# テストと確認

- [x] `pnpm tsc --noEmit` ... exit=0
- [x] e2e 27 TC × 4 round = 108/108 PASS (flaky 0)
- [x] 既存 27 TC 全 PASS (回帰なし)

# scope-out した残 Issue

F-4 (`wrappers/nijiDao.ts:407,422` の `useReadNijiGovernorGetReceipt as any`) と F-5 (`utils/lookupNNSOrENS.ts:14` の `client: any`) は、 実装にコメント済の通り **意図的な any** です。

- F-4 ... wagmi の generic 推論が深く展開しすぎて TS2589 error になるため、 hook 呼出を any 経由で迂回する設計
- F-5 ... viem の PublicClient 型が chains narrow で wagmi 戻り値型と衝突するため、 client を any 受けして readContract で抽象化する設計

narrow 試行は failure risk が高く、 wagmi メジャー up 時に再検討するのが妥当と判断したため本 PR では scope-out しました。

# 関連

Closes #169

Refs #168
