### PR TITLE
🧪 test(contracts): NijiAuctionHouseV3 で未 cover な観点を補完

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiAuctionHouseV3KiwaTest.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiAuctionHouseV3KiwaTest.t.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.15;
+
+import 'forge-std/Test.sol';
+import { DeployUtils } from './helpers/DeployUtils.sol';
+import { NijiAuctionHouseProxy } from '../../contracts/proxies/NijiAuctionHouseProxy.sol';
+import { NijiAuctionHouseV3 } from '../../contracts/NijiAuctionHouseV3.sol';
+import { INijiAuctionHouseV3 as IAH } from '../../contracts/interfaces/INijiAuctionHouseV3.sol';
+
+/// @notice 既存 NijiAuctionHouseV3.t.sol (892 行) で未 cover な観点を補完する kiwa-design 由来の test。
+contract NijiAuctionHouseV3KiwaTest is Test, DeployUtils {
+    address owner = address(0x1111);
+    address noundersDAO = address(0x2222);
+    address minter = address(0x3333);
+    address nonOwner = address(0x4444);
+    uint32 internal startTimestamp = 1702289583;
+
+    NijiAuctionHouseV3 internal auction;
+
+    // Niji 関連の event 宣言 (既存 contract と一致が必要)
+    event AuctionTimeBufferUpdated(uint256 timeBuffer);
+    event AuctionReservePriceUpdated(uint256 reservePrice);
+    event AuctionMinBidIncrementPercentageUpdated(uint256 minBidIncrementPercentage);
+
+    function setUp() public virtual {
+        vm.warp(startTimestamp);
+        (NijiAuctionHouseProxy auctionProxy, ) = _deployAuctionHouseAndToken(owner, noundersDAO, minter);
+        auction = NijiAuctionHouseV3(address(auctionProxy));
+        // 注 ... 既存 NijiAuctionHouseV3TestBase は setUp で unpause するが、 本 kiwa-test
+        //       は unpause 自体を test 対象にするため deploy 直後の paused state を保持
+    }
+
+    // ====================================================
+    // TC-001 状態遷移: deploy 直後 paused、 unpause で _createAuction 自動発火
+    // ====================================================
+    function test_TC001_unpause_autoCreatesAuction() public {
+        assertTrue(auction.paused(), 'deployed contract must be paused');
+        // 初期 auctionStorage.startTime = 0
+        IAH.AuctionV2View memory before = auction.auction();
+        assertEq(before.startTime, 0, 'startTime must be 0 before unpause');
+
+        vm.prank(owner);
+        auction.unpause();
+
+        assertFalse(auction.paused(), 'auction must be unpaused');
+        IAH.AuctionV2View memory afterAuction = auction.auction();
+        assertGt(afterAuction.startTime, 0, 'startTime must be > 0 after unpause (_createAuction fired)');
+    }
+
+    // ====================================================
+    // TC-002 異常系: non-owner が unpause で revert
+    // ====================================================
+    function test_TC002_unpause_nonOwner_reverts() public {
+        vm.prank(nonOwner);
+        vm.expectRevert();
+        auction.unpause();
+    }
+
+    // ====================================================
+    // TC-003 異常系: non-owner が pause で revert
+    // ====================================================
+    function test_TC003_pause_nonOwner_reverts() public {
+        vm.prank(owner);
+        auction.unpause();
+
+        vm.prank(nonOwner);
+        vm.expectRevert();
+        auction.pause();
+    }
+
+    // ====================================================
+    // TC-004 状態遷移: pause 後 settleCurrentAndCreateNewAuction が whenNotPaused で revert
+    // ====================================================
+    function test_TC004_settleCurrentAndCreateNew_whenPaused_reverts() public {
+        vm.prank(owner);
+        auction.unpause();
+
+        vm.prank(owner);
+        auction.pause();
+
+        vm.expectRevert(); // EnforcedPause
+        auction.settleCurrentAndCreateNewAuction();
+    }
+
+    // ====================================================
+    // TC-005 正常系: setTimeBuffer で event
+    // ====================================================
+    function test_TC005_setTimeBuffer_emitsEvent() public {
+        uint56 newBuffer = 120; // 2 minutes
+
+        vm.expectEmit(false, false, false, true);
+        emit AuctionTimeBufferUpdated(uint256(newBuffer));
+
+        vm.prank(owner);
+        auction.setTimeBuffer(newBuffer);
+        assertEq(auction.timeBuffer(), newBuffer);
+    }
+
+    // ====================================================
+    // TC-006 異常系: setTimeBuffer が MAX_TIME_BUFFER 超で revert
+    // ====================================================
+    function test_TC006_setTimeBuffer_overMax_reverts() public {
+        uint56 maxBuffer = auction.MAX_TIME_BUFFER();
+        vm.prank(owner);
+        vm.expectRevert();
+        auction.setTimeBuffer(maxBuffer + 1);
+    }
+
+    // ====================================================
+    // TC-007 正常系: setReservePrice で event + 更新
+    // ====================================================
+    function test_TC007_setReservePrice_emitsEvent() public {
+        uint192 newReserve = 0.5 ether;
+
+        vm.expectEmit(false, false, false, true);
+        emit AuctionReservePriceUpdated(uint256(newReserve));
+
+        vm.prank(owner);
+        auction.setReservePrice(newReserve);
+        assertEq(auction.reservePrice(), newReserve);
+    }
+}

