### PR TITLE
⏸️ feat(niji-contracts): NijiToken に Pausable を実装 (Issue #27)

### DIFF
--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -14,10 +14,11 @@ import { IVotes } from '@openzeppelin/contracts-v5/governance/utils/IVotes.sol';
 import { EIP712 } from '@openzeppelin/contracts-v5/utils/cryptography/EIP712.sol';
 import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 import { ReentrancyGuard } from '@openzeppelin/contracts-v5/utils/ReentrancyGuard.sol';
+import { Pausable } from '@openzeppelin/contracts-v5/utils/Pausable.sol';
 import { NijiDescriptor } from './NijiDescriptor.sol';
 import { INijiSeeder } from './interfaces/INijiSeeder.sol';
 
-contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGuard {
+contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGuard, Pausable {
     // =============================================================
     //                           ERRORS
     // =============================================================
@@ -360,6 +361,21 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     }
 
     // =============================================================
+    //                      PAUSABLE
+    // =============================================================
+
+    /// @notice Pause mint / transfer / burn (owner only)
+    /// @dev Inherits Pausable.paused() / Paused / Unpaused events. Emergency switch for security incidents.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpause mint / transfer / burn (owner only)
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    // =============================================================
     //                      VIEW FUNCTIONS
     // =============================================================
 
@@ -396,11 +412,12 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @dev Multi-inheritance override: ERC721Enumerable + ERC721Votes both override `_update`.
     /// Calling super.* chains both extensions: enumeration bookkeeping + voting unit transfer.
+    ///      `whenNotPaused` blocks mint / transfer / burn when paused (Pausable extension).
     function _update(
         address to,
         uint256 tokenId,
         address auth
-    ) internal override(ERC721Enumerable, ERC721Votes) returns (address) {
+    ) internal override(ERC721Enumerable, ERC721Votes) whenNotPaused returns (address) {
         return super._update(to, tokenId, auth);
     }
 

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -503,5 +503,31 @@ describe('NijiToken', () => {
       await token.unpause();
       await expect(token['mint(address)'](other.address)).to.not.be.reverted;
     });
+
+    it('should keep transferOwnership / acceptOwnership available while paused (owner rescue path)', async () => {
+      await token.pause();
+      await expect(token.transferOwnership(other.address)).to.not.be.reverted;
+      await expect(token.connect(other).acceptOwnership()).to.not.be.reverted;
+      expect(await token.owner()).to.equal(other.address);
+      expect(await token.paused()).to.be.true;
+    });
+
+    it('should keep owner admin setters callable while paused (setMintingActive)', async () => {
+      await token.pause();
+      await expect(token.setMintingActive(true)).to.not.be.reverted;
+      expect(await token.isMintingActive()).to.be.true;
+      expect(await token.paused()).to.be.true;
+    });
+
+    it('should keep view functions (tokenURI / getSeed) callable while paused', async () => {
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token.pause();
+
+      const uri = await token.tokenURI(0);
+      expect(uri).to.include('data:application/json;base64,');
+      const seed = await token.getSeed(0);
+      expect(seed.special).to.be.at.least(0);
+    });
   });
 });

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -429,4 +429,79 @@ describe('NijiToken', () => {
       expect(await unlimitedToken.remainingSupply()).to.equal(ethers.MaxUint256);
     });
   });
