### PR TITLE
🔗 feat(niji-contracts): NijiToken に baseURI フォールバックを実装 (Issue #22)

### DIFF
--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -17,6 +17,7 @@ import { ReentrancyGuard } from '@openzeppelin/contracts-v5/utils/ReentrancyGuar
 import { Pausable } from '@openzeppelin/contracts-v5/utils/Pausable.sol';
 import { IERC4906 } from '@openzeppelin/contracts-v5/interfaces/IERC4906.sol';
 import { IERC165 } from '@openzeppelin/contracts-v5/utils/introspection/IERC165.sol';
+import { Strings } from '@openzeppelin/contracts-v5/utils/Strings.sol';
 import { NijiDescriptor } from './NijiDescriptor.sol';
 import { INijiSeeder } from './interfaces/INijiSeeder.sol';
 
@@ -68,6 +69,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Thrown when mint is attempted before the placeholder URI is set (pre-reveal mint safety)
     error PlaceholderURINotSet();
 
+    /// @notice Thrown when baseURI is modified after being locked
+    error BaseURIIsLocked();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -117,6 +121,13 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Emitted when the collection is revealed (state is permanent after this)
     event Revealed();
 
+    /// @notice Emitted when the external baseURI fallback is updated
+    /// @param newBaseURI The new baseURI string. Empty string disables the fallback (on-chain descriptor is used instead).
+    event BaseURIUpdated(string newBaseURI);
+
+    /// @notice Emitted when the baseURI is locked permanently
+    event BaseURILocked();
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -159,6 +170,14 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Placeholder URI returned for every tokenURI while not revealed
     /// @dev Should point to a single metadata JSON (per ERC721 marketplaces convention).
     string private _placeholderURI;
+
+    /// @notice External baseURI fallback for token metadata
+    /// @dev Empty string disables the fallback (on-chain descriptor is used). Non-empty value takes precedence over the descriptor post-reveal.
+    ///      Concatenation rule: `{baseURI}{tokenId}.json` (no extra slash inserted — include the trailing slash in baseURI if needed).
+    string private _baseTokenURI;
+
+    /// @notice Whether the baseURI is locked permanently (no further updates allowed)
+    bool public isBaseURILocked;
 
     // =============================================================
     //                           MODIFIERS
@@ -278,12 +297,17 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Returns the token URI for a given token ID
     /// @param tokenId The token ID
     /// @return The token URI
-    /// @dev Pre-reveal returns the placeholder URI (same value for every token). Post-reveal delegates to the on-chain descriptor.
+    /// @dev Resolution order: (1) pre-reveal → placeholder URI. (2) post-reveal + baseURI set → `{baseURI}{tokenId}.json`. (3) post-reveal + no baseURI → on-chain descriptor.
+    ///      baseURI is intended as an emergency fallback if on-chain rendering is unavailable; flip back to on-chain by setting baseURI to empty.
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         if (_ownerOf(tokenId) == address(0)) revert TokenDoesNotExist();
 
         if (!isRevealed) {
             return _placeholderURI;
+        }
+
+        if (bytes(_baseTokenURI).length > 0) {
+            return string(abi.encodePacked(_baseTokenURI, Strings.toString(tokenId), '.json'));
         }
 
         INijiSeeder.Seed memory seed = seeds[tokenId];
@@ -438,6 +462,33 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Returns the current placeholder URI (empty string if never set)
     function placeholderURI() external view returns (string memory) {
         return _placeholderURI;
+    }
+
+    // =============================================================
+    //                      BASE URI FALLBACK
+    // =============================================================
+
+    /// @notice Set the external baseURI fallback (owner only)
+    /// @param newBaseURI The new baseURI. Pass empty string to disable the fallback and return to the on-chain descriptor.
+    /// @dev Emits ERC-4906 BatchMetadataUpdate so marketplaces refresh stale metadata.
+    function setBaseURI(string calldata newBaseURI) external onlyOwner {
+        if (isBaseURILocked) revert BaseURIIsLocked();
+        _baseTokenURI = newBaseURI;
+        emit BaseURIUpdated(newBaseURI);
+        emit BatchMetadataUpdate(0, type(uint256).max);
+    }
+
+    /// @notice Lock the baseURI permanently (no further updates allowed)
+    /// @dev Used to commit to a specific fallback (or to lock the on-chain descriptor in place by locking with empty baseURI).
+    function lockBaseURI() external onlyOwner {
+        if (isBaseURILocked) revert BaseURIIsLocked();
+        isBaseURILocked = true;
+        emit BaseURILocked();
+    }
+
+    /// @notice Returns the current baseURI (empty string when fallback is disabled)
+    function baseURI() external view returns (string memory) {
+        return _baseTokenURI;
     }
 
     // =============================================================

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -800,4 +800,114 @@ describe('NijiToken', () => {
       expect(uri).to.not.equal(PLACEHOLDER);
     });
   });
