### PR TITLE
🗑️ refactor(niji-webapp): react-stepz (メンテ停止 dep) を削除 (Issue #150)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -83,7 +83,6 @@
     "react-redux": "^9.0.0",
     "react-router": "^7.6.2",
     "react-router-dom": "^7.6.0",
-    "react-stepz": "^1.0.2",
     "react-swipeable": "^7.0.0",
     "react-tooltip": "^4.5.1",
     "react-transition-group": "^4.4.5",

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
@@ -8,7 +8,6 @@ import { Col, FormControl, FormGroup, InputGroup, Row } from 'react-bootstrap';
 import { encodeFunctionData, getAbiItem } from 'viem';
 
 import 'bs-custom-file-input';
-import 'react-stepz/dist/index.css';
 
 import ModalBottomButtonRow from '@/components/ModalBottomButtonRow';
 import ModalTitle from '@/components/ModalTitle';

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.tsx
@@ -16,7 +16,6 @@ import { buildEtherscanApiQuery } from '@/utils/etherscan';
 import { ProposalActionModalStepProps } from '../..';
 
 import 'bs-custom-file-input';
-import 'react-stepz/dist/index.css';
 
 const FunctionCallSelectFunctionStep: React.FC<ProposalActionModalStepProps> = props => {
   const { onNextBtnClick, onPrevBtnClick, state, setState } = props;

--- a/packages/niji-webapp/src/pages/CreateCandidate/index.tsx
+++ b/packages/niji-webapp/src/pages/CreateCandidate/index.tsx
@@ -7,7 +7,6 @@ import { nijiTokenBuyerAddress } from '@niji/sdk/react';
 import clsx from 'clsx';
 import { Alert, Button, Col } from 'react-bootstrap';
 import { Link } from 'react-router';
-import { withStepProgress } from 'react-stepz';
 import { toast } from 'sonner';
 import { formatEther } from 'viem';
 
@@ -269,4 +268,4 @@ const CreateCandidatePage = () => {
   );
 };
 
-export default withStepProgress(CreateCandidatePage);
+export default CreateCandidatePage;

--- a/packages/niji-webapp/src/pages/CreateProposal/index.tsx
+++ b/packages/niji-webapp/src/pages/CreateProposal/index.tsx
@@ -9,7 +9,6 @@ import { nijiLegacyTreasuryAddress, nijiTokenBuyerAddress } from '@niji/sdk/reac
 import clsx from 'clsx';
 import { Alert, Button, Col, Form } from 'react-bootstrap';
 import { Link } from 'react-router';
-import { withStepProgress } from 'react-stepz';
 import { filter } from 'remeda';
 import { toast } from 'sonner';
 import { useAccount } from 'wagmi';
@@ -359,4 +358,4 @@ const CreateProposalPage = () => {
   );
 };
 
-export default withStepProgress(CreateProposalPage);
+export default CreateProposalPage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -652,9 +652,6 @@ importers:
       react-router-dom:
         specifier: ^7.6.0
         version: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react-stepz:
-        specifier: ^1.0.2
-        version: 1.0.2(react@19.1.0)
       react-swipeable:
         specifier: ^7.0.0
         version: 7.0.2(react@19.1.0)
@@ -12884,12 +12881,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react-stepz@1.0.2:
-    resolution: {integrity: sha512-vGST7yNBDVtE9wDRyM1vwrQAikzaD91lnVq2aKHmfdvHAwrJKzUjNWI3nZrI4jFlPUaLDwc5zRlyJEq0YoKtug==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^16.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -31457,11 +31448,6 @@ snapshots:
       set-cookie-parser: 2.7.1
     optionalDependencies:
       react-dom: 19.1.0(react@19.1.0)
-
-  react-stepz@1.0.2(react@19.1.0):
-    dependencies:
-      react: 19.1.0
-      tiny-invariant: 1.3.3
 
   react-style-singleton@2.2.3(@types/react@19.1.8)(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## 概要

`react-stepz@^1.0.2` (npm で 2 年以上更新なし、 React 16 peer 固定で React 19 不互換) を削除した。 webapp 内 実使用は HOC wrap 2 file + CSS import 2 file の合計 4 file のみで、 自作代替 component の追加は不要と判断 (`useStepProgress` / `StepProgressBar` / `Step` の consumer が 0 件、 HOC は何の効果も生んでいない dead wrap)。

## 課題

`withStepProgress(Component)` は内部で `<StepProgress>` context provider を提供するが、 webapp 内に `useStepProgress` を呼ぶ consumer が存在しない。 CSS の class (`._thGid` 等) も scoped で webapp から参照不能。 つまり 4 file 全部が dead use。

```mermaid
graph LR
    A[withStepProgress wrap] -->|context 提供| B[Provider]
    B -.|consumer 0 件|.-> X[useStepProgress 未使用]
    C[react-stepz CSS] -->|scoped class| Y[参照不能]
```

## 解決方法

- `CreateProposal/index.tsx` ... `import { withStepProgress }` 削除 + `export default withStepProgress(...)` → `export default CreateProposalPage`
- `CreateCandidate/index.tsx` ... 同上
- `FunctionCallEnterArgsStep/index.tsx` ... `import 'react-stepz/dist/index.css'` 削除
- `FunctionCallSelectFunctionStep/index.tsx` ... 同上
- `package.json` ... `react-stepz` devDeps から削除、 lockfile 再生成

## 検証

| 項目 | 結果 |
|---|---|
| pnpm install | react-stepz の peer warning (react@^16) が消滅 |
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| vitest (`pnpm test`) | 30 tests PASS / 1 todo |
| build (`pnpm build`) | 29.37s 成功 |

## 受入条件

- [x] `react-stepz` を package.json から削除
- [x] `grep -rn "react-stepz" packages/niji-webapp/src/` 結果 0 件
- [x] typecheck / vitest / build 通過

## 関連

- Issue #25 (不要依存削除、 同類)
- PR #203 (Issue #151、 react-diff-viewer 移行、 同 series)

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
