### PR TITLE
🧪 test(webapp): legacy e2e 5 spec を kiwa fixture base で復帰 (Issue #178)

### DIFF
--- a/packages/niji-webapp/tests/e2e/01-auction.spec.ts
+++ b/packages/niji-webapp/tests/e2e/01-auction.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * Niji auction — contract layer (anvil 31337)
+ *
+ * 仕様 ... auctionStorage / reservePrice / minBidIncrement / createBid を直接 chain
+ *         layer で確認する。 PR #168 の AUCTION_DURATION=60 (1 分) を前提に、
+ *         各 test を snapshot/revert で独立化して状態共有を切る。
+ *
+ * 前提 (global-setup.ts):
+ *   - anvil 8547 chain-id 31337
+ *   - deploy-niji-full 完了 (deterministic deploy)
+ *   - auto-settler が並走で auction を進める可能性があるため、 各 test 冒頭で
+ *     snapshot を取り finally で revert (chain time 進行を test 範囲内に閉じる)
+ */
+import { expect } from '@playwright/test';
+import { dappE2eTest as test } from '@kiwa-test/core';
+import { parseEther } from 'viem';
+
+import {
+  ADDRESSES,
+  ANVIL_KEYS,
+  auctionAbi,
+  makeWallet,
+  publicClient,
+  readAuction,
+  revertChain,
+  snapshotChain,
+  tokenAbi,
+} from './helpers/chain';
+
+test.describe('Niji auction — contract layer (anvil 31337)', () => {
+  test('TC-A01 auctionStorage が unpause 直後の活きた auction を返す', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const [nounId, , amount, startTime, endTime, bidder, settled] = await readAuction();
+      expect(nounId).toBeGreaterThanOrEqual(0n);
+      expect(startTime).toBeGreaterThan(0);
+      expect(endTime).toBeGreaterThan(startTime);
+      // auction が未入札の場合 amount=0、 既存 bid が乗っている場合は >0 のまま許容
+      if (amount === 0n) {
+        expect(bidder.toLowerCase()).toBe('0x0000000000000000000000000000000000000000');
+      }
+      expect(settled).toBe(false);
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-A02 NijiToken.totalSupply が AuctionHouse 経由で 1 mint 以上', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const total = await publicClient.readContract({
+        address: ADDRESSES.NijiToken,
+        abi: tokenAbi,
+        functionName: 'totalSupply',
+      });
+      expect(total).toBeGreaterThanOrEqual(1n);
+
+      // 現 auction の nounId が出品中 (= AuctionHouseProxy 所有)
+      const [nounId] = await readAuction();
+      const owner = await publicClient.readContract({
+        address: ADDRESSES.NijiToken,
+        abi: tokenAbi,
+        functionName: 'ownerOf',
+        args: [nounId],
+      });
+      expect(owner.toLowerCase()).toBe(ADDRESSES.AuctionHouseProxy.toLowerCase());
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-A03 reservePrice と minBidIncrementPercentage が deploy 値と一致', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const reserve = await publicClient.readContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'reservePrice',
+      });
+      expect(reserve).toBe(parseEther('0.001'));
+      const minInc = await publicClient.readContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'minBidIncrementPercentage',
+      });
+      expect(minInc).toBe(2);
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-A04 bidder1 が reservePrice ちょうどで入札成功 (snapshot 内で完結)', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const { account, client } = makeWallet(ANVIL_KEYS.bidder1);
+      const [nounId, , currentAmount] = await readAuction();
+
+      // 既存 bid が乗っているケース (auto-settler 走行中) は +2% で上書き、 未入札なら reserve ちょうど
+      const bidValue =
+        currentAmount === 0n ? parseEther('0.001') : (currentAmount * 102n) / 100n + 1n;
+
+      const txHash = await client.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounId],
+        value: bidValue,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+      const [, , amountAfter, , , bidderAfter] = await readAuction();
+      expect(amountAfter).toBeGreaterThanOrEqual(bidValue);
+      expect(bidderAfter.toLowerCase()).toBe(account.address.toLowerCase());
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-A05 bidder2 が +2% の上書き入札に成功 (snapshot 内で 2 連続 bid)', async () => {
+    const snapId = await snapshotChain();
+    try {
+      // 1) bidder1 が reservePrice ちょうど (or 既存 +2%) で bid
+      const { client: client1 } = makeWallet(ANVIL_KEYS.bidder1);
+      const [nounId, , initialAmount] = await readAuction();
+      const firstBid =
+        initialAmount === 0n ? parseEther('0.001') : (initialAmount * 102n) / 100n + 1n;
+      const tx1 = await client1.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounId],
+        value: firstBid,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: tx1 });
+
+      // 2) bidder2 が +2% で上書き
+      const { account: acc2, client: client2 } = makeWallet(ANVIL_KEYS.bidder2);
+      const [, , currentAmount] = await readAuction();
+      const newBid = (currentAmount * 102n) / 100n + 1n;
+      const tx2 = await client2.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounId],
+        value: newBid,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: tx2 });
+
+      const [, , amountAfter, , , bidderAfter] = await readAuction();
+      expect(amountAfter).toBeGreaterThanOrEqual(newBid);
+      expect(bidderAfter.toLowerCase()).toBe(acc2.address.toLowerCase());
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+});