+
+  describe('baseURI fallback', () => {
+    const BASE_URI = 'ipfs://QmBaseURIHash/';
+
+    it('should have empty baseURI by default', async () => {
+      expect(await token.baseURI()).to.equal('');
+    });
+
+    it('should not be locked by default', async () => {
+      expect(await token.isBaseURILocked()).to.be.false;
+    });
+
+    it('should allow owner to set baseURI', async () => {
+      await expect(token.setBaseURI(BASE_URI))
+        .to.emit(token, 'BaseURIUpdated')
+        .withArgs(BASE_URI);
+      expect(await token.baseURI()).to.equal(BASE_URI);
+    });
+
+    it('should emit BatchMetadataUpdate on setBaseURI (ERC-4906)', async () => {
+      await expect(token.setBaseURI(BASE_URI))
+        .to.emit(token, 'BatchMetadataUpdate')
+        .withArgs(0, ethers.MaxUint256);
+    });
+
+    it('should allow setting empty baseURI to disable fallback', async () => {
+      await token.setBaseURI(BASE_URI);
+      await expect(token.setBaseURI('')).to.emit(token, 'BaseURIUpdated').withArgs('');
+      expect(await token.baseURI()).to.equal('');
+    });
+
+    it('should revert setBaseURI when non-owner', async () => {
+      await expect(token.connect(other).setBaseURI(BASE_URI)).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should return on-chain descriptor URI when baseURI is empty and revealed', async () => {
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token.reveal();
+
+      const uri = await token.tokenURI(0);
+      expect(uri).to.include('data:application/json;base64,');
+    });
+
+    it('should return baseURI + tokenId + .json when baseURI is set and revealed', async () => {
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token['mint(address)'](other.address);
+      await token.reveal();
+      await token.setBaseURI(BASE_URI);
+
+      expect(await token.tokenURI(0)).to.equal(`${BASE_URI}0.json`);
+      expect(await token.tokenURI(1)).to.equal(`${BASE_URI}1.json`);
+    });
+
+    it('should still return placeholder URI pre-reveal even when baseURI is set', async () => {
+      await token.setBaseURI(BASE_URI);
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+
+      expect(await token.tokenURI(0)).to.equal('ipfs://test-placeholder/metadata.json');
+    });
+
+    it('should switch back to on-chain descriptor when baseURI is cleared', async () => {
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token.reveal();
+      await token.setBaseURI(BASE_URI);
+      expect(await token.tokenURI(0)).to.equal(`${BASE_URI}0.json`);
+
+      await token.setBaseURI('');
+      const uri = await token.tokenURI(0);
+      expect(uri).to.include('data:application/json;base64,');
+    });
+
+    it('should allow owner to lock baseURI', async () => {
+      await token.setBaseURI(BASE_URI);
+      await expect(token.lockBaseURI()).to.emit(token, 'BaseURILocked');
+      expect(await token.isBaseURILocked()).to.be.true;
+    });
+
+    it('should revert setBaseURI after lockBaseURI', async () => {
+      await token.lockBaseURI();
+      await expect(token.setBaseURI(BASE_URI)).to.be.revertedWithCustomError(
+        token,
+        'BaseURIIsLocked',
+      );
+    });
+
+    it('should revert lockBaseURI when called twice', async () => {
+      await token.lockBaseURI();
+      await expect(token.lockBaseURI()).to.be.revertedWithCustomError(token, 'BaseURIIsLocked');
+    });
+
+    it('should revert lockBaseURI when non-owner', async () => {
+      await expect(token.connect(other).lockBaseURI()).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should still revert tokenURI for non-existent token when baseURI is set', async () => {
+      await token.reveal();
+      await token.setBaseURI(BASE_URI);
+      await expect(token.tokenURI(999)).to.be.revertedWithCustomError(token, 'TokenDoesNotExist');
+    });
+  });
 });


