### PR TITLE
🎭 feat(niji-contracts): NijiToken に Reveal メカニズムを実装 (Issue #20)

### DIFF
--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -15,10 +15,12 @@ import { EIP712 } from '@openzeppelin/contracts-v5/utils/cryptography/EIP712.sol
 import { Ownable2Step, Ownable } from '@openzeppelin/contracts-v5/access/Ownable2Step.sol';
 import { ReentrancyGuard } from '@openzeppelin/contracts-v5/utils/ReentrancyGuard.sol';
 import { Pausable } from '@openzeppelin/contracts-v5/utils/Pausable.sol';
+import { IERC4906 } from '@openzeppelin/contracts-v5/interfaces/IERC4906.sol';
+import { IERC165 } from '@openzeppelin/contracts-v5/utils/introspection/IERC165.sol';
 import { NijiDescriptor } from './NijiDescriptor.sol';
 import { INijiSeeder } from './interfaces/INijiSeeder.sol';
 
-contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGuard, Pausable {
+contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGuard, Pausable, IERC4906 {
     // =============================================================
     //                           ERRORS
     // =============================================================
@@ -62,6 +64,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Thrown when placeholder URI is set to an empty string
     error EmptyPlaceholderURI();
+
+    /// @notice Thrown when mint is attempted before the placeholder URI is set (pre-reveal mint safety)
+    error PlaceholderURINotSet();
 
     // =============================================================
     //                           EVENTS
@@ -245,9 +250,12 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Internal mint function
     /// @dev Uses _mint (not _safeMint) to remain compatible with auction house contracts that do not implement IERC721Receiver — matching NounsToken behavior.
+    ///      Reverts if the collection is still unrevealed and the placeholder URI is unset (otherwise tokenURI would return an empty string and break marketplaces).
     /// @param to The recipient address
     /// @return tokenId The minted token ID
     function _mintTo(address to) internal returns (uint256) {
+        if (!isRevealed && bytes(_placeholderURI).length == 0) revert PlaceholderURINotSet();
+
         uint256 tokenId = _currentTokenId;
 
         // Generate seed for this token
@@ -408,19 +416,23 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Set the placeholder URI used for unrevealed tokens (owner only, only allowed pre-reveal)
     /// @param newPlaceholderURI URI string returned for every tokenURI while not revealed
+    /// @dev Emits ERC-4906 BatchMetadataUpdate so marketplaces refresh stale placeholder metadata.
     function setPlaceholderURI(string calldata newPlaceholderURI) external onlyOwner {
         if (isRevealed) revert RevealAlreadyDone();
         if (bytes(newPlaceholderURI).length == 0) revert EmptyPlaceholderURI();
         _placeholderURI = newPlaceholderURI;
         emit PlaceholderURIUpdated(newPlaceholderURI);
+        emit BatchMetadataUpdate(0, type(uint256).max);
     }
 
     /// @notice Reveal the collection (owner only, one-way switch)
     /// @dev After this call, tokenURI delegates to the on-chain descriptor for every token. Cannot be undone.
+    ///      Emits ERC-4906 BatchMetadataUpdate so marketplaces refresh from placeholder to on-chain metadata.
     function reveal() external onlyOwner {
         if (isRevealed) revert RevealAlreadyDone();
         isRevealed = true;
         emit Revealed();
+        emit BatchMetadataUpdate(0, type(uint256).max);
     }
 
     /// @notice Returns the current placeholder URI (empty string if never set)
@@ -536,14 +548,17 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     }
 
     /// @dev Multi-inheritance override for `supportsInterface` (ERC721Enumerable + ERC721).
-    ///      Also advertises `IVotes` so on-chain ERC165 probes (Governor / aggregators) can detect Votes support.
+    ///      Also advertises `IVotes` (Governor / aggregators) and `IERC4906` (marketplace metadata refresh).
     function supportsInterface(bytes4 interfaceId)
         public
         view
-        override(ERC721, ERC721Enumerable)
+        override(ERC721, ERC721Enumerable, IERC165)
         returns (bool)
     {
-        return interfaceId == type(IVotes).interfaceId || super.supportsInterface(interfaceId);
+        return
+            interfaceId == type(IVotes).interfaceId ||
+            interfaceId == bytes4(0x49064906) || // ERC-4906 (MetadataUpdate / BatchMetadataUpdate)
+            super.supportsInterface(interfaceId);
     }
 
     // =============================================================

--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -57,6 +57,12 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
     error RenounceOwnershipDisabled();
 
+    /// @notice Thrown when reveal is called after it was already executed
+    error RevealAlreadyDone();
+
+    /// @notice Thrown when placeholder URI is set to an empty string
+    error EmptyPlaceholderURI();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -99,6 +105,13 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @param amount The amount of ETH withdrawn (wei)
     event Withdrawn(address indexed to, uint256 amount);
 
+    /// @notice Emitted when the placeholder URI is updated (only available pre-reveal)
+    /// @param newPlaceholderURI The new placeholder URI used while not revealed
+    event PlaceholderURIUpdated(string newPlaceholderURI);
+
+    /// @notice Emitted when the collection is revealed (state is permanent after this)
+    event Revealed();
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -132,6 +145,15 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Whether the provenance hash is locked
     bool public isProvenanceHashLocked;
+
+    /// @notice Whether the collection has been revealed (one-way switch)
+    /// @dev Pre-reveal: tokenURI returns the placeholder URI for every token.
+    ///      Post-reveal: tokenURI delegates to the on-chain descriptor as usual.
+    bool public isRevealed;
+
+    /// @notice Placeholder URI returned for every tokenURI while not revealed
+    /// @dev Should point to a single metadata JSON (per ERC721 marketplaces convention).
+    string private _placeholderURI;
 
     // =============================================================
     //                           MODIFIERS
@@ -248,8 +270,13 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Returns the token URI for a given token ID
     /// @param tokenId The token ID
     /// @return The token URI
+    /// @dev Pre-reveal returns the placeholder URI (same value for every token). Post-reveal delegates to the on-chain descriptor.
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         if (_ownerOf(tokenId) == address(0)) revert TokenDoesNotExist();
+
+        if (!isRevealed) {
+            return _placeholderURI;
+        }
 
         INijiSeeder.Seed memory seed = seeds[tokenId];
         uint256[] memory traitIndices = _seedToTraitIndices(seed);
@@ -373,6 +400,32 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     function lockProvenanceHash() external onlyOwner {
         if (isProvenanceHashLocked) revert ProvenanceHashLocked();
         isProvenanceHashLocked = true;
+    }
+
+    // =============================================================
+    //                      REVEAL
+    // =============================================================
+
+    /// @notice Set the placeholder URI used for unrevealed tokens (owner only, only allowed pre-reveal)
+    /// @param newPlaceholderURI URI string returned for every tokenURI while not revealed
+    function setPlaceholderURI(string calldata newPlaceholderURI) external onlyOwner {
+        if (isRevealed) revert RevealAlreadyDone();
+        if (bytes(newPlaceholderURI).length == 0) revert EmptyPlaceholderURI();
+        _placeholderURI = newPlaceholderURI;
+        emit PlaceholderURIUpdated(newPlaceholderURI);
+    }
+
+    /// @notice Reveal the collection (owner only, one-way switch)
+    /// @dev After this call, tokenURI delegates to the on-chain descriptor for every token. Cannot be undone.
+    function reveal() external onlyOwner {
+        if (isRevealed) revert RevealAlreadyDone();
+        isRevealed = true;
+        emit Revealed();
+    }
+
+    /// @notice Returns the current placeholder URI (empty string if never set)
+    function placeholderURI() external view returns (string memory) {
+        return _placeholderURI;
     }
 
     // =============================================================

--- a/packages/niji-contracts/test/niji/NijiIntegration.test.ts
+++ b/packages/niji-contracts/test/niji/NijiIntegration.test.ts
@@ -88,6 +88,7 @@ describe('NijiIntegration', () => {
   describe('full flow: mint → tokenURI → attributes', () => {
     it('should produce valid tokenURI with attributes after mint', async () => {
       await token['mint(address)'](minter.address);
+      await token.reveal();
 
       const uri = await token.tokenURI(0);
       const json = decodeTokenURI(uri);
@@ -112,6 +113,7 @@ describe('NijiIntegration', () => {
   describe('descriptor swap after mint', () => {
     it('should use new descriptor for tokenURI', async () => {
       await token['mint(address)'](minter.address);
+      await token.reveal();
 
       // Deploy new descriptor with different resolution
       const newArt = await deployNijiArt(owner.address);

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -163,6 +163,7 @@ describe('NijiToken', () => {
     beforeEach(async () => {
       await token.toggleMinting();
       await token['mint(address)'](other.address);
+      await token.reveal(); // Reveal so tokenURI returns on-chain metadata, not the placeholder
     });
 
     it('should return valid tokenURI', async () => {
@@ -531,6 +532,7 @@ describe('NijiToken', () => {
     it('should keep view functions (tokenURI / getSeed) callable while paused', async () => {
       await token.toggleMinting();
       await token['mint(address)'](other.address);
+      await token.reveal(); // ensure tokenURI returns on-chain metadata, not the empty placeholder
       await token.pause();
 
       const uri = await token.tokenURI(0);
@@ -659,6 +661,95 @@ describe('NijiToken', () => {
       const tokenIface = token.interface;
       const callData = tokenIface.encodeFunctionData('withdrawAmount', [ethers.parseEther('1')]);
       await expect(rejecting.callOn(tokenAddr, callData)).to.be.reverted;
+    });
+  });
+
+  describe('reveal', () => {
+    const PLACEHOLDER = 'ipfs://QmPlaceholderHash/metadata.json';
+
+    it('should not be revealed by default', async () => {
+      expect(await token.isRevealed()).to.be.false;
+    });
+
+    it('should return empty placeholder URI by default', async () => {
+      expect(await token.placeholderURI()).to.equal('');
+    });
+
+    it('should allow owner to set placeholder URI before reveal', async () => {
+      await expect(token.setPlaceholderURI(PLACEHOLDER))
+        .to.emit(token, 'PlaceholderURIUpdated')
+        .withArgs(PLACEHOLDER);
+      expect(await token.placeholderURI()).to.equal(PLACEHOLDER);
+    });
+
+    it('should revert setPlaceholderURI with empty string', async () => {
+      await expect(token.setPlaceholderURI('')).to.be.revertedWithCustomError(
+        token,
+        'EmptyPlaceholderURI',
+      );
+    });
+
+    it('should revert setPlaceholderURI when non-owner', async () => {
+      await expect(
+        token.connect(other).setPlaceholderURI(PLACEHOLDER),
+      ).to.be.revertedWithCustomError(token, 'OwnableUnauthorizedAccount');
+    });
+
+    it('should return placeholder URI for every token pre-reveal', async () => {
+      await token.setPlaceholderURI(PLACEHOLDER);
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token['mint(address)'](other.address);
+
+      expect(await token.tokenURI(0)).to.equal(PLACEHOLDER);
+      expect(await token.tokenURI(1)).to.equal(PLACEHOLDER);
+    });
+
+    it('should still revert tokenURI for non-existent token pre-reveal', async () => {
+      await token.setPlaceholderURI(PLACEHOLDER);
+      await expect(token.tokenURI(999)).to.be.revertedWithCustomError(
+        token,
+        'TokenDoesNotExist',
+      );
+    });
+
+    it('should allow owner to reveal exactly once', async () => {
+      await expect(token.reveal()).to.emit(token, 'Revealed');
+      expect(await token.isRevealed()).to.be.true;
+    });
+
+    it('should revert reveal when called twice', async () => {
+      await token.reveal();
+      await expect(token.reveal()).to.be.revertedWithCustomError(token, 'RevealAlreadyDone');
+    });
+
+    it('should revert reveal when non-owner', async () => {
+      await expect(token.connect(other).reveal()).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should revert setPlaceholderURI after reveal', async () => {
+      await token.reveal();
+      await expect(token.setPlaceholderURI(PLACEHOLDER)).to.be.revertedWithCustomError(
+        token,
+        'RevealAlreadyDone',
+      );
+    });
+
+    it('should switch tokenURI from placeholder to on-chain after reveal', async () => {
+      await token.setPlaceholderURI(PLACEHOLDER);
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+
+      expect(await token.tokenURI(0)).to.equal(PLACEHOLDER);
+
+      await token.reveal();
+
+      const uri = await token.tokenURI(0);
+      expect(uri).to.include('data:application/json;base64,');
+      expect(uri).to.not.equal(PLACEHOLDER);
     });
   });
 });

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -671,15 +671,22 @@ describe('NijiToken', () => {
       expect(await token.isRevealed()).to.be.false;
     });
 
-    it('should return empty placeholder URI by default', async () => {
-      expect(await token.placeholderURI()).to.equal('');
+    it('should have a default placeholder URI from helper setup', async () => {
+      // Helper deployNijiToken sets a default placeholder so mint paths work in tests.
+      expect(await token.placeholderURI()).to.equal('ipfs://test-placeholder/metadata.json');
     });
 
-    it('should allow owner to set placeholder URI before reveal', async () => {
+    it('should allow owner to update placeholder URI before reveal', async () => {
       await expect(token.setPlaceholderURI(PLACEHOLDER))
         .to.emit(token, 'PlaceholderURIUpdated')
         .withArgs(PLACEHOLDER);
       expect(await token.placeholderURI()).to.equal(PLACEHOLDER);
+    });
+
+    it('should emit BatchMetadataUpdate on setPlaceholderURI (ERC-4906)', async () => {
+      await expect(token.setPlaceholderURI(PLACEHOLDER))
+        .to.emit(token, 'BatchMetadataUpdate')
+        .withArgs(0, ethers.MaxUint256);
     });
 
     it('should revert setPlaceholderURI with empty string', async () => {
@@ -713,9 +720,50 @@ describe('NijiToken', () => {
       );
     });
 
+    it('should revert mint when placeholder URI is unset and not revealed', async () => {
+      // Deploy a fresh contract without going through the helper (which sets a default placeholder)
+      const factory = await ethers.getContractFactory('NijiToken');
+      const freshToken = await factory.deploy(
+        'Fresh',
+        'FRESH',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        10,
+      );
+      await freshToken.toggleMinting();
+      await expect(freshToken['mint(address)'](other.address)).to.be.revertedWithCustomError(
+        freshToken,
+        'PlaceholderURINotSet',
+      );
+    });
+
+    it('should allow mint after placeholder URI is set', async () => {
+      const factory = await ethers.getContractFactory('NijiToken');
+      const freshToken = await factory.deploy(
+        'Fresh',
+        'FRESH',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        10,
+      );
+      await freshToken.toggleMinting();
+      await freshToken.setPlaceholderURI(PLACEHOLDER);
+      await expect(freshToken['mint(address)'](other.address)).to.not.be.reverted;
+    });
+
     it('should allow owner to reveal exactly once', async () => {
       await expect(token.reveal()).to.emit(token, 'Revealed');
       expect(await token.isRevealed()).to.be.true;
+    });
+
+    it('should emit BatchMetadataUpdate on reveal (ERC-4906)', async () => {
+      await expect(token.reveal())
+        .to.emit(token, 'BatchMetadataUpdate')
+        .withArgs(0, ethers.MaxUint256);
+    });
+
+    it('should advertise IERC4906 via supportsInterface', async () => {
+      expect(await token.supportsInterface('0x49064906')).to.be.true;
     });
 
     it('should revert reveal when called twice', async () => {

--- a/packages/niji-contracts/test/niji/helpers/deployers.ts
+++ b/packages/niji-contracts/test/niji/helpers/deployers.ts
@@ -39,11 +39,15 @@ export async function deployNijiToken(
   maxSupply: number,
 ): Promise<NijiToken> {
   const factory = await ethers.getContractFactory('NijiToken');
-  return (await factory.deploy(
+  const token = (await factory.deploy(
     name,
     symbol,
     descriptorAddress,
     seederAddress,
     maxSupply,
   )) as unknown as NijiToken;
+  // Pre-reveal mint guard requires a placeholder URI. Tests that exercise mint paths
+  // without explicit placeholder setup get a deterministic default here.
+  await token.setPlaceholderURI('ipfs://test-placeholder/metadata.json');
+  return token;
 }


### PR DESCRIPTION
# 概要

NijiToken に Reveal メカニズムを追加しました。
mint 直後はプレースホルダー画像 (例 IPFS にアップロードした「??? 表紙」) を返し、 owner が `reveal()` を呼んだ瞬間に全 token が onchain SVG metadata に切り替わる仕掛けです。
ホルダーは reveal 前に流通している間も traits が見えず、 公開タイミングを揃えられるようになります。

# 課題

これまでの NijiToken は mint した瞬間に onchain SVG が確定し、 traits まで丸見えでした。
generative collection の通例 ... reveal イベントで一斉公開 ... を行う手段がなく、 早期 mint 者が先に traits を確認できる優位を持ってしまう状態でした。
secondary market への「??? 表紙」 段階の出品もできませんでした。

# 詳細

ERC721 の `tokenURI(tokenId)` は OpenZeppelin の標準実装を override しており、 現状は `descriptor.tokenURI(...)` を直接呼んで onchain JSON を返しています。
新しい reveal 機構は `isRevealed` bool と `_placeholderURI` string の 2 つの state で表現します。

```mermaid
graph LR
    A[tokenURI 呼び出し] --> B{isRevealed?}
    B -->|false| C[_placeholderURI を返す]
    B -->|true| D[descriptor.tokenURI で onchain SVG 返す]
```

# 解決方法

- `setPlaceholderURI(string)` で reveal 前の URI を owner が設定可能 (空文字は revert、 reveal 後は revert)
- `reveal()` で `isRevealed = true` に切替 (二度目以降は `RevealAlreadyDone` で revert)
- `tokenURI(tokenId)` は `isRevealed = false` の間は全 token が同じ placeholder を返し、 `true` 以降は従来通り onchain SVG を返す

「一度 reveal したら戻せない」 一方通行設計にすることで、 二度公開を繰り返す詐欺的 collection との差別化と、 ホルダーに対する公開保証が成り立ちます。

# 仕組み

```mermaid
graph LR
    A[Phase 1 mint] --> B[isRevealed=false]
    B --> C[全 token が placeholder URI]
    C --> D[owner が reveal を呼ぶ]
    D --> E[isRevealed=true 固定]
    E --> F[全 token が onchain SVG metadata]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiToken.sol` | `isRevealed` `_placeholderURI` storage / `setPlaceholderURI` `reveal` `placeholderURI` 関数 / `PlaceholderURIUpdated` `Revealed` event / `RevealAlreadyDone` `EmptyPlaceholderURI` error を追加。 `tokenURI` に reveal 分岐を入れた |
| `packages/niji-contracts/test/niji/NijiToken.test.ts` | reveal describe 12 件を追加 (default state / setPlaceholderURI 4 ケース / pre-reveal tokenURI / 非存在 token / reveal 1 回限定 / 非 owner / 切替確認 / pause test の reveal 前置補正) |
| `packages/niji-contracts/test/niji/NijiIntegration.test.ts` | tokenURI を扱う既存 2 件で reveal 前置を追加 |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiToken.test.ts` 70+ 件全 pass (reveal 12 件新規 + 既存 pausable / withdraw / mint / tokenURI 系を reveal 前置で全部維持)
- [x] `pnpm hardhat test` 全 267 件 pass (regression なし)
- [x] reveal 前後で tokenURI が placeholder → onchain に切り替わることを確認

レビューで見てほしいところ。

reveal を「一方通行 one-way switch」 にしている設計 (二度目 revert) で問題ないかをご確認ください。
途中で配置画像差し替えしたい運用は想定せず、 公開タイミング保証 + secondary market 透明性のため戻せない方針にしました。

# 関連

Closes #20
