### PR TITLE
🐛 fix(makefile): Makefile ANVIL_PORT を 8545 → 8547 に修正 (Issue #165 完結)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ WEBAPP_PID := $(LOG_DIR)/webapp.pid
 WEBAPP_ENV := $(ROOT)/packages/niji-webapp/.env
 WEBAPP_ENV_EXAMPLE := $(ROOT)/packages/niji-webapp/.env.example.local
 
-ANVIL_PORT := 8545
+ANVIL_PORT := 8547
 WEBAPP_PORT := 2424
 
 .PHONY: help dev dev-sepolia dev-fg dev-stop dev-status dev-logs setup setup-env install build anvil-bg webapp-bg


### PR DESCRIPTION
## 概要

repo root の Makefile 中 `ANVIL_PORT` が 8545 hardcode のまま残っており、 Niji webapp が想定する anvil port (8547) と drift していた。 1 行修正で同期する。

## 課題

PR #146 / PR #167 を経て webapp 側は anvil 8547 で運用しており、 関連設定もすべて 8547 に統一済。

- `packages/niji-webapp/src/constants/anvil.ts` ... `ANVIL_PORT = 8547`
- `packages/niji-webapp/src/wagmi.ts` ... PR #201 で hardhat chain rpcUrls を `ANVIL_RPC_URL` (8547) で override
- `.env.example.local` ... `VITE_HARDHAT_JSONRPC=http://127.0.0.1:8547`

Makefile が 8545 のままだと `make dev` で起動した anvil と webapp の port mismatch で webapp が contract を読めず、 chain-past-auctions / auction-render などが ECONNREFUSED で fail する。 Issue #199 / PR #201 で発覚した root cause と同系統の問題。

## 解決方法

`Makefile` 27 行目 `ANVIL_PORT := 8545` → `ANVIL_PORT := 8547` の 1 行修正。

## 検証

| 項目 | 結果 |
|---|---|
| `make help` 動作 | 通過、 URL 表示が `anvil http://127.0.0.1:8547 (chain id 31337)` に正しく更新 |

## 補足 (Issue #165 全体経緯)

Issue #165 の Makefile 本体は PR #167 経由で既に master に取り込み済 (commit 94febae2b)。 旧 PR #166 は base が `develop` で develop と master の divergent + 当時 `nouns-` 旧 path 多数 commit を含み rebase 不能。 本 PR は master ベースで Makefile の port 同期のみを修正、 Issue #165 を完結させる。

## 受入条件

- [x] `Makefile` `ANVIL_PORT` が 8547 (webapp と整合)
- [x] `make help` で正しい URL 表示

## 関連

- Issue #165 (Makefile 追加)、 PR #167 で本体 merge 済
- 旧 PR #166 (base develop、 rebase 不能で別 branch で置換)
- PR #201 (Issue #199、 viem hardhat chain rpcUrls override で 8547 同期)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
