### PR TITLE
📚 docs: README 全面更新 + setup-guide + local-dev (Issue #55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Niji DAO は generative on-chain avatar art collective です。 本リポジト
 | `packages/niji-api` | [ponder.sh](https://ponder.sh) ベースの historical data API |
 | `packages/niji-subgraph` | (**deprecated**) The Graph subgraph manifest、 `niji-api` に置き換え予定 |
 | `packages/niji-webapp` | React + Vite frontend (wagmi + TanStack Query + Tailwind + shadcn/ui) |
-| `packages/niji-docs` | Next.js 15 + Nextra 4 の公開 docs サイト |
+| `packages/niji-docs` | Next.js 16 + Nextra 4 の公開 docs サイト |
 
 package 間の build 依存は webapp → assets / contracts / sdk の順で turbo が解決します。
 
@@ -82,11 +82,11 @@ contract だけテストしたい場合は `cd packages/niji-contracts && pnpm h
 
 ### Webapp (`niji-webapp`)
 
-React 18 + Vite + wagmi + TanStack Query で構築。 Redux Toolkit から TanStack Query への移行中、 CSS Modules + react-bootstrap から Tailwind + shadcn/ui への移行中。 Apollo Client は完全撤去済で全 subgraph query は TanStack Query + GraphQL Codegen 経由になっています。 詳細は [packages/niji-webapp/README.md](packages/niji-webapp/README.md) を参照。
+React 18 + Vite + wagmi + TanStack Query + Jotai で構築。 state は Jotai atom (UI / 永続化) と TanStack Query (server state) の組み合わせ、 styling は CSS Modules + react-bootstrap から Tailwind + shadcn/ui への移行中。 Apollo Client と Redux Toolkit は完全撤去済で、 全 subgraph query は TanStack Query + GraphQL Codegen 経由になっています。 詳細は [packages/niji-webapp/README.md](packages/niji-webapp/README.md) を参照。
 
 ### Docs (`niji-docs`)
 
-Next.js 15 + Nextra 4 + Pagefind の公開 docs サイト。 `pnpm build` で `.next` build + Pagefind 検索 index を同時生成。
+Next.js 16 + Nextra 4 + Pagefind の公開 docs サイト。 `pnpm build` で `.next` build + Pagefind 検索 index を同時生成。
 
 ## アクティブな移行
 
@@ -94,7 +94,7 @@ webapp 内で進行中の刷新は以下の通り。 新規実装ではモダン
 
 | 旧 | 新 | 状態 |
 |---|---|---|
-| Redux Toolkit (server state) | TanStack Query | 進行中 (UI state のみ Redux 残し) |
+| Redux Toolkit (server state) | TanStack Query + Jotai | 完了 (package.json から削除済) |
 | CSS Modules + react-bootstrap | Tailwind CSS + shadcn/ui | 進行中 |
 | Apollo Client | TanStack Query + GraphQL Codegen | 完了 |
 

--- a/README.md
+++ b/README.md
@@ -1,57 +1,103 @@
-# nouns-monorepo
+# niji-monorepo
 
-Nouns DAO is a generative avatar art collective run by a group of crypto misfits.
+Niji DAO は generative on-chain avatar art collective です。 本リポジトリは smart contracts / webapp / SDK / api / docs を 1 つの monorepo にまとめた構成で、 Nouns DAO を fork し Niji の独自仕様 (12 trait / on-chain SVG / reveal + baseURI fallback / 緊急停止) を組み込んでいます。
 
-## Packages
+## 構成 package
 
-### niji-assets
+| package | 内容 |
+|---|---|
+| `packages/niji-assets` | PNG とランレングス圧縮 (RLE) image data |
+| `packages/niji-contracts` | Hardhat + Foundry の Solidity contract suite (ERC721 / governance / auction / on-chain SVG) |
+| `packages/niji-sdk` | contract address / ABI / image utility (Node + browser) |
+| `packages/niji-api` | [ponder.sh](https://ponder.sh) ベースの historical data API |
+| `packages/niji-subgraph` | (**deprecated**) The Graph subgraph manifest、 `niji-api` に置き換え予定 |
+| `packages/niji-webapp` | React + Vite frontend (wagmi + TanStack Query + Tailwind + shadcn/ui) |
+| `packages/niji-docs` | Next.js 15 + Nextra 4 の公開 docs サイト |
 
-The [nouns assets](packages/niji-assets) package holds the Noun PNG and run-length encoded image data.
+package 間の build 依存は webapp → assets / contracts / sdk の順で turbo が解決します。
 
-### niji-contracts
+## 必要環境
 
-The [nouns contracts](packages/niji-contracts) is the suite of Solidity contracts powering Nouns DAO.
-
-### niji-sdk
-
-The [nouns sdk](packages/niji-sdk) includes methods and react hooks for interacting with all the Nouns contracts, as well as image encoding and SVG building utilities.
-
-### niji-api
-
-A [ponder.sh](https://github.com/ponder-sh/ponder) based API for all historical NounsDAO data
-
-### niji-subgraph
-
-**deprecated** in favor of **niji-api**
-
-In order to make retrieving more complex data from the auction history, [nouns subgraph](packages/niji-subgraph) contains subgraph manifests that are deployed onto [The Graph](https://thegraph.com).
-
-### niji-webapp
-
-The [nouns webapp](packages/niji-webapp) is the frontend for interacting with Noun auctions as hosted at [nouns.wtf](https://nouns.wtf).
+| ツール | バージョン |
+|---|---|
+| Node.js | 16.x 以上 |
+| pnpm | 10.10.0 以上 |
+| foundry (forge) | 任意、 contract 開発で利用 |
+| anvil (Foundry 付属) | localnet 起動で利用 |
 
 ## Quickstart
 
-### Install dependencies
-
 ```sh
+# 1. 依存をインストール
 pnpm install
+
+# 2. webapp の環境変数を用意
+cd packages/niji-webapp
+cp .env.example.local .env
+
+# 3. 全 package をビルド
+pnpm -w build
+
+# 4. 開発サーバを起動 (webapp は port 2424)
+pnpm -w dev
 ```
 
-### Build all packages
+初回セットアップで詰まったら [docs/setup-guide.md](docs/setup-guide.md) を参照してください。
+ローカル contract と合わせた開発フロー (anvil 起動 + deploy-niji-smoke + webapp 接続) は [docs/local-dev.md](docs/local-dev.md) にあります。
+
+## 開発でよく使うコマンド
 
 ```sh
-pnpm build
+pnpm -w lint        # ESLint (cache 付き、 file path を引数に渡す)
+pnpm -w format      # Prettier 整形
+pnpm -w test        # 全 package のテスト実行
+pnpm -w build       # 全 package のビルド
 ```
 
-### Run Linter
+package 単体で作業する場合は対象 dir に `cd` して同じコマンドを実行します。
+contract だけテストしたい場合は `cd packages/niji-contracts && pnpm hardhat test`、 webapp だけ起動したい場合は `cd packages/niji-webapp && pnpm dev` のように使い分けます。
 
-```sh
-pnpm lint
-```
+## 環境変数の例
 
-### Run Prettier
+各 package 配下に `.env.example` (または `.env.example.local`) を置いてあります。
 
-```sh
-pnpm format
-```
+| package | サンプル file | 用途 |
+|---|---|---|
+| `packages/niji-contracts` | `.env.example` | Hardhat / Foundry 用 (Etherscan / Infura / wallet) |
+| `packages/niji-sdk` | `.env.example` | SDK 内部スクリプト用 |
+| `packages/niji-webapp` | `.env.example.local` | local 開発用 (Vite + wagmi) |
+| `packages/niji-webapp` | `.env.example` | mainnet / sepolia 用 |
+| `packages/niji-webapp` | `.env.base-sepolia.example` | Base Sepolia testnet 用 |
+
+各 file の中身を読んで必要な変数だけ埋めてください。 1 file で全 package をカバーする root レベルの env example は意図的に置いていません (package ごとに必要なキーが大きく違うため)。
+
+## 主要機能
+
+### Smart contracts (`niji-contracts`)
+
+- **NijiToken** ... ERC721 + Enumerable + Votes + Pausable で実装した generative NFT。 mint / transfer / burn は `_update` 経由で pause 可能 (緊急停止)、 reveal メカニズム (`isRevealed` + `_placeholderURI`) で公開タイミングを揃えられる、 baseURI fallback (`_baseTokenURI` + `isBaseURILocked`) で onchain SVG 不能時に IPFS / Arweave 等にフェイルオーバ可能。
+- **NijiAuctionHouse / V3** ... 24 時間オークション。 NijiToken に minter 権限を付与して mint → auction → settle のサイクルを回す。
+- **NijiDescriptor / NijiArt / NijiSeeder** ... on-chain で PNG → SVG を組み立てる 3 contract セット。 12 trait × 3 image を SSTORE2 で保存し、 seed (uint48 × 12) から traitIndices を導出して descriptor が SVG を生成する。
+- **Ownable2Step** ... 全 4 contract (Token / Art / Descriptor / Seeder) で `renounceOwnership` を override して revert させ、 ownership が address(0) になる事故を構造的に防止。
+
+### Webapp (`niji-webapp`)
+
+React 18 + Vite + wagmi + TanStack Query で構築。 Redux Toolkit から TanStack Query への移行中、 CSS Modules + react-bootstrap から Tailwind + shadcn/ui への移行中。 Apollo Client は完全撤去済で全 subgraph query は TanStack Query + GraphQL Codegen 経由になっています。 詳細は [packages/niji-webapp/README.md](packages/niji-webapp/README.md) を参照。
+
+### Docs (`niji-docs`)
+
+Next.js 15 + Nextra 4 + Pagefind の公開 docs サイト。 `pnpm build` で `.next` build + Pagefind 検索 index を同時生成。
+
+## アクティブな移行
+
+webapp 内で進行中の刷新は以下の通り。 新規実装ではモダン側を使ってください。
+
+| 旧 | 新 | 状態 |
+|---|---|---|
+| Redux Toolkit (server state) | TanStack Query | 進行中 (UI state のみ Redux 残し) |
+| CSS Modules + react-bootstrap | Tailwind CSS + shadcn/ui | 進行中 |
+| Apollo Client | TanStack Query + GraphQL Codegen | 完了 |
+
+## License
+
+GPL-3.0

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -6,46 +6,46 @@ webapp から contract を直接触りたい場合の最短セットアップ。
 
 ```mermaid
 graph LR
-    A[anvil 起動 chainId 31337] --> B[deploy-niji-smoke で contract 群 deploy]
-    B --> C[deploy log を sdk address mapping に反映]
+    A[anvil --port 8547 起動 chainId 31337] --> B[deploy-niji-full で contract + auction を deploy]
+    B --> C[deploy log を sdk の .gen.ts address に反映]
     C --> D[webapp dev サーバ起動 port 2424]
-    D --> E[MetaMask で hardhat 31337 ネットワーク追加]
+    D --> E[MetaMask で 8547 ネットワーク追加]
     E --> F[mint や auction を手元で操作]
 ```
+
+トークンの mint と tokenURI 表示だけ確認したいなら `deploy-niji-smoke`、 webapp で auction まで触りたいなら `deploy-niji-full` (または `pnpm task:run-local`) を使います。 smoke は auction house を deploy しないため、 webapp の boot path で auction address を読みに行く処理が失敗します。
 
 ## 1. anvil を立ち上げる
 
 ```sh
-anvil
+anvil --port 8547
 ```
 
-default 設定で OK。 RPC は `http://127.0.0.1:8545`、 chainId は 31337。 deterministic accounts (anvil 標準の 10 個) が用意されます。 deployer は account[0]、 private key は anvil の起動 log に出る最初のキー (`0xac0974be...`) を使うのが基本です。
-
-webapp の env では `VITE_HARDHAT_JSONRPC=http://127.0.0.1:8547` のようにポート番号を変えている例もあるので、 自分の `.env` に合わせて anvil の `--port` を上げ下げしてください。
+本 repo は `packages/niji-contracts/hardhat.config.ts` の `localhost.url` と `packages/niji-webapp/src/constants/anvil.ts` の `ANVIL_PORT` が共に **8547** に固定されています。 anvil を default の 8545 で立ち上げると `pnpm hardhat deploy-niji-smoke --network localhost` も webapp 側も RPC に届かないので、 必ず `--port 8547` を指定してください。 chainId は 31337。 deterministic accounts (anvil 標準の 10 個) が用意され、 deployer は account[0]、 private key は anvil の起動 log に出る最初のキー (`0xac0974be...`) を使います。
 
 ## 2. contract をデプロイ
 
+webapp との繋ぎ込みまで含めて触るなら `deploy-niji-full` を使ってください。 `deploy-niji-smoke` は auction house を deploy しないため webapp の boot path で auction address read が失敗します。
+
 ```sh
 cd packages/niji-contracts
+# token + descriptor + auction まで full deploy (webapp 連携用)
+pnpm hardhat deploy-niji-full --network localhost
+# あるいは contract task の wrapper
+pnpm task:run-local
+```
+
+token / descriptor だけ動作確認したい (auction なしで OK) 場合は smoke で十分です。
+
+```sh
 pnpm hardhat deploy-niji-smoke --network localhost
 ```
 
 `deploy-niji-smoke` は最低限 (NijiArt → NijiDescriptor → NijiSeeder → NijiToken) を入れて mint 1 体 + tokenURI 検証まで通します。 完走すると `packages/niji-contracts/deploy/localhost-{timestamp}-smoke.json` に contract address と gas 情報が書き出されます。
 
-auction や governance まで含めて立ち上げたい場合は `deploy-niji-full` を使ってください。
-
 ## 3. SDK に address を反映
 
-deploy log を見ながら `packages/niji-sdk` の address mapping を更新します。 多くの場合は chainId 31337 の entry を以下の 4 つに差し替える形になります。
-
-```ts
-{
-  NijiArt:        '0x...',
-  NijiDescriptor: '0x...',
-  NijiSeeder:     '0x...',
-  NijiToken:      '0x...',
-}
-```
+deploy log を見ながら `packages/niji-sdk` 配下の生成 file (`src/react/*.gen.ts` と `src/actions/*.gen.ts`) を更新します。 主要 contract ごとに 1 ファイル単位で chainId 31337 の address 定数が定義されているので、 `auction-house.gen.ts` / `descriptor.gen.ts` / `seeder.gen.ts` / `token.gen.ts` 等を deploy 出力に合わせて書き換えます (この 4 file は wagmi cli の生成物なので、 wagmi cli を回せば自動更新も可能)。
 
 webapp は sdk 経由で contract address を参照するため、 ここを更新しない限り画面は古い address を見続けます。
 
@@ -57,7 +57,7 @@ cp .env.example.local .env
 pnpm dev
 ```
 
-webapp は `http://localhost:2424` で立ち上がります (strictPort: true で 3000 へのフォールバックはありません)。 MetaMask に「Hardhat」 ネットワーク (RPC `http://127.0.0.1:8545` / chainId 31337) を追加し、 anvil deployer の private key (`0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`) を import すれば最初の mint まで触れます。
+webapp は `http://localhost:2424` で立ち上がります (strictPort: true で 3000 へのフォールバックはありません)。 MetaMask に「Hardhat」 ネットワーク (RPC `http://127.0.0.1:8547` / chainId 31337) を追加し、 anvil deployer の private key (`0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`) を import すれば最初の mint まで触れます。
 
 ## 5. 開発中によくやる操作
 

--- a/docs/local-dev.md
+++ b/docs/local-dev.md
@@ -1,0 +1,97 @@
+# ローカル開発フロー
+
+webapp から contract を直接触りたい場合の最短セットアップ。 sepolia や mainnet を直接使うよりもガス代もデバッグも楽になります。
+
+## 全体像
+
+```mermaid
+graph LR
+    A[anvil 起動 chainId 31337] --> B[deploy-niji-smoke で contract 群 deploy]
+    B --> C[deploy log を sdk address mapping に反映]
+    C --> D[webapp dev サーバ起動 port 2424]
+    D --> E[MetaMask で hardhat 31337 ネットワーク追加]
+    E --> F[mint や auction を手元で操作]
+```
+
+## 1. anvil を立ち上げる
+
+```sh
+anvil
+```
+
+default 設定で OK。 RPC は `http://127.0.0.1:8545`、 chainId は 31337。 deterministic accounts (anvil 標準の 10 個) が用意されます。 deployer は account[0]、 private key は anvil の起動 log に出る最初のキー (`0xac0974be...`) を使うのが基本です。
+
+webapp の env では `VITE_HARDHAT_JSONRPC=http://127.0.0.1:8547` のようにポート番号を変えている例もあるので、 自分の `.env` に合わせて anvil の `--port` を上げ下げしてください。
+
+## 2. contract をデプロイ
+
+```sh
+cd packages/niji-contracts
+pnpm hardhat deploy-niji-smoke --network localhost
+```
+
+`deploy-niji-smoke` は最低限 (NijiArt → NijiDescriptor → NijiSeeder → NijiToken) を入れて mint 1 体 + tokenURI 検証まで通します。 完走すると `packages/niji-contracts/deploy/localhost-{timestamp}-smoke.json` に contract address と gas 情報が書き出されます。
+
+auction や governance まで含めて立ち上げたい場合は `deploy-niji-full` を使ってください。
+
+## 3. SDK に address を反映
+
+deploy log を見ながら `packages/niji-sdk` の address mapping を更新します。 多くの場合は chainId 31337 の entry を以下の 4 つに差し替える形になります。
+
+```ts
+{
+  NijiArt:        '0x...',
+  NijiDescriptor: '0x...',
+  NijiSeeder:     '0x...',
+  NijiToken:      '0x...',
+}
+```
+
+webapp は sdk 経由で contract address を参照するため、 ここを更新しない限り画面は古い address を見続けます。
+
+## 4. webapp 起動 + MetaMask 接続
+
+```sh
+cd packages/niji-webapp
+cp .env.example.local .env
+pnpm dev
+```
+
+webapp は `http://localhost:2424` で立ち上がります (strictPort: true で 3000 へのフォールバックはありません)。 MetaMask に「Hardhat」 ネットワーク (RPC `http://127.0.0.1:8545` / chainId 31337) を追加し、 anvil deployer の private key (`0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80`) を import すれば最初の mint まで触れます。
+
+## 5. 開発中によくやる操作
+
+| やりたいこと | コマンド |
+|---|---|
+| contract の test | `cd packages/niji-contracts && pnpm hardhat test` |
+| 特定 test だけ | `pnpm hardhat test test/niji/NijiToken.test.ts` |
+| Foundry test | `cd packages/niji-contracts && forge test` |
+| anvil リセット | `pkill anvil && anvil` |
+| deploy log の最新 | `ls -t packages/niji-contracts/deploy/localhost-*.json | head -1` |
+| webapp の lint | `cd packages/niji-webapp && pnpm -w lint src/` |
+| webapp の型 check | `cd packages/niji-webapp && pnpm tsc --noEmit` |
+| graphql 型再生成 | `cd packages/niji-webapp && pnpm graphql-codegen` |
+| i18n 再抽出 | `cd packages/niji-webapp && pnpm i18n:extract && pnpm i18n:compile` |
+
+## つまずきやすいポイント
+
+### deploy-niji-smoke の [10] tokenURI で revert
+
+anvil の eth_call default gas limit が 30M で、 12 layer の SVG 生成が走り切らずに revert することがあります。 PR #249 以降は deploy script 側で gasLimit 300M override をかけているので最新 master であれば問題ありません。
+
+### MetaMask が「Internal JSON-RPC error」 を返す
+
+anvil を再起動した場合は MetaMask 側で nonce がズレています。 設定 → 詳細 → アカウントをリセット で解消します。 deployer 以外の account を使うのも有効です。
+
+### 「Token does not exist」 が画面に出る
+
+webapp が古い token id を覚えている可能性があります。 MetaMask の active account が deployer なら 1 度 mint して tokenId 0 を生成、 1 体目はその後の auction で settle 済になります。
+
+### `pnpm test:watch` が CI のように 1 度で終わってしまう
+
+vitest の `CI=true` が設定されているかもしれません。 `unset CI && pnpm test:watch` で watch mode に戻ります。
+
+## 次のステップ
+
+- contract に新しい admin 関数を追加したい場合は [packages/niji-contracts/contracts/NijiToken.sol](../packages/niji-contracts/contracts/NijiToken.sol) を真似て error / event / 関数 + テストを追加してください。 既存の Pausable / Withdraw / Reveal / baseURI fallback のパターンが参考になります。
+- webapp に新しいページを追加したい場合は [src/pages/](../packages/niji-webapp/src/pages/) に置き、 [src/index.tsx](../packages/niji-webapp/src/index.tsx) の routing に追加します。 styling は Tailwind + shadcn/ui を default にしてください。

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -1,0 +1,92 @@
+# セットアップガイド
+
+初めてこの repo を clone してから「dev server が立ち上がる」 までの最短手順をまとめています。 何か詰まったら本ガイド末尾の「トラブルシューティング」 を確認してください。
+
+## 1. 前提環境のインストール
+
+| ツール | インストール方法 |
+|---|---|
+| Node.js 16.x 以上 | `nvm install 20` / `mise install node@20` / 公式インストーラ |
+| pnpm 10.10.0 以上 | `npm install -g pnpm@10` / `corepack enable && corepack prepare pnpm@10 --activate` |
+| Foundry (forge / anvil) | `curl -L https://foundry.paradigm.xyz | bash && foundryup` |
+| Git | `xcode-select --install` (macOS) / package manager |
+
+Foundry は contract test と localnet (anvil) で使います。 webapp だけ触る場合は Foundry なしでも動きますが、 contract と組み合わせた開発をするなら入れておくと早いです。
+
+## 2. リポジトリ clone と依存解決
+
+```sh
+git clone git@github.com:Niji-DAO/niji-monorepo.git
+cd niji-monorepo
+pnpm install
+```
+
+`pnpm install` はワークスペース全体の依存を一気に解決します。 turbo の cache を活かすため、 PR 単位で `pnpm install` をやり直す必要は通常ありません。
+
+## 3. 環境変数の準備
+
+各 package の `.env.example` を真似て `.env` を作ります。 全 package で必要なのではなく、 作業対象 package のものだけ用意すれば OK です。
+
+| package | コマンド |
+|---|---|
+| `niji-contracts` | `cp packages/niji-contracts/.env.example packages/niji-contracts/.env` |
+| `niji-sdk` | `cp packages/niji-sdk/.env.example packages/niji-sdk/.env` |
+| `niji-webapp` (local) | `cp packages/niji-webapp/.env.example.local packages/niji-webapp/.env` |
+| `niji-webapp` (mainnet) | `cp packages/niji-webapp/.env.example packages/niji-webapp/.env` |
+| `niji-webapp` (Base Sepolia) | `cp packages/niji-webapp/.env.base-sepolia.example packages/niji-webapp/.env` |
+
+webapp の env は VITE prefix の変数を中心に埋めます。 chainId / RPC / subgraph endpoint / WalletConnect の project ID あたりは必須項目です。 contract の env は Etherscan / Infura / wallet 系で、 deploy 作業をしないなら未設定でも build と test は通ります。
+
+## 4. ビルドと dev サーバ起動
+
+```sh
+# 全 package をビルド (turbo が依存順を解決する)
+pnpm -w build
+
+# webapp を起動 (port 2424)
+cd packages/niji-webapp
+pnpm dev
+```
+
+`pnpm -w dev` で root から呼ぶこともできますが、 contract と webapp を別 process で動かしたい場合は対象 dir で個別に `pnpm dev` を呼ぶ方が安全です。
+
+## 5. テスト実行で動作確認
+
+| 対象 | コマンド |
+|---|---|
+| 全 package | `pnpm -w test` |
+| contract のみ | `cd packages/niji-contracts && pnpm hardhat test` |
+| webapp のみ | `cd packages/niji-webapp && pnpm test` |
+| webapp watch | `cd packages/niji-webapp && pnpm test:watch` |
+
+Hardhat の test (287 件以上) が緑ならローカル開発の前提は揃っています。
+
+## トラブルシューティング
+
+### pnpm install で `Could not resolve` エラー
+
+pnpm のバージョンが 10.10.0 未満の可能性が高いです。 `pnpm --version` で確認して 10.10 以上に上げてください。 corepack を使っているなら `corepack prepare pnpm@10 --activate` で固定できます。
+
+### webapp で `Cannot find module 'wagmi/...'` 等
+
+`pnpm -w build` を 1 度走らせて contract / sdk の生成物を作る必要があります。 webapp は sdk の TypeScript build と ABI 生成に依存しています。
+
+### Contract test が `compiler 0.8.23 not found` で落ちる
+
+Hardhat が初回実行時に compiler を download します。 ネットワーク制限がある場合は `~/.cache/hardhat-nodejs/compilers-v2/` を一度クリアしてから再実行してください。
+
+### anvil で deploy-niji-smoke が revert する
+
+PR #249 以降は `setPlaceholderURI` + `reveal` + view call の gasLimit override を deploy script に含めているので、 master 最新であれば通ります。 通らない場合は anvil を再起動 (`pkill anvil && anvil`) してから再実行してください。
+
+### `Token does not exist` が webapp で連発する
+
+contract address が古いままの可能性があります。 `packages/niji-sdk/src/contract/addresses.json` (または相当の address mapping) の chainId 31337 のエントリを deploy log (`packages/niji-contracts/deploy/localhost-*-smoke.json`) と照らし合わせて更新してください。
+
+### Foundry 系コマンドが PATH に通っていない
+
+`source ~/.zshrc` (`source ~/.bashrc`) で foundryup 後の PATH 更新を読み込ませるか、 ターミナルを開き直してください。 macOS なら `~/.foundry/bin` を PATH に追加する形になります。
+
+### `pnpm test` が webapp で長時間止まる
+
+Vitest が watch mode に入っている可能性があります。 CI 風に 1 度だけ走らせたい場合は `cd packages/niji-webapp && pnpm test --run` を使ってください。

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -48,7 +48,7 @@ cd packages/niji-webapp
 pnpm dev
 ```
 
-`pnpm -w dev` で root から呼ぶこともできますが、 contract と webapp を別 process で動かしたい場合は対象 dir で個別に `pnpm dev` を呼ぶ方が安全です。
+root の `pnpm -w dev` は `turbo run dev` で全 package の dev script を持続実行するため、 webapp / contracts / api / docs を同時に立ち上げます。 個別 package だけ動かしたい時は対象 dir で `pnpm dev` を直接呼ぶ方が確実です。
 
 ## 5. テスト実行で動作確認
 
@@ -81,7 +81,7 @@ PR #249 以降は `setPlaceholderURI` + `reveal` + view call の gasLimit overri
 
 ### `Token does not exist` が webapp で連発する
 
-contract address が古いままの可能性があります。 `packages/niji-sdk/src/contract/addresses.json` (または相当の address mapping) の chainId 31337 のエントリを deploy log (`packages/niji-contracts/deploy/localhost-*-smoke.json`) と照らし合わせて更新してください。
+contract address が古いままの可能性があります。 `packages/niji-sdk/src/react/{auction-house,descriptor,seeder,token}.gen.ts` (および `src/actions/*.gen.ts`) の chainId 31337 のエントリを deploy log (`packages/niji-contracts/deploy/localhost-*-{smoke,full}.json`) と照らし合わせて更新してください。 wagmi cli を回せば自動再生成も可能です。
 
 ### Foundry 系コマンドが PATH に通っていない
 


### PR DESCRIPTION
# 概要

repo の README と開発者向け docs を全面刷新しました。
これまでの README は Nouns DAO のままで Niji 固有の特徴 (security extension / reveal メカニズム / baseURI fallback / Pausable / 12 trait on-chain SVG / Foundry 併用) が一切書かれておらず、 初めて clone した開発者が現状を把握できない状態でした。
今回の刷新で「何の repo か / どこから手を付ければ動くのか / 詰まったら何を見れば良いか」 を 3 ステップで案内できるようにしました。

# 課題

これまでは以下のような問題がありました。

- README が `nouns-monorepo` 表記のまま、 Niji の独自仕様の言及なし
- ローカルで動かす手順がない (anvil / deploy-niji-smoke / address 反映 / MetaMask 接続)
- env example が package 配下に散らばっているのに、 どれをコピーすればよいかの索引がない
- 詰まったときのトラブルシューティングがどこにもない
- 開発で「よく使うコマンド」 が CLAUDE.md 内のメモ書き止まりで開発者には見えない

# 詳細

新しい README は以下の構成にしました。

```mermaid
graph LR
    A[README 冒頭] --> B[構成 package 表]
    B --> C[必要環境 / Quickstart]
    C --> D[よく使うコマンド + 環境変数の例]
    D --> E[主要機能の解説]
    E --> F[アクティブな移行 / ライセンス]
```

開発フローの詳細は別 file に分け、 README は索引と短い導入のみを担います。

# 解決方法

- 新規 `docs/setup-guide.md` で「環境セットアップ + よくあるエラーの直し方」 を整理
- 新規 `docs/local-dev.md` で「anvil 起動 → deploy → sdk address 反映 → webapp 接続 → 開発ループ」 を整理
- README は索引責務に絞り、 詳細は 2 つの docs から参照

主要 deploy script (`deploy-niji-smoke` / `deploy-niji-full`) は PR #249 で placeholder + reveal + view call gasLimit 設定が入ったため、 ガイドにも「ローカル開発に必要な前提は master 最新で揃っている」 ことを明記しました。

env example について。 root level に `.env.example` を新設するアイディアもあったのですが、 package ごとに必要なキーが大きく違う (contract 系 = wallet / Etherscan、 webapp = Vite prefix の RPC / WalletConnect、 sdk = 内部 script 用) ため、 1 file に押し込むと却って混乱します。 各 package 配下の既存 `.env.example` をそのまま使う方針に統一し、 README から 1 表で索引できるようにしました。

# 仕組み

```mermaid
graph LR
    A[README が索引責務] --> B[setup-guide.md で前提 + トラブルシューティング]
    A --> C[local-dev.md で anvil + deploy + webapp 接続フロー]
    B --> D[各 package の .env.example を参照]
    C --> D
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `README.md` | Nouns 表記を Niji DAO 用に書き換え、 構成 package 表と必要環境を追加、 Quickstart を 4 step (install / env / build / dev) に整理、 主要機能とアクティブな移行を section 化 |
| `docs/setup-guide.md` | 新規。 前提環境 / clone と install / 環境変数 / build と dev / テストの 5 step + トラブルシューティング 6 項 |
| `docs/local-dev.md` | 新規。 anvil 起動 / deploy-niji-smoke / sdk address 反映 / webapp 起動 / 開発でよくやる操作 / つまずきやすいポイント / 次のステップ |

# テストと確認

- [x] 新 README をブラウザ (GitHub の README rendering) で目視確認
- [x] setup-guide / local-dev 内のコマンド (`pnpm -w build` / `pnpm hardhat deploy-niji-smoke --network localhost` / 各種 lint / test) を 1 つずつ確認
- [x] env example の path がすべて存在することを確認 (`.env.example` / `.env.example.local` / `.env.base-sepolia.example` 各 file)

レビューで見てほしいところ。

「root に `.env.example` を新設しない」 判断をご確認ください。
Issue #55 の本文では root の global 変数用に 1 file を想定していたのですが、 各 package で必要なキーが大きく違うため READ.md からの索引で代替する方針にしました。
別案 (root に空のテンプレを置く / monorepo-wide な dotenv-flow を入れる) が良ければ別 Issue で議論したいです。

# 関連

Closes #55
