### PR TITLE
🔧 fix(niji-contracts): deploy-niji-full に SDK 31337 address sync を追加 (Issue #192)

### DIFF
--- a/packages/niji-contracts/tasks/deploy-niji-full.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-full.ts
@@ -482,6 +482,37 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
     fs.writeFileSync(logPath, JSON.stringify(deployLog, null, 2));
     console.log(`\n📝 Deploy log: ${logPath}`);
 
+    // chainId 31337 (anvil / hardhat) のときだけ SDK gen.ts の 31337 entry を実 deploy
+    // address に書き換える。 wagmi.config.ts は mainnet/sepolia のみを宣言しており
+    // 31337 は test 用 patch entry のため、 deploy 結果と drift しないよう毎回同期する。
+    if (deployLog.chainId === 31337) {
+      const sdkActionsDir = path.join(__dirname, '../../niji-sdk/src/actions');
+      const sdkReactDir = path.join(__dirname, '../../niji-sdk/src/react');
+      const targets: { file: string; addr: string }[] = [
+        { file: 'auction-house.gen.ts', addr: auctionProxyAddr ?? '' },
+        { file: 'token.gen.ts', addr: tokenAddrFinal ?? '' },
+        { file: 'descriptor.gen.ts', addr: descAddrFinal },
+      ];
+      let patched = 0;
+      for (const { file, addr } of targets) {
+        if (!addr) continue;
+        for (const baseDir of [sdkActionsDir, sdkReactDir]) {
+          const fp = path.join(baseDir, file);
+          if (!fs.existsSync(fp)) continue;
+          const orig = fs.readFileSync(fp, 'utf-8');
+          const patchedSrc = orig.replace(
+            /(\n\s*31337:\s*)'0x[0-9a-fA-F]{40}'/,
+            `$1'${addr}'`,
+          );
+          if (patchedSrc !== orig) {
+            fs.writeFileSync(fp, patchedSrc);
+            patched++;
+          }
+        }
+      }
+      console.log(`📝 SDK 31337 address sync: ${patched} file(s) updated`);
+    }
+
     // Return addresses for scripting
     return {
       art: artAddr,


### PR DESCRIPTION
## 概要

`deploy-niji-full --network localhost` の終端で SDK の chain 31337 address を実 deploy 値に同期する step を追加した。

## 課題

`deploy-niji-full` は anvil 上で毎回別 address に deploy されるが、 SDK の `packages/niji-sdk/src/{actions,react}/{auction-house,token,descriptor}.gen.ts` 内 31337 entry は手動 hardcode で deploy 値と drift する。 結果 webapp wagmi が contract を読めず、 e2e (chain-past-auctions / auction-render / settle-niji0 / crystal-ball) の主要 spec が壊れていた。

## 詳細

`packages/niji-sdk/wagmi.config.ts` は mainnet/sepolia のみを宣言しており、 31337 entry は test 用 patch として手動で gen.ts に追加されていたものなので、 wagmi codegen 経路では同期できない設計だった。

```mermaid
graph LR
    A[deploy-niji-full] -->|新 address| B[deploy/localhost-*.json]
    A -->|31337 entry 書き換え step 追加| C[niji-sdk *.gen.ts]
    C -->|pnpm -F @niji/sdk build| D[dist/]
    D -->|webapp HMR| E[wagmi が contract を読める]
```

## 解決方法

`deploy-niji-full` task の終端 (deploy log 出力直後) で、 `chainId === 31337` のときだけ以下を行う。

- 対象 ... 3 contract (AuctionHouse / Token / Descriptor) × 2 path (actions / react) = 最大 6 file
- 置換 ... `\n  31337: '0x[40]'` を実 deploy address に sed-style 置換
- 結果 ... `📝 SDK 31337 address sync: N file(s) updated` の log を出力

mainnet / sepolia entry は触らず、 31337 のみ書き換える。

## 検証

ローカルで `pnpm exec hardhat deploy-niji-full --network localhost` 実行で 6 file 同期が成功、 `chain-past-auctions` spec の SDK address 一致 TC-013 (`chain hook が auctions を取得 (SDK address 一致)`) が green 化。 全体は 13 件失敗 → 5 件失敗に縮小 (残 5 件は auction 多数生成前提の test 設計問題で別 Issue 候補)。

## 受入条件

- [x] deploy-niji-full 後に SDK 31337 address が deploy 結果と一致
- [x] 既存 chain-past-auctions TC-001 / TC-004 / TC-006 / TC-007 / TC-011 / TC-012 / TC-013 が green
- [x] PR 作成

## 関連

- 発覚経路 ... Issue #178 (legacy 5 spec 書き直し) の e2e 実走中
- Closes #192
- 残存 spec 失敗 ... TC-002 / TC-003 / TC-005 / TC-008 / TC-010 (auction 多数生成前提の navigation 系) と auto-settler 古 hardcode address は別 Issue で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
