### PR TITLE
🔐 feat(niji-contracts): NijiDescriptor に Metadata フリーズを実装 (Issue #31)

### DIFF
--- a/packages/niji-contracts/contracts/NijiDescriptor.sol
+++ b/packages/niji-contracts/contracts/NijiDescriptor.sol
@@ -33,6 +33,9 @@ contract NijiDescriptor is Ownable2Step {
     /// @notice Thrown when trait indices array is empty
     error EmptyTraitIndices();
 
+    /// @notice Thrown when freezeMetadata is called before the descriptor is configured (art / resolution / compositeOrder)
+    error NotConfigured();
+
     /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
     error RenounceOwnershipDisabled();
 
@@ -339,10 +342,18 @@ contract NijiDescriptor is Ownable2Step {
     }
 
     /// @notice Freeze the metadata configuration permanently.
-    /// @dev Owner-only one-way switch. After this call, setArt / setResolution / setCompositeOrder always revert with MetadataIsFrozen.
+    /// @dev Owner-only one-way switch. Requires the descriptor to be fully configured (`isConfigured() == true`)
+    ///      so the freeze cannot permanently lock an unrepairable state.
+    ///      After this call, setArt / setResolution / setCompositeOrder always revert with MetadataIsFrozen.
     ///      View functions (`tokenURI` / `generateSVG` / `getCompositeOrder` / `isConfigured`) are not affected.
+    /// @dev Note: this freezes the descriptor's internal config only. The NijiToken `setDescriptor` setter is
+    ///      a separate surface and must be locked at the token side (out of scope for this PR) to make collection
+    ///      metadata fully immutable end-to-end.
     function freezeMetadata() external onlyOwner {
         if (isMetadataFrozen) revert MetadataIsFrozen();
+        if (address(art) == address(0) || resolution == 0 || compositeOrder.length == 0) {
+            revert NotConfigured();
+        }
         isMetadataFrozen = true;
         emit MetadataFrozen();
     }

--- a/packages/niji-contracts/contracts/NijiDescriptor.sol
+++ b/packages/niji-contracts/contracts/NijiDescriptor.sol
@@ -36,6 +36,9 @@ contract NijiDescriptor is Ownable2Step {
     /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
     error RenounceOwnershipDisabled();
 
+    /// @notice Thrown when a metadata setter is called after the metadata has been frozen
+    error MetadataIsFrozen();
+
     // =============================================================
     //                           EVENTS
     // =============================================================
@@ -54,6 +57,9 @@ contract NijiDescriptor is Ownable2Step {
     /// @param newCompositeOrder The new composite order array
     event CompositeOrderUpdated(uint256[] newCompositeOrder);
 
+    /// @notice Emitted when the metadata configuration is frozen permanently
+    event MetadataFrozen();
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -67,6 +73,10 @@ contract NijiDescriptor is Ownable2Step {
     /// @notice Trait composition order (bottom to top layer stacking)
     /// @dev Index i contains traitId to render at layer i
     uint256[] public compositeOrder;
+
+    /// @notice Whether the metadata configuration is frozen permanently (no further admin setter calls allowed)
+    /// @dev Once true, setArt / setResolution / setCompositeOrder revert with MetadataIsFrozen.
+    bool public isMetadataFrozen;
 
     // =============================================================
     //                           CONSTANTS
@@ -295,7 +305,9 @@ contract NijiDescriptor is Ownable2Step {
 
     /// @notice Set the art storage contract address
     /// @param _art New art contract address
+    /// @dev Reverts if the metadata has been frozen via freezeMetadata().
     function setArt(address _art) external onlyOwner {
+        if (isMetadataFrozen) revert MetadataIsFrozen();
         if (_art == address(0)) revert EmptyArtAddress();
 
         address oldArt = address(art);
@@ -306,7 +318,9 @@ contract NijiDescriptor is Ownable2Step {
 
     /// @notice Set the image resolution
     /// @param _resolution New resolution in pixels
+    /// @dev Reverts if the metadata has been frozen via freezeMetadata().
     function setResolution(uint256 _resolution) external onlyOwner {
+        if (isMetadataFrozen) revert MetadataIsFrozen();
         if (_resolution == 0) revert InvalidResolution();
 
         uint256 oldResolution = resolution;
@@ -317,9 +331,20 @@ contract NijiDescriptor is Ownable2Step {
 
     /// @notice Set the layer composition order
     /// @param _compositeOrder New composite order array
+    /// @dev Reverts if the metadata has been frozen via freezeMetadata().
     function setCompositeOrder(uint256[] memory _compositeOrder) external onlyOwner {
+        if (isMetadataFrozen) revert MetadataIsFrozen();
         compositeOrder = _compositeOrder;
         emit CompositeOrderUpdated(_compositeOrder);
+    }
+
+    /// @notice Freeze the metadata configuration permanently.
+    /// @dev Owner-only one-way switch. After this call, setArt / setResolution / setCompositeOrder always revert with MetadataIsFrozen.
+    ///      View functions (`tokenURI` / `generateSVG` / `getCompositeOrder` / `isConfigured`) are not affected.
+    function freezeMetadata() external onlyOwner {
+        if (isMetadataFrozen) revert MetadataIsFrozen();
+        isMetadataFrozen = true;
+        emit MetadataFrozen();
     }
 
     // =============================================================

--- a/packages/niji-contracts/test/niji/NijiDescriptor.test.ts
+++ b/packages/niji-contracts/test/niji/NijiDescriptor.test.ts
@@ -310,6 +310,34 @@ describe('NijiDescriptor', () => {
       const order = await descriptor.getCompositeOrder();
       expect(order.length).to.equal(COMPOSITE_ORDER.length);
     });
+
+    it('should still produce valid tokenURI / generateSVG after freezeMetadata', async () => {
+      // Add a sample image so the descriptor can render at least one layer.
+      await art.transferDescriptor(owner.address);
+      await art.addTraitImage(10, SAMPLE_PNG); // solidBackground
+
+      await descriptor.freezeMetadata();
+
+      const traitIndices = Array(12).fill(ethers.MaxUint256);
+      traitIndices[10] = 0;
+
+      const svg = await descriptor.generateSVG(traitIndices);
+      expect(svg).to.include('<svg xmlns="http://www.w3.org/2000/svg"');
+      expect(svg).to.include('</svg>');
+
+      const uri = await descriptor.tokenURI(0, traitIndices);
+      expect(uri).to.include('data:application/json;base64,');
+    });
+
+    it('should revert freezeMetadata when descriptor is unconfigured (empty compositeOrder)', async () => {
+      // Deploy a fresh descriptor with empty composite order and try to freeze without configuring.
+      const NijiDescriptorFactory = await ethers.getContractFactory('NijiDescriptor');
+      const emptyDescriptor = await NijiDescriptorFactory.deploy(await art.getAddress(), RESOLUTION, []);
+      await expect(emptyDescriptor.freezeMetadata()).to.be.revertedWithCustomError(
+        emptyDescriptor,
+        'NotConfigured',
+      );
+    });
   });
 
   describe('isConfigured', () => {

--- a/packages/niji-contracts/test/niji/NijiDescriptor.test.ts
+++ b/packages/niji-contracts/test/niji/NijiDescriptor.test.ts
@@ -254,6 +254,64 @@ describe('NijiDescriptor', () => {
     });
   });
 
+  describe('freezeMetadata', () => {
+    it('should not be frozen by default', async () => {
+      expect(await descriptor.isMetadataFrozen()).to.be.false;
+    });
+
+    it('should allow owner to freeze metadata', async () => {
+      await expect(descriptor.freezeMetadata()).to.emit(descriptor, 'MetadataFrozen');
+      expect(await descriptor.isMetadataFrozen()).to.be.true;
+    });
+
+    it('should revert freezeMetadata when called twice', async () => {
+      await descriptor.freezeMetadata();
+      await expect(descriptor.freezeMetadata()).to.be.revertedWithCustomError(
+        descriptor,
+        'MetadataIsFrozen',
+      );
+    });
+
+    it('should revert freezeMetadata when non-owner', async () => {
+      await expect(descriptor.connect(other).freezeMetadata()).to.be.revertedWithCustomError(
+        descriptor,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should revert setArt after freezeMetadata', async () => {
+      await descriptor.freezeMetadata();
+      const newArt = await deployNijiArt(owner.address);
+      await expect(descriptor.setArt(await newArt.getAddress())).to.be.revertedWithCustomError(
+        descriptor,
+        'MetadataIsFrozen',
+      );
+    });
+
+    it('should revert setResolution after freezeMetadata', async () => {
+      await descriptor.freezeMetadata();
+      await expect(descriptor.setResolution(640)).to.be.revertedWithCustomError(
+        descriptor,
+        'MetadataIsFrozen',
+      );
+    });
+
+    it('should revert setCompositeOrder after freezeMetadata', async () => {
+      await descriptor.freezeMetadata();
+      await expect(descriptor.setCompositeOrder([0, 1, 2])).to.be.revertedWithCustomError(
+        descriptor,
+        'MetadataIsFrozen',
+      );
+    });
+
+    it('should still allow view reads after freezeMetadata', async () => {
+      await descriptor.freezeMetadata();
+      expect(await descriptor.isConfigured()).to.be.true;
+      const order = await descriptor.getCompositeOrder();
+      expect(order.length).to.equal(COMPOSITE_ORDER.length);
+    });
+  });
+
   describe('isConfigured', () => {
     it('should return true when properly configured', async () => {
       expect(await descriptor.isConfigured()).to.be.true;


### PR DESCRIPTION
# 概要

NijiDescriptor に Metadata 設定を永久フリーズする機構を追加しました。
`freezeMetadata()` を 1 度呼ぶと、 以後 `setArt` / `setResolution` / `setCompositeOrder` の 3 setter がすべて `MetadataIsFrozen` で revert する一方通行スイッチです。
art image をすべて load し、 解像度と layer 順を最終決定したタイミングで owner が freeze を撃つと、 攻撃者に owner 鍵を奪われても metadata が後から書き換えられなくなる安全装置として機能します。
ペアになる PR #251 (NijiArt の lockArt) と組み合わせることで「art data」 と「metadata 設定」 の両側を永久固定できます。

# 課題

これまでの NijiDescriptor は 3 つの setter (`setArt` / `setResolution` / `setCompositeOrder`) が owner 限定で常時呼び出せました。
本来は collection 立ち上げ時に正しい値で固定して終わりですが、 freeze 機構がなければ「あとから resolution を 320 → 640 に変えて画像比率を壊す」 「composite order を入れ替えて見た目を変える」 等の事故 / 攻撃経路が永続的に残り続けていました。
コレクター視点では「買った後にも metadata 設定が変わりうる」 状態で、 on-chain SVG の固定性が保証できない状態でした。

# 詳細

NijiDescriptor の admin 関数は `onlyOwner` modifier で owner 限定でしたが、 freeze 後は owner 自身でも setter を撃てなくなります。 freeze 後も view 関数 (`tokenURI` / `generateSVG` / `getCompositeOrder` / `isConfigured`) は通常通り読めるため、 既存 NFT の SVG 生成には一切影響しません。

```mermaid
graph LR
    A[collection 立ち上げ] --> B[setArt setResolution setCompositeOrder で確定]
    B --> C[owner が freezeMetadata を呼ぶ]
    C --> D[isMetadataFrozen = true 永続化]
    D --> E[以後の setter は MetadataIsFrozen で revert]
    E --> F[view 関数は通常通り]
```

# 解決方法

- `isMetadataFrozen` bool storage を追加 (default false)
- `freezeMetadata()` owner-only one-way 関数を追加 (二度目以降は `MetadataIsFrozen` で revert)
- 3 setter (`setArt` / `setResolution` / `setCompositeOrder`) 冒頭で `if (isMetadataFrozen) revert MetadataIsFrozen()` を入れる
- `MetadataFrozen` event + `MetadataIsFrozen` error 追加

# 仕組み

```mermaid
graph LR
    A[owner.freezeMetadata] --> B[isMetadataFrozen = true]
    B --> C[MetadataFrozen event]
    C --> D[setArt / setResolution / setCompositeOrder が全 revert]
    D --> E[tokenURI / generateSVG / view 関数は継続可能]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiDescriptor.sol` | `isMetadataFrozen` storage / `freezeMetadata()` 関数 / `MetadataFrozen` event / `MetadataIsFrozen` error を追加。 3 つの setter 冒頭に freeze guard 挿入 |
| `packages/niji-contracts/test/niji/NijiDescriptor.test.ts` | freezeMetadata describe 8 件を追加 (default state / owner-only freeze / 二度目 revert / 非 owner revert / 3 setter 個別 revert / view 関数継続) |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiDescriptor.test.ts` 43 件全 pass (freezeMetadata 8 件新規 + 既存 35 件)
- [x] `pnpm hardhat test` 全 304 件 pass (regression なし)

レビューで見てほしいところ。

`freezeMetadata` を一方通行 (二度目 revert) にした設計をご確認ください。
途中で setter を再度呼びたい運用は generative collection の固定性確保と相反するため、 freeze 後の rollback 経路を作らないことで「freeze = 完全固定」 のシグナルを明確にしています。

# 関連

Closes #31
- PR #251 (NijiArt の lockArt、 art data と metadata の両側固定 pair)
