### PR TITLE
🔧 fix(contracts): anvil-auto-settler の AUCTION_HOUSE を deploy log 動的読込化 (Issue #196)

### DIFF
--- a/packages/niji-contracts/scripts/anvil-auto-settler.ts
+++ b/packages/niji-contracts/scripts/anvil-auto-settler.ts
@@ -9,16 +9,66 @@
  *     pnpm -w exec tsx packages/niji-contracts/scripts/anvil-auto-settler.ts
  *
  * 環境変数 — ANVIL_RPC (default http://127.0.0.1:8547)
- *           AUCTION_HOUSE (default 0x59b670...857b、 fresh anvil 上の決定論的 address)
+ *           AUCTION_HOUSE (省略時は deploy log `deploy/localhost-*-full.json` の最新から
+ *                          `NijiAuctionHouseProxy` を動的読込。 PR #193 の SDK 31337 sync と同じ pattern)
  *           DEPLOYER_PK (必須、 default なし — repo に anvil mnemonic 鍵を残さないため
  *                        OSS secret scanner / 010-env-guard の誤検知を予防)
  *           POLL_MS (default 5000)
  */
 
+import fs from 'node:fs';
+import path from 'node:path';
+
 import { ethers } from 'ethers';
 
+// CommonJS module 配下のため `__dirname` は global 利用可能。 tsx + CommonJS 解釈で安定。
+
+/**
+ * `packages/niji-contracts/deploy/localhost-*-full.json` の最新を読んで
+ * NijiAuctionHouseProxy address を返す。 見つからない場合は undefined。
+ */
+function loadLatestAuctionHouseFromDeployLog(): string | undefined {
+  const deployDir = path.join(__dirname, '../deploy');
+  if (!fs.existsSync(deployDir)) return undefined;
+  const files = fs
+    .readdirSync(deployDir)
+    .filter(f => /^localhost-.*-full\.json$/.test(f))
+    .sort()
+    .reverse();
+  if (files.length === 0) return undefined;
+  const latest = path.join(deployDir, files[0]);
+  try {
+    const json = JSON.parse(fs.readFileSync(latest, 'utf-8')) as {
+      contracts?: { NijiAuctionHouseProxy?: string };
+    };
+    return json.contracts?.NijiAuctionHouseProxy;
+  } catch {
+    return undefined;
+  }
+}
+
 const RPC = process.env.ANVIL_RPC ?? 'http://127.0.0.1:8547';
-const AUCTION_HOUSE = process.env.AUCTION_HOUSE ?? '0x1Dbbf529D78d6507B0dd71F6c02f41138d828990';
+
+let AUCTION_HOUSE: string;
+let AUCTION_HOUSE_SOURCE: 'env' | 'deploy-log' | 'none';
+if (process.env.AUCTION_HOUSE) {
+  AUCTION_HOUSE = process.env.AUCTION_HOUSE;
+  AUCTION_HOUSE_SOURCE = 'env';
+} else {
+  const fromLog = loadLatestAuctionHouseFromDeployLog();
+  if (fromLog) {
+    AUCTION_HOUSE = fromLog;
+    AUCTION_HOUSE_SOURCE = 'deploy-log';
+  } else {
+    console.error(
+      '[auto-settler] AUCTION_HOUSE が解決できません。 以下のいずれかで指定してください:\n' +
+        '  1) pnpm exec hardhat deploy-niji-full --network localhost を先に実行 (deploy log から自動取得)\n' +
+        '  2) AUCTION_HOUSE=0x... を env で明示指定',
+    );
+    process.exit(2);
+  }
+}
+
 const DEPLOYER_PK = process.env.DEPLOYER_PK ?? '';
 if (!DEPLOYER_PK) {
   console.error(
@@ -102,7 +152,7 @@ async function tick(): Promise<void> {
 async function main(): Promise<void> {
   const net = await provider.getNetwork();
   console.log(
-    `[auto-settler] start — RPC=${RPC} chainId=${net.chainId} AuctionHouse=${AUCTION_HOUSE} poll=${POLL_MS}ms`,
+    `[auto-settler] start — RPC=${RPC} chainId=${net.chainId} AuctionHouse=${AUCTION_HOUSE} (source=${AUCTION_HOUSE_SOURCE}) poll=${POLL_MS}ms`,
   );
 
   while (!stopping) {


### PR DESCRIPTION
## 概要

`packages/niji-contracts/scripts/anvil-auto-settler.ts` の AUCTION_HOUSE default を deploy log (`packages/niji-contracts/deploy/localhost-*-full.json` の最新) からの動的取得に変更した。 PR #193 で SDK gen.ts に入れた address sync と同じ pattern で auto-settler 側も drift を解消する。

## 課題

旧実装は AUCTION_HOUSE default に古 hardcode `0x1Dbbf529D78d6507B0dd71F6c02f41138d828990` を使用していたが、 `deploy-niji-full` は anvil 上で毎回別 address に deploy されるため、 env 未指定で auto-settler を起動すると存在しない contract を polling して silently no-op していた。 結果 dev e2e で auction が時間進行で settle されず、 chain-past-auctions の navigation 系 spec (TC-002/003/005/008/010) が auction #0 一つだけの state で fail する原因の一つになっていた。

## 詳細

```mermaid
graph LR
    A[deploy-niji-full] -->|address 書き出し| B[deploy/localhost-*.json]
    B -->|loadLatestAuctionHouseFromDeployLog| C[anvil-auto-settler]
    D[env AUCTION_HOUSE] -.->|明示指定時のみ| C
    C -->|source=deploy-log or env を log 出力| E[起動時に出典が見える]
```

## 解決方法

3 点の改修。

- `loadLatestAuctionHouseFromDeployLog()` を追加し、 最新 deploy log の `contracts.NijiAuctionHouseProxy` を読む
- env `AUCTION_HOUSE` 明示指定は最優先 (override 維持)、 未指定なら deploy log を使う、 どちらも解決不可なら起動失敗で原因を明示
- 起動 log に source (`env` / `deploy-log`) を併記し挙動を可視化

CommonJS module 配下のため `__dirname` global を使用 (`import.meta.url` は CommonJS では undefined になる)。

## 検証

| 経路 | 結果 |
|---|---|
| `source=deploy-log` | `AuctionHouse=0xa79E2BDa2F900A3856a5502FE5f06F13bC7Ac843 (source=deploy-log)` (最新 deploy 値) |
| `source=env` | `AuctionHouse=0xDEAD...EEEF (source=env)` (env 明示指定が log に反映) |
| typecheck (`pnpm exec tsc --noEmit`) | 既存 type errors (sharp / 旧 Nouns→Niji 名残) のみで本 patch 起因なし |

## 受入条件

- [x] auto-settler の AUCTION_HOUSE が deploy 結果と一致
- [x] env 明示指定は引き続き有効 (override 維持)
- [x] PR 作成

## 関連

- 前提 PR ... #193 (Issue #192、 SDK 31337 address sync)
- 後続 Issue ... #197 (chain-past-auctions navigation 系 5 TC を seed-driven 化)
- 発覚経路 ... Issue #178 / #180 の e2e 走行中に auto-settler が古 address で silently no-op していることが判明

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
