### PR TITLE
🗑️ refactor(niji-webapp): @fortawesome/* (3 package + types) 削除 + lucide-react に統一 (Issue #152)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -30,9 +30,6 @@
     "not op_mini all"
   ],
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^6.7.0",
-    "@fortawesome/free-solid-svg-icons": "^6.7.0",
-    "@fortawesome/react-fontawesome": "^0.2.2",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@heroicons/react": "^1.0.6",
     "@lingui/core": "^5.9.0",
@@ -120,7 +117,6 @@
     "@types/pngjs": "^6.0.1",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
-    "@types/react-fontawesome": "^1.6.5",
     "@types/redux-logger": "^3.0.13",
     "@vitejs/plugin-react": "^5.0.0",
     "@vitest/browser-playwright": "^4.0.0",

--- a/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
+++ b/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
@@ -1,10 +1,9 @@
 import React, { ReactNode, useCallback, useEffect, useState, useMemo } from 'react';
 
-import { faCircleCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { MinusCircleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
+import { CheckCircle2, X } from 'lucide-react';
 import { FormControl, FormSelect, FormText, InputGroup, Spinner } from 'react-bootstrap';
 import { map } from 'remeda';
 
@@ -512,12 +511,8 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
                       <Spinner animation="border" />
                     </span>
                   )}
-                  {isApprovalTxSuccessful && (
-                    <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
-                  )}
-                  {approvalErrorMessage && (
-                    <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
-                  )}
+                  {isApprovalTxSuccessful && <CheckCircle2 height={20} width={20} color="green" />}
+                  {approvalErrorMessage && <X height={20} width={20} color="red" />}
                 </strong>
                 <Trans>Set approval</Trans>
               </li>
@@ -528,11 +523,9 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
                       <Spinner animation="border" />
                     </span>
                   )}
-                  {isTxSuccessful && (
-                    <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
-                  )}
+                  {isTxSuccessful && <CheckCircle2 height={20} width={20} color="green" />}
                   {(errorMessage || approvalErrorMessage) && (
-                    <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
+                    <X height={20} width={20} color="red" />
                   )}
                   {!(
                     isWaiting ||

--- a/packages/niji-webapp/src/components/AuctionActivity/index.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { nijiAuctionHouseAddress } from '@niji/sdk/react';
+import { Info } from 'lucide-react';
 import { Col, Row } from 'react-bootstrap';
 
 import AuctionActivityDateHeadline from '@/components/AuctionActivityDateHeadline';
@@ -138,7 +137,7 @@ const AuctionActivity: React.FC<AuctionActivityProps> = (props: AuctionActivityP
         {auctionEnded && (
           <Row className={classes.activityRow}>
             <Col lg={12} className={classes.nextNounLink}>
-              <FontAwesomeIcon icon={faInfoCircle} />
+              <Info className="inline-block h-4 w-4" />
               <a href={'/crystal-ball'} target={'_blank'} rel="noreferrer">
                 <Trans>Help mint the next Niji</Trans>
               </a>

--- a/packages/niji-webapp/src/components/CandidateSponsors/Signature.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/Signature.tsx
@@ -2,12 +2,11 @@ import type { Address } from '@/utils/types';
 
 import React, { useEffect } from 'react';
 
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { CheckCircle2 } from 'lucide-react';
 
 import ShortAddress from '@/components/ShortAddress';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
@@ -158,7 +157,7 @@ const Signature: React.FC<CandidateSignatureProps> = props => {
         {props.isUpdateToProposal && !props.isAccountSigner && (
           <p className={classes.sigStatus}>
             <span>
-              <FontAwesomeIcon icon={faCircleCheck} />
+              <CheckCircle2 className="inline-block h-4 w-4" />
             </span>
             <Trans>Re-signed</Trans>
           </p>

--- a/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx
@@ -1,11 +1,10 @@
 import { ReactNode, useCallback, useEffect, useState } from 'react';
 
-import { faCircleCheck, faXmark } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { nijiGovernorAddress } from '@niji/sdk/react';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
+import { CheckCircle2, X } from 'lucide-react';
 import { Spinner } from 'react-bootstrap';
 import {
   encodeAbiParameters,
@@ -428,11 +427,9 @@ const SignatureForm = (props: Readonly<SignatureFormProps>) => {
                       </span>
                     )}
                     {isGetSignatureTxSuccessful && (
-                      <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
+                      <CheckCircle2 height={20} width={20} color="green" />
                     )}
-                    {getSignatureErrorMessage && (
-                      <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
-                    )}
+                    {getSignatureErrorMessage && <X height={20} width={20} color="red" />}
                   </strong>
                   <Trans>Signature request</Trans>
                 </li>
@@ -443,11 +440,9 @@ const SignatureForm = (props: Readonly<SignatureFormProps>) => {
                         <Spinner animation="border" />
                       </span>
                     )}
-                    {isTxSuccessful && (
-                      <FontAwesomeIcon icon={faCircleCheck} height={20} width={20} color="green" />
-                    )}
+                    {isTxSuccessful && <CheckCircle2 height={20} width={20} color="green" />}
                     {(getSignatureErrorMessage || errorMessage) && (
-                      <FontAwesomeIcon icon={faXmark} height={20} width={20} color="red" />
+                      <X height={20} width={20} color="red" />
                     )}
                     {!(
                       isWaiting ||

--- a/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-import { faCircleCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
+import { CheckCircle2 } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { Link } from 'react-router';
 import { useAccount } from 'wagmi';
@@ -134,7 +133,7 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
       <div className={classes.wrapper}>
         {isThresholdMet && (
           <p className={classes.thresholdMet}>
-            <FontAwesomeIcon icon={faCircleCheck} /> Sponsor threshold met
+            <CheckCircle2 className="inline-block h-4 w-4" /> Sponsor threshold met
           </p>
         )}
         <div

--- a/packages/niji-webapp/src/components/LanguageSelectionModal/index.tsx
+++ b/packages/niji-webapp/src/components/LanguageSelectionModal/index.tsx
@@ -1,9 +1,8 @@
 import { FC } from 'react';
 
-import { faCheck } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { useAtom } from 'jotai/react';
+import { Check } from 'lucide-react';
 
 import Modal from '@/components/Modal';
 import { activeLocaleAtom } from '@/i18n/activeLocaleAtom';
@@ -34,9 +33,7 @@ const LanguageSelectionModal: FC<LanguageSelectionModalProps> = ({ onDismiss }) 
             }}
           >
             {LOCALE_LABEL[locale]}
-            {locale === activeLocale && (
-              <FontAwesomeIcon icon={faCheck} height={24} width={24} className={classes.icon} />
-            )}
+            {locale === activeLocale && <Check height={24} width={24} className={classes.icon} />}
           </div>
         );
       })}

--- a/packages/niji-webapp/src/components/NavBar/index.tsx
+++ b/packages/niji-webapp/src/components/NavBar/index.tsx
@@ -1,18 +1,10 @@
 import { useState } from 'react';
 
-import {
-  faFaucetDrip,
-  faFile,
-  faHouse,
-  faPenToSquare,
-  faPlay,
-  faUsers,
-} from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import { nijiTreasuryAddress, useReadNijiTreasuryBalancesInEth } from '@niji/sdk/react';
 import clsx from 'clsx';
 import { ConnectKitButton } from 'connectkit';
+import { Droplet, File, House, Play, SquarePen, Users } from 'lucide-react';
 import { Container, Dropdown, Nav, Navbar } from 'react-bootstrap';
 import { Link, useLocation } from 'react-router';
 import { formatEther } from 'viem';
@@ -74,7 +66,7 @@ const NavBar = () => {
   const v3DaoNavItem = (
     <NavDropdown
       buttonText="DAO"
-      buttonIcon={<FontAwesomeIcon icon={faUsers} />}
+      buttonIcon={<Users className="h-4 w-4" />}
       buttonStyle={nonWalletButtonStyle}
     >
       <Dropdown.Item
@@ -141,7 +133,7 @@ const NavBar = () => {
               <Nav.Link href="/lp/" className={classes.nounsNavLink} onClick={closeNav}>
                 <NavBarButton
                   buttonText={<Trans>LP</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faHouse} />}
+                  buttonIcon={<House className="h-4 w-4" />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>
@@ -154,7 +146,7 @@ const NavBar = () => {
                 >
                   <NavBarButton
                     buttonText={<Trans>Faucet</Trans>}
-                    buttonIcon={<FontAwesomeIcon icon={faFaucetDrip} />}
+                    buttonIcon={<Droplet className="h-4 w-4" />}
                     buttonStyle={nonWalletButtonStyle}
                   />
                 </Nav.Link>
@@ -162,7 +154,7 @@ const NavBar = () => {
               <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink} onClick={closeNav}>
                 <NavBarButton
                   buttonText={isDaoGteV3 ? <Trans>Proposals</Trans> : <Trans>DAO</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faFile} />}
+                  buttonIcon={<File className="h-4 w-4" />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>
@@ -177,7 +169,7 @@ const NavBar = () => {
                     >
                       <NavBarButton
                         buttonText={<Trans>Candidates</Trans>}
-                        buttonIcon={<FontAwesomeIcon icon={faPenToSquare} />}
+                        buttonIcon={<SquarePen className="h-4 w-4" />}
                         buttonStyle={nonWalletButtonStyle}
                       />
                     </Nav.Link>
@@ -194,7 +186,7 @@ const NavBar = () => {
               <Nav.Link href="/lp/" className={classes.nounsNavLink}>
                 <NavBarButton
                   buttonText={<Trans>LP</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faHouse} />}
+                  buttonIcon={<House className="h-4 w-4" />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>
@@ -202,7 +194,7 @@ const NavBar = () => {
                 <Nav.Link as={Link} to="/faucet" className={classes.nounsNavLink}>
                   <NavBarButton
                     buttonText={<Trans>Faucet</Trans>}
-                    buttonIcon={<FontAwesomeIcon icon={faFaucetDrip} />}
+                    buttonIcon={<Droplet className="h-4 w-4" />}
                     buttonStyle={nonWalletButtonStyle}
                   />
                 </Nav.Link>
@@ -213,7 +205,7 @@ const NavBar = () => {
                 <Nav.Link as={Link} to="/vote" className={classes.nounsNavLink} onClick={closeNav}>
                   <NavBarButton
                     buttonText={<Trans>DAO</Trans>}
-                    buttonIcon={<FontAwesomeIcon icon={faUsers} />}
+                    buttonIcon={<Users className="h-4 w-4" />}
                     buttonStyle={nonWalletButtonStyle}
                   />
                 </Nav.Link>
@@ -228,7 +220,7 @@ const NavBar = () => {
               >
                 <NavBarButton
                   buttonText={<Trans>Playground</Trans>}
-                  buttonIcon={<FontAwesomeIcon icon={faPlay} />}
+                  buttonIcon={<Play className="h-4 w-4" />}
                   buttonStyle={nonWalletButtonStyle}
                 />
               </Nav.Link>

--- a/packages/niji-webapp/src/components/NavBarButton/index.tsx
+++ b/packages/niji-webapp/src/components/NavBarButton/index.tsx
@@ -1,8 +1,7 @@
 import { FC, HTMLAttributes } from 'react';
 
-import { faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 
 import navDropdownClasses from '../NavBar/NavBarDropdown.module.css';
 
@@ -125,7 +124,11 @@ const NavBarButton: FC<NavBarButtonProps> = ({
                 isButtonUp === true ? navDropdownClasses.arrowUp : navDropdownClasses.arrowDown
               }
             >
-              <FontAwesomeIcon icon={isButtonUp === true ? faSortUp : faSortDown} />{' '}
+              {isButtonUp === true ? (
+                <ChevronUp className="inline-block h-4 w-4" />
+              ) : (
+                <ChevronDown className="inline-block h-4 w-4" />
+              )}{' '}
             </div>
           )}
         </div>

--- a/packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx
+++ b/packages/niji-webapp/src/components/NavLocaleSwitcher/index.tsx
@@ -1,10 +1,9 @@
 import React, { HTMLAttributes, useState } from 'react';
 
-import { faCheck, faGlobe, faSortDown, faSortUp } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import { useAtom } from 'jotai/react';
+import { Check, ChevronDown, ChevronUp, Globe } from 'lucide-react';
 import { Dropdown } from 'react-bootstrap';
 
 import LanguageSelectionModal from '@/components/LanguageSelectionModal';
@@ -94,10 +93,14 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
       >
         <div className={navDropdownClasses.button}>
           <div className={navDropdownClasses.dropdownBtnContent}>
-            {<FontAwesomeIcon icon={faGlobe} />}
+            <Globe className="inline-block h-4 w-4" />
           </div>
           <div className={buttonUp ? navDropdownClasses.arrowUp : navDropdownClasses.arrowDown}>
-            <FontAwesomeIcon icon={buttonUp ? faSortUp : faSortDown} />{' '}
+            {buttonUp ? (
+              <ChevronUp className="inline-block h-4 w-4" />
+            ) : (
+              <ChevronDown className="inline-block h-4 w-4" />
+            )}{' '}
           </div>
         </div>
       </div>
@@ -118,7 +121,7 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
       >
         <NavBarButton
           buttonText={<Trans>Language</Trans>}
-          buttonIcon={<FontAwesomeIcon icon={faGlobe} />}
+          buttonIcon={<Globe className="h-4 w-4" />}
           buttonStyle={buttonStyle}
         />
       </div>
@@ -161,9 +164,7 @@ const NavLocaleSwitcher: React.FC<NavLocalSwitcherProps> = props => {
                 onClick={() => setActiveLocale(locale)}
               >
                 {LOCALE_LABEL[locale]}
-                {activeLocale === locale && (
-                  <FontAwesomeIcon icon={faCheck} height={24} width={24} />
-                )}
+                {activeLocale === locale && <Check height={24} width={24} />}
               </div>
             );
           })}

--- a/packages/niji-webapp/src/components/SettleManuallyBtn/index.tsx
+++ b/packages/niji-webapp/src/components/SettleManuallyBtn/index.tsx
@@ -1,9 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
 
-import { faInfoCircle } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Trans } from '@lingui/react/macro';
 import dayjs from 'dayjs';
+import { Info } from 'lucide-react';
 
 import { Auction } from '@/wrappers/nijiAuction';
 
@@ -66,7 +65,7 @@ const SettleManuallyBtn: React.FC<{
           </>
         ) : (
           <>
-            <FontAwesomeIcon icon={faInfoCircle} />
+            <Info className="inline-block h-4 w-4" />
             {mins !== 0 ? (
               <Trans>You can settle manually in {mins + 1} minutes</Trans>
             ) : (

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalGroup.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalGroup.tsx
@@ -1,8 +1,7 @@
 import React, { useEffect } from 'react';
 
-import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import clsx from 'clsx';
+import { ChevronDown } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 
 import { VoteSignalDetail } from '@/wrappers/nijiData';
@@ -58,7 +57,7 @@ const VoteSignalGroup = (props: Props) => {
               ease: 'easeInOut',
             }}
           >
-            <FontAwesomeIcon icon={faChevronDown} />
+            <ChevronDown className="inline-block h-4 w-4" />
           </motion.div>
         )}
       </button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -493,15 +493,6 @@ importers:
 
   packages/niji-webapp:
     dependencies:
-      '@fortawesome/fontawesome-svg-core':
-        specifier: ^6.7.0
-        version: 6.7.2
-      '@fortawesome/free-solid-svg-icons':
-        specifier: ^6.7.0
-        version: 6.7.2
-      '@fortawesome/react-fontawesome':
-        specifier: ^0.2.2
-        version: 0.2.2(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.1.0)
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.11.0)
@@ -758,9 +749,6 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.1.6(@types/react@19.1.8)
-      '@types/react-fontawesome':
-        specifier: ^1.6.5
-        version: 1.6.8
       '@types/redux-logger':
         specifier: ^3.0.13
         version: 3.0.13
@@ -2191,28 +2179,9 @@ packages:
   '@formatjs/intl-localematcher@0.6.1':
     resolution: {integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==}
 
-  '@fortawesome/fontawesome-common-types@6.7.2':
-    resolution: {integrity: sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==}
-    engines: {node: '>=6'}
-
   '@fortawesome/fontawesome-free@6.7.2':
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
-
-  '@fortawesome/fontawesome-svg-core@6.7.2':
-    resolution: {integrity: sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    resolution: {integrity: sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==}
-    engines: {node: '>=6'}
-
-  '@fortawesome/react-fontawesome@0.2.2':
-    resolution: {integrity: sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==}
-    deprecated: v0.2.x is no longer supported. Unless you are still using FontAwesome 5, please update to v3.1.1 or greater.
-    peerDependencies:
-      '@fortawesome/fontawesome-svg-core': ~1 || ~6
-      react: '>=16.3'
 
   '@gql.tada/internal@1.0.8':
     resolution: {integrity: sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==}
@@ -5344,9 +5313,6 @@ packages:
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
       '@types/react': ^19.0.0
-
-  '@types/react-fontawesome@1.6.8':
-    resolution: {integrity: sha512-+dQ+4jccHraCd/FI4uSeY/O7c1RZ+wVASTgpCgbC6ijh1zSDsr0cb9XU3Dbfy5eJPyXq5QPp9W9RJTVRf+5+pA==}
 
   '@types/react-transition-group@4.4.12':
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
@@ -17598,23 +17564,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@fortawesome/fontawesome-common-types@6.7.2': {}
-
   '@fortawesome/fontawesome-free@6.7.2': {}
-
-  '@fortawesome/fontawesome-svg-core@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
-
-  '@fortawesome/free-solid-svg-icons@6.7.2':
-    dependencies:
-      '@fortawesome/fontawesome-common-types': 6.7.2
-
-  '@fortawesome/react-fontawesome@0.2.2(@fortawesome/fontawesome-svg-core@6.7.2)(react@19.1.0)':
-    dependencies:
-      '@fortawesome/fontawesome-svg-core': 6.7.2
-      prop-types: 15.8.1
-      react: 19.1.0
 
   '@gql.tada/internal@1.0.8(graphql@16.11.0)(typescript@5.9.2)':
     dependencies:
@@ -21812,10 +21762,6 @@ snapshots:
   '@types/range-parser@1.2.4': {}
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
-    dependencies:
-      '@types/react': 19.1.8
-
-  '@types/react-fontawesome@1.6.8':
     dependencies:
       '@types/react': 19.1.8
 


### PR DESCRIPTION
## 概要

`@fortawesome/fontawesome-svg-core` + `@fortawesome/free-solid-svg-icons` + `@fortawesome/react-fontawesome` の 3 package と `@types/react-fontawesome` (devDep) を削除し、 11 file の icon を既存 `lucide-react` (shadcn/ui default icon library) に置換した。 icon library 重複が解消され bundle 64 KB 削減。

## 詳細

`grep -rln "@fortawesome" packages/niji-webapp/src/` で webapp 内 11 file の use を特定。 各 icon を lucide-react 同等 icon に mapping。

| FontAwesome | Lucide |
|---|---|
| `faCircleCheck` | `CheckCircle2` |
| `faXmark` | `X` |
| `faChevronDown` / `faSortDown` | `ChevronDown` |
| `faSortUp` | `ChevronUp` |
| `faGlobe` | `Globe` |
| `faInfoCircle` | `Info` |
| `faHouse` | `House` |
| `faFaucetDrip` | `Droplet` |
| `faCheck` | `Check` |
| `faFile` | `File` |
| `faPenToSquare` | `SquarePen` |
| `faUsers` | `Users` |
| `faPlay` | `Play` |

各 use 箇所は `<FontAwesomeIcon icon={faX} height={N} width={N} />` 形式から `<X className="inline-block h-4 w-4" />` または `<X height={N} width={N} color="..." />` 形式に書き換え (既存 height/width 指定は維持、 lucide-react は同 props を受け取る)。

## 解決方法

- 11 file (CandidateSponsors 3 file / NavBar / VoteSignalGroup / NavLocaleSwitcher / NavBarButton / LanguageSelectionModal / AuctionActivity / AddNijisToForkModal / SettleManuallyBtn) で fortawesome import を削除 + lucide-react import 追加
- `package.json` ... 3 fortawesome package (deps) + `@types/react-fontawesome` (devDeps) を削除、 lockfile 再生成

## 検証

| 項目 | 結果 |
|---|---|
| pnpm install | fortawesome 関連 entry 全除去 |
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| vitest (`pnpm test`) | 30 tests PASS / 1 todo |
| build (`pnpm build`) | 28.61s 成功 |
| bundle size | 64 KB 削減 (33316 KB → 33252 KB) |

## 受入条件

- [x] `@fortawesome/*` 3 package + `@types/react-fontawesome` 削除
- [x] `grep -rn "fortawesome" packages/niji-webapp/src/` 結果 0 件
- [x] typecheck / vitest / build 通過

## 関連

- Issue #25 (不要依存削除、 同類)
- PR #207 (Issue #154、 react-transition-group 削除、 同 series)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
