### PR TITLE
🧪 test(webapp): chain-past-auctions navigation 系 5 TC を seed-driven に書き換え (Issue #197)

### DIFF
--- a/packages/niji-webapp/tests/e2e/chain-past-auctions.spec.ts
+++ b/packages/niji-webapp/tests/e2e/chain-past-auctions.spec.ts
@@ -15,7 +15,7 @@
 import { expect } from '@playwright/test';
 import { dappE2eTest as test } from '@kiwa-test/core';
 
-import { increaseTime, revertChain, snapshotChain } from './helpers/chain';
+import { increaseTime, revertChain, seedPastAuctions, snapshotChain } from './helpers/chain';
 
 const CHAIN_HOOK_POLL_MS = 11_000;
 
@@ -48,40 +48,56 @@ test.describe('chain-past-auctions (subgraph 未起動 fallback)', () => {
   });
 
   test('TC-002 状態遷移: 前ボタン 1 回で過去 Niji へ遷移', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
-    await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+    const snapId = await snapshotChain();
+    try {
+      // navigation 系は過去 auction >= 1 件が前提。 seed で 1 件 settle 進めて
+      // ←ボタンが active になる状態を作る (Issue #197)。
+      await seedPastAuctions(1);
 
-    const before = page.url();
-    const leftArrow = page.getByRole('button', { name: '←' }).first();
-    await leftArrow.waitFor({ timeout: 5_000 });
-    await leftArrow.click();
-    await page.waitForTimeout(1_500);
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+      await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
 
-    expect(page.url()).not.toBe(before);
-    expect(page.url()).toMatch(/\/niji\/\d+$/);
+      const before = page.url();
+      const leftArrow = page.getByRole('button', { name: '←' }).first();
+      await leftArrow.waitFor({ timeout: 5_000 });
+      await leftArrow.click();
+      await page.waitForTimeout(1_500);
 
-    const hasSvgImg = await page.evaluate(() =>
-      Array.from(document.querySelectorAll('img')).some(
-        i => i.src.startsWith('data:image/svg+xml;base64,') && i.src.length > 1000,
-      ),
-    );
-    expect(hasSvgImg).toBe(true);
+      expect(page.url()).not.toBe(before);
+      expect(page.url()).toMatch(/\/niji\/\d+$/);
+
+      const hasSvgImg = await page.evaluate(() =>
+        Array.from(document.querySelectorAll('img')).some(
+          i => i.src.startsWith('data:image/svg+xml;base64,') && i.src.length > 1000,
+        ),
+      );
+      expect(hasSvgImg).toBe(true);
+    } finally {
+      await revertChain(snapId);
+    }
   });
 
   test('TC-003 状態遷移: 次ボタンで最新 Niji に戻る', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
-    await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+    const snapId = await snapshotChain();
+    try {
+      await seedPastAuctions(1);
 
-    await page.getByRole('button', { name: '←' }).first().click();
-    await page.waitForTimeout(1_500);
-    const prevUrl = page.url();
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+      await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
 
-    await page.getByRole('button', { name: '→' }).first().click();
-    await page.waitForTimeout(1_500);
+      await page.getByRole('button', { name: '←' }).first().click();
+      await page.waitForTimeout(1_500);
+      const prevUrl = page.url();
 
-    expect(page.url()).not.toBe(prevUrl);
+      await page.getByRole('button', { name: '→' }).first().click();
+      await page.waitForTimeout(1_500);
+
+      expect(page.url()).not.toBe(prevUrl);
+    } finally {
+      await revertChain(snapId);
+    }
   });
 
   test('TC-004 正常系: /niji/0 直接 navigate で Nijider 枠が描画', async ({ page }) => {
@@ -110,24 +126,32 @@ test.describe('chain-past-auctions (subgraph 未起動 fallback)', () => {
   });
 
   test('TC-005 状態遷移: 前ボタン 3 連打で連続して過去 Niji へ', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
-    await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+    const snapId = await snapshotChain();
+    try {
+      // 3 連打分の遷移を確認するため過去 auction を 3 件 seed
+      await seedPastAuctions(3);
 
-    let lastUrl = page.url();
-    let movements = 0;
-    const leftArrow = page.getByRole('button', { name: '←' }).first();
-    for (let i = 0; i < 3; i++) {
-      const disabled = await leftArrow.isDisabled().catch(() => true);
-      if (disabled) break;
-      await leftArrow.click();
-      await page.waitForTimeout(1_500);
-      if (page.url() !== lastUrl) {
-        movements++;
-        lastUrl = page.url();
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+      await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+
+      let lastUrl = page.url();
+      let movements = 0;
+      const leftArrow = page.getByRole('button', { name: '←' }).first();
+      for (let i = 0; i < 3; i++) {
+        const disabled = await leftArrow.isDisabled().catch(() => true);
+        if (disabled) break;
+        await leftArrow.click();
+        await page.waitForTimeout(1_500);
+        if (page.url() !== lastUrl) {
+          movements++;
+          lastUrl = page.url();
+        }
       }
+      expect(movements).toBeGreaterThanOrEqual(1);
+    } finally {
+      await revertChain(snapId);
     }
-    expect(movements).toBeGreaterThanOrEqual(1);
   });
 
   test('TC-006 境界値: /niji/0 で前ボタンが disabled', async ({ page }) => {
@@ -151,45 +175,59 @@ test.describe('chain-past-auctions (subgraph 未起動 fallback)', () => {
   });
 
   test('TC-008 UI feature 網羅: ArrowLeft キーで navigation', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
-    await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+    const snapId = await snapshotChain();
+    try {
+      await seedPastAuctions(1);
 
-    const before = page.url();
-    await page.keyboard.press('ArrowLeft');
-    await page.waitForTimeout(1_500);
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+      await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
 
-    // AuctionNavigation の useCallback は first key で空 navigate→次キーで実遷移する hack を
-    // 持つので 2 回押す
-    if (page.url() === before) {
+      const before = page.url();
       await page.keyboard.press('ArrowLeft');
       await page.waitForTimeout(1_500);
+
+      // AuctionNavigation の useCallback は first key で空 navigate→次キーで実遷移する hack を
+      // 持つので 2 回押す
+      if (page.url() === before) {
+        await page.keyboard.press('ArrowLeft');
+        await page.waitForTimeout(1_500);
+      }
+      expect(page.url()).toMatch(/\/niji\/\d+$/);
+    } finally {
+      await revertChain(snapId);
     }
-    expect(page.url()).toMatch(/\/niji\/\d+$/);
   });
 
   test('TC-010 冪等性: 直接 URL と前ボタン経由で同一 Niji を描画', async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
-    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
-    await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+    const snapId = await snapshotChain();
+    try {
+      await seedPastAuctions(1);
 
-    // 前ボタンで 1 つ戻った URL を取得
-    await page.getByRole('button', { name: '←' }).first().click();
-    await page.waitForTimeout(1_500);
-    const viaPrev = page.url();
-    const match = viaPrev.match(/\/niji\/(\d+)$/);
-    expect(match).not.toBeNull();
+      await page.goto('/', { waitUntil: 'domcontentloaded' });
+      await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+      await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
 
-    // 直接 URL navigate
-    await page.goto(viaPrev, { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+      // 前ボタンで 1 つ戻った URL を取得
+      await page.getByRole('button', { name: '←' }).first().click();
+      await page.waitForTimeout(1_500);
+      const viaPrev = page.url();
+      const match = viaPrev.match(/\/niji\/(\d+)$/);
+      expect(match).not.toBeNull();
 
-    const hasSvgImg = await page.evaluate(() =>
-      Array.from(document.querySelectorAll('img')).some(
-        i => i.src.startsWith('data:image/svg+xml;base64,') && i.src.length > 1000,
-      ),
-    );
-    expect(hasSvgImg).toBe(true);
+      // 直接 URL navigate
+      await page.goto(viaPrev, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(CHAIN_HOOK_POLL_MS);
+
+      const hasSvgImg = await page.evaluate(() =>
+        Array.from(document.querySelectorAll('img')).some(
+          i => i.src.startsWith('data:image/svg+xml;base64,') && i.src.length > 1000,
+        ),
+      );
+      expect(hasSvgImg).toBe(true);
+    } finally {
+      await revertChain(snapId);
+    }
   });
 
   // TC-011 は anvil chain time を進めて auto-settler の settle 動作を観察する。

--- a/packages/niji-webapp/tests/e2e/helpers/chain.ts
+++ b/packages/niji-webapp/tests/e2e/helpers/chain.ts
@@ -197,3 +197,32 @@ export async function readAuction() {
     functionName: 'auctionStorage',
   })) as readonly [bigint, number, bigint, number, number, `0x${string}`, boolean];
 }
+
+/**
+ * 過去 auction を n 件 settle 済の状態に進める helper。 各 settle で
+ *
+ *   1) auction の endTime を 5s 越えるまで chain 時計を warp
+ *   2) deployer wallet から settleCurrentAndCreateNewAuction を呼ぶ
+ *   3) tx receipt 待ち
+ *
+ * を繰り返し、 chain 上に過去 N 件 + 現在 active 1 件の auction を準備する。
+ * 呼出側は snapshot/revert と組み合わせて test 範囲内に閉じる前提。
+ *
+ * @param n 進める settle 回数 (= 生成される過去 auction の件数)
+ */
+export async function seedPastAuctions(n: number): Promise<void> {
+  if (n <= 0) return;
+  const { client } = makeWallet(ANVIL_KEYS.deployer);
+  for (let i = 0; i < n; i++) {
+    const [, , , , endTime] = await readAuction();
+    const now = Number((await publicClient.getBlock()).timestamp);
+    const delta = endTime > now ? endTime - now + 5 : 5;
+    await increaseTime(delta);
+    const tx = await client.writeContract({
+      address: ADDRESSES.AuctionHouseProxy,
+      abi: auctionAbi,
+      functionName: 'settleCurrentAndCreateNewAuction',
+    });
+    await publicClient.waitForTransactionReceipt({ hash: tx });
+  }
+}


### PR DESCRIPTION
## 概要

`packages/niji-webapp/tests/e2e/chain-past-auctions.spec.ts` の navigation 系 5 TC (TC-002 / TC-003 / TC-005 / TC-008 / TC-010) を、 「auction 多数生成済」 を暗黙の前提とする fragile 構造から、 `seedPastAuctions(n)` helper 経由で test 内に必要件数を準備する seed-driven 設計に書き換えた。

## 課題

これら 5 TC は ← / → ボタン navigation や ArrowLeft キー操作を検証する design で、 auction が 2 件以上存在する state を前提にしていた。 deploy 直後 (auction #0 のみ) では ← ボタンが disabled で fail し、 auto-settler が長く走った state でしか pass しない fragile な test だった。

## 詳細

```mermaid
graph LR
    A[test start] --> B[snapshotChain]
    B --> C[seedPastAuctions n]
    C --> D[navigation 検証]
    D --> E[revertChain]
```

5 TC を snapshot/revert で test 範囲内に閉じる pattern (既存 TC-011 と同 pattern) に統一。

- TC-002 / TC-003 / TC-008 / TC-010 ... `seedPastAuctions(1)` で 1 件 settle
- TC-005 (前ボタン 3 連打) ... `seedPastAuctions(3)` で 3 件 settle

`seedPastAuctions` helper は `helpers/chain.ts` に追加し、 内部で `increaseTime` (endTime 越え warp) + `settleCurrentAndCreateNewAuction` 呼出を n 回繰り返す。

## 検証

| 項目 | 結果 |
|---|---|
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| 5 TC 設計 contract (snapshot/revert + seed-driven 独立化) | 充足 |

## 既知の制約 (PR scope 外)

4 round 連続 PASS 検証は本 PR 時点で未完了。 原因は **webapp wagmi `usePublicClient()` の transport.url が `http://127.0.0.1:8545` を見ているのに anvil は 8547 で起動している port mismatch** で、 chain-past-auctions 全 12 TC が ECONNREFUSED で fail している。 これは #197 scope を超える既存問題で、 Issue #199 で別途修正する。 #199 merge 後に本 spec で 4 round flaky 0 検証を改めて行う。

## 受入条件

- [x] TC-002 / TC-003 / TC-005 / TC-008 / TC-010 を seed-driven + snapshot/revert で書き換え
- [x] 他 chain-past-auctions spec (TC-001/004/006/007/011/012/013) の挙動は維持 (touch なし)
- [x] PR 作成
- [ ] 4 round 連続 PASS で flaky 0 (Issue #199 解消後に再検証)

## 関連

- 前提 PR ... #194 (Issue #178、 snapshot/revert pattern 確立)、 #198 (Issue #196、 auto-settler address sync)
- 関連 Issue ... #199 (本 PR の 4 round 検証 blocker)

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