--- a/packages/niji-webapp/tests/e2e/02-settle.spec.ts
+++ b/packages/niji-webapp/tests/e2e/02-settle.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Niji auction — settle flow (1 分 duration)
+ *
+ * 仕様 ... bid → 期限切れ → settle → 新 auction 開始 のフルフロー検証。
+ *         PR #168 で auction が 1 分 duration になったため、 increaseTime(65) で
+ *         endTime を 1 回越えた状態にしてから settle を呼ぶ。
+ *         各 test は snapshot/revert で完結し、 他 spec の chain state に影響しない。
+ */
+import { expect } from '@playwright/test';
+import { dappE2eTest as test } from '@kiwa-test/core';
+import { parseEther } from 'viem';
+
+import {
+  ADDRESSES,
+  ANVIL_KEYS,
+  auctionAbi,
+  increaseTime,
+  makeWallet,
+  publicClient,
+  readAuction,
+  revertChain,
+  snapshotChain,
+  tokenAbi,
+} from './helpers/chain';
+
+test.describe('Niji auction — settle flow', () => {
+  test('TC-S01 bid → 期限切れ → settle で winner が落札 token を受領 + 新 auction 開始', async () => {
+    const snapId = await snapshotChain();
+    try {
+      // 1) bidder2 が現 auction に bid
+      const { account: winner, client: winnerClient } = makeWallet(ANVIL_KEYS.bidder2);
+      const [nounIdBefore, , currentAmount, , endTime] = await readAuction();
+      const bidValue =
+        currentAmount === 0n ? parseEther('0.001') : (currentAmount * 102n) / 100n + 1n;
+      const bidTx = await winnerClient.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounIdBefore],
+        value: bidValue,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: bidTx });
+
+      // 2) endTime を超えるまで chain 時計を warp (1 分 duration なので 65s で十分)
+      const now = Number((await publicClient.getBlock()).timestamp);
+      const delta = endTime > now ? endTime - now + 5 : 5;
+      await increaseTime(delta);
+
+      // 3) settle (任意 caller、 deployer で実行)
+      const { client: deployerClient } = makeWallet(ANVIL_KEYS.deployer);
+      const settleTx = await deployerClient.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'settleCurrentAndCreateNewAuction',
+      });
+      await publicClient.waitForTransactionReceipt({ hash: settleTx });
+
+      // 4) 旧 nounId の所有者が winner
+      const ownerOfOld = await publicClient.readContract({
+        address: ADDRESSES.NijiToken,
+        abi: tokenAbi,
+        functionName: 'ownerOf',
+        args: [nounIdBefore],
+      });
+      expect(ownerOfOld.toLowerCase()).toBe(winner.address.toLowerCase());
+
+      // 5) 新 auction が nounIdBefore+1 で開始
+      const [nounIdAfter, , amountAfter, , , bidderAfter, settledAfter] = await readAuction();
+      expect(nounIdAfter).toBe(nounIdBefore + 1n);
+      expect(amountAfter).toBe(0n);
+      expect(bidderAfter.toLowerCase()).toBe('0x0000000000000000000000000000000000000000');
+      expect(settledAfter).toBe(false);
+
+      // 6) totalSupply が増えている
+      const total = await publicClient.readContract({
+        address: ADDRESSES.NijiToken,
+        abi: tokenAbi,
+        functionName: 'totalSupply',
+      });
+      expect(total).toBeGreaterThanOrEqual(nounIdAfter + 1n);
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-S02 settle 後の新 auction に bidder1 が入札成功', async () => {
+    const snapId = await snapshotChain();
+    try {
+      // setup ... 現 auction を期限切れにして settle
+      const [nounIdBefore, , , , endTimeBefore] = await readAuction();
+      const now = Number((await publicClient.getBlock()).timestamp);
+      const delta = endTimeBefore > now ? endTimeBefore - now + 5 : 5;
+      await increaseTime(delta);
+
+      const { client: deployerClient } = makeWallet(ANVIL_KEYS.deployer);
+      const settleTx = await deployerClient.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'settleCurrentAndCreateNewAuction',
+      });
+      await publicClient.waitForTransactionReceipt({ hash: settleTx });
+
+      // 新 auction に bidder1 が bid
+      const { account: bidder, client: bidderClient } = makeWallet(ANVIL_KEYS.bidder1);
+      const [nounIdNew] = await readAuction();
+      expect(nounIdNew).toBe(nounIdBefore + 1n);
+
+      const bidTx = await bidderClient.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounIdNew],
+        value: parseEther('0.001'),
+      });
+      await publicClient.waitForTransactionReceipt({ hash: bidTx });
+
+      const [, , amount, , , bidderAfter] = await readAuction();
+      expect(amount).toBe(parseEther('0.001'));
+      expect(bidderAfter.toLowerCase()).toBe(bidder.address.toLowerCase());
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+});

