### PR TITLE
🚫 feat(niji-contracts): 4 contract で renounceOwnership を無効化 (Issue #29)

### DIFF
--- a/packages/niji-contracts/contracts/NijiArt.sol
+++ b/packages/niji-contracts/contracts/NijiArt.sol
@@ -30,6 +30,9 @@ contract NijiArt is Ownable2Step {
     /// @notice Thrown when PNG data is empty
     error EmptyPngData();
 
+    /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
+    error RenounceOwnershipDisabled();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -220,5 +223,11 @@ contract NijiArt is Ownable2Step {
     function getTraitPointers(uint256 traitId) external view returns (address[] memory) {
         if (traitId >= traitCount) revert InvalidTraitId(traitId, traitCount - 1);
         return traitPointers[traitId];
+    }
+
+    /// @notice Disabled to prevent the contract from becoming permanently unowned.
+    /// @dev Always reverts. Use `transferOwnership` (Ownable2Step two-step transfer) for ownership change instead.
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipDisabled();
     }
 }

--- a/packages/niji-contracts/contracts/NijiDescriptor.sol
+++ b/packages/niji-contracts/contracts/NijiDescriptor.sol
@@ -33,6 +33,9 @@ contract NijiDescriptor is Ownable2Step {
     /// @notice Thrown when trait indices array is empty
     error EmptyTraitIndices();
 
+    /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
+    error RenounceOwnershipDisabled();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -339,5 +342,11 @@ contract NijiDescriptor is Ownable2Step {
     /// @return True if art, resolution, and compositeOrder are set
     function isConfigured() external view returns (bool) {
         return address(art) != address(0) && resolution > 0 && compositeOrder.length > 0;
+    }
+
+    /// @notice Disabled to prevent the contract from becoming permanently unowned.
+    /// @dev Always reverts. Use `transferOwnership` (Ownable2Step two-step transfer) for ownership change instead.
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipDisabled();
     }
 }

--- a/packages/niji-contracts/contracts/NijiSeeder.sol
+++ b/packages/niji-contracts/contracts/NijiSeeder.sol
@@ -19,6 +19,9 @@ contract NijiSeeder is INijiSeeder, Ownable2Step {
     /// @notice Thrown when art address is invalid
     error InvalidArtAddress();
 
+    /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
+    error RenounceOwnershipDisabled();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -158,5 +161,11 @@ contract NijiSeeder is INijiSeeder, Ownable2Step {
         }
 
         return counts;
+    }
+
+    /// @notice Disabled to prevent the contract from becoming permanently unowned.
+    /// @dev Always reverts. Use `transferOwnership` (Ownable2Step two-step transfer) for ownership change instead.
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipDisabled();
     }
 }

--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -54,6 +54,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @param reason The raw revert data returned by the owner-side call (helps diagnose smart-wallet rejections)
     error WithdrawFailed(bytes reason);
 
+    /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
+    error RenounceOwnershipDisabled();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -471,6 +474,12 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
         override(ERC721Enumerable, ERC721Votes)
     {
         super._increaseBalance(account, amount);
+    }
+
+    /// @notice Disabled to prevent the contract from becoming permanently unowned.
+    /// @dev Always reverts. Use `transferOwnership` (Ownable2Step two-step transfer) for ownership change instead.
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipDisabled();
     }
 
     /// @dev Multi-inheritance override for `supportsInterface` (ERC721Enumerable + ERC721).

