### PR TITLE
🔧 fix(webapp): chain hook bid blockTimestamp を実 chain 時刻に

### DIFF
--- a/packages/niji-webapp/src/hooks/useChainPastAuctions.ts
+++ b/packages/niji-webapp/src/hooks/useChainPastAuctions.ts
@@ -81,6 +81,24 @@ async function fetchChainPastAuctions(
     client.getLogs({ address: auctionHouse, event: AUCTION_BID, fromBlock: 0n, toBlock: 'latest' }),
   ]);
 
+  // bid event に出てくる unique blockNumber を集めて Promise.all で batch 取得 (Issue #179)。
+  // 同 block に複数 bid がある場合は 1 回しか fetch しない、 RPC call 数を最小化。
+  type BidLog = (typeof bids)[number];
+  const blockSet = new Set<bigint>();
+  for (const b of bids as BidLog[]) {
+    if (b.blockNumber !== null && b.blockNumber !== undefined) {
+      blockSet.add(b.blockNumber);
+    }
+  }
+  const uniqueBlocks: bigint[] = Array.from(blockSet);
+  const blockTimestamps = new Map<bigint, bigint>();
+  await Promise.all(
+    uniqueBlocks.map(async (bn: bigint) => {
+      const block = await client.getBlock({ blockNumber: bn });
+      blockTimestamps.set(bn, block.timestamp);
+    }),
+  );
+
   // nounId 別に bid 履歴を集約
   const bidsByNoun = new Map<
     bigint,
@@ -102,7 +120,7 @@ async function fetchChainPastAuctions(
       amount: value,
       sender,
       blockNumber: log.blockNumber!,
-      blockTimestamp: 0n, // block timestamp は別途 fetch 必要、 dev 用途では 0 で十分
+      blockTimestamp: blockTimestamps.get(log.blockNumber!) ?? 0n,
       txHash: log.transactionHash!,
       txIndex: BigInt(log.transactionIndex!),
     });


### PR DESCRIPTION
# 概要

`useChainPastAuctions` の bid event 整形で `blockTimestamp: 0n` 固定だった箇所を `publicClient.getBlock` の batch 取得で実 chain 時刻に置換する 1 file fix。

# 課題

dev (anvil) で chain hook 経由の bid 履歴を BidHistory component が表示すると、 timestamp が 0 (= Unix epoch = 1970/01/01) になる。 hook 内で実装コメント「dev 用途では 0 で十分」 と置いていた前提が、 prod 移行 / UX 改善時に問題化。

# 詳細

```mermaid
graph LR
    A[bid event log] --> B[blockTimestamp = 0n 固定]
    B --> C[BidHistory が 1970/01/01 表示]
```

# 解決方法

bid から unique blockNumber を集めて `Promise.all` で `getBlock` 並列実行、 `Map<bigint, bigint>` に cache。 bid 整形時に Map から timestamp を引いて詰める (cache miss は 0n fallback)。

# 仕組み

```mermaid
graph LR
    A[bids array] --> B[Set blockNumber で重複排除]
    B --> C[Promise.all getBlock 並列]
    C --> D[Map blockNumber to timestamp cache]
    D --> E[bid 整形時に Map から引く]
```

| 変更したファイル | 何を変えたか |
|---|---|
| `src/hooks/useChainPastAuctions.ts` | bid blockTimestamp を batch 取得 + Map cache 経路に置換 (RPC call 数最小化) |

# テストと確認

- [x] `pnpm tsc --noEmit` exit=0
- [x] e2e 27 TC 全 PASS

# 関連

Closes #179