--- a/packages/niji-webapp/tests/e2e/03-bid-errors.spec.ts
+++ b/packages/niji-webapp/tests/e2e/03-bid-errors.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Niji auction — error paths (revert 確認)
+ *
+ * 仕様 ... reservePrice 未満 / minBidIncrement 未満 / 不正 nounId / active 中 settle の revert 確認。
+ *         各 test は snapshot/revert で完結し、 前 test の bid state に影響されないよう
+ *         必要な前提 bid を test 内で行う。
+ */
+import { expect } from '@playwright/test';
+import { dappE2eTest as test } from '@kiwa-test/core';
+import { parseEther } from 'viem';
+
+import {
+  ADDRESSES,
+  ANVIL_KEYS,
+  auctionAbi,
+  makeWallet,
+  publicClient,
+  readAuction,
+  revertChain,
+  snapshotChain,
+} from './helpers/chain';
+
+test.describe('Niji auction — error paths', () => {
+  test('TC-E01 reservePrice 未満の入札は revert (未入札 auction で 0.0001 ETH)', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const { client } = makeWallet(ANVIL_KEYS.bidder2);
+      const [nounId, , currentAmount] = await readAuction();
+
+      // 既存 bid が乗っている case は reservePrice 未満が成立しないため value=1 wei で代替
+      // (どちらにせよ reservePrice / increment いずれかで revert する)
+      const tooLow = currentAmount === 0n ? parseEther('0.0001') : 1n;
+
+      await expect(
+        client.writeContract({
+          address: ADDRESSES.AuctionHouseProxy,
+          abi: auctionAbi,
+          functionName: 'createBid',
+          args: [nounId],
+          value: tooLow,
+        }),
+      ).rejects.toThrow(/below reservePrice|reservePrice|increment|increase|higher/i);
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-E02 minBidIncrement 未満の上書き入札は revert', async () => {
+    const snapId = await snapshotChain();
+    try {
+      // setup ... reservePrice ちょうど / 既存 +2% で 1 回 bid して上書き対象を作る
+      const { client: bidder1Client } = makeWallet(ANVIL_KEYS.bidder1);
+      const [nounId, , initial] = await readAuction();
+      const firstBid = initial === 0n ? parseEther('0.001') : (initial * 102n) / 100n + 1n;
+      const tx1 = await bidder1Client.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounId],
+        value: firstBid,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: tx1 });
+
+      // bidder2 が +1 wei で上書き試行 → +2% 未満で revert
+      const { client: bidder2Client } = makeWallet(ANVIL_KEYS.bidder2);
+      const [, , currentAmount] = await readAuction();
+      await expect(
+        bidder2Client.writeContract({
+          address: ADDRESSES.AuctionHouseProxy,
+          abi: auctionAbi,
+          functionName: 'createBid',
+          args: [nounId],
+          value: currentAmount + 1n,
+        }),
+      ).rejects.toThrow(/increment|increase|higher than/i);
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-E03 間違った nounId への入札は revert', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const { client } = makeWallet(ANVIL_KEYS.bidder2);
+      const [nounId] = await readAuction();
+      const wrong = nounId + 100n;
+      await expect(
+        client.writeContract({
+          address: ADDRESSES.AuctionHouseProxy,
+          abi: auctionAbi,
+          functionName: 'createBid',
+          args: [wrong],
+          value: parseEther('0.01'),
+        }),
+      ).rejects.toThrow(/Niji not up for auction|nounId|not for sale|not on auction|auction/i);
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-E04 auction が active な間に settle は revert', async () => {
+    const snapId = await snapshotChain();
+    try {
+      // setup ... reservePrice ちょうどで bid を入れて active 状態を確保
+      const { account: bidder1, client: bidder1Client } = makeWallet(ANVIL_KEYS.bidder1);
+      const [nounId, , initial] = await readAuction();
+      const firstBid = initial === 0n ? parseEther('0.001') : (initial * 102n) / 100n + 1n;
+      const bidTx = await bidder1Client.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounId],
+        value: firstBid,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: bidTx });
+
+      const { client: bidder2Client } = makeWallet(ANVIL_KEYS.bidder2);
+      await expect(
+        bidder2Client.writeContract({
+          address: ADDRESSES.AuctionHouseProxy,
+          abi: auctionAbi,
+          functionName: 'settleCurrentAndCreateNewAuction',
+        }),
+      ).rejects.toThrow(/Auction hasn't begun|Auction|not.*ended|hasn't.*completed/i);
+
+      // 落札者 / 金額 は変わっていない
+      const [, , amount, , , bidder] = await readAuction();
+      expect(amount).toBeGreaterThanOrEqual(firstBid);
+      expect(bidder.toLowerCase()).toBe(bidder1.address.toLowerCase());
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+
+  test('TC-E05 bidder1 の残高が 1 回 bid で激減せず 9999 ETH 以上残る', async () => {
+    const snapId = await snapshotChain();
+    try {
+      const { account: bidder1, client } = makeWallet(ANVIL_KEYS.bidder1);
+      const [nounId, , initial] = await readAuction();
+      const bidValue = initial === 0n ? parseEther('0.001') : (initial * 102n) / 100n + 1n;
+      const tx = await client.writeContract({
+        address: ADDRESSES.AuctionHouseProxy,
+        abi: auctionAbi,
+        functionName: 'createBid',
+        args: [nounId],
+        value: bidValue,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: tx });
+
+      const balance = await publicClient.getBalance({ address: bidder1.address });
+      // anvil 初期残高 10000 ETH、 0.001 ETH bid + gas を引いても 9999 ETH 以上残る
+      expect(balance).toBeGreaterThan(parseEther('9999'));
+    } finally {
+      await revertChain(snapId);
+    }
+  });
+});

