### PR TITLE
🧪 test(webapp): TC-011 を snapshot/revert で安定化

### DIFF
--- a/packages/niji-webapp/tests/e2e/chain-past-auctions.spec.ts
+++ b/packages/niji-webapp/tests/e2e/chain-past-auctions.spec.ts
@@ -15,7 +15,7 @@
 import { expect } from '@playwright/test';
 import { dappE2eTest as test } from '@kiwa-test/core';
 
-import { increaseTime } from './helpers/chain';
+import { increaseTime, revertChain, snapshotChain } from './helpers/chain';
 
 const CHAIN_HOOK_POLL_MS = 11_000;
 
@@ -192,10 +192,10 @@ test.describe('chain-past-auctions (subgraph 未起動 fallback)', () => {
     expect(hasSvgImg).toBe(true);
   });
 
-  // TC-011 は anvil chain time を 2 回 +10 分 進めて auto-settler の連続 settle を観察する
-  // 設計だが、 1 分 duration auction (PR #168 で変更) と相まって browser の wagmi reconnect
-  // race が flaky を生む。 follow-up Issue で chain time 進行を seal して動作観察に変更予定。
-  test.fixme('TC-011 並行処理: 30 秒間開きっぱなしで auto-settler が走っても破綻しない', async ({
+  // TC-011 は anvil chain time を進めて auto-settler の settle 動作を観察する。
+  // 過去 30s waitForTimeout + 連続 increaseTime で wagmi reconnect race が flaky だったため、
+  // snapshot/revert で chain state を test 範囲内に閉じる (Issue #181)。
+  test('TC-011 並行処理: chain 時計進行下で auto-settler が走っても webapp が破綻しない', async ({
     page,
   }) => {
     const consoleErrors: string[] = [];
@@ -204,25 +204,29 @@ test.describe('chain-past-auctions (subgraph 未起動 fallback)', () => {
     });
     page.on('pageerror', err => consoleErrors.push(`pageerror: ${err.message}`));
 
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+    const snapId = await snapshotChain();
+    try {
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
 
-    // 5 分 duration を強制超えさせるため anvil の chain 時計を 10 分進める
-    // (auto-settler が並走しているなら 5s polling で連続 settle が走る)
-    await increaseTime(600);
-    await page.waitForTimeout(10_000);
-    await increaseTime(600);
-    await page.waitForTimeout(10_000);
+      // chain 時計を 70 秒進めて 1 分 duration auction を 1 回 endTime 越え状態に
+      // auto-settler が 5s polling で settle するのを最大 12 秒待つ
+      await increaseTime(70);
+      await page.waitForTimeout(12_000);
 
-    // BigInt error / pageerror が出ていないこと
-    expect(consoleErrors.filter(e => /BigInt|pageerror/i.test(e))).toEqual([]);
-    // 何らかの Niji 画像が引き続き描画されている
-    const hasSvgImg = await page.evaluate(() =>
-      Array.from(document.querySelectorAll('img')).some(
-        i => i.src.startsWith('data:image/svg+xml;base64,') && i.src.length > 1000,
-      ),
-    );
-    expect(hasSvgImg).toBe(true);
+      // BigInt error / pageerror が出ていないこと
+      expect(consoleErrors.filter(e => /BigInt|pageerror/i.test(e))).toEqual([]);
+      // 何らかの Niji 画像が引き続き描画されている
+      const hasSvgImg = await page.evaluate(() =>
+        Array.from(document.querySelectorAll('img')).some(
+          i => i.src.startsWith('data:image/svg+xml;base64,') && i.src.length > 1000,
+        ),
+      );
+      expect(hasSvgImg).toBe(true);
+    } finally {
+      // 他 test に chain time 進行を漏らさないよう必ず snapshot に revert
+      await revertChain(snapId);
+    }
   });
 
   test('TC-012 回帰: BigInt serialize error が出ない', async ({ page }) => {

--- a/packages/niji-webapp/tests/e2e/helpers/chain.ts
+++ b/packages/niji-webapp/tests/e2e/helpers/chain.ts
@@ -109,6 +109,32 @@ export const tokenAbi = [
   },
 ] as const;
 
+/** anvil_snapshot で chain state を保存し snapshot id を返す (Hex)。 */
+export async function snapshotChain(): Promise<`0x${string}`> {
+  const rpc = (method: string, params: unknown[]) =>
+    fetch('http://127.0.0.1:8547', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    });
+  const res = await rpc('evm_snapshot', []);
+  const body = (await res.json()) as { result: `0x${string}` };
+  return body.result;
+}
+
+/** anvil_revert で保存した snapshot に chain state を戻す。 */
+export async function revertChain(snapshotId: `0x${string}`): Promise<boolean> {
+  const rpc = (method: string, params: unknown[]) =>
+    fetch('http://127.0.0.1:8547', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+    });
+  const res = await rpc('evm_revert', [snapshotId]);
+  const body = (await res.json()) as { result: boolean };
+  return body.result;
+}
+
 /** anvil_setNextBlockTimestamp + mine で chain 時刻を進める。 */
 export async function increaseTime(seconds: number) {
   const block = await publicClient.getBlock();


### PR DESCRIPTION
# 概要

PR #175 で `test.fixme` 化していた TC-011 (auto-settler 並走時の webapp 描画維持) を、 anvil snapshot/revert で chain state を test 範囲内に閉じる形で書き直し fixme 解除する。

# 課題

TC-011 は元々 `increaseTime(600)` を 2 回 + `waitForTimeout(10_000)` を挟む設計だったが、 PR #168 で AUCTION_DURATION = 1 分に変更したことで test 中に複数回 settle が走る race condition が発生、 wagmi reconnect が flaky を生み skip していた。

# 詳細

```mermaid
graph LR
    A[旧: increaseTime x 2 + 30s wait] --> B[wagmi reconnect race]
    B --> C[flaky]
```

# 解決方法

- `tests/e2e/helpers/chain.ts` に `snapshotChain` / `revertChain` helper を追加 (evm_snapshot / evm_revert)
- TC-011 を **snapshot → goto → increaseTime 70s → 12s 待機 → assertion → revert** の構造に
- 連続 increaseTime を 1 回に短縮し wagmi reconnect race を最小化
- `finally` で必ず revert し他 test に chain time 進行を漏らさない

# 仕組み

```mermaid
sequenceDiagram
  participant Test as TC-011
  participant Anvil as anvil 8547
  participant Web as webapp
  participant Auto as auto-settler
  Test->>Anvil: evm_snapshot → snapId
  Test->>Web: page.goto('/')
  Test->>Anvil: increaseTime(70)
  Test->>Test: waitForTimeout(12_000)
  Auto->>Anvil: settleCurrentAndCreateNewAuction
  Test->>Web: pageerror 検出 + SVG 描画 check
  Test->>Anvil: evm_revert(snapId)
```

| 変更したファイル | 何を変えたか |
|---|---|
| `tests/e2e/helpers/chain.ts` | snapshotChain / revertChain helper 追加 |
| `tests/e2e/chain-past-auctions.spec.ts` | TC-011 を snapshot/revert で書き直し + fixme 解除 |

# テストと確認

- [x] `pnpm tsc --noEmit` exit=0
- [x] TC-011 単体 PASS
- [x] e2e 27 TC 全 PASS (前 26 → 27、 fixme 解除分が増加)

# 関連

Closes #181
