### PR TITLE
🗑️ chore(niji-webapp): @heroicons/react を lucide-react に統一 (14 file)

### DIFF
--- a/packages/niji-webapp/package.json
+++ b/packages/niji-webapp/package.json
@@ -31,7 +31,6 @@
   ],
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.2.0",
-    "@heroicons/react": "^1.0.6",
     "@lingui/core": "^5.9.0",
     "@lingui/detect-locale": "^5.9.0",
     "@lingui/loader": "^5.9.0",

--- a/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
+++ b/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
@@ -1,9 +1,8 @@
 import React, { ReactNode, useCallback, useEffect, useState, useMemo } from 'react';
 
-import { MinusCircleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
-import { CheckCircle2, X } from 'lucide-react';
+import { MinusCircle as MinusCircleIcon, CheckCircle2, X } from 'lucide-react';
 import { FormControl, FormSelect, FormText, InputGroup, Spinner } from 'react-bootstrap';
 import { map } from 'remeda';
 

--- a/packages/niji-webapp/src/components/BidHistoryModal/index.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModal/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { XIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
+import { X as XIcon } from 'lucide-react';
 import ReactDOM from 'react-dom';
 
 import BidHistoryModalRow from '@/components/BidHistoryModalRow';

--- a/packages/niji-webapp/src/components/BidHistoryModalRow/index.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModalRow/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { ExternalLinkIcon } from '@heroicons/react/solid';
 import { i18n } from '@lingui/core';
 import { blo } from 'blo';
 import clsx from 'clsx';
+import { ExternalLink as ExternalLinkIcon } from 'lucide-react';
 
 import _trophy from '@/assets/icons/trophy.svg';
 import TruncatedAmount from '@/components/TruncatedAmount';

--- a/packages/niji-webapp/src/components/BrandDropdown/index.tsx
+++ b/packages/niji-webapp/src/components/BrandDropdown/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ChevronDownIcon } from '@heroicons/react/solid';
+import { ChevronDown as ChevronDownIcon } from 'lucide-react';
 
 import classes from './BrandDropdown.module.css';
 

--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { ScaleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
+import { Scale as ScaleIcon } from 'lucide-react';
 import { Spinner } from 'react-bootstrap';
 import { map } from 'remeda';
 

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { ScaleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
+import { Scale as ScaleIcon } from 'lucide-react';
 import { Spinner } from 'react-bootstrap';
 
 import HorizontalStackedNijis from '@/components/HorizontalStackedNijis';

--- a/packages/niji-webapp/src/components/DelegationModal/index.tsx
+++ b/packages/niji-webapp/src/components/DelegationModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { XIcon } from '@heroicons/react/solid';
+import { X as XIcon } from 'lucide-react';
 import ReactDOM from 'react-dom';
 
 import { cn } from '@/lib/utils';

--- a/packages/niji-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/niji-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { XIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
+import { X as XIcon } from 'lucide-react';
 import ReactDOM from 'react-dom';
 
 import { Backdrop } from '@/components/Modal';

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransaction.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransaction.tsx
@@ -1,8 +1,8 @@
 import { Fragment } from 'react';
 
-import { InformationCircleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import { nijiPayerAddress, nijiTokenBuyerAddress } from '@niji/sdk/react';
+import { Info as InformationCircleIcon } from 'lucide-react';
 import { formatUnits } from 'viem';
 
 import ShortAddress from '@/components/ShortAddress';

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransactions.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransactions.tsx
@@ -1,8 +1,8 @@
 import { Fragment } from 'react';
 
-import { InformationCircleIcon } from '@heroicons/react/solid';
 import { Trans } from '@lingui/react/macro';
 import { nijiPayerAddress, nijiTokenBuyerAddress } from '@niji/sdk/react';
+import { Info as InformationCircleIcon } from 'lucide-react';
 import { formatUnits } from 'viem';
 
 import ShortAddress from '@/components/ShortAddress';

--- a/packages/niji-webapp/src/components/Proposals/index.tsx
+++ b/packages/niji-webapp/src/components/Proposals/index.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 
-import { ClockIcon } from '@heroicons/react/solid';
 import { i18n } from '@lingui/core';
 import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
@@ -8,6 +7,7 @@ import dayjs from 'dayjs';
 import en from 'dayjs/locale/en';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { useAtom } from 'jotai/react';
+import { Clock as ClockIcon } from 'lucide-react';
 import { Alert, Button, Col, Container, Row, Spinner } from 'react-bootstrap';
 import { Link, useLocation, useNavigate } from 'react-router';
 import { filter, find, last } from 'remeda';

--- a/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.tsx
+++ b/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react';
 
-import { XIcon } from '@heroicons/react/solid';
+import { X as XIcon } from 'lucide-react';
 import ReactDOM from 'react-dom';
 
 import NijisTransition from '@/components/NijisTransition';

--- a/packages/niji-webapp/src/components/VoteCardPager/index.tsx
+++ b/packages/niji-webapp/src/components/VoteCardPager/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/solid';
 import clsx from 'clsx';
+import { ChevronLeft as ChevronLeftIcon, ChevronRight as ChevronRightIcon } from 'lucide-react';
 
 import classes from './VoteCardPager.module.css';
 

--- a/packages/niji-webapp/src/pages/Vote/index.tsx
+++ b/packages/niji-webapp/src/pages/Vote/index.tsx
@@ -2,7 +2,6 @@ import type { Address } from '@/utils/types';
 
 import { Fragment, ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
 
-import { SearchIcon } from '@heroicons/react/solid';
 import { i18n } from '@lingui/core';
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
@@ -14,6 +13,7 @@ import en from 'dayjs/locale/en';
 import advanced from 'dayjs/plugin/advancedFormat';
 import timezone from 'dayjs/plugin/timezone';
 import utc from 'dayjs/plugin/utc';
+import { Search as SearchIcon } from 'lucide-react';
 import { Button, Card, Col, Row, Spinner } from 'react-bootstrap';
 import { Link, useParams } from 'react-router';
 import { isNonNullish } from 'remeda';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,9 +496,6 @@ importers:
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.11.0)
-      '@heroicons/react':
-        specifier: ^1.0.6
-        version: 1.0.6(react@19.1.0)
       '@lingui/core':
         specifier: ^5.9.0
         version: 5.9.2(@lingui/babel-plugin-lingui-macro@5.9.2(babel-plugin-macros@3.1.0)(typescript@5.9.2))(babel-plugin-macros@3.1.0)
@@ -2409,11 +2406,6 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
-
-  '@heroicons/react@1.0.6':
-    resolution: {integrity: sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==}
-    peerDependencies:
-      react: '>= 16'
 
   '@hono/node-server@1.13.3':
     resolution: {integrity: sha512-tEo3hcyQ6chvSnJ3tKzfX4z2sd7Q+ZkBwwBdW1Ya8Mz29dukxC2xcWiB/lAMwGJrYMW8QTgknIsLu1AsnMBe7A==}
@@ -17938,10 +17930,6 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.5.0(react@19.1.0)
-
-  '@heroicons/react@1.0.6(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
 
   '@hono/node-server@1.13.3(hono@4.7.9)':
     dependencies:


### PR DESCRIPTION
# 概要

`packages/niji-webapp` で並存していた 2 系統の icon library (`@heroicons/react` v1 + `lucide-react`) を `lucide-react` に統一する。
PR #208 (`@fortawesome/*` → lucide-react 統一、 Issue #152) と同じ方針で icon library を 1 つに揃え、 bundle 軽量化 + 一貫性向上 + dep 1 件削減を進める。

14 file の import 行のみを alias 形 (`X as XIcon` 等) に置換 ... component 本体のコード変更は不要。

Closes #242

# 課題

webapp は icon library を 2 系統で持っており用途が重複している。

- `@heroicons/react` ^1.0.6 ... v1 系で `@heroicons/react/solid` から `XIcon` / `ChevronLeftIcon` 等を 14 file で import
- `lucide-react` ... 既に webapp + sdk + docs で広く使用中 (PR #208 で `@fortawesome/*` から統一済)

heroicons v1 系は古く (現行は v2.x)、 同じような icon (X / Chevron / Info / Clock 等) が 2 系統存在することで bundle に同等画像が重複する。

# 詳細

14 file の使用 icon と lucide-react 同等品の mapping。

| heroicons (v1 `/solid`) | lucide-react | 該当 file |
|---|---|---|
| `XIcon` | `X` | BidHistoryModal / DynamicQuorumInfoModal / SolidColorBackgroundModal / DelegationModal (4 file) |
| `ChevronLeftIcon` / `ChevronRightIcon` | `ChevronLeft` / `ChevronRight` | VoteCardPager (1 file) |
| `ChevronDownIcon` | `ChevronDown` | BrandDropdown (1 file) |
| `InformationCircleIcon` | `Info` | ProposalContent/ProposalTransaction.tsx + ProposalTransactions.tsx (2 file) |
| `ScaleIcon` | `Scale` | ByLineHoverCard / DelegateHoverCard (2 file) |
| `MinusCircleIcon` | `MinusCircle` | AddNijisToForkModal (1 file) |
| `ClockIcon` | `Clock` | Proposals (1 file) |
| `ExternalLinkIcon` | `ExternalLink` | BidHistoryModalRow (1 file) |
| `SearchIcon` | `Search` | pages/Vote (1 file) |

14 file の各使用箇所は `<XIcon className={...} />` の単純 props pattern で、 lucide-react は同等の `className` prop に対応する。
alias 形 import (`import { X as XIcon } from 'lucide-react'`) を使うため component 本体の JSX は変更不要。

# 解決方法

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/components/BidHistoryModal/index.tsx` ほか 13 file | import 行を `import { <Name> as <NameIcon> } from 'lucide-react';` に置換 |
| `packages/niji-webapp/package.json` | `@heroicons/react` ^1.0.6 を `dependencies` から削除 |

# 仕組み

```mermaid
graph LR
    A[before: @heroicons/react v1 + lucide-react 2 系統] --> B[14 file の import 行を alias 形に置換]
    B --> C[pnpm remove @heroicons/react]
    C --> D[after: lucide-react のみ]
```

# テストと確認

- [x] `pnpm -F @niji/webapp check` (tsc --noEmit) 成功
- [x] `pnpm -F @niji/webapp build` 成功 (vite build、 dist 生成完了)
- [x] `grep -rn "@heroicons/react"` で残った参照が 0 件であることを確認

# レビューで見てほしいところ

- 各 icon の lucide-react 同等品の選定 ... `XIcon → X` / `InformationCircleIcon → Info` 等は名前が完全一致しないため、 視覚的に同等であることを念のため確認したい
- alias 形 import の選択 ... component 本体の JSX 変更を避けるため import 側で `as` を使ったが、 将来的には alias を外して lucide-react ネイティブ名 (`<X />` 等) に揃える経路もある (本 PR スコープ外)

# 関連

- Closes #242
- #240 / PR #241 (直前の bs-custom-file-input 整理)
- #152 / PR #208 (`@fortawesome/*` 削除 + lucide-react 統一、 本 PR と同じ方針)
- #25 (不要依存削除 epic)
