### PR TITLE
🗑️ refactor(niji-webapp): react-tooltip v4 削除 + @radix-ui/react-tooltip に統一 (Issue #149)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -84,7 +84,6 @@
     "react-router": "^7.6.2",
     "react-router-dom": "^7.6.0",
     "react-swipeable": "^7.0.0",
-    "react-tooltip": "^4.5.1",
     "react-transition-group": "^4.4.5",
     "redux": "^5.0.1",
     "redux-devtools-extension": "^2.13.9",

--- a/packages/niji-webapp/src/components/HoverCard.tsx
+++ b/packages/niji-webapp/src/components/HoverCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import ReactTooltip from 'react-tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface HoverCardProps {
   hoverCardContent: (dataTip: string) => React.ReactNode;
@@ -10,21 +10,17 @@ interface HoverCardProps {
 }
 
 const HoverCard: React.FC<HoverCardProps> = props => {
-  const { hoverCardContent, tip, id } = props;
+  const { hoverCardContent, tip } = props;
 
   return (
-    <>
-      <ReactTooltip
-        id={id}
-        arrowColor={'rgba(0,0,0,0)'}
-        className="!box-border !h-fit !w-max !min-w-[217px] !rounded-xl !border !border-gray-200 !bg-white !text-black !shadow-sm"
-        effect={'solid'}
-        getContent={hoverCardContent}
-      />
-      <div data-tip={tip} data-for={id}>
-        {props.children}
-      </div>
-    </>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span>{props.children}</span>
+      </TooltipTrigger>
+      <TooltipContent className="!box-border !h-fit !w-max !min-w-[217px] !rounded-xl !border !border-gray-200 !bg-white !text-black !shadow-sm">
+        {hoverCardContent(tip)}
+      </TooltipContent>
+    </Tooltip>
   );
 };
 

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
@@ -5,13 +5,13 @@ import React from 'react';
 
 import { Trans } from '@lingui/react/macro';
 import { nijiGovernorAddress } from '@niji/sdk/react';
-import ReactTooltip from 'react-tooltip';
 
 import ModalBottomButtonRow from '@/components/ModalBottomButtonRow';
 import ModalLabel from '@/components/ModalLabel';
 import ModalTextPrimary from '@/components/ModalTextPrimary';
 import ModalTitle from '@/components/ModalTitle';
 import ShortAddress from '@/components/ShortAddress';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import useStreamPaymentTransactions from '@/hooks/useStreamPaymentTransactions';
 import {
   formatTokenAmount,
@@ -45,14 +45,6 @@ const StreamPaymentsReviewStep: React.FC<FinalProposalActionStepProps> = props =
 
   return (
     <>
-      <ReactTooltip
-        id={'address-tooltip'}
-        effect={'solid'}
-        className={classes.hover}
-        getContent={() => {
-          return state.address;
-        }}
-      />
       <ModalTitle>
         <Trans>Review Streaming Payment Action</Trans>
       </ModalTitle>
@@ -70,9 +62,14 @@ const StreamPaymentsReviewStep: React.FC<FinalProposalActionStepProps> = props =
         <Trans>To</Trans>
       </ModalLabel>
       <ModalTextPrimary>
-        <span data-for="address-tooltip" data-tip="address">
-          <ShortAddress address={state.address} />
-        </span>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <ShortAddress address={state.address} />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className={classes.hover}>{state.address}</TooltipContent>
+        </Tooltip>
       </ModalTextPrimary>
 
       <ModalLabel>

--- a/packages/niji-webapp/src/pages/Vote/index.tsx
+++ b/packages/niji-webapp/src/pages/Vote/index.tsx
@@ -16,7 +16,6 @@ import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
 import { Button, Card, Col, Row, Spinner } from 'react-bootstrap';
 import { Link, useParams } from 'react-router';
-import ReactTooltip from 'react-tooltip';
 import { isNonNullish } from 'remeda';
 import { toast } from 'sonner';
 import { zeroAddress } from 'viem';
@@ -27,6 +26,7 @@ import ProposalContent from '@/components/ProposalContent';
 import ProposalHeader from '@/components/ProposalHeader';
 import ShortAddress from '@/components/ShortAddress';
 import StreamWithdrawModal from '@/components/StreamWithdrawModal';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import VoteCard, { VoteCardVariant } from '@/components/VoteCard';
 import VoteModal from '@/components/VoteModal';
 import VoteSignals from '@/components/VoteSignals/VoteSignals';
@@ -710,32 +710,36 @@ const VotePage = () => {
                       <Trans>Threshold</Trans>
                     </h1>
                   </div>
-                  {isV2Prop && (
-                    <ReactTooltip
-                      id={'view-dq-info'}
-                      className={classes.delegateHover}
-                      getContent={() => {
-                        return <Trans>View Threshold Info</Trans>;
-                      }}
-                    />
+                  {isV2Prop ? (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <div
+                          onClick={() => setShowDynamicQuorumInfoModal(true)}
+                          className={clsx(classes.thresholdInfo, classes.cursorPointer)}
+                        >
+                          <span>
+                            <Trans>Current Threshold</Trans>
+                          </span>
+                          <h3>
+                            <Trans>{i18n.number(Number(currentQuorum ?? 0))} votes</Trans>
+                            <SearchIcon className={cn(classes.dqIcon, 'inline-block')} />
+                          </h3>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent className={classes.delegateHover}>
+                        <Trans>View Threshold Info</Trans>
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <div className={classes.thresholdInfo}>
+                      <span>
+                        <Trans>Threshold</Trans>
+                      </span>
+                      <h3>
+                        <Trans>{proposal.quorumVotes} votes</Trans>
+                      </h3>
+                    </div>
                   )}
-                  <div
-                    data-for="view-dq-info"
-                    data-tip="View Dynamic Quorum Info"
-                    onClick={() => setShowDynamicQuorumInfoModal(isV2Prop)}
-                    className={clsx(classes.thresholdInfo, isV2Prop ? classes.cursorPointer : '')}
-                  >
-                    <span>
-                      {isV2Prop ? <Trans>Current Threshold</Trans> : <Trans>Threshold</Trans>}
-                    </span>
-                    <h3>
-                      <Trans>
-                        {isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes}{' '}
-                        votes
-                      </Trans>
-                      {isV2Prop && <SearchIcon className={cn(classes.dqIcon, 'inline-block')} />}
-                    </h3>
-                  </div>
                 </div>
               </Card.Body>
             </Card>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -655,9 +655,6 @@ importers:
       react-swipeable:
         specifier: ^7.0.0
         version: 7.0.2(react@19.1.0)
-      react-tooltip:
-        specifier: ^4.5.1
-        version: 4.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -12897,13 +12894,6 @@ packages:
     peerDependencies:
       react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
 
-  react-tooltip@4.5.1:
-    resolution: {integrity: sha512-Zo+CSFUGXar1uV+bgXFFDe7VeS2iByeIp5rTgTcc2HqtuOS5D76QapejNNfx320MCY91TlhTQat36KGFTqgcvw==}
-    engines: {npm: '>=6.13'}
-    peerDependencies:
-      react: '>=16.0.0'
-      react-dom: '>=16.0.0'
-
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
@@ -14919,11 +14909,6 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -31461,13 +31446,6 @@ snapshots:
     dependencies:
       react: 19.1.0
 
-  react-tooltip@4.5.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      uuid: 7.0.3
-
   react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.4
@@ -33834,8 +33812,6 @@ snapshots:
   uuid@2.0.1: {}
 
   uuid@3.4.0: {}
-
-  uuid@7.0.3: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
## 概要

`react-tooltip@^4.5.1` (EOL 気味、 React 19 互換性 risk) を削除し、 use 箇所 3 file を既存 `@radix-ui/react-tooltip` (shadcn wrap `components/ui/tooltip.tsx`) に統一した。 webapp は既に `@radix-ui/react-tooltip` を採用しており、 重複が解消された。

## 課題

`react-tooltip` v4 は 2022 年最終リリース、 React 19 で peer warning と runtime risk あり。 webapp 内に v5 移行 PR (API 大幅変更) を出すか、 既存 Radix Tooltip で統一するか選択肢があった。 重複解消の観点で Radix Tooltip 統一を採択。

```mermaid
graph LR
    A[react-tooltip v4] -->|EOL + React 19 不互換| X[削除]
    B[Radix Tooltip 既存 ui/tooltip] --> Y[統一 wrap]
    A -.置換.-> B
```

## 解決方法

- `HoverCard.tsx` ... `ReactTooltip` + `data-tip` / `data-for` 経路を `<Tooltip><TooltipTrigger asChild><TooltipContent>` Radix Tooltip に書き換え
- `StreamPaymentsReviewStep/index.tsx` ... `<ReactTooltip id="address-tooltip" />` + `data-for/data-tip` 紐づけを `ShortAddress` の wrap Tooltip に書き換え
- `Vote/index.tsx` ... `view-dq-info` tooltip を Radix Tooltip に置換、 isV2Prop 分岐を整理 (Tooltip wrap は isV2Prop 時のみ)
- `package.json` ... `react-tooltip` を依存から削除、 lockfile 再生成

`TooltipProvider` は `src/index.tsx:271` で既に root wrap 済のため追加 provider は不要。

## 検証

| 項目 | 結果 |
|---|---|
| pnpm install | react-tooltip の peer warning 消滅 |
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| vitest (`pnpm test`) | 30 tests PASS / 1 todo |
| build (`pnpm build`) | 35.91s 成功 |

## 受入条件

- [x] `react-tooltip` を package.json から削除
- [x] `grep -rn "from 'react-tooltip'" packages/niji-webapp/src/` 結果 0 件
- [x] typecheck / vitest / build 通過

## 関連

- Issue #25 (不要依存削除、 同類)
- PR #204 (Issue #150、 react-stepz 削除、 同 series)
- PR #203 (Issue #151、 react-diff-viewer 移行、 同 series)

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
