### PR TITLE
🔐 feat(niji-contracts): NijiArt に Art ロック機構を実装 (Issue #30)

### DIFF
--- a/packages/niji-contracts/contracts/NijiArt.sol
+++ b/packages/niji-contracts/contracts/NijiArt.sol
@@ -115,7 +115,9 @@ contract NijiArt is Ownable2Step {
     /// @notice Store a batch of PNG images for a trait category
     /// @param traitId The trait category index
     /// @param pngDataArray Array of raw PNG bytes
-    /// @dev Each PNG is stored via SSTORE2 as contract bytecode. Reverts if the art has been locked via lockArt().
+    /// @dev Each PNG is stored via SSTORE2 as contract bytecode. `onlyDescriptor` guards the caller first
+    ///      (non-descriptor → `SenderIsNotDescriptor`); after the descriptor passes that gate, the lock check
+    ///      reverts with `ArtIsLocked` if `lockArt()` has been called.
     function addTraitImages(uint256 traitId, bytes[] calldata pngDataArray) external onlyDescriptor {
         if (isArtLocked) revert ArtIsLocked();
         if (traitId >= traitCount) revert InvalidTraitId(traitId, traitCount - 1);
@@ -137,7 +139,9 @@ contract NijiArt is Ownable2Step {
     /// @notice Store a single PNG image for a trait category
     /// @param traitId The trait category index
     /// @param pngData Raw PNG bytes
-    /// @dev PNG is stored via SSTORE2 as contract bytecode. Reverts if the art has been locked via lockArt().
+    /// @dev PNG is stored via SSTORE2 as contract bytecode. `onlyDescriptor` guards the caller first
+    ///      (non-descriptor → `SenderIsNotDescriptor`); after the descriptor passes that gate, the lock check
+    ///      reverts with `ArtIsLocked` if `lockArt()` has been called.
     function addTraitImage(uint256 traitId, bytes calldata pngData) external onlyDescriptor {
         if (isArtLocked) revert ArtIsLocked();
         if (traitId >= traitCount) revert InvalidTraitId(traitId, traitCount - 1);

--- a/packages/niji-contracts/contracts/NijiArt.sol
+++ b/packages/niji-contracts/contracts/NijiArt.sol
@@ -33,6 +33,9 @@ contract NijiArt is Ownable2Step {
     /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
     error RenounceOwnershipDisabled();
 
+    /// @notice Thrown when trait image addition is attempted after the art has been locked
+    error ArtIsLocked();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -54,6 +57,9 @@ contract NijiArt is Ownable2Step {
     /// @param newDescriptor The new descriptor address
     event DescriptorUpdated(address indexed oldDescriptor, address indexed newDescriptor);
 
+    /// @notice Emitted when the art is locked permanently
+    event ArtLocked();
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -69,6 +75,10 @@ contract NijiArt is Ownable2Step {
 
     /// @notice Mapping: traitCategory => array of SSTORE2 pointers (one per image)
     mapping(uint256 => address[]) internal traitPointers;
+
+    /// @notice Whether the art data is locked permanently (no further trait image additions allowed)
+    /// @dev Once true, addTraitImage / addTraitImages revert with ArtIsLocked.
+    bool public isArtLocked;
 
     // =============================================================
     //                           MODIFIERS
@@ -105,8 +115,9 @@ contract NijiArt is Ownable2Step {
     /// @notice Store a batch of PNG images for a trait category
     /// @param traitId The trait category index
     /// @param pngDataArray Array of raw PNG bytes
-    /// @dev Each PNG is stored via SSTORE2 as contract bytecode
+    /// @dev Each PNG is stored via SSTORE2 as contract bytecode. Reverts if the art has been locked via lockArt().
     function addTraitImages(uint256 traitId, bytes[] calldata pngDataArray) external onlyDescriptor {
+        if (isArtLocked) revert ArtIsLocked();
         if (traitId >= traitCount) revert InvalidTraitId(traitId, traitCount - 1);
 
         uint256 startIndex = traitPointers[traitId].length;
@@ -126,8 +137,9 @@ contract NijiArt is Ownable2Step {
     /// @notice Store a single PNG image for a trait category
     /// @param traitId The trait category index
     /// @param pngData Raw PNG bytes
-    /// @dev PNG is stored via SSTORE2 as contract bytecode
+    /// @dev PNG is stored via SSTORE2 as contract bytecode. Reverts if the art has been locked via lockArt().
     function addTraitImage(uint256 traitId, bytes calldata pngData) external onlyDescriptor {
+        if (isArtLocked) revert ArtIsLocked();
         if (traitId >= traitCount) revert InvalidTraitId(traitId, traitCount - 1);
         if (pngData.length == 0) revert EmptyPngData();
 
@@ -223,6 +235,15 @@ contract NijiArt is Ownable2Step {
     function getTraitPointers(uint256 traitId) external view returns (address[] memory) {
         if (traitId >= traitCount) revert InvalidTraitId(traitId, traitCount - 1);
         return traitPointers[traitId];
+    }
+
+    /// @notice Lock the art data permanently — no further trait images can be added.
+    /// @dev Owner-only one-way switch. After this call, addTraitImage / addTraitImages always revert with ArtIsLocked.
+    ///      descriptor swap via transferDescriptor is still allowed, only the image store is frozen.
+    function lockArt() external onlyOwner {
+        if (isArtLocked) revert ArtIsLocked();
+        isArtLocked = true;
+        emit ArtLocked();
     }
 
     /// @notice Disabled to prevent the contract from becoming permanently unowned.

--- a/packages/niji-contracts/test/niji/NijiArt.test.ts
+++ b/packages/niji-contracts/test/niji/NijiArt.test.ts
@@ -211,6 +211,15 @@ describe('NijiArt', () => {
       await art.lockArt();
       await expect(art.transferDescriptor(other.address)).to.not.be.reverted;
     });
+
+    it('should revert addTraitImage with SenderIsNotDescriptor for non-descriptor callers even when locked', async () => {
+      // Modifier order: onlyDescriptor runs before the lock check, so non-descriptor callers
+      // always see SenderIsNotDescriptor regardless of lock state.
+      await art.lockArt();
+      await expect(
+        art.connect(owner).addTraitImage(0, SAMPLE_PNG),
+      ).to.be.revertedWithCustomError(art, 'SenderIsNotDescriptor');
+    });
   });
 
   describe('getTraitName', () => {

--- a/packages/niji-contracts/test/niji/NijiArt.test.ts
+++ b/packages/niji-contracts/test/niji/NijiArt.test.ts
@@ -163,6 +163,56 @@ describe('NijiArt', () => {
     });
   });
 
+  describe('lockArt', () => {
+    it('should not be locked by default', async () => {
+      expect(await art.isArtLocked()).to.be.false;
+    });
+
+    it('should allow owner to lock art', async () => {
+      await expect(art.lockArt()).to.emit(art, 'ArtLocked');
+      expect(await art.isArtLocked()).to.be.true;
+    });
+
+    it('should revert lockArt when called twice', async () => {
+      await art.lockArt();
+      await expect(art.lockArt()).to.be.revertedWithCustomError(art, 'ArtIsLocked');
+    });
+
+    it('should revert lockArt when non-owner', async () => {
+      await expect(art.connect(other).lockArt()).to.be.revertedWithCustomError(
+        art,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should revert addTraitImage after lockArt', async () => {
+      await art.lockArt();
+      await expect(
+        art.connect(descriptor).addTraitImage(0, SAMPLE_PNG),
+      ).to.be.revertedWithCustomError(art, 'ArtIsLocked');
+    });
+
+    it('should revert addTraitImages after lockArt', async () => {
+      await art.lockArt();
+      await expect(
+        art.connect(descriptor).addTraitImages(0, [SAMPLE_PNG, SAMPLE_PNG]),
+      ).to.be.revertedWithCustomError(art, 'ArtIsLocked');
+    });
+
+    it('should still allow getTraitImage reads after lockArt', async () => {
+      await art.connect(descriptor).addTraitImage(0, SAMPLE_PNG);
+      await art.lockArt();
+      const png = await art.getTraitImage(0, 0);
+      expect(png.length).to.be.greaterThan(0);
+      expect(png.toLowerCase()).to.equal('0x' + SAMPLE_PNG.toString('hex'));
+    });
+
+    it('should still allow transferDescriptor after lockArt', async () => {
+      await art.lockArt();
+      await expect(art.transferDescriptor(other.address)).to.not.be.reverted;
+    });
+  });
+
   describe('getTraitName', () => {
     it('should return specific trait name', async () => {
       expect(await art.getTraitName(0)).to.equal('special');


### PR DESCRIPTION
# 概要

NijiArt に Art データを永久ロックする機構を追加しました。
`lockArt()` を 1 度呼ぶと、 以後 `addTraitImage` / `addTraitImages` がすべて `ArtIsLocked` で revert する一方通行スイッチです。
collection の trait image をすべて load し終わったタイミングで owner が lock を撃つと、 攻撃者に owner 鍵を奪われても新規 image を後から追加できなくなる安全装置として機能します。

# 課題

これまでの NijiArt は descriptor 経由で `addTraitImage` / `addTraitImages` を後付けで何度でも呼べました。
本来は collection 立ち上げ時に必要 image を一度に load し終わるはずですが、 lock 機構がなければ「あとから別な image を勝手に挿入する」 経路が永続的に残り続けていました。
コレクター視点では「買った後にも trait pool に未知の image が追加されうる」 状態で、 generative collection の固定性が保証できない状態でした。

# 詳細

NijiArt の image 追加は `onlyDescriptor` modifier で descriptor 限定でしたが、 lock は contract owner が直接撃てるようにします。 lock 後も view 関数 (`getTraitImage` / `getTraitImageCount` / `getTraitPointers`) は通常通り読めるため、 既存 NFT の SVG 生成には一切影響しません。

```mermaid
graph LR
    A[collection 立ち上げ] --> B[addTraitImages で全 image load]
    B --> C[owner が lockArt を呼ぶ]
    C --> D[isArtLocked = true 永続化]
    D --> E[以後の addTraitImage は ArtIsLocked で revert]
    E --> F[view 関数 / transferDescriptor は通常通り]
```

# 解決方法

- `isArtLocked` bool storage を追加 (default false)
- `lockArt()` owner-only one-way 関数を追加 (二度目以降は `ArtIsLocked` で revert)
- `addTraitImage` / `addTraitImages` 冒頭で `if (isArtLocked) revert ArtIsLocked()` を入れる
- `transferDescriptor` は lock の影響を受けない (descriptor swap は将来的にも残す必要があるため image 固定とは独立に保つ)
- `ArtLocked` event + `ArtIsLocked` error 追加

# 仕組み

```mermaid
graph LR
    A[owner.lockArt] --> B[isArtLocked = true]
    B --> C[ArtLocked event]
    C --> D[addTraitImage 系が全 revert]
    D --> E[getTraitImage 読みは継続可能]
    D --> F[transferDescriptor は引き続き可能]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiArt.sol` | `isArtLocked` storage / `lockArt()` 関数 / `ArtLocked` event / `ArtIsLocked` error を追加。 `addTraitImage` `addTraitImages` 冒頭に lock guard 挿入 |
| `packages/niji-contracts/test/niji/NijiArt.test.ts` | lockArt describe 7 件を追加 (default state / owner-only / 二度目 revert / 非 owner revert / addTraitImage 系 revert / view 関数継続 / transferDescriptor 継続) |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiArt.test.ts` 34 件全 pass (lockArt 7 件新規 + 既存 27 件)
- [x] `pnpm hardhat test` 全 295 件 pass (regression なし)

レビューで見てほしいところ。

`lockArt` を一方通行 (二度目 revert) にした設計をご確認ください。
途中で image を差し替えたい運用は generative 性質的に想定せず、 lock 後の rollback 経路を作らないことで「lock = 完全固定」 のシグナルを明確にしています。
`transferDescriptor` を lock 対象に含めない判断 (descriptor の bug fix 等で将来差し替え可能性を残す) も合わせてご確認ください。

# 関連

Closes #30