--- a/packages/niji-contracts/tests/spec/contract/test-spec-niji-auction-house-v3.ja.md
+++ b/packages/niji-contracts/tests/spec/contract/test-spec-niji-auction-house-v3.ja.md
@@ -1,0 +1,59 @@
+# test-spec — NijiAuctionHouseV3 (Foundry contract test)
+
+## 対象機能
+
+NijiAuctionHouseV3 の **既存 `NijiAuctionHouseV3.t.sol` で未 cover** な観点を補完する。 createBid / settle 系は既存 cover 済のため重複させず、 unpause / pause / event / setter / sanctionsOracle 経路を中心に。
+
+## 仕様の要約
+
+- `unpause()` ... onlyOwner、 `_unpause()` + `auctionStorage.startTime == 0 || .settled` で `_createAuction()` 自動呼出
+- `pause()` ... onlyOwner、 _pause() のみ (auction 進行は止めない)
+- `setTimeBuffer(uint56)` ... onlyOwner、 MAX_TIME_BUFFER 上限、 AuctionTimeBufferUpdated event
+- `setReservePrice(uint192)` ... onlyOwner、 AuctionReservePriceUpdated event
+- `setMinBidIncrementPercentage(uint8)` ... onlyOwner、 0 で revert (既存 cover)、 AuctionMinBidIncrementPercentageUpdated event
+- `auction()` view ... auctionStorage を AuctionV2View 形式で返す
+
+## 主な品質リスク
+
+| 基準 | スコア | 根拠 |
+|---|---|---|
+| 売上影響 | 高 | auction 経路の収益 core |
+| セキュリティ影響 | 高 | onlyOwner + nonReentrant + whenNotPaused の組合せ |
+| データ破壊 | 中 | sanctionsOracle 設定 mismatch で sanctioned bidder block 失敗 |
+| 利用頻度 | 高 | 全 auction で経由 |
+| 過去障害 | 中 | PR #168 で 1 分 duration / Nijider 枠 settle 改修 |
+
+→ **総合リスク = 高**
+
+## 推奨テスト構成
+
+Foundry forge test (`test/foundry/NijiAuctionHouseV3KiwaTest.t.sol`)、 既存と重複しない 7 TC。
+
+## テスト観点一覧
+
+1 正常系 / 2 異常系 / 4 状態遷移 / 5 権限 / 10 セキュリティ / 11 回帰
+
+## テストケース一覧
+
+| ID | 観点 | 内容 |
+|---|---|---|
+| TC-001 | 状態遷移 | deploy 直後 paused、 unpause() で _createAuction 自動発火 + auctionStorage.startTime != 0 |
+| TC-002 | 異常系 | non-owner が unpause で revert |
+| TC-003 | 異常系 | non-owner が pause で revert |
+| TC-004 | 状態遷移 | pause() で paused、 settleCurrentAndCreateNewAuction が whenNotPaused で revert |
+| TC-005 | 正常系 | setTimeBuffer 成功で AuctionTimeBufferUpdated event |
+| TC-006 | 異常系 | setTimeBuffer が MAX_TIME_BUFFER 超で revert |
+| TC-007 | 正常系 | setReservePrice 成功で AuctionReservePriceUpdated event + reservePrice 更新 |
+
+## 自動化すべきテスト
+
+全 7 件 自動化推奨。
+
+## 手動確認でよいテスト
+
+(なし)
+
+## 不足している仕様
+
+- createBid / settle 経路は既存 `NijiAuctionHouseV3.t.sol` で cover 済、 本 spec では重複させない
+- sanctionsOracle の statictly 設定変更 test は別 Issue で扱う (mainnet Oracle 連携が必要)