--- a/packages/niji-contracts/test/niji/NijiArt.test.ts
+++ b/packages/niji-contracts/test/niji/NijiArt.test.ts
@@ -147,6 +147,15 @@ describe('NijiArt', () => {
     () => descriptor,
   );
 
+  describe('renounceOwnership disabled (non-owner)', () => {
+    it('should revert with OwnableUnauthorizedAccount when called by non-owner', async () => {
+      await expect(art.connect(other).renounceOwnership()).to.be.revertedWithCustomError(
+        art,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+  });
+
   describe('getTraitNames', () => {
     it('should return all trait names', async () => {
       const names = await art.getTraitNames();

--- a/packages/niji-contracts/test/niji/NijiDescriptor.test.ts
+++ b/packages/niji-contracts/test/niji/NijiDescriptor.test.ts
@@ -245,6 +245,15 @@ describe('NijiDescriptor', () => {
     () => owner,
   );
 
+  describe('renounceOwnership disabled (non-owner)', () => {
+    it('should revert with OwnableUnauthorizedAccount when called by non-owner', async () => {
+      await expect(descriptor.connect(other).renounceOwnership()).to.be.revertedWithCustomError(
+        descriptor,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+  });
+
   describe('isConfigured', () => {
     it('should return true when properly configured', async () => {
       expect(await descriptor.isConfigured()).to.be.true;

--- a/packages/niji-contracts/test/niji/NijiSeeder.test.ts
+++ b/packages/niji-contracts/test/niji/NijiSeeder.test.ts
@@ -231,4 +231,13 @@ describe('NijiSeeder', () => {
     () => other,
     () => owner,
   );
+
+  describe('renounceOwnership disabled (non-owner)', () => {
+    it('should revert with OwnableUnauthorizedAccount when called by non-owner', async () => {
+      await expect(seeder.connect(other).renounceOwnership()).to.be.revertedWithCustomError(
+        seeder,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+  });
 });

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -313,6 +313,15 @@ describe('NijiToken', () => {
     () => minter,
   );
 
+  describe('renounceOwnership disabled (non-owner)', () => {
+    it('should revert with OwnableUnauthorizedAccount when called by non-owner', async () => {
+      await expect(token.connect(other).renounceOwnership()).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+  });
+
   describe('contractURI', () => {
     it('should return ipfs:// with empty hash by default', async () => {
       expect(await token.contractURI()).to.equal('ipfs://');

--- a/packages/niji-contracts/test/niji/helpers/behaviors.ts
+++ b/packages/niji-contracts/test/niji/helpers/behaviors.ts
@@ -67,5 +67,14 @@ export function shouldBehaveLikeOwnable2Step(
         contract.connect(nonPendingOwner).acceptOwnership(),
       ).to.be.revertedWithCustomError(contract, 'OwnableUnauthorizedAccount');
     });
+
+    it('renounceOwnership should revert with RenounceOwnershipDisabled when called by owner', async () => {
+      const contract = getContract();
+
+      await expect(contract.renounceOwnership()).to.be.revertedWithCustomError(
+        contract,
+        'RenounceOwnershipDisabled',
+      );
+    });
   });
 }


### PR DESCRIPTION
# 概要

NijiToken / NijiArt / NijiDescriptor / NijiSeeder の 4 contract で `renounceOwnership()` を override し、 常に revert させて contract が unowned 状態になる経路を完全に塞ぎました。
誤って `renounceOwnership` を呼び出すと owner が `address(0)` に書き換わり、 以後すべての onlyOwner 関数が永久に呼び出せなくなる致命的事故を構造的に防止します。
ownership の移行は `transferOwnership` (Ownable2Step の 2 段階移行) のみが正規経路として残ります。

# 課題

OpenZeppelin の `Ownable` が提供する `renounceOwnership` は便利ですが、 一度呼ぶと取り返しがつかない壊滅的な関数でもあります。
NijiToken は mint / transfer 制御、 NijiArt は trait 画像追加、 NijiDescriptor は metadata 生成、 NijiSeeder は seed 生成と、 どれも長期運用で owner 権限による設定変更が必要です。
ここで owner を放棄してしまうと、 mint 停止すら不可能になります。

# 詳細

4 contract はすべて `Ownable2Step` を継承しており、 親 `Ownable` の `renounceOwnership` が継承経路上で呼べる状態でした。
オーナー鍵を保有していれば一度の transaction で contract を再起不能にできてしまうため、 ヒューマンエラーへの耐性が無い状態でした。

```mermaid
graph LR
    A[誤操作で renounceOwnership 呼び出し] --> B[owner が address 0 に書き換わる]
    B --> C[onlyOwner 関数すべて呼び出し不可]
    C --> D[mint 制御 / 設定変更 / 緊急停止 全て不能]
```

# 解決方法

各 contract で `renounceOwnership()` を override し、 共通エラー `RenounceOwnershipDisabled` で必ず revert させました。
`onlyOwner` modifier は残しているため、 非 owner が呼んだ場合は OpenZeppelin 標準の `OwnableUnauthorizedAccount` が先に発火し、 owner が呼んだ場合は `RenounceOwnershipDisabled` で revert します。

```mermaid
graph LR
    A[renounceOwnership 呼び出し] --> B{呼び出し元判定}
    B -->|owner 以外| C[OwnableUnauthorizedAccount で revert]
    B -->|owner| D[RenounceOwnershipDisabled で revert]
    A2[ownership 移行] --> E[transferOwnership + acceptOwnership の 2-step のみ]
```

# 仕組み

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiToken.sol` | `RenounceOwnershipDisabled` error 追加、 `renounceOwnership()` を `onlyOwner override` で常に revert |
| `packages/niji-contracts/contracts/NijiArt.sol` | 同上 |
| `packages/niji-contracts/contracts/NijiDescriptor.sol` | 同上 |
| `packages/niji-contracts/contracts/NijiSeeder.sol` | 同上 |
| `packages/niji-contracts/test/niji/helpers/behaviors.ts` | `shouldBehaveLikeOwnable2Step` 共通ヘルパに owner からの renounceOwnership が `RenounceOwnershipDisabled` で revert する 1 ケースを追加 (4 contract に自動伝播) |
| `packages/niji-contracts/test/niji/NijiToken.test.ts` `NijiArt.test.ts` `NijiDescriptor.test.ts` `NijiSeeder.test.ts` | 非 owner から renounceOwnership 呼び出しで `OwnableUnauthorizedAccount` が revert する describe を 4 file に追加 (helper の 4 番目 arg `nonPendingOwner` は contract によって owner か非 owner が混在するため、 個別 file 側で独立記述) |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiToken.test.ts test/niji/NijiArt.test.ts test/niji/NijiDescriptor.test.ts test/niji/NijiSeeder.test.ts` 130 件全 pass
- [x] `pnpm hardhat test` 全 231 件 pass (regression なし)
- [x] 各 contract の owner 経路は `RenounceOwnershipDisabled` を確認、 非 owner 経路は `OwnableUnauthorizedAccount` を確認

レビューで見てほしいところ。

`renounceOwnership` を `public view override onlyOwner` で declare しています (state を変更しない revert-only 実装のため `view` を付与)。
`onlyOwner` modifier を残すことで非 owner からの呼び出しが `RenounceOwnershipDisabled` で revert する前に `OwnableUnauthorizedAccount` で revert するため、 攻撃者に内部仕様を漏らさない設計にしています。
方針合っているかご確認お願いします。

# 関連

Closes #29