+
+  describe('pausable', () => {
+    it('should not be paused by default', async () => {
+      expect(await token.paused()).to.be.false;
+    });
+
+    it('should allow owner to pause', async () => {
+      await expect(token.pause()).to.emit(token, 'Paused').withArgs(owner.address);
+      expect(await token.paused()).to.be.true;
+    });
+
+    it('should allow owner to unpause', async () => {
+      await token.pause();
+      await expect(token.unpause()).to.emit(token, 'Unpaused').withArgs(owner.address);
+      expect(await token.paused()).to.be.false;
+    });
+
+    it('should revert when non-owner tries to pause', async () => {
+      await expect(token.connect(other).pause()).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should revert when non-owner tries to unpause', async () => {
+      await token.pause();
+      await expect(token.connect(other).unpause()).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should block mint when paused', async () => {
+      await token.toggleMinting();
+      await token.pause();
+      await expect(token['mint(address)'](other.address)).to.be.revertedWithCustomError(
+        token,
+        'EnforcedPause',
+      );
+    });
+
+    it('should block mintBatch when paused', async () => {
+      await token.toggleMinting();
+      await token.pause();
+      await expect(token.mintBatch(other.address, 2)).to.be.revertedWithCustomError(
+        token,
+        'EnforcedPause',
+      );
+    });
+
+    it('should block transfer when paused', async () => {
+      await token.toggleMinting();
+      const tokenId = await token['mint(address)'].staticCall(other.address);
+      await token['mint(address)'](other.address);
+      await token.pause();
+      await expect(
+        token.connect(other).transferFrom(other.address, owner.address, tokenId),
+      ).to.be.revertedWithCustomError(token, 'EnforcedPause');
+    });
+
+    it('should block burn when paused', async () => {
+      await token.toggleMinting();
+      const tokenId = await token['mint()'].staticCall();
+      await token['mint()']();
+      await token.pause();
+      await expect(token.burn(tokenId)).to.be.revertedWithCustomError(token, 'EnforcedPause');
+    });
+
+    it('should resume operations when unpaused', async () => {
+      await token.toggleMinting();
+      await token.pause();
+      await token.unpause();
+      await expect(token['mint(address)'](other.address)).to.not.be.reverted;
+    });
+  });
 });


### PR DESCRIPTION
# 概要

NijiToken に OpenZeppelin v5 の Pausable extension を組み込み、 owner だけが mint / transfer / burn を一時停止できる緊急停止スイッチを追加しました。
セキュリティインシデント (exploit 発見 / 不正 mint 検知 / metadata 異常 等) が起きた時に、 owner が即座に全動作を凍結できる安全機構として機能します。
解凍も owner だけが行えるため、 攻撃者に乗っ取られない限り対応の時間を稼ぐことができます。

# 課題

これまでの NijiToken には緊急停止機構がありませんでした。
万一 mint 系のロジックや transfer 経路に問題が見つかっても、 個別の `setMintingActive(false)` で mint だけは止められますが、 既存トークンの transfer や burn は止まりません。
ガバナンスや auction house で不正が見つかった時に、 chain 全体の動きを止める手段がない状態でした。

# 詳細

OpenZeppelin v5 では ERC721 の hook が `_beforeTokenTransfer` から `_update` に変わっており、 mint / transfer / burn すべての経路がここを通ります。
NijiToken は ERC721Enumerable と ERC721Votes の両方を継承しているため、 既存実装でも `_update` を override して `super._update(...)` を呼んでいます。

```mermaid
graph LR
    A[mint / transfer / burn 呼び出し] --> B[_update override]
    B --> C[ERC721Enumerable + ERC721Votes super]
    C --> D[トークン状態更新]
```

# 解決方法

`_update` の override に `whenNotPaused` modifier を追加し、 paused 状態の時は mint / transfer / burn すべてを revert させます。
合わせて owner 専用の `pause()` / `unpause()` を追加して、 緊急時に状態を切り替えられるようにしました。

# 仕組み

```mermaid
graph LR
    A[owner.pause を呼ぶ] --> B[paused = true]
    B --> C[mint / transfer / burn が revert]
    C --> D[owner.unpause で paused = false に戻す]
    D --> E[通常運用に復帰]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiToken.sol` | OpenZeppelin v5 の Pausable を継承し `_update` に `whenNotPaused` を追加。 owner 専用の `pause()` / `unpause()` を新設して緊急停止と復帰を 2 関数で扱えるようにした |
| `packages/niji-contracts/test/niji/NijiToken.test.ts` | pausable describe ブロックを新設し default state / owner only / paused 状態での mint / mintBatch / transfer / burn revert / unpause 後の復帰など 9 ケースを追加した |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiToken.test.ts` 58 件全 pass (pausable 9 件新規 + 既存 49 件)
- [x] `pnpm hardhat test test/niji/NijiToken.edge.test.ts test/niji/NijiIntegration.test.ts test/niji/NijiToken.votes.test.ts` 39 件全 pass (regression なし)
- [x] OpenZeppelin v5 Pausable の標準 event (Paused / Unpaused) と revert (EnforcedPause / OwnableUnauthorizedAccount) を確認

レビューで見てほしいところ。

`_update` の `whenNotPaused` 配置で mint / transfer / burn 全経路を 1 箇所で塞げているか、 個別関数に modifier を散らす実装と比べて見落としがないかをご確認ください。

# 関連

Closes #27