--- a/packages/niji-webapp/tests/e2e/04-routes.spec.ts
+++ b/packages/niji-webapp/tests/e2e/04-routes.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Niji webapp — route smoke tests
+ *
+ * 仕様 ... /playground / /traits / /nijis / /vote / /lp/ の主要ルートが 200 + 描画
+ *         される smoke test。 chain state には依存しないため snapshot 不要、
+ *         kiwa dappE2eTest fixture の page 経由でアクセスする。
+ */
+import { expect } from '@playwright/test';
+import { dappE2eTest as test } from '@kiwa-test/core';
+
+test.describe('Niji webapp — route smoke tests', () => {
+  test('TC-R01 /playground が表示され Generate Nijis ボタンがある', async ({ page }) => {
+    await page.goto('/playground');
+    await expect(page.getByText('Playground').first()).toBeVisible({ timeout: 15_000 });
+    const generateBtn = page.getByRole('button', { name: /Generate Nijis|Niji/i }).first();
+    await expect(generateBtn).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('TC-R02 /playground の初期 4 体以上が data:image/svg+xml で描画される', async ({
+    page,
+  }) => {
+    await page.goto('/playground');
+    await page.waitForFunction(
+      () => {
+        const imgs = Array.from(document.querySelectorAll('img'));
+        const svgImgs = imgs.filter(i => i.src.startsWith('data:image/svg+xml;base64,'));
+        return svgImgs.length >= 4;
+      },
+      { timeout: 20_000 },
+    );
+  });
+
+  test('TC-R03 /traits が 200 で返る', async ({ page, request }) => {
+    // /traits は重い PNG zip 生成 + subgraph 接続を含む。 page.goto では teardown 待ちで
+    // timeout するため、 純粋な HTTP status を request fixture で確認する。
+    const res = await request.get('/traits');
+    expect(res.status()).toBe(200);
+  });
+
+  test('TC-R04 /nijis が 200 で表示される', async ({ page }) => {
+    const res = await page.goto('/nijis');
+    expect(res?.status()).toBe(200);
+    await expect(page.locator('body')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('TC-R05 /vote が 200 で表示される (DAO governance page)', async ({ page }) => {
+    const res = await page.goto('/vote');
+    expect(res?.status()).toBe(200);
+    await expect(page.locator('body')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('TC-R06 /lp/ が 200 + LP HTML を返す + 画像/共創 H2 描画', async ({ page }) => {
+    const res = await page.goto('/lp/');
+    expect(res?.status()).toBe(200);
+    await expect(page.locator('html[lang="ja"]')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('共創で進化する').first()).toBeVisible({ timeout: 10_000 });
+    const headerLogo = page.locator('img[src="/lp/assets/images/lo_niji.png"]').first();
+    await expect(headerLogo).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('TC-R07 /lp (trailing slash 無) が 301 → /lp/ に redirect される', async ({ request }) => {
+    const res = await request.get('/lp', { maxRedirects: 0 });
+    expect(res.status()).toBe(301);
+    expect(res.headers()['location']).toBe('/lp/');
+  });
+
+  test('TC-R08 /lp/ の Launch App リンクをクリックで / に戻り webapp ロゴが描画', async ({
+    page,
+  }) => {
+    await page.goto('/lp/');
+    await expect(page.getByText('共創で進化する').first()).toBeVisible({ timeout: 10_000 });
+    const launch = page.locator('a.launch_bt').first();
+    await expect(launch).toBeVisible();
+    await launch.click();
+    await page.waitForURL(/\/$/, { timeout: 10_000 });
+    await expect(page.locator('img[alt="Niji DAO"]').first()).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/packages/niji-webapp/tests/e2e/05-ui-auction.spec.ts
+++ b/packages/niji-webapp/tests/e2e/05-ui-auction.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Niji auction — UI (http://localhost:2424/)
+ *
+ * 仕様 ... webapp top の auction UI が wagmi + chain hook 経由で描画されることを
+ *         確認する。 NavBar / TESTNET / LP link click までを smoke。
+ *         入札金額 / 残り時間 / Niji #N タイトル / SVG image は subgraph 経路または
+ *         chain hook + wallet 接続が必要なため、 入札 UI 部の文言検証は
+ *         chain-past-auctions.spec.ts (TC-001, TC-004 等) でカバー済として
+ *         本 spec では行わない。
+ */
+import { expect } from '@playwright/test';
+import { dappE2eTest as test } from '@kiwa-test/core';
+
+test.describe('Niji auction — UI (http://localhost:2424/)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    // wagmi polling が走り続けるので networkidle は使わず NavBar 描画完了で代用
+    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+  });
+
+  test('TC-U01 NavBar に Niji ロゴ (fav_180.png) が描画されている', async ({ page }) => {
+    const logo = page.locator('img[alt="Niji DAO"]').first();
+    await expect(logo).toBeVisible({ timeout: 10_000 });
+    const src = await logo.getAttribute('src');
+    expect(src).toMatch(/fav_180\.png/);
+  });
+
+  test('TC-U02 TESTNET バッジが NavBar 内に出ている (chainId != 1)', async ({ page }) => {
+    // 'TESTNET' は NavBar 内 span で body 全体のどこかに出ていれば OK
+    await expect(page.locator('body')).toContainText('TESTNET', { timeout: 15_000 });
+  });
+
+  test('TC-U03 NavBar の LP リンクをクリックすると /lp/ に遷移する', async ({ page }) => {
+    // a[href="/lp/"] は desktop + mobile collapse の 2 個あるので visible な方を取る
+    const lpLink = page.locator('a[href="/lp/"]:visible').first();
+    await expect(lpLink).toBeVisible({ timeout: 15_000 });
+    await lpLink.click();
+    await page.waitForURL('**/lp/', { timeout: 10_000 });
+    await expect(page.getByText('共創で進化する')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/packages/niji-webapp/tests/e2e/helpers/chain.ts
+++ b/packages/niji-webapp/tests/e2e/helpers/chain.ts
@@ -1,3 +1,7 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import {
   createPublicClient,
   createWalletClient,
@@ -7,6 +11,8 @@ import {
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 export const anvil = defineChain({
   id: 31337,
   name: 'Anvil',
@@ -14,19 +20,54 @@ export const anvil = defineChain({
   rpcUrls: { default: { http: ['http://127.0.0.1:8547'] } },
 });
 
+type DeployedAddresses = {
+  AuctionHouseProxy: `0x${string}`;
+  NijiToken: `0x${string}`;
+  NijiArt: `0x${string}`;
+  NijiDescriptor: `0x${string}`;
+  NijiSeeder: `0x${string}`;
+  WETH: `0x${string}`;
+};
+
 /**
- * deploy-niji-full --network localhost は anvil の deterministic deploy で常に
- * 同じ address を返す (deployer = account #0、 nonce 起点 0)。 この前提を test に
- * ハードコードする。
+ * 最新の deploy-niji-full ログ (packages/niji-contracts/deploy/localhost-*-full.json) を
+ * 読んで address を返す。 SDK の address gen は別 PR で再生成される設計のため、 test 側は
+ * 実 deploy 出力を真実の source として扱う。
  */
-export const ADDRESSES = {
-  AuctionHouseProxy: '0x1Dbbf529D78d6507B0dd71F6c02f41138d828990',
-  NijiToken: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9',
-  NijiArt: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-  NijiDescriptor: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-  NijiSeeder: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
-  WETH: '0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE',
-} as const;
+function loadLatestDeployAddresses(): DeployedAddresses {
+  const repoRoot = path.resolve(__dirname, '../../../../..');
+  const deployDir = path.join(repoRoot, 'packages/niji-contracts/deploy');
+  const files = readdirSync(deployDir)
+    .filter(f => /^localhost-.*-full\.json$/.test(f))
+    .sort()
+    .reverse();
+  if (files.length === 0) {
+    throw new Error(
+      `No deploy log found at ${deployDir}. Run \`pnpm exec hardhat deploy-niji-full --network localhost\` first.`,
+    );
+  }
+  const latest = path.join(deployDir, files[0]);
+  const json = JSON.parse(readFileSync(latest, 'utf-8')) as {
+    contracts: {
+      NijiArt: string;
+      NijiDescriptor: string;
+      NijiSeeder: string;
+      NijiToken: string;
+      NijiAuctionHouseProxy: string;
+      WETH: string;
+    };
+  };
+  return {
+    AuctionHouseProxy: json.contracts.NijiAuctionHouseProxy as `0x${string}`,
+    NijiToken: json.contracts.NijiToken as `0x${string}`,
+    NijiArt: json.contracts.NijiArt as `0x${string}`,
+    NijiDescriptor: json.contracts.NijiDescriptor as `0x${string}`,
+    NijiSeeder: json.contracts.NijiSeeder as `0x${string}`,
+    WETH: json.contracts.WETH as `0x${string}`,
+  };
+}
+
+export const ADDRESSES: DeployedAddresses = loadLatestDeployAddresses();
 
 // anvil default accounts (HD path m/44'/60'/0'/0/N)
 export const ANVIL_KEYS = {


### PR DESCRIPTION
## 概要

PR #168 で kiwa-play 移行時に `.context/scratch/legacy-e2e-backup/` へ退避していた legacy e2e 5 spec を、 kiwa `dappE2eTest` fixture と 1 分 duration auction (PR #168 で導入) に合わせて書き直し、 `packages/niji-webapp/tests/e2e/` 配下に復帰させた。

## 課題

退避先 5 spec は 24h auction 前提 + `@playwright/test` 直 import で書かれており、 PR #168 後の `AUCTION_DURATION = 60` (1 分) と kiwa fixture 環境では bid → settle flow が破綻していた。 また `helpers/chain.ts` の ADDRESSES は古い hardcode で deploy 結果と drift しており contract が読めなかった。

## 詳細

### 書き直した 5 spec (合計 23 TC)

```mermaid
graph LR
    A[legacy 24h spec 5 件] -->|kiwa fixture 化 + 1 分 duration 対応| B[新 5 spec 23 TC]
    B -->|snapshot/revert で独立化| C[4 round flaky 0]
```

- `01-auction.spec.ts` (5 TC) ... auctionStorage / reservePrice / minBidIncrement / createBid (snapshot/revert で各 test 独立化)
- `02-settle.spec.ts` (2 TC) ... bid → 期限切れ (65s warp) → settle → 新 auction 開始の full flow
- `03-bid-errors.spec.ts` (5 TC) ... reservePrice 未満 / minBidIncrement 未満 / 不正 nounId / active 中 settle revert / bidder1 残高確認
- `04-routes.spec.ts` (8 TC) ... /playground / /traits / /nijis / /vote / /lp/ smoke、 /traits は `request` fixture で 200 を直接取得 (page.goto では teardown が timeout する)
- `05-ui-auction.spec.ts` (3 TC) ... NavBar / TESTNET / LP link (旧 fixme 3 件は SDK address 問題のため整理して削除、 該当検証は chain-past-auctions TC-001 等でカバー済)

### helpers/chain.ts の deploy log 動的読込

`packages/niji-contracts/deploy/localhost-*-full.json` の最新を読んで ADDRESSES を組み立てる `loadLatestDeployAddresses()` を追加。 SDK 側の 31337 entry は PR #193 (Issue #192) で deploy task と同期されるが、 test 側も deploy 結果を直接 source として扱うことで二重に drift を防ぐ。

### snapshot/revert pattern

01-03 系の各 test は冒頭で `snapshotChain()`、 finally で `revertChain(snapId)` し、 chain time 進行 / bid state / settle 結果が他 spec に漏れない設計。 既存 `chain-past-auctions.spec.ts` TC-011 と同 pattern。

## 検証

ローカルで 4 round 連続実行 (`SKIP_GLOBAL_SETUP=1 pnpm exec playwright test 01-auction 02-settle 03-bid-errors 04-routes 05-ui-auction --reporter=line`)。

| round | 結果 | 所要 |
|---|---|---|
| 1 | 23 passed | 48.6s |
| 2 | 23 passed | 1.1m |
| 3 | 23 passed | 52.5s |
| 4 | 23 passed | 41.4s |

flaky 0 確定。

## 受入条件

- [x] 5 spec が kiwa fixture で 4 round 連続 PASS
- [x] backup dir (`.context/scratch/legacy-e2e-backup/`) 削除
- [x] flaky 0

## 関連

- 親 Issue ... #172 (m-2 / m-3 切り出し)
- 前提 PR ... #193 (Issue #192、 SDK 31337 address sync)
- 既存 spec の chain-past-auctions TC-002 / TC-003 / TC-005 / TC-008 / TC-010 は auction 多数生成前提の test 設計問題で別 Issue 候補 (auto-settler の長時間走行が必要)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
