### PR TITLE
🌐 feat(webapp): i18n missing 訳 73+76 件埋め (ja-JP / zh-CN、 Issue #137)

### DIFF
--- a/packages/niji-webapp/src/locales/ja-JP.po
+++ b/packages/niji-webapp/src/locales/ja-JP.po
@@ -20,7 +20,7 @@ msgstr ""
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
-msgstr ""
+msgstr "Niji DUNA は、Niji DAO の分散型の特性に整合する堅牢な法的枠組みを提供するため、<0/> を通じてワイオミング州で設立された、法的に認められた分散型非法人非営利協会です。この構造により、Niji DAO は分散型ガバナンスの理念を損なうことなく、有限責任保護と法的明確性を保ちながら運営できます。"
 
 #: src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.tsx
 msgid "At this time only USDC and WETH streams are supported"
@@ -40,7 +40,7 @@ msgstr "票あり"
 
 #: src/pages/Playground/index.tsx
 msgid "Generate Nijis"
-msgstr ""
+msgstr "Niji を生成"
 
 #: src/pages/Candidate/index.tsx
 msgid "Cancel candidate"
@@ -69,7 +69,7 @@ msgstr "これにより、以前のすべてのスポンサーとフィードバ
 
 #: src/components/Bid/index.tsx
 msgid "Pick the next Niji"
-msgstr ""
+msgstr "次の Niji を選ぶ"
 
 #. placeholder {0}: i18n.number((proposalThreshold || 0) + 1)
 #: src/components/CreateProposalButton/index.tsx
@@ -146,7 +146,7 @@ msgstr "無効な引数"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "Required % of Nijis to Pass"
-msgstr ""
+msgstr "可決に必要な Niji の割合 (%)"
 
 #: src/components/NijiInfoRowHolder.tsx
 #: src/components/Winner/index.tsx
@@ -155,7 +155,7 @@ msgstr "落札者"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
-msgstr ""
+msgstr "Niji はオンチェーンアバターコミュニティの形成を改善するための実験的な試みです。{cryptopunksLink} のようなプロジェクトがデジタルコミュニティとアイデンティティのブートストラップを試みた一方で、Niji はアイデンティティ、コミュニティ、ガバナンス、およびコミュニティが利用できるトレジャリーのブートストラップを試みます。"
 
 #: src/components/ProposalContent/index.tsx
 msgid "This proposal interacts with the <0>original treasury</0>"
@@ -167,7 +167,7 @@ msgstr "提案候補は誰でも作成できます。候補がNijisの投票者�
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Nijis & Traits"
-msgstr ""
+msgstr "Niji とトレイト"
 
 #: src/components/ForkStatus/index.tsx
 msgid "In Escrow"
@@ -191,7 +191,7 @@ msgstr "コンパウンドガバナンス"
 
 #: src/components/Documentation/index.tsx
 msgid "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
-msgstr ""
+msgstr "投票の過半数を維持または獲得する目的で Niji オークションの頻度を変更しようとする"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Delegate {availableVotes} Votes"
@@ -216,7 +216,7 @@ msgstr "署名待ち"
 #. placeholder {0}: nounId.toString()
 #: src/components/AuctionActivityNijiTitle/index.tsx
 msgid "Niji {0}"
-msgstr ""
+msgstr "Niji {0}"
 
 #: src/components/Proposals/index.tsx
 msgid "Making a proposal requires {threshold} votes"
@@ -275,7 +275,7 @@ msgstr "アクティブなフォークはありません。"
 
 #: src/components/Documentation/index.tsx
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
-msgstr ""
+msgstr "その結果、Niji Foundation は Niji DAO が代替案を実装する準備が整うまで、拒否権の管理者となることを想定しており、したがってこの権限を行使する条件を明確にしたいと考えています。"
 
 #: src/components/BidHistoryModal/index.tsx
 msgid "Bids for"
@@ -291,7 +291,7 @@ msgstr "かそれ以上"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
-msgstr ""
+msgstr "Niji のアートワークは {publicDomainLink} にあります。"
 
 #: src/pages/NijisPage.tsx
 #: src/pages/Playground/index.tsx
@@ -309,7 +309,7 @@ msgstr "キューに入りました"
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploy Niji fork"
-msgstr ""
+msgstr "Niji フォークをデプロイ"
 
 #: src/components/ProposalHeader/CandidateHeader.tsx
 #: src/components/ProposalHeader/index.tsx
@@ -326,7 +326,7 @@ msgstr "提案候補は誰でも作成できます。候補がNijisの投票者�
 
 #: src/components/Documentation/index.tsx
 msgid "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
-msgstr ""
+msgstr "DUNA モデルを採用することで、Niji DAO は分散型の自律性と法的確実性のバランスを求める DAO の先駆的な事例を示し、分散型ガバナンス革新の最前線における地位をさらに確固たるものにします。"
 
 #: src/components/VoteSignals/VoteSignals.tsx
 msgid "Add your feedback"
@@ -378,7 +378,7 @@ msgstr "承認を設定"
 
 #: src/components/Holder/index.tsx
 msgid "Failed to fetch Niji info"
-msgstr ""
+msgstr "Niji 情報の取得に失敗しました"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "s"
@@ -402,7 +402,7 @@ msgstr "引き出し可能"
 
 #: src/components/Documentation/index.tsx
 msgid "You can experiment with off-chain Niji generation at the {playgroundLink}."
-msgstr ""
+msgstr "{playgroundLink} でオフチェーンの Niji 生成を試すことができます。"
 
 #. placeholder {0}: i18n.number(availableVotes)
 #: src/components/VoteModal/index.tsx
@@ -417,7 +417,7 @@ msgstr "あなたは提案 {0} に投票することに成功しました。"
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "Faucet"
-msgstr ""
+msgstr "Faucet"
 
 #: src/components/VoteModal/index.tsx
 msgid "Thank you for voting."
@@ -486,7 +486,7 @@ msgstr "委任された更新に失敗しました"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
-msgstr ""
+msgstr "Niji には誰もが関わる方法があります。カエルに名前を付けるような気まぐれな取り組みから、ローズパレード用の巨大な山車を作るような野心的なプロジェクト、さらには Prop House のようなクリプトインフラまで。Niji はあらゆる規模と領域のプロジェクトに資金を提供します。"
 
 #: src/components/Footer.tsx
 #: src/pages/Forks/index.tsx
@@ -512,11 +512,11 @@ msgstr "委任Niji: "
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
-msgstr ""
+msgstr "Niji オークションコントラクトは、24 時間ごとに 1 つの Niji を永遠にオークションする、自己完結型の Niji 生成と配布のメカニズムとして機能します。オークション収益 (ETH) の 100% は自動的に Niji DAO トレジャリーに預けられ、Niji 所有者によって管理されます。"
 
 #: src/pages/Playground/index.tsx
 msgid "The playground was built using the {nijiProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nijiSDKLink}."
-msgstr ""
+msgstr "遊び場は {nijiProtocolLink} を使用して構築されました。Niji のトレイトは Niji Seed によって決定されます。シードは {nijiAssetsLink} を使って生成され、{nijiSDKLink} を使ってレンダリングされました。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Address"
@@ -554,7 +554,7 @@ msgstr "投票できるのは {0} 以前に所有していた、または委任�
 
 #: src/components/Documentation/index.tsx
 msgid "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
-msgstr ""
+msgstr "Nijider への配布は 24 時間オークションの頻度を妨げません。Niji は Nijider のマルチシグに直接送られ、オークションは次に利用可能な Niji ID で予定どおり継続されます。"
 
 #: src/components/CandidateSponsors/Signature.tsx
 msgid "Re-signed"
@@ -583,7 +583,7 @@ msgstr "バージョン"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Download official Niji DAO brand assets including our iconic noggles in various formats."
-msgstr ""
+msgstr "象徴的なノグルズを含む Niji DAO 公式ブランドアセットを各種フォーマットでダウンロード。"
 
 #: src/components/Holder/index.tsx
 msgid "Held by"
@@ -595,7 +595,7 @@ msgstr "Nijiders"
 
 #: src/components/NijiContent/index.tsx
 msgid "送信中…"
-msgstr ""
+msgstr "送信中…"
 
 #: src/pages/Candidate/index.tsx
 msgid "Edit"
@@ -607,7 +607,7 @@ msgstr "アクション詳細の確認"
 
 #: src/components/Documentation/index.tsx
 msgid "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
-msgstr ""
+msgstr "オークションが決済されるたびに、決済トランザクションは新しい Niji のミントと新しい 24 時間オークションの開始を引き起こします。"
 
 #: src/pages/CreateCandidate/index.tsx
 msgid "Candidate Created!"
@@ -617,7 +617,7 @@ msgstr "候補が作成されました！"
 #: src/components/NijiContent/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Niji DAO"
-msgstr ""
+msgstr "Niji DAO"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijider's Reward"
@@ -638,7 +638,7 @@ msgstr "実行されました"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DAO uses a fork of {compoundGovLink}."
-msgstr ""
+msgstr "Niji DAO は {compoundGovLink} のフォークを使用しています。"
 
 #: src/pages/EditProposal/index.tsx
 msgid "Edit Proposal"
@@ -700,7 +700,7 @@ msgstr "もう一度やり直してください。"
 
 #: src/components/Documentation/index.tsx
 msgid "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
-msgstr ""
+msgstr "属性の希少性に関する明示的なルールは存在しません。すべての Niji は等しくレアです。"
 
 #: src/pages/Vote/index.tsx
 msgid "Proposal Queued!"
@@ -713,7 +713,7 @@ msgstr "新しいフォークを開始"
 #: src/pages/Governance/index.tsx
 #: src/pages/NijisPage.tsx
 msgid "Niji"
-msgstr ""
+msgstr "Niji"
 
 #: src/pages/CreateCandidate/index.tsx
 msgid "Create Proposal Candidate"
@@ -749,7 +749,7 @@ msgstr "反対"
 
 #: src/pages/Nounders/index.tsx
 msgid "The Nijiders reward is intended as compensation for our pre and post-launch contributions to the project, and to help us participate meaningfully in governance as the project matures. Since there are 10 Nijiders, after 5 years each Nijider could receive up to 1% of the Niji supply."
-msgstr ""
+msgstr "Nijider 報酬は、プロジェクトへのローンチ前後の貢献に対する報酬として、またプロジェクトが成熟するにつれてガバナンスに有意義に参加できるように意図されています。Nijider は 10 人いるため、5 年後にはそれぞれが Niji 総供給量の最大 1% を受け取れる可能性があります。"
 
 #: src/components/ProposalStatus/index.tsx
 #: src/components/ProposalStatusCopy/index.tsx
@@ -762,7 +762,7 @@ msgstr "デリゲーション"
 
 #: src/pages/TraitsPage.tsx
 msgid "Filename"
-msgstr ""
+msgstr "ファイル名"
 
 #: src/components/Proposals/index.tsx
 msgid "About Proposal Candidates"
@@ -859,7 +859,7 @@ msgstr "戻る"
 #. placeholder {0}: nijisRequired !== undefined ? ( <> {nijisRequired} {threshold === 0 ? nijiSingular : nijiPlural} </> ) : ( '...' )
 #: src/pages/Governance/index.tsx
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
-msgstr ""
+msgstr "Niji は <0>Niji DAO</0> を統治します。Niji は提案に投票することも、票を第三者に委任することもできます。提案を提出するには最低 <1>{0}</1> が必要です。"
 
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
@@ -934,7 +934,7 @@ msgstr "フォークは、トークン保有者のグループが一緒にプロ
 
 #: src/pages/Nounders/index.tsx
 msgid "All Niji auction proceeds are sent to the Niji DAO. For this reason, we, the project's founders (‘Nijiders’) have chosen to compensate ourselves with Nijis. Every 10th Niji for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to individual Nijiders."
-msgstr ""
+msgstr "Niji オークション収益はすべて Niji DAO に送られます。このため、プロジェクトの創設者である私たち ('Nijiders') は、自分たち自身に Niji で報酬を与えることを選択しました。プロジェクト最初の 5 年間、10 個ごとの Niji は私たちのマルチシグ (5/10) に送られ、そこでベスティングされて各 Nijider に配布されます。"
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploy Fork"
@@ -942,7 +942,7 @@ msgstr "フォークをデプロイ"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
-msgstr ""
+msgstr "Niji Foundation は拒否権を、通常の業務遂行の中では行使すべきでない緊急権限であると考えています。Niji Foundation は、Niji DAO または Niji Foundation に重大な法的または存続上のリスクをもたらす提案に対して拒否権を行使します。これには (これらに限定されませんが) 以下のような提案が含まれます。"
 
 #: src/pages/EditProposal/index.tsx
 msgid "View the candidate"
@@ -984,7 +984,7 @@ msgstr "委任Niji: "
 
 #: src/components/Documentation/index.tsx
 msgid "All Nijis are members of Niji DAO."
-msgstr ""
+msgstr "すべての Niji は Niji DAO のメンバーです。"
 
 #: src/components/DelegationCandidateInfo/index.tsx
 msgid "Now has"
@@ -992,7 +992,7 @@ msgstr "今持っています"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "Build With Niji. Get Funded."
-msgstr ""
+msgstr "Niji と共に作ろう。資金を得よう。"
 
 #: src/components/Winner/index.tsx
 msgid "You"
@@ -1041,11 +1041,11 @@ msgstr "投票を提出"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji Traits"
-msgstr ""
+msgstr "Niji トレイト"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
-msgstr ""
+msgstr "Niji は Ethereum のブロックハッシュに基づいてランダムに生成されます。Niji トレイトの希少性を支配する 'if' 文やその他のルールは存在せず、すべての Niji が等しくレアです。執筆時点では、Niji は以下で構成されています。"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Your <0>{availableVotes}</0> votes are being delegated to a new account."
@@ -1053,7 +1053,7 @@ msgstr "あなたは<0>{availableVotes}</0>アカウントに委任されてい�
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
-msgstr ""
+msgstr "Niji コミュニティは提案拒否権の代替案 ('rage quit' など) の予備的検討を行いましたが、満足のいく解決策を実装するためには、さらに多くの研究、開発、テストを必要とする難しい問題であることが今や明らかです。"
 
 #: src/components/ProposalStatus/index.tsx
 #: src/components/ProposalStatusCopy/index.tsx
@@ -1079,7 +1079,7 @@ msgstr "トークン保有者は、ガバナンス提案に応じてフォーク
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
-msgstr ""
+msgstr "ウガンダの学校から LA のコーヒーショップまで、サンパウロのクリプトハブからメルボルンのデリまで、Niji は創造的な人々がアイデアを実現する場所どこにでも存在します。<0/> で nounish な人、場所、物を探索してみよう。"
 
 #: src/components/LanguageSelectionModal/index.tsx
 msgid "Select Language"
@@ -1092,7 +1092,7 @@ msgstr "最低入札額の {0} ETHと同じかそれ以上の入札額を設定�
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploying Niji fork and beginning the forking period"
-msgstr ""
+msgstr "Niji フォークをデプロイしてフォーク期間を開始"
 
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
@@ -1112,7 +1112,7 @@ msgstr "提案中のトランザクション"
 
 #: src/components/Documentation/index.tsx
 msgid "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
-msgstr ""
+msgstr "ワイオミング州の DUNA 法の下で、Niji DAO は自らの名義で資産を保有し、契約を締結し、法的措置に参加できます。ガバナンスは完全に分散化されたままで、決定は Niji 保有者によるオンチェーン投票によってのみ制御されます。これにより Niji DAO は持続的にプロジェクトに資金を提供し、トレジャリーを管理し、デジタルと物理の世界の両方で自信を持って交流できます。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Review Function Call Action"
@@ -1120,7 +1120,7 @@ msgstr "関数呼び出しアクションのレビュー"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
-msgstr ""
+msgstr "Niji Seeder コントラクトは、ミントプロセス中に Niji のトレイトを決定するために使用されます。Seeder コントラクトは、将来のトレイト生成アルゴリズムのアップグレードを可能にするために置き換え可能です。さらに、Niji DAO によってロックして、将来の更新を防ぐこともできます。現在、Niji トレイトは疑似乱数生成を使用して決定されます。"
 
 #: src/components/Bid/index.tsx
 #: src/components/NijiContent/index.tsx
@@ -1138,7 +1138,7 @@ msgstr "提案 {0} に投票"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
-msgstr ""
+msgstr "Niji は Ethereum 上に直接保存され、IPFS のような他のネットワークへのポインタを使用しません。これは Niji のパーツがカスタムの run-length encoding (RLE) という可逆圧縮の形式を使用して圧縮され、オンチェーンに保存されているために可能です。"
 
 #: src/components/NijiInfoCard.tsx
 msgid "Bids"
@@ -1161,7 +1161,7 @@ msgstr "説明"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
-msgstr ""
+msgstr "Niji DAO は {compoundGovLink} のフォークを利用し、Niji エコシステムの主要なガバナンス機関です。Niji DAO トレジャリーは、毎日の Niji オークションからの ETH 収益の 100% を受け取ります。各 Niji は Niji DAO の取り消し不能なメンバーであり、すべてのガバナンス事項において 1 票の権利を持ちます。Niji の票は譲渡不能 (Niji を売却すると票も一緒に移ります) ですが委任可能で、Niji を所有している限り票を他の誰かに割り当てることができます。"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Change"
@@ -1218,7 +1218,7 @@ msgstr "すべての特性は<0>CC0</0>（クリエイティブ・コモンズ�
 
 #: src/components/Documentation/index.tsx
 msgid "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
-msgstr ""
+msgstr "詳細は以下をご覧ください。または {playgroundLink} を使ってオフチェーンで Niji の作成を開始しましょう。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
 msgid "No arguments required "
@@ -1233,12 +1233,12 @@ msgstr "ストリーミング支払いアクションを追加"
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "LP"
-msgstr ""
+msgstr "LP"
 
 #. placeholder {0}: isForked ? ` #${id}` : ''
 #: src/pages/Fork/index.tsx
 msgid "Niji DAO Fork{0}"
-msgstr ""
+msgstr "Niji DAO Fork{0}"
 
 #. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
 #: src/pages/Vote/index.tsx
@@ -1255,7 +1255,7 @@ msgstr "WTF?"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
-msgstr ""
+msgstr "Nijider は Niji という形で報酬を受け取ります (最初の 5 年間は供給量の 10%)。"
 
 #. placeholder {0}: (proposalThreshold ?? 0) + 1
 #. placeholder {1}: proposalThreshold === 0 || proposalThreshold === null ? 'vote' : 'votes'
@@ -1303,7 +1303,7 @@ msgstr "票になります"
 
 #: src/components/DelegateHoverCard/index.tsx
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
-msgstr ""
+msgstr "<0>{numVotesForProp}</0> Niji で投票"
 
 #: src/components/VoteSignals/VoteSignals.tsx
 msgid "Pre-voting feedback"
@@ -1316,7 +1316,7 @@ msgstr "あと{0}で始まります"
 
 #: src/components/Documentation/index.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
-msgstr ""
+msgstr "提案拒否権は当初、Niji DAO トレジャリーに対する '51% 攻撃' 問題への一時的な解決策として構想されました。Nijider は当初、Niji の健全な配布が DAO の保護として十分であると考えていましたが、インセンティブとリスクのより完全な理解により、権利が削除される前により堅牢なゲーム理論的解決策を実装すべきという一般的な合意が Nijider、Niji Foundation、より広いコミュニティ内で形成されました。"
 
 #: src/components/CurrentDelegatePannel/index.tsx
 msgid "Current Delegate"
@@ -1334,11 +1334,11 @@ msgstr "デリゲートが更新されました"
 #. placeholder {0}: i18n.number(Number(nounSvgs ? (nounSvgs.length / 365).toFixed(2) : '0'))
 #: src/pages/Playground/index.tsx
 msgid "You've generated {0} years worth of Nijis"
-msgstr ""
+msgstr "{0} 年分の Niji を生成しました"
 
 #: src/components/Documentation/index.tsx
 msgid "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
-msgstr ""
+msgstr "Niji オークション収益の 100% が Niji DAO に送られるため、Nijider は自身に Niji で報酬を与えることを選びました。プロジェクト最初の 5 年間、10 個ごとの Niji (Niji id #0、#10、#20、#30 など) は自動的に Nijider のマルチシグに送られ、ベスティングされ、プロジェクトの創設メンバー間で共有されます。"
 
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
@@ -1353,7 +1353,7 @@ msgstr "ユーザーはすでに投票済みです"
 
 #: src/pages/Governance/index.tsx
 msgid "This treasury exists for <0>Niji DAO</0> participants to allocate resources for the long-term growth and prosperity of the Niji project."
-msgstr ""
+msgstr "このトレジャリーは、<0>Niji DAO</0> の参加者が Niji プロジェクトの長期的な成長と繁栄のためにリソースを割り当てるために存在します。"
 
 #: src/components/ProposalHeader/CandidateHeader.tsx
 #: src/components/ProposalHeader/index.tsx
@@ -1386,7 +1386,7 @@ msgstr "あなたの<0>{availableVotes}</0>票が新しいアカウントに委�
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
-msgstr ""
+msgstr "現在反対している Niji の割合 (%)"
 
 #: src/pages/CreateProposal/index.tsx
 msgid "Tip"
@@ -1441,11 +1441,11 @@ msgstr "1分で手動で決済できます"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "Niji is a global community."
-msgstr ""
+msgstr "Niji はグローバルなコミュニティです。"
 
 #: src/components/Documentation/index.tsx
 msgid "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
-msgstr ""
+msgstr "決済は落札者にとって最も強くインセンティブが与えられますが、誰でもトリガーできます。これにより Ethereum が稼働しており興味のある入札者がいる限り、システムは Niji をトラストレスにオークションすることができます。"
 
 #: src/pages/CreateProposal/index.tsx
 msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
@@ -1454,7 +1454,7 @@ msgstr "この提案にはUSDC資金移動アクションが含まれている�
 #. placeholder {0}: i18n.number(availableVotes)
 #: src/components/VoteModal/index.tsx
 msgid "Voting with <0>{0}</0> Niji"
-msgstr ""
+msgstr "<0>{0}</0> Niji で投票中"
 
 #: src/components/VoteModal/index.tsx
 msgid "Error"
@@ -1486,7 +1486,7 @@ msgstr "特性を探索"
 
 #: src/components/Documentation/index.tsx
 msgid "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
-msgstr ""
+msgstr "'Nijider' は Niji を立ち上げた 10 人のビルダーのグループです。Nijider は以下のとおりです。"
 
 #: src/pages/Vote/index.tsx
 msgid "Transaction Successful!"
@@ -1506,11 +1506,11 @@ msgstr "トークン"
 
 #: src/components/Documentation/index.tsx
 msgid "The treasury is controlled exclusively by Nijis via governance."
-msgstr ""
+msgstr "トレジャリーはガバナンスを通じて Niji によってのみ制御されます。"
 
 #: src/components/Documentation/index.tsx
 msgid "One Niji is trustlessly auctioned every 24 hours, forever."
-msgstr ""
+msgstr "1 つの Niji が 24 時間ごとに、永遠にトラストレスにオークションされます。"
 
 #: src/components/Proposals/index.tsx
 msgid "No candidates found"
@@ -1527,7 +1527,7 @@ msgstr "投票を委任するアカウントのイーサリアムアドレスま
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Generate endless Nijis assembled from the onchain artwork"
-msgstr ""
+msgstr "オンチェーンアートワークから組み立てられた無限の Niji を生成"
 
 #. placeholder {0}: dayjs(endDate).fromNow()
 #: src/components/StartOrEndTime/index.tsx
@@ -1548,11 +1548,11 @@ msgstr "提案が更新されました！"
 #: src/pages/Fork/WithdrawNijisButton.tsx
 #: src/pages/Fork/WithdrawNijisButton.tsx
 msgid "Withdraw Nijis from escrow"
-msgstr ""
+msgstr "Niji をエスクローから引き出す"
 
 #: src/components/NijiInfoRowHolder.tsx
 msgid "Niji Auction House"
-msgstr ""
+msgstr "Niji オークションハウス"
 
 #: src/pages/NijisPage.tsx
 msgid "Go to auction"
@@ -1597,7 +1597,7 @@ msgstr "レビューして追加"
 
 #: src/components/Documentation/index.tsx
 msgid "100% of Niji auction proceeds are trustlessly sent to the treasury."
-msgstr ""
+msgstr "Niji オークション収益の 100% はトラストレスにトレジャリーに送られます。"
 
 #: src/components/ProposalHeader/CandidateHeader.tsx
 msgid "<0>Proposed by: </0><1>{proposerLink}</1>{transactionLink}"
@@ -1661,7 +1661,7 @@ msgstr "投票を委任する"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DUNA"
-msgstr ""
+msgstr "Niji DUNA"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "Add Action Details"
@@ -1682,7 +1682,7 @@ msgstr "Nijiderへの報酬"
 
 #: src/components/Documentation/index.tsx
 msgid "One Niji is equal to one vote."
-msgstr ""
+msgstr "1 Niji は 1 票に等しい。"
 
 #: src/pages/CandidateHistoryPage/index.tsx
 msgid "Proposal Candidate"
@@ -1702,7 +1702,7 @@ msgstr "投票がありません。"
 
 #: src/components/Documentation/index.tsx
 msgid "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
-msgstr ""
+msgstr "トレイトの生成は真にランダムではありません。ペンディングブロックで Niji をミントする際にトレイトを予測できます。"
 
 #: src/components/StreamWithdrawModal/index.tsx
 msgid "There was an error withdrawing to your wallet."
@@ -1710,7 +1710,7 @@ msgstr "ウォレットへの引き出し中にエラーが発生しました。
 
 #: src/components/Documentation/index.tsx
 msgid "Niji Seeder Contract"
-msgstr ""
+msgstr "Niji Seeder コントラクト"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
@@ -1720,11 +1720,11 @@ msgstr "賛成"
 
 #: src/components/AuctionActivity/index.tsx
 msgid "Help mint the next Niji"
-msgstr ""
+msgstr "次の Niji のミントを支援"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "One Niji, Every Day, Forever."
-msgstr ""
+msgstr "毎日 1 つの Niji を、永遠に。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Function"
@@ -1732,17 +1732,17 @@ msgstr "関数"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "The logos, traits and every Niji generated on the playground are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
-msgstr ""
+msgstr "ロゴ、トレイト、および遊び場で生成されたすべての Niji は <0>CC0</0> (Creative Commons Zero) であり、パブリックドメインにあり、制限なくあらゆる目的に自由に使用できます。"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Download the individual traits that compose Nijis"
-msgstr ""
+msgstr "Niji を構成する個別のトレイトをダウンロード"
 
 #. placeholder {0}: humanizeTraitKey(traitKey)
 #. placeholder {1}: NijiImageData.images[traitKey].length
 #: src/components/Documentation/index.tsx
 msgid "{0} ({1})"
-msgstr ""
+msgstr "{0} ({1})"
 
 #: src/pages/Vote/index.tsx
 msgid "Objection only period"
@@ -1761,7 +1761,7 @@ msgstr "ロード中..."
 
 #: src/pages/Fork/index.tsx
 msgid "Fork Niji DAO"
-msgstr ""
+msgstr "Niji DAO をフォーク"
 
 #: src/pages/EditCandidate/index.tsx
 #: src/pages/EditProposal/index.tsx
@@ -1790,7 +1790,7 @@ msgstr "提案者の機能"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
-msgstr ""
+msgstr "無限のアート作品をご覧ください！Niji はアイデアに資金を提供し、コラボレーションを育むことでポジティブな影響をもたらす、コミュニティ所有のブランドです。コレクターや技術者から、非営利団体やブランドまで、Niji はすべての人のためのものです。"
 
 #: src/components/Banner/index.tsx
 msgid "EVERY DAY,"

--- a/packages/niji-webapp/src/locales/zh-CN.po
+++ b/packages/niji-webapp/src/locales/zh-CN.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
-msgstr ""
+msgstr "Niji DUNA 是一个通过 <0/> 在怀俄明州设立的、法律上认可的去中心化非法人非营利协会,旨在提供与 Niji DAO 去中心化特性相一致的强大法律框架。该结构使 Niji DAO 能够在不损害其去中心化治理精神的情况下运营,享有有限责任保护和法律明确性。"
 
 #: src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.tsx
 msgid "At this time only USDC and WETH streams are supported"
@@ -35,7 +35,7 @@ msgstr "拥有"
 
 #: src/pages/Playground/index.tsx
 msgid "Generate Nijis"
-msgstr ""
+msgstr "生成 Niji"
 
 #: src/pages/Candidate/index.tsx
 msgid "Cancel candidate"
@@ -64,7 +64,7 @@ msgstr "这将清除所有先前的支持者和反馈投票"
 
 #: src/components/Bid/index.tsx
 msgid "Pick the next Niji"
-msgstr ""
+msgstr "选择下一个 Niji"
 
 #. placeholder {0}: i18n.number((proposalThreshold || 0) + 1)
 #: src/components/CreateProposalButton/index.tsx
@@ -141,7 +141,7 @@ msgstr "参数无效"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "Required % of Nijis to Pass"
-msgstr ""
+msgstr "通过所需的 Niji 百分比"
 
 #: src/components/NijiInfoRowHolder.tsx
 #: src/components/Winner/index.tsx
@@ -150,7 +150,7 @@ msgstr "获胜者"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
-msgstr ""
+msgstr "Niji 是改进链上头像社区形成的实验性尝试。虽然 {cryptopunksLink} 等项目曾尝试引导数字社区和身份,但 Niji 尝试引导身份、社区、治理以及可供社区使用的金库。"
 
 #: src/components/ProposalContent/index.tsx
 msgid "This proposal interacts with the <0>original treasury</0>"
@@ -162,7 +162,7 @@ msgstr "任何人都可创建提案候选。若候选获得足够签名，即可
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Nijis & Traits"
-msgstr ""
+msgstr "Niji 与特征"
 
 #: src/components/ForkStatus/index.tsx
 msgid "In Escrow"
@@ -186,7 +186,7 @@ msgstr "Compound 治理"
 
 #: src/components/Documentation/index.tsx
 msgid "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
-msgstr ""
+msgstr "为了维持或获得投票多数而试图改变 Niji 拍卖节奏"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Delegate {availableVotes} Votes"
@@ -211,7 +211,7 @@ msgstr "等待签名"
 #. placeholder {0}: nounId.toString()
 #: src/components/AuctionActivityNijiTitle/index.tsx
 msgid "Niji {0}"
-msgstr ""
+msgstr "Niji {0}"
 
 #: src/components/Proposals/index.tsx
 msgid "Making a proposal requires {threshold} votes"
@@ -270,7 +270,7 @@ msgstr "当前无正在进行的分叉。"
 
 #: src/components/Documentation/index.tsx
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
-msgstr ""
+msgstr "因此,Niji 基金会预计将担任否决权的管理者,直到 Niji DAO 准备好实施替代方案,因此希望明确行使此权力的条件。"
 
 #: src/components/BidHistoryModal/index.tsx
 msgid "Bids for"
@@ -286,7 +286,7 @@ msgstr "或以上"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
-msgstr ""
+msgstr "Niji 艺术作品位于 {publicDomainLink}。"
 
 #: src/pages/NijisPage.tsx
 #: src/pages/Playground/index.tsx
@@ -304,7 +304,7 @@ msgstr "已排队"
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploy Niji fork"
-msgstr ""
+msgstr "部署 Niji 分叉"
 
 #: src/components/ProposalHeader/CandidateHeader.tsx
 #: src/components/ProposalHeader/index.tsx
@@ -321,7 +321,7 @@ msgstr "任何人都可创建提案候选。若候选人获得足够的 Niji 投
 
 #: src/components/Documentation/index.tsx
 msgid "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
-msgstr ""
+msgstr "通过采用 DUNA 模式,Niji DAO 为寻求平衡去中心化自治与法律确定性的 DAO 树立了开创性的榜样,进一步巩固了其在去中心化治理创新前沿的地位。"
 
 #: src/components/VoteSignals/VoteSignals.tsx
 msgid "Add your feedback"
@@ -373,7 +373,7 @@ msgstr "设置批准"
 
 #: src/components/Holder/index.tsx
 msgid "Failed to fetch Niji info"
-msgstr ""
+msgstr "获取 Niji 信息失败"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "s"
@@ -397,7 +397,7 @@ msgstr "可提取"
 
 #: src/components/Documentation/index.tsx
 msgid "You can experiment with off-chain Niji generation at the {playgroundLink}."
-msgstr ""
+msgstr "你可以在 {playgroundLink} 试验链下 Niji 生成。"
 
 #. placeholder {0}: i18n.number(availableVotes)
 #: src/components/VoteModal/index.tsx
@@ -412,7 +412,7 @@ msgstr "您已成功对提案 {0} 进行投票"
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "Faucet"
-msgstr ""
+msgstr "Faucet"
 
 #: src/components/VoteModal/index.tsx
 msgid "Thank you for voting."
@@ -481,7 +481,7 @@ msgstr "委托更新失败"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
-msgstr ""
+msgstr "每个人都有方法参与 Niji。从给青蛙起名这样的奇思妙想,到为玫瑰花车游行建造巨型花车的雄心勃勃的项目,甚至像 Prop House 这样的加密基础设施。Niji 资助各种规模和领域的项目。"
 
 #: src/components/Footer.tsx
 #: src/pages/Forks/index.tsx
@@ -507,11 +507,11 @@ msgstr "<0>委托的 Nijis：</0>"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
-msgstr ""
+msgstr "Niji 拍卖合约将作为一个自给自足的 Niji 生成和分发机制,每 24 小时拍卖一个 Niji,永远持续。100% 的拍卖收益 (ETH) 自动存入 Niji DAO 金库,由 Niji 所有者治理。"
 
 #: src/pages/Playground/index.tsx
 msgid "The playground was built using the {nijiProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nijiSDKLink}."
-msgstr ""
+msgstr "游乐场使用 {nijiProtocolLink} 构建。Niji 的特征由 Niji Seed 决定。Seed 使用 {nijiAssetsLink} 生成,并使用 {nijiSDKLink} 渲染。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Address"
@@ -549,7 +549,7 @@ msgstr "只有您在 {0} 之前拥有或被委托的 Nijis 才可投票。"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
-msgstr ""
+msgstr "Nijider 分发不会干扰 24 小时拍卖的节奏。Niji 直接发送到 Nijider 的多重签名,拍卖按计划继续进行,使用下一个可用的 Niji ID。"
 
 #: src/components/CandidateSponsors/Signature.tsx
 msgid "Re-signed"
@@ -578,7 +578,7 @@ msgstr "版本"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Download official Niji DAO brand assets including our iconic noggles in various formats."
-msgstr ""
+msgstr "下载官方 Niji DAO 品牌资产,包括各种格式的我们标志性的 noggles。"
 
 #: src/components/Holder/index.tsx
 msgid "Held by"
@@ -590,7 +590,7 @@ msgstr "Nijiders"
 
 #: src/components/NijiContent/index.tsx
 msgid "送信中…"
-msgstr ""
+msgstr "发送中…"
 
 #: src/pages/Candidate/index.tsx
 msgid "Edit"
@@ -602,7 +602,7 @@ msgstr "审核操作详情"
 
 #: src/components/Documentation/index.tsx
 msgid "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
-msgstr ""
+msgstr "每次拍卖结算时,结算交易也会导致铸造一个新的 Niji 并开始一个新的 24 小时拍卖。"
 
 #: src/pages/CreateCandidate/index.tsx
 msgid "Candidate Created!"
@@ -612,7 +612,7 @@ msgstr "候选已创建！"
 #: src/components/NijiContent/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Niji DAO"
-msgstr ""
+msgstr "Niji DAO"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijider's Reward"
@@ -633,7 +633,7 @@ msgstr "活跃"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DAO uses a fork of {compoundGovLink}."
-msgstr ""
+msgstr "Niji DAO 使用 {compoundGovLink} 的分叉。"
 
 #: src/pages/EditProposal/index.tsx
 msgid "Edit Proposal"
@@ -695,7 +695,7 @@ msgstr "请再试一次。"
 
 #: src/components/Documentation/index.tsx
 msgid "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
-msgstr ""
+msgstr "不存在关于属性稀缺性的明确规则;所有 Niji 同样稀有。"
 
 #: src/pages/Vote/index.tsx
 msgid "Proposal Queued!"
@@ -708,7 +708,7 @@ msgstr "开始新分叉"
 #: src/pages/Governance/index.tsx
 #: src/pages/NijisPage.tsx
 msgid "Niji"
-msgstr ""
+msgstr "Niji"
 
 #: src/pages/CreateCandidate/index.tsx
 msgid "Create Proposal Candidate"
@@ -734,7 +734,7 @@ msgstr "您已提供 <0>{0}</0> 条反馈 {1}"
 
 #: src/components/NijiContent/index.tsx
 msgid "For this reason, we, the project's founders (‘Nijiders’) have chosen to compensate ourselves with Nijis. Every 10th Niji for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to Nijiders."
-msgstr ""
+msgstr "因此,我们这些项目创始人 ('Nijider') 选择以 Niji 作为自己的报酬。在项目最初的 5 年里,每第 10 个 Niji 将被发送到我们的多重签名 (5/10),在那里它将被归属并分配给 Nijider。"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
@@ -744,7 +744,7 @@ msgstr "反对"
 
 #: src/pages/Nounders/index.tsx
 msgid "The Nijiders reward is intended as compensation for our pre and post-launch contributions to the project, and to help us participate meaningfully in governance as the project matures. Since there are 10 Nijiders, after 5 years each Nijider could receive up to 1% of the Niji supply."
-msgstr ""
+msgstr "Nijider 奖励旨在作为对我们在项目启动前后贡献的补偿,并帮助我们随着项目的成熟有意义地参与治理。由于有 10 个 Nijider,5 年后每个 Nijider 可以获得高达 1% 的 Niji 供应量。"
 
 #: src/components/ProposalStatus/index.tsx
 #: src/components/ProposalStatusCopy/index.tsx
@@ -757,7 +757,7 @@ msgstr "委托"
 
 #: src/pages/TraitsPage.tsx
 msgid "Filename"
-msgstr ""
+msgstr "文件名"
 
 #: src/components/Proposals/index.tsx
 msgid "About Proposal Candidates"
@@ -854,7 +854,7 @@ msgstr "返回"
 #. placeholder {0}: nijisRequired !== undefined ? ( <> {nijisRequired} {threshold === 0 ? nijiSingular : nijiPlural} </> ) : ( '...' )
 #: src/pages/Governance/index.tsx
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
-msgstr ""
+msgstr "Niji 治理 <0>Niji DAO</0>。Niji 可以对提案投票或将其投票委托给第三方。提交提案至少需要 <1>{0}</1>。"
 
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
@@ -929,7 +929,7 @@ msgstr "分叉为代币持有者群体提供了一种加密原生途径，使他
 
 #: src/pages/Nounders/index.tsx
 msgid "All Niji auction proceeds are sent to the Niji DAO. For this reason, we, the project's founders (‘Nijiders’) have chosen to compensate ourselves with Nijis. Every 10th Niji for the first 5 years of the project will be sent to our multisig (5/10), where it will be vested and distributed to individual Nijiders."
-msgstr ""
+msgstr "所有 Niji 拍卖收益都被发送到 Niji DAO。因此,我们这些项目创始人 ('Nijider') 选择以 Niji 作为自己的报酬。在项目最初的 5 年里,每第 10 个 Niji 将被发送到我们的多重签名 (5/10),在那里它将被归属并分配给各个 Nijider。"
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploy Fork"
@@ -937,7 +937,7 @@ msgstr "部署分叉"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
-msgstr ""
+msgstr "Niji 基金会认为否决权是一种紧急权力,在正常业务过程中不应行使。Niji 基金会将否决会给 Niji DAO 或 Niji 基金会带来重大法律或存续风险的提案,包括 (但不限于) 以下提案:"
 
 #: src/pages/EditProposal/index.tsx
 msgid "View the candidate"
@@ -979,7 +979,7 @@ msgstr "<0>已委托 Niji：</0>"
 
 #: src/components/Documentation/index.tsx
 msgid "All Nijis are members of Niji DAO."
-msgstr ""
+msgstr "所有 Niji 都是 Niji DAO 的成员。"
 
 #: src/components/DelegationCandidateInfo/index.tsx
 msgid "Now has"
@@ -987,7 +987,7 @@ msgstr "现在拥有"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "Build With Niji. Get Funded."
-msgstr ""
+msgstr "与 Niji 共同建设。获得资助。"
 
 #: src/components/Winner/index.tsx
 msgid "You"
@@ -1036,11 +1036,11 @@ msgstr "提交投票"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji Traits"
-msgstr ""
+msgstr "Niji 特征"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
-msgstr ""
+msgstr "Niji 基于以太坊区块哈希随机生成。没有 'if' 语句或其他规则来管理 Niji 特征的稀缺性,这使得所有 Niji 同样稀有。截至撰写本文时,Niji 由以下组成:"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Your <0>{availableVotes}</0> votes are being delegated to a new account."
@@ -1048,7 +1048,7 @@ msgstr "您的 <0>{availableVotes}</0> 票正在委托给新账户。"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
-msgstr ""
+msgstr "Niji 社区已经对提案否决权的替代方案 ('rage quit' 等) 进行了初步探索,但现在很清楚这是一个困难的问题,在实施令人满意的解决方案之前需要更多的研究、开发和测试。"
 
 #: src/components/ProposalStatus/index.tsx
 #: src/components/ProposalStatusCopy/index.tsx
@@ -1074,7 +1074,7 @@ msgstr "任何代币持有者均可针对某项治理提案，发出分叉（即
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
-msgstr ""
+msgstr "从乌干达的学校到洛杉矶的咖啡店,从圣保罗的加密中心到墨尔本的熟食店,Niji 生活在富有创造力的人们将想法付诸实践的地方。通过 <0/> 探索 nounish 的人、地点和事物。"
 
 #: src/components/LanguageSelectionModal/index.tsx
 msgid "Select Language"
@@ -1087,7 +1087,7 @@ msgstr "请出价大于或等于最低竞标金额 {0} ETH"
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploying Niji fork and beginning the forking period"
-msgstr ""
+msgstr "部署 Niji 分叉并开始分叉期"
 
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
@@ -1107,7 +1107,7 @@ msgstr "提议的交易"
 
 #: src/components/Documentation/index.tsx
 msgid "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
-msgstr ""
+msgstr "根据怀俄明州的 DUNA 法案,Niji DAO 可以以自己的名义持有资产、签订合同并参与法律行动。治理保持完全去中心化,决策完全由 Niji 持有者通过链上投票控制。这使 Niji DAO 能够可持续地资助项目、管理其金库,并在数字和物理世界中自信地互动。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Review Function Call Action"
@@ -1115,7 +1115,7 @@ msgstr "审核函数调用操作"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
-msgstr ""
+msgstr "Niji Seeder 合约用于在铸造过程中确定 Niji 特征。Seeder 合约可以被替换以允许未来的特征生成算法升级。此外,它可以被 Niji DAO 锁定以防止任何未来的更新。目前,Niji 特征使用伪随机数生成确定:"
 
 #: src/components/Bid/index.tsx
 #: src/components/NijiContent/index.tsx
@@ -1133,7 +1133,7 @@ msgstr "在提案 {0} 上投票"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
-msgstr ""
+msgstr "Niji 直接存储在以太坊上,不使用指向 IPFS 等其他网络的指针。这是可能的,因为 Niji 部件使用自定义的 run-length encoding (RLE) 压缩并存储在链上,这是一种无损压缩形式。"
 
 #: src/components/NijiInfoCard.tsx
 msgid "Bids"
@@ -1156,7 +1156,7 @@ msgstr "描述"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
-msgstr ""
+msgstr "Niji DAO 使用 {compoundGovLink} 的分叉,是 Niji 生态系统的主要治理机构。Niji DAO 金库接收来自每日 Niji 拍卖的 100% ETH 收益。每个 Niji 都是 Niji DAO 的不可撤销成员,在所有治理事项中有权获得一票。Niji 投票不可转让 (如果你出售你的 Niji,投票权也会随之转移),但可以委托,这意味着只要你拥有 Niji,你就可以将你的投票分配给其他人。"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Change"
@@ -1213,7 +1213,7 @@ msgstr "所有特征均为<0>CC0</0>（知识共享零协议），这意味着�
 
 #: src/components/Documentation/index.tsx
 msgid "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
-msgstr ""
+msgstr "在下面了解更多信息,或使用 {playgroundLink} 开始链下创建 Niji。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
 msgid "No arguments required "
@@ -1228,12 +1228,12 @@ msgstr "添加流支付操作"
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "LP"
-msgstr ""
+msgstr "LP"
 
 #. placeholder {0}: isForked ? ` #${id}` : ''
 #: src/pages/Fork/index.tsx
 msgid "Niji DAO Fork{0}"
-msgstr ""
+msgstr "Niji DAO 分叉{0}"
 
 #. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
 #: src/pages/Vote/index.tsx
@@ -1250,7 +1250,7 @@ msgstr "什么情况？"
 
 #: src/components/Documentation/index.tsx
 msgid "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
-msgstr ""
+msgstr "Nijider 以 Niji 的形式获得奖励 (前 5 年供应量的 10%)。"
 
 #. placeholder {0}: (proposalThreshold ?? 0) + 1
 #. placeholder {1}: proposalThreshold === 0 || proposalThreshold === null ? 'vote' : 'votes'
@@ -1260,14 +1260,14 @@ msgstr "在此次委托后，您的账户将少于{0}{1}。如果您没有足够
 
 #: src/components/NijiContent/index.tsx
 msgid "All Niji auction proceeds are sent to the"
-msgstr ""
+msgstr "所有 Niji 拍卖收益都被发送到"
 
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Nijis"
-msgstr ""
+msgstr "Niji"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "Auction ends in"
@@ -1298,7 +1298,7 @@ msgstr "将拥有"
 
 #: src/components/DelegateHoverCard/index.tsx
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
-msgstr ""
+msgstr "以 <0>{numVotesForProp}</0> Niji 投票"
 
 #: src/components/VoteSignals/VoteSignals.tsx
 msgid "Pre-voting feedback"
@@ -1311,7 +1311,7 @@ msgstr "{0}开始"
 
 #: src/components/Documentation/index.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
-msgstr ""
+msgstr "提案否决权最初被设想为对 Niji DAO 金库 '51% 攻击' 问题的临时解决方案。虽然 Nijider 最初认为 Niji 的健康分配将为 DAO 提供足够的保护,但对激励和风险的更完整理解使 Nijider、Niji 基金会和更广泛的社区内达成了普遍共识,即在删除该权利之前应实施更强大的博弈论解决方案。"
 
 #: src/components/CurrentDelegatePannel/index.tsx
 msgid "Current Delegate"
@@ -1329,11 +1329,11 @@ msgstr "委托已更新！"
 #. placeholder {0}: i18n.number(Number(nounSvgs ? (nounSvgs.length / 365).toFixed(2) : '0'))
 #: src/pages/Playground/index.tsx
 msgid "You've generated {0} years worth of Nijis"
-msgstr ""
+msgstr "你已经生成了 {0} 年的 Niji"
 
 #: src/components/Documentation/index.tsx
 msgid "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
-msgstr ""
+msgstr "因为 100% 的 Niji 拍卖收益都被发送到 Niji DAO,所以 Nijider 选择以 Niji 作为自己的报酬。在项目的前 5 年里,每第 10 个 Niji (Niji id #0、#10、#20、#30 等) 将自动发送到 Nijider 的多重签名以进行归属并在项目的创始成员之间共享。"
 
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
@@ -1348,7 +1348,7 @@ msgstr "用户已投票"
 
 #: src/pages/Governance/index.tsx
 msgid "This treasury exists for <0>Niji DAO</0> participants to allocate resources for the long-term growth and prosperity of the Niji project."
-msgstr ""
+msgstr "这个金库的存在是为了让 <0>Niji DAO</0> 参与者为 Niji 项目的长期增长和繁荣分配资源。"
 
 #: src/components/ProposalHeader/CandidateHeader.tsx
 #: src/components/ProposalHeader/index.tsx
@@ -1381,7 +1381,7 @@ msgstr "您的 <0>{availableVotes}</0> 票已委托给一个新账户。"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
-msgstr ""
+msgstr "当前反对的 Niji 百分比"
 
 #: src/pages/CreateProposal/index.tsx
 msgid "Tip"
@@ -1436,11 +1436,11 @@ msgstr "您可以在 1 分钟内手动结算"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "Niji is a global community."
-msgstr ""
+msgstr "Niji 是一个全球社区。"
 
 #: src/components/Documentation/index.tsx
 msgid "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
-msgstr ""
+msgstr "虽然结算对中标者激励最强,但任何人都可以触发,这使得系统在以太坊运行且有感兴趣的投标者的情况下能够无信任地拍卖 Niji。"
 
 #: src/pages/CreateProposal/index.tsx
 msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
@@ -1449,7 +1449,7 @@ msgstr "由于此提案包含 USDC 资金转移操作，我们添加了一个额
 #. placeholder {0}: i18n.number(availableVotes)
 #: src/components/VoteModal/index.tsx
 msgid "Voting with <0>{0}</0> Niji"
-msgstr ""
+msgstr "正在以 <0>{0}</0> Niji 投票"
 
 #: src/components/VoteModal/index.tsx
 msgid "Error"
@@ -1481,7 +1481,7 @@ msgstr "探索特征"
 
 #: src/components/Documentation/index.tsx
 msgid "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
-msgstr ""
+msgstr "'Nijider' 是发起 Niji 的十名建造者群体。Nijider 如下:"
 
 #: src/pages/Vote/index.tsx
 msgid "Transaction Successful!"
@@ -1501,11 +1501,11 @@ msgstr "令牌"
 
 #: src/components/Documentation/index.tsx
 msgid "The treasury is controlled exclusively by Nijis via governance."
-msgstr ""
+msgstr "金库通过治理完全由 Niji 控制。"
 
 #: src/components/Documentation/index.tsx
 msgid "One Niji is trustlessly auctioned every 24 hours, forever."
-msgstr ""
+msgstr "每 24 小时无信任地拍卖一个 Niji,永远持续。"
 
 #: src/components/Proposals/index.tsx
 msgid "No candidates found"
@@ -1522,7 +1522,7 @@ msgstr "输入您想要委托投票的账户的以太坊地址或 ENS 名称。"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Generate endless Nijis assembled from the onchain artwork"
-msgstr ""
+msgstr "生成由链上艺术作品组装而成的无尽 Niji"
 
 #. placeholder {0}: dayjs(endDate).fromNow()
 #: src/components/StartOrEndTime/index.tsx
@@ -1543,11 +1543,11 @@ msgstr "提案已更新！"
 #: src/pages/Fork/WithdrawNijisButton.tsx
 #: src/pages/Fork/WithdrawNijisButton.tsx
 msgid "Withdraw Nijis from escrow"
-msgstr ""
+msgstr "从托管中取出 Niji"
 
 #: src/components/NijiInfoRowHolder.tsx
 msgid "Niji Auction House"
-msgstr ""
+msgstr "Niji 拍卖行"
 
 #: src/pages/NijisPage.tsx
 msgid "Go to auction"
@@ -1592,7 +1592,7 @@ msgstr "审核并添加"
 
 #: src/components/Documentation/index.tsx
 msgid "100% of Niji auction proceeds are trustlessly sent to the treasury."
-msgstr ""
+msgstr "100% 的 Niji 拍卖收益无信任地发送到金库。"
 
 #: src/components/ProposalHeader/CandidateHeader.tsx
 msgid "<0>Proposed by: </0><1>{proposerLink}</1>{transactionLink}"
@@ -1656,7 +1656,7 @@ msgstr "委托"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji DUNA"
-msgstr ""
+msgstr "Niji DUNA"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "Add Action Details"
@@ -1677,7 +1677,7 @@ msgstr "Nijiders 奖励"
 
 #: src/components/Documentation/index.tsx
 msgid "One Niji is equal to one vote."
-msgstr ""
+msgstr "一个 Niji 等于一票。"
 
 #: src/pages/CandidateHistoryPage/index.tsx
 msgid "Proposal Candidate"
@@ -1697,7 +1697,7 @@ msgstr "您没有投票。"
 
 #: src/components/Documentation/index.tsx
 msgid "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
-msgstr ""
+msgstr "特征生成并非真正随机。在 pending 区块上铸造 Niji 时可以预测特征。"
 
 #: src/components/StreamWithdrawModal/index.tsx
 msgid "There was an error withdrawing to your wallet."
@@ -1705,7 +1705,7 @@ msgstr "提取到您的钱包时出错。"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji Seeder Contract"
-msgstr ""
+msgstr "Niji Seeder 合约"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
@@ -1715,11 +1715,11 @@ msgstr "支持"
 
 #: src/components/AuctionActivity/index.tsx
 msgid "Help mint the next Niji"
-msgstr ""
+msgstr "帮助铸造下一个 Niji"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "One Niji, Every Day, Forever."
-msgstr ""
+msgstr "每天一个 Niji,永远持续。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Function"
@@ -1727,17 +1727,17 @@ msgstr "函数"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "The logos, traits and every Niji generated on the playground are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
-msgstr ""
+msgstr "游乐场上生成的徽标、特征和每个 Niji 都是 <0>CC0</0> (Creative Commons Zero),这意味着它们处于公共领域,可以无限制地自由用于任何目的。"
 
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Download the individual traits that compose Nijis"
-msgstr ""
+msgstr "下载组成 Niji 的各个特征"
 
 #. placeholder {0}: humanizeTraitKey(traitKey)
 #. placeholder {1}: NijiImageData.images[traitKey].length
 #: src/components/Documentation/index.tsx
 msgid "{0} ({1})"
-msgstr ""
+msgstr "{0} ({1})"
 
 #: src/pages/Vote/index.tsx
 msgid "Objection only period"
@@ -1756,7 +1756,7 @@ msgstr "加载中..."
 
 #: src/pages/Fork/index.tsx
 msgid "Fork Niji DAO"
-msgstr ""
+msgstr "分叉 Niji DAO"
 
 #: src/pages/EditCandidate/index.tsx
 #: src/pages/EditProposal/index.tsx
@@ -1785,7 +1785,7 @@ msgstr "提案者功能"
 
 #: src/components/NijisIntroSection/index.tsx
 msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
-msgstr ""
+msgstr "看哪,一件无限的艺术作品!Niji 是一个社区所有的品牌,通过资助创意和促进合作产生积极影响。从收藏家和技术人员到非营利组织和品牌,Niji 适合每个人。"
 
 #: src/components/Banner/index.tsx
 msgid "EVERY DAY,"


### PR DESCRIPTION
## 概要

PR #120 (Nouns → Niji 全面 rename) で msgid が変わり、 旧 Nouns 訳との対応が切れて `msgstr ""` のまま compile されていた ja-JP / zh-CN 訳を埋めた。 ja-JP 73 件 / zh-CN 76 件、 計 **149 件**。

## 課題

ja-JP / zh-CN ロケールに切り替えた際に英語フォールバックが表示される箇所が大量に残っていた。 該当箇所は `Documentation` / `BrandAssetsPage` / `Playground` / `NijisIntroSection` / `Governance` / `NijiContent` / `Fork` 等に分散。

```mermaid
graph LR
    A[旧 Nouns msgid] --> B[旧 ja-JP/zh-CN 訳 99% カバー]
    C[PR #120 rename] --> D[新 Niji msgid 抽出]
    D --> E[msgstr 空 73+76 件]
    E --> F[英語フォールバック表示]
    G[本 PR] -->|Niji 文脈 + 既存語彙統一| H[全 149 件埋め]
```

## 解決方法

各 po file の `msgstr ""` を Niji 文脈 + 既存訳の語彙統一で埋める。

- Niji 固有名詞 (`Niji DAO` / `Niji DUNA` / `Nijider` / `Niji Seeder Contract` 等) は和訳せず原文維持
- 一般的な動詞 / 名詞は標準的な訳語に統一 (`treasury` → 「金庫」 / 「トレジャリー」、 `multisig` → 「マルチシグ」)
- `送信中…` (UI 短文) はそのまま / `Faucet` `LP` のような短ラベルは原文維持
- placeholder (`{0}` / `<0/>` 等) を完全保持し lingui compile 通過

## 検証

| 項目 | 結果 |
|---|---|
| lingui compile (`pnpm i18n:compile`) | 204ms 成功 |
| typecheck (`pnpm exec tsc --noEmit`) | PASS |
| vitest (`pnpm test`) | 30 tests PASS / 1 todo |
| build (`pnpm build`) | 20.73s 成功 |
| 残 empty msgstr | 1 件 / file (header `msgid ""` 対応、 po file 仕様上正常) |

## 受入条件

- [x] ja-JP.po / zh-CN.po の本文 msgstr が全件埋まる
- [x] lingui compile 通過
- [x] typecheck / vitest / build 通過

## 関連

- PR #120 (Nouns → Niji rename、 取りこぼし元)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqCHNM1PMk4d2eopYKar1r
