### PR TITLE
🗑️ refactor(niji-webapp): axios v0.30 (dead dep) を削除 (Issue #148)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -55,7 +55,6 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@wagmi/core": "catalog:",
     "abitype": "^1.0.8",
-    "axios": "^0.30.0",
     "bad-words": "^3.0.4",
     "blo": "^2.0.0",
     "bootstrap": "^5.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,9 +568,6 @@ importers:
       abitype:
         specifier: ^1.0.8
         version: 1.0.8(typescript@5.9.2)(zod@3.25.76)
-      axios:
-        specifier: '>=0.30.0'
-        version: 1.10.0
       bad-words:
         specifier: ^3.0.4
         version: 3.0.4
@@ -23549,14 +23546,6 @@ snapshots:
 
   aws4@1.11.0: {}
 
-  axios@1.10.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.3
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.10.0(debug@4.4.1):
     dependencies:
       follow-redirects: 1.15.9(debug@4.4.1)
@@ -26610,8 +26599,6 @@ snapshots:
   folder-walker@3.2.0:
     dependencies:
       from2: 2.3.0
-
-  follow-redirects@1.15.9: {}
 
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:


### PR DESCRIPTION
## 概要

`axios@^0.30.0` (5 年以上前の旧 major、 セキュリティ patch 来てない) を削除した。

## 課題

`axios@^0.30.0` は最新の v1.x ではない極めて古い版数で、 セキュリティ patch も停止状態。 webapp は既に TanStack Query (内部 fetch) + wagmi (内部 fetch / viem transport) を採用しており、 HTTP client 3 重化の余地もあった。

## 詳細

`grep -rln "axios" packages/niji-webapp/ | grep -v "node_modules|pnpm-lock"` の結果が **`package.json:58` 1 行のみ** で、 webapp 全域に import 0 件の dead dep だった。 fetch / TanStack / wagmi への置換は不要、 package.json から該当行を削除するだけで済んだ。

## 解決方法

- `packages/niji-webapp/package.json` の dependencies から `axios` を削除
- `pnpm install` で lockfile 再生成 (axios 関連 entry 除去)

## 検証

| 項目 | 結果 |
|---|---|
| pnpm install | 通過、 axios 関連 entry 除去 |
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| vitest (`pnpm test`) | 30 tests PASS / 1 todo |
| build (`pnpm build`) | 26.20s 成功 |

## 受入条件

- [x] `packages/niji-webapp/package.json` から `axios` 削除
- [x] `grep -rn "from 'axios'" packages/niji-webapp/src/` 結果 0 件
- [x] typecheck / vitest / build 通過

## 関連

- Issue #25 (不要依存削除、 同類)
- PR #202 (Issue #153、 graph-ts 削除、 同 series)
- PR #204 (Issue #150、 react-stepz 削除、 同 series)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
