### PR TITLE
🗑️ chore(niji-webapp): dead な bs-custom-file-input を削除

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -52,7 +52,6 @@
     "bad-words": "^3.0.4",
     "blo": "^2.0.0",
     "bootstrap": "^5.3.6",
-    "bs-custom-file-input": "^1.3.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "connectkit": "^1.9.1",

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
@@ -7,8 +7,6 @@ import { Trans } from '@lingui/react/macro';
 import { Col, FormControl, FormGroup, InputGroup, Row } from 'react-bootstrap';
 import { encodeFunctionData, getAbiItem } from 'viem';
 
-import 'bs-custom-file-input';
-
 import ModalBottomButtonRow from '@/components/ModalBottomButtonRow';
 import ModalTitle from '@/components/ModalTitle';
 

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.tsx
@@ -15,8 +15,6 @@ import { buildEtherscanApiQuery } from '@/utils/etherscan';
 
 import { ProposalActionModalStepProps } from '../..';
 
-import 'bs-custom-file-input';
-
 const FunctionCallSelectFunctionStep: React.FC<ProposalActionModalStepProps> = props => {
   const { onNextBtnClick, onPrevBtnClick, state, setState } = props;
 

--- a/packages/niji-webapp/src/vite-env.d.ts
+++ b/packages/niji-webapp/src/vite-env.d.ts
@@ -6,5 +6,3 @@ declare module '*.svg?react' {
   const SVGComponent: React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
   export default SVGComponent;
 }
-
-declare module 'bs-custom-file-input';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,9 +559,6 @@ importers:
       bootstrap:
         specifier: ^5.3.6
         version: 5.3.6(@popperjs/core@2.11.8)
-      bs-custom-file-input:
-        specifier: ^1.3.4
-        version: 1.3.4
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -6518,10 +6515,6 @@ packages:
     resolution: {integrity: sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  bs-custom-file-input@1.3.4:
-    resolution: {integrity: sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA==}
-    engines: {node: '>=8'}
 
   bs58@4.0.1:
     resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
@@ -23624,8 +23617,6 @@ snapshots:
       electron-to-chromium: 1.5.190
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
-
-  bs-custom-file-input@1.3.4: {}
 
   bs58@4.0.1:
     dependencies:


### PR DESCRIPTION
# 概要

`packages/niji-webapp` から Bootstrap 4 の `custom-file` UI を有効化する `bs-custom-file-input` 依存と関連の side-effect import 3 箇所を削除する。
2 component で side-effect import (`import 'bs-custom-file-input'`) があるが、 対応する `<input type="file">` markup や `custom-file` クラスは両 file で 0 件で実質 no-op。

Closes #240

# 課題

`bs-custom-file-input` は Bootstrap 4 の `custom-file` 表示を有効化する helper だが、 webapp の `ProposalActionsModal` 配下 2 file では対応する markup が無く実質 no-op。
`vite-env.d.ts` の module declaration もこの dep の参照を維持するだけの dead 設定。

# 詳細

```mermaid
graph LR
    A[FunctionCallEnterArgsStep] -->|side-effect import| B[bs-custom-file-input]
    C[FunctionCallSelectFunctionStep] -->|side-effect import| B
    D[vite-env.d.ts] -->|declare module| B
    B -->|本来 ... custom-file 有効化| E["input type=file の表示変更"]
    A -.->|markup 内に file input なし| F[no-op]
    C -.->|markup 内に file input なし| F
```

参照箇所 (grep の結果)。

| file | line | 内容 |
|---|---|---|
| `packages/niji-webapp/src/vite-env.d.ts` | 10 | `declare module 'bs-custom-file-input';` |
| `packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx` | 10 | `import 'bs-custom-file-input';` (side-effect) |
| `packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.tsx` | 18 | 同上 |
| `packages/niji-webapp/package.json` | dependencies | `"bs-custom-file-input": "^1.3.4"` |

両 component を grep して `type="file"` / `custom-file` / `<Form.File>` / `<FormFile>` の markup は **0 件** であることを確認済み。

# 解決方法

3 箇所 + dep を整理する。

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/vite-env.d.ts` | `declare module 'bs-custom-file-input';` 行を削除 |
| `packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx` | side-effect import 行を削除 |
| `packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.tsx` | side-effect import 行を削除 |
| `packages/niji-webapp/package.json` | `bs-custom-file-input` ^1.3.4 を `dependencies` から削除 |

# 仕組み

```mermaid
graph LR
    A[before: dead bs-custom-file-input + 2 file side-effect] --> B[edit 3 file]
    B --> C[pnpm remove bs-custom-file-input]
    C --> D[after: clean state]
```

# テストと確認

- [x] `pnpm -F @niji/webapp check` (tsc --noEmit) 成功
- [x] `pnpm -F @niji/webapp build` 成功 (vite build、 dist 生成完了)
- [x] `grep -rn "bs-custom-file-input"` で残った参照が 0 件であることを確認

# レビューで見てほしいところ

なし — side-effect が実質 no-op で、 削除しても観測される挙動は変わらない。

# 関連

- Closes #240
- #238 / PR #239 (直前の web-vitals 整理)
- #25 (不要依存削除 epic)