### PR DESCRIPTION
# 概要

既存 `NijiAuctionHouseV3.t.sol` (892 行) で未 cover な観点を kiwa-design で 6 観点 7 TC 補完する。 createBid / settle 系は既存 cover との重複を避け、 unpause / pause / setter event / 状態遷移を中心に。

# 課題

NijiAuctionHouseV3 の test は既存 forge test で createBid / settle / setMinBidIncrementPercentage 経路が cover 済だが、 unpause での _createAuction 自動発火 / pause 状態の settle revert / setTimeBuffer / setReservePrice の event 確認が薄かった。

# 詳細

```mermaid
graph LR
    A[既存 NijiAuctionHouseV3.t.sol] --> B[createBid / settle / setMinBidIncrement cover]
    C[新 NijiAuctionHouseV3KiwaTest.t.sol] --> D[unpause / pause / setTimeBuffer / setReservePrice cover]
    B & D --> E[両方で観点 cover 完成]
```

# 解決方法

`packages/niji-contracts/tests/spec/contract/test-spec-niji-auction-house-v3.ja.md` に spec、 `test/foundry/NijiAuctionHouseV3KiwaTest.t.sol` で 7 TC。 既存 DeployUtils を継承して setUp は unpause しないまま (deploy 直後 paused state を test 対象)。

# 仕組み

```mermaid
graph TD
    A[setUp] --> B[_deployAuctionHouseAndToken]
    B --> C[paused state 保持]
    C --> D[TC-001 unpause 自動 _createAuction]
    C --> E[TC-002/003 nonOwner revert]
    C --> F[TC-004 pause 後 settle revert]
    C --> G[TC-005/006 setTimeBuffer]
    C --> H[TC-007 setReservePrice]
```

| 変更したファイル | 何を変えたか |
|---|---|
| `tests/spec/contract/test-spec-niji-auction-house-v3.ja.md` | 9 section / 7 TC 仕様書 |
| `test/foundry/NijiAuctionHouseV3KiwaTest.t.sol` | 7 forge test (6 観点 cover) |

# テストと確認

- [x] forge test 7/7 PASS、 219ms

# 観点 cover 詳細

| TC | 観点 | 内容 |
|---|---|---|
| TC-001 | 状態遷移 | unpause で _createAuction 自動発火 + startTime != 0 |
| TC-002 | 異常系 | non-owner unpause revert |
| TC-003 | 異常系 | non-owner pause revert |
| TC-004 | 状態遷移 | pause 後 settle revert (whenNotPaused) |
| TC-005 | 正常系 | setTimeBuffer event + 値更新 |
| TC-006 | 異常系 | setTimeBuffer over MAX_TIME_BUFFER revert |
| TC-007 | 正常系 | setReservePrice event + 値更新 |

# 関連

Closes #182

Refs #171 (meta、 これで 4 module 全 child 完了)
