### PR TITLE
🐛 fix(webapp): viem hardhat chain default rpcUrls を ANVIL_RPC_URL で override (Issue #199)

### DIFF
--- a/packages/niji-webapp/src/wagmi.ts
+++ b/packages/niji-webapp/src/wagmi.ts
@@ -1,10 +1,22 @@
 import { find, pipe } from 'remeda';
+import { defineChain } from 'viem';
 import { createConfig, createStorage, http, fallback, webSocket } from 'wagmi';
-import { baseSepolia, hardhat } from 'wagmi/chains';
+import { baseSepolia, hardhat as viemHardhat } from 'wagmi/chains';
 import { coinbaseWallet, injected, walletConnect } from 'wagmi/connectors';
 
 import { CHAIN_ID, WALLET_CONNECT_V2_PROJECT_ID } from './config';
 import { ANVIL_RPC_URL } from './constants/anvil';
+
+// viem 標準 hardhat chain は rpcUrls.default.http = ['http://127.0.0.1:8545'] 固定だが、
+// Niji webapp は anvil を 8547 で起動するため、 wagmi が hardhat chain を chain registry
+// から resolve するときに 8545 を見て ECONNREFUSED を起こす。 chain registry 側の
+// rpcUrls を ANVIL_RPC_URL に override した local 版 hardhat に差し替えて root cause 解消。
+const hardhat = defineChain({
+  ...viemHardhat,
+  rpcUrls: {
+    default: { http: [ANVIL_RPC_URL] },
+  },
+});
 
 // Niji webapp は dev (anvil 31337) と prod (Base Sepolia 84532) の 2 chain のみを
 // サポートする。 旧 Nouns 由来の mainnet / sepolia 設定は撤廃。


### PR DESCRIPTION
## 概要

webapp の `usePublicClient()` が返す client の transport が `http://127.0.0.1:8545` を見て ECONNREFUSED していた問題を修正。 viem 標準 hardhat chain (default `rpcUrls.default.http[0] = 'http://127.0.0.1:8545'`) を `defineChain` で override し、 ANVIL_RPC_URL (8547) を default 化した。

## 課題

`packages/niji-webapp/src/wagmi.ts` の transports は `http(import.meta.env.VITE_HARDHAT_JSONRPC ?? ANVIL_RPC_URL)` で URL 指定済だったが、 viem `http()` transport は `url || chain?.rpcUrls.default.http[0]` の logic で url が falsy 時に chain.rpcUrls にフォールバックする。 wagmi の publicClient 内部 path で transport が `chain.rpcUrls` を見る経路があり、 結果 chain-past-auctions の chain hook が 8545 へ request して ECONNREFUSED で永遠 retry。 chain-past-auctions e2e の全 12 TC が壊れる原因。

## 詳細

```mermaid
graph LR
    A[viem hardhat default] -->|rpcUrls.default = 8545| B[publicClient transport.url]
    C[Niji anvil] -->|起動 port = 8547| D[実 RPC endpoint]
    B -.ECONNREFUSED.-> D
    E[defineChain override] -->|rpcUrls.default = ANVIL_RPC_URL| B
```

viem の `http()` transport 実装 (検証済 `node_modules/.pnpm/viem@2.33.0/.../clients/transports/http.js`)。

```js
const url_ = url || chain?.rpcUrls.default.http[0];
```

URL 引数が明示されていても wagmi 内部の create paths で `chain.rpcUrls` が見られる場面があり、 chain registry 側を整える必要があった。

## 解決方法

`viemHardhat` を import 時 alias 化し、 `defineChain({ ...viemHardhat, rpcUrls: { default: { http: [ANVIL_RPC_URL] } } })` で chain registry 側の default URL も 8547 に上書きした local 版 hardhat に差し替える。 transport の URL 引数と chain.rpcUrls の両方で 8547 を見る形にして root cause 解消。

## 検証

| 項目 | 結果 |
|---|---|
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| webapp 内 window dump (`SUPPORTED_CHAINS[0].rpcUrls.default.http`) | `["http://127.0.0.1:8547"]` 確認済 |

実 e2e (chain-past-auctions 全 12 TC) の green 化は anvil / webapp / auto-settler を全 restart した clean state で要確認。 PR #200 (Issue #197) の 4 round flaky 0 検証は本 PR merge + 環境 restart 後に再走する。

## 受入条件

- [x] `usePublicClient().transport.url` 系の経路で ANVIL_RPC_URL (8547) を返す chain 設定が宣言された
- [ ] chain-past-auctions TC-001 / TC-004 / TC-013 等が PASS (環境 restart 後に検証)
- [x] PR 作成

## 関連

- 発覚経路 ... Issue #197 (chain-past-auctions navigation 系 seed-driven 化) e2e debug 中
- 関連 Issue / PR ... #200 (Issue #197、 本 PR merge + 環境 restart 後に 4 round 検証)

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