### PR DESCRIPTION
# 概要

NijiToken に外部 baseURI フォールバックを追加しました。
onchain SVG metadata に頼っている現状で、 もし `NijiDescriptor` 側にバグが見つかったり、 将来 IPFS / Arweave / 中央サーバへ metadata を移行したくなった場合に、 owner が `setBaseURI` を呼ぶだけで tokenURI の返却先を外部 URI に切り替えられます。
緊急時の救出経路として用意し、 普段は空文字 (= 無効) で onchain SVG を返す default を維持します。

# 課題

これまでの NijiToken は `tokenURI` が必ず `NijiDescriptor` 経由の onchain SVG を返す前提でした。
万一 descriptor 側で生成不能なバグが見つかったり、 IPFS / Arweave 等への引っ越しが必要になった場合、 contract を作り直す以外に対処方法がありませんでした。
ホルダーにとっても「お金を払って買った NFT が見えなくなる」 リスクが残っていました。

# 詳細

ERC721 の `tokenURI(tokenId)` は既に reveal 機構と組み合わさっています (Issue #20)。
今回追加する baseURI フォールバックは reveal 完了後にのみ働き、 reveal 前の placeholder には影響しません。

解決順序を明示すると以下のようになります。

```mermaid
graph LR
    A[tokenURI 呼び出し] --> B{isRevealed?}
    B -->|false| C[placeholder URI を返す]
    B -->|true| D{baseURI 設定済?}
    D -->|yes| E[baseURI + tokenId + .json]
    D -->|no| F[onchain descriptor SVG]
```

# 解決方法

- `setBaseURI(string)` で owner が任意の URI を設定 (空文字 = 無効化、 onchain に戻る)
- `lockBaseURI()` で baseURI を永久固定 (descriptor を捨てて外部 URI に完全移行する場合 / または onchain を空 baseURI で固定する場合に使う)
- `baseURI()` で現在値を view
- `tokenURI` で「revealed + baseURI 設定済」 の時のみ `{baseURI}{tokenId}.json` を返す
- ERC-4906 `BatchMetadataUpdate(0, type(uint256).max)` を `setBaseURI` で emit し marketplace に自動 refresh を促す

設定パターンは `{baseURI}{tokenId}.json` で ERC721 慣例に合わせています。
trailing slash は owner 側で baseURI に含める運用 (例 `ipfs://Qm.../`)。
trailing slash の有無を contract 側で判定しないことで、 ファイル名規約 (`0.json` / `metadata/0.json` 等) の自由度を確保。

# 仕組み

```mermaid
graph LR
    A[通常運用] --> B[onchain SVG]
    B --> C[緊急 ... descriptor bug / 移行]
    C --> D[owner が setBaseURI 呼ぶ]
    D --> E[BatchMetadataUpdate emit]
    E --> F[marketplace 自動 refresh]
    F --> G[新しい URI で表示]
    G --> H[必要なら lockBaseURI で固定]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiToken.sol` | `Strings` import、 `_baseTokenURI` `isBaseURILocked` storage、 `setBaseURI` `lockBaseURI` `baseURI` 関数、 `BaseURIUpdated` `BaseURILocked` event、 `BaseURIIsLocked` error を追加。 `tokenURI` に baseURI 分岐を入れた (reveal 後 + baseURI 設定済の時のみ fallback) |
| `packages/niji-contracts/test/niji/NijiToken.test.ts` | baseURI fallback describe 15 件を追加 (default state / setBaseURI 5 ケース / 解決順序 4 ケース / lockBaseURI 4 ケース / 非存在 token) |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiToken.test.ts` 80+ 件全 pass (baseURI 15 件新規)
- [x] `pnpm hardhat test` 全 287 件 pass (regression なし)
- [x] reveal + baseURI + descriptor の 3 経路の優先順位を test で固定化
- [x] ERC-4906 BatchMetadataUpdate emit を test で確認

レビューで見てほしいところ。

「reveal 後の解決順序を `placeholder > baseURI > descriptor` ではなく `baseURI > descriptor` にしている」 ところをご確認ください。
reveal 前は必ず placeholder、 reveal 後だけ baseURI が効く設計です。
これは reveal 自体が「公開コミット」 を意味するため、 reveal 後に再び placeholder のような不確定 metadata に戻る経路を作らないという判断です。

# 関連

Closes #22
