### PR TITLE
🔄 refactor(webapp): pastAuctions slice を Jotai atom に移行 (Issue #213)

### DIFF
--- a/packages/niji-webapp/src/index.tsx
+++ b/packages/niji-webapp/src/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@niji/sdk/react';
 import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { useSetAtom } from 'jotai/react';
 import { createRoot } from 'react-dom/client';
 import { Provider as ReduxProvider } from 'react-redux';
 import { parseAbiItem } from 'viem';
@@ -30,6 +31,7 @@ import { useAppDispatch, useAppSelector } from './hooks';
 import { useChainPastAuctions } from './hooks/useChainPastAuctions';
 import { LanguageProvider } from './i18n/LanguageProvider';
 import reportWebVitals from './reportWebVitals';
+import { pastAuctionsAtom, subgraphAuctionsToReduxSafe } from './state/atoms/pastAuctionsAtom';
 import {
   appendBid,
   reduxSafeAuction,
@@ -41,7 +43,6 @@ import {
   setFullAuction,
 } from './state/slices/auction';
 import { setLastAuctionNounId, setOnDisplayAuctionNounId } from './state/slices/onDisplayAuction';
-import { addPastAuctions } from './state/slices/pastAuctions';
 import { nounPath } from './utils/history';
 import { defaultChain, config as wagmiConfig } from './wagmi';
 import { latestAuctionsQuery } from './wrappers/subgraph';
@@ -231,7 +232,7 @@ const ChainSubscriber: React.FC = () => {
 
 const PastAuctions: React.FC = () => {
   const latestAuctionId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
-  const dispatch = useAppDispatch();
+  const setPastAuctions = useSetAtom(pastAuctionsAtom);
 
   // subgraph URL が空 (anvil dev で local subgraph 未起動 等) なら chain fallback を primary
   // として常用、 prod (Base Sepolia 等) は subgraph 経路を primary とし、 useQuery が error
@@ -256,12 +257,12 @@ const PastAuctions: React.FC = () => {
   useEffect(() => {
     if (chainFallbackEnabled) {
       if (chainAuctions) {
-        dispatch(addPastAuctions(chainAuctions));
+        setPastAuctions(subgraphAuctionsToReduxSafe(chainAuctions));
       }
     } else if (auctions) {
-      dispatch(addPastAuctions({ auctions }));
+      setPastAuctions(subgraphAuctionsToReduxSafe({ auctions }));
     }
-  }, [auctions, chainAuctions, chainFallbackEnabled, latestAuctionId, dispatch]);
+  }, [auctions, chainAuctions, chainFallbackEnabled, latestAuctionId, setPastAuctions]);
 
   return <></>;
 };

--- a/packages/niji-webapp/src/state/atoms/pastAuctionsAtom.ts
+++ b/packages/niji-webapp/src/state/atoms/pastAuctionsAtom.ts
@@ -1,19 +1,25 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { AuctionState } from '@/state/slices/auction';
+
+import { atom } from 'jotai/vanilla';
 
 import { GetLatestAuctionsQuery } from '@/subgraphs/graphql';
 import { Address } from '@/utils/types';
 
-import { AuctionState } from './auction';
+/**
+ * 過去 auction list の view state。
+ *
+ * 旧 Redux slice (state/slices/pastAuctions.ts) の `pastAuctions: AuctionState[]` を Jotai
+ * atom に 1:1 移行したもの (Issue #213、 Phase 1 決定 Q1 = TanStack Query + Jotai)。 fetch は
+ * subgraph (TanStack Query) または `useChainPastAuctions` (chain fallback) で行い、 結果を
+ * `subgraphAuctionsToReduxSafe()` で整形してから本 atom に書き込む。
+ */
+export const pastAuctionsAtom = atom<AuctionState[]>([]);
 
-interface PastAuctionsState {
-  pastAuctions: AuctionState[];
-}
-
-const initialState: PastAuctionsState = {
-  pastAuctions: [],
-};
-
-const reduxSafePastAuctions = (data: GetLatestAuctionsQuery): AuctionState[] => {
+/**
+ * subgraph 形 `GetLatestAuctionsQuery` を AuctionState[] に変換する純粋関数。 旧 slice 内の
+ * `reduxSafePastAuctions` をそのまま atom file に移植 (BigInt → string 整形を含む)。
+ */
+export const subgraphAuctionsToReduxSafe = (data: GetLatestAuctionsQuery): AuctionState[] => {
   const auctions = data.auctions;
   if (!auctions) return [];
   return auctions.map(auction => {
@@ -40,17 +46,3 @@ const reduxSafePastAuctions = (data: GetLatestAuctionsQuery): AuctionState[] => 
     };
   });
 };
-
-const pastAuctionsSlice = createSlice({
-  name: 'pastAuctions',
-  initialState: initialState,
-  reducers: {
-    addPastAuctions: (state, action: PayloadAction<GetLatestAuctionsQuery>) => {
-      state.pastAuctions = reduxSafePastAuctions(action.payload);
-    },
-  },
-});
-
-export const { addPastAuctions } = pastAuctionsSlice.actions;
-
-export default pastAuctionsSlice.reducer;

--- a/packages/niji-webapp/src/store.ts
+++ b/packages/niji-webapp/src/store.ts
@@ -6,14 +6,12 @@ import account from '@/state/slices/account';
 import application from '@/state/slices/application';
 import auction from '@/state/slices/auction';
 import onDisplayAuction from '@/state/slices/onDisplayAuction';
-import pastAuctions from '@/state/slices/pastAuctions';
 
 const createRootReducer = () =>
   combineReducers({
     account,
     application,
     auction,
-    pastAuctions,
     onDisplayAuction,
   });
 const loggerMiddleware = createLogger();

--- a/packages/niji-webapp/src/wrappers/onDisplayAuction.ts
+++ b/packages/niji-webapp/src/wrappers/onDisplayAuction.ts
@@ -1,4 +1,7 @@
+import { useAtomValue } from 'jotai/react';
+
 import { useAppSelector } from '@/hooks';
+import { pastAuctionsAtom } from '@/state/atoms/pastAuctionsAtom';
 import { compareBids } from '@/utils/compareBids';
 import { generateEmptyNounderAuction, isNounderNiji } from '@/utils/nounderNiji';
 import { Address, Bid, BidEvent } from '@/utils/types';
@@ -37,7 +40,7 @@ const useOnDisplayAuction = (): Auction | undefined => {
     state => state.onDisplayAuction.onDisplayAuctionNounId,
   );
   const currentAuction = useAppSelector(state => state.auction.activeAuction);
-  const pastAuctions = useAppSelector(state => state.pastAuctions.pastAuctions);
+  const pastAuctions = useAtomValue(pastAuctionsAtom);
 
   if (
     onDisplayAuctionNounId === undefined ||
@@ -80,7 +83,7 @@ const useOnDisplayAuction = (): Auction | undefined => {
 export const useAuctionBids = (auctionNounId: bigint): Bid[] | undefined => {
   const lastAuctionNounId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
   const lastAuctionBids = useAppSelector(state => state.auction.bids);
-  const pastAuctions = useAppSelector(state => state.pastAuctions.pastAuctions);
+  const pastAuctions = useAtomValue(pastAuctionsAtom);
 
   // auction requested is active auction
   if (lastAuctionNounId === Number(auctionNounId)) {


### PR DESCRIPTION
## 概要

`packages/niji-webapp/src/state/slices/pastAuctions.ts` (56 行) を Jotai atom に移行、 consumer 2 file (index.tsx PastAuctions / wrappers/onDisplayAuction.ts) を置換した。 旧 slice 内の `reduxSafePastAuctions` 変換関数は atom file (`subgraphAuctionsToReduxSafe`) として同居移植。 Issue #155 Phase 2-4。

## 課題

旧 slice の `pastAuctions: AuctionState[]` は subgraph (TanStack Query) または `useChainPastAuctions` (chain fallback) の fetch 結果を変換して hold する単純な view state。 Redux dispatch + selector の mental overhead を Jotai atom で簡素化、 変換関数を atom file に同居させて責務集約。

```mermaid
graph LR
    A[useQuery latestAuctions] -->|subgraph| C[subgraphAuctionsToReduxSafe]
    B[useChainPastAuctions] -->|chain fallback| C
    C -->|setPastAuctions| D[pastAuctionsAtom]
    D -->|useAtomValue| E[useOnDisplayAuction / useAuctionBids]
```

## 解決方法

- `state/atoms/pastAuctionsAtom.ts` 新設 (`AuctionState[]` primitive atom + `subgraphAuctionsToReduxSafe` 変換関数 = 旧 slice 内 `reduxSafePastAuctions` の移植)
- `index.tsx` PastAuctions ... `dispatch(addPastAuctions(...))` → `setPastAuctions(subgraphAuctionsToReduxSafe(...))`、 `useSetAtom` import 追加
- `wrappers/onDisplayAuction.ts` ... `useAppSelector(state => state.pastAuctions.pastAuctions)` を `useAtomValue(pastAuctionsAtom)` に置換 (`useOnDisplayAuction` / `useAuctionBids` 2 hook 内 2 箇所)
- `store.ts` から `pastAuctions` import + combineReducers 登録を削除
- `state/slices/pastAuctions.ts` を削除

## 検証

| 項目 | 結果 |
|---|---|
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| vitest (`pnpm test`) | 30 tests PASS / 1 todo |
| build (`pnpm build`) | 25.82s 成功 |

## 受入条件

- [x] `state/atoms/pastAuctionsAtom.ts` 追加
- [x] consumer 全件 grep で Redux 経路 0 件 (`state.pastAuctions` / `addPastAuctions` ともに 0 件)
- [x] typecheck / vitest / build 通過

## 関連

- 親 Issue #155 (Phase 2-4)
- PR #221 (Issue #212、 candidates atom 化、 同 pattern)

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
