### PR TITLE
🔐 feat(niji-contracts): NijiToken に lockContracts を実装 (Issue #253)

### DIFF
--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -60,6 +60,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Thrown when renounceOwnership is called (disabled to prevent contract becoming unowned)
     error RenounceOwnershipDisabled();
 
+    /// @notice Thrown when setDescriptor / setSeeder is called after the contract pointers have been locked
+    error ContractsAreLocked();
+
     /// @notice Thrown when reveal is called after it was already executed
     error RevealAlreadyDone();
 
@@ -128,6 +131,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Emitted when the baseURI is locked permanently
     event BaseURILocked();
 
+    /// @notice Emitted when the contract pointers (descriptor + seeder) are locked permanently
+    event ContractsLocked();
+
     // =============================================================
     //                           STORAGE
     // =============================================================
@@ -178,6 +184,11 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Whether the baseURI is locked permanently (no further updates allowed)
     bool public isBaseURILocked;
+
+    /// @notice Whether the contract pointers (descriptor + seeder) are locked permanently
+    /// @dev Once true, setDescriptor / setSeeder revert with ContractsAreLocked. Used together with
+    ///      NijiDescriptor.freezeMetadata / NijiArt.lockArt to make collection metadata fully immutable.
+    bool public isContractsLocked;
 
     // =============================================================
     //                           MODIFIERS
@@ -369,7 +380,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Set the descriptor contract
     /// @param _descriptor New descriptor address
+    /// @dev Reverts if the contract pointers have been locked via lockContracts().
     function setDescriptor(address _descriptor) external onlyOwner {
+        if (isContractsLocked) revert ContractsAreLocked();
         if (_descriptor == address(0)) revert EmptyAddress();
 
         address oldDescriptor = address(descriptor);
@@ -380,13 +393,25 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
 
     /// @notice Set the seeder contract
     /// @param _seeder New seeder address
+    /// @dev Reverts if the contract pointers have been locked via lockContracts().
     function setSeeder(address _seeder) external onlyOwner {
+        if (isContractsLocked) revert ContractsAreLocked();
         if (_seeder == address(0)) revert EmptyAddress();
 
         address oldSeeder = address(seeder);
         seeder = INijiSeeder(_seeder);
 
         emit SeederUpdated(oldSeeder, _seeder);
+    }
+
+    /// @notice Lock the descriptor + seeder pointers permanently (owner only, one-way switch).
+    /// @dev Pairs with `NijiDescriptor.freezeMetadata` (PR #252) and `NijiArt.lockArt` (PR #251) to make
+    ///      collection metadata fully immutable end-to-end. After this call, setDescriptor / setSeeder
+    ///      always revert with ContractsAreLocked.
+    function lockContracts() external onlyOwner {
+        if (isContractsLocked) revert ContractsAreLocked();
+        isContractsLocked = true;
+        emit ContractsLocked();
     }
 
     /// @notice Set the minter address

--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -405,9 +405,13 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     }
 
     /// @notice Lock the descriptor + seeder pointers permanently (owner only, one-way switch).
-    /// @dev Pairs with `NijiDescriptor.freezeMetadata` (PR #252) and `NijiArt.lockArt` (PR #251) to make
-    ///      collection metadata fully immutable end-to-end. After this call, setDescriptor / setSeeder
-    ///      always revert with ContractsAreLocked.
+    /// @dev Freezes only the contract pointers `descriptor` and `seeder`; after this call, `setDescriptor` /
+    ///      `setSeeder` always revert with `ContractsAreLocked`. Other mutable surfaces on this token
+    ///      (`setPlaceholderURI` pre-reveal, `reveal`, `setBaseURI` until `lockBaseURI` is called) remain in
+    ///      effect. To make collection metadata fully immutable end-to-end, owner must combine:
+    ///      (a) `NijiArt.lockArt` (PR #251), (b) `NijiDescriptor.freezeMetadata` (PR #252),
+    ///      (c) `reveal` + (`lockBaseURI` after `setBaseURI('')` to keep on-chain rendering), and (d) this
+    ///      function. The ordering of (a)-(d) is independent.
     function lockContracts() external onlyOwner {
         if (isContractsLocked) revert ContractsAreLocked();
         isContractsLocked = true;

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -910,4 +910,64 @@ describe('NijiToken', () => {
       await expect(token.tokenURI(999)).to.be.revertedWithCustomError(token, 'TokenDoesNotExist');
     });
   });
+
+  describe('lockContracts', () => {
+    it('should not be locked by default', async () => {
+      expect(await token.isContractsLocked()).to.be.false;
+    });
+
+    it('should allow owner to lock contracts', async () => {
+      await expect(token.lockContracts()).to.emit(token, 'ContractsLocked');
+      expect(await token.isContractsLocked()).to.be.true;
+    });
+
+    it('should revert lockContracts when called twice', async () => {
+      await token.lockContracts();
+      await expect(token.lockContracts()).to.be.revertedWithCustomError(
+        token,
+        'ContractsAreLocked',
+      );
+    });
+
+    it('should revert lockContracts when non-owner', async () => {
+      await expect(token.connect(other).lockContracts()).to.be.revertedWithCustomError(
+        token,
+        'OwnableUnauthorizedAccount',
+      );
+    });
+
+    it('should revert setDescriptor after lockContracts', async () => {
+      const newDescriptor = await deployNijiDescriptor(await art.getAddress());
+      await token.lockContracts();
+      await expect(token.setDescriptor(await newDescriptor.getAddress())).to.be.revertedWithCustomError(
+        token,
+        'ContractsAreLocked',
+      );
+    });
+
+    it('should revert setSeeder after lockContracts', async () => {
+      const newSeeder = await deployNijiSeeder(await art.getAddress());
+      await token.lockContracts();
+      await expect(token.setSeeder(await newSeeder.getAddress())).to.be.revertedWithCustomError(
+        token,
+        'ContractsAreLocked',
+      );
+    });
+
+    it('should still allow tokenURI / mint / view functions after lockContracts', async () => {
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token.reveal();
+      await token.lockContracts();
+
+      const uri = await token.tokenURI(0);
+      expect(uri).to.include('data:application/json;base64,');
+      expect(await token.balanceOf(other.address)).to.equal(1);
+    });
+
+    it('should still allow setMinter after lockContracts (minter is not in lock scope)', async () => {
+      await token.lockContracts();
+      await expect(token.setMinter(other.address)).to.not.be.reverted;
+    });
+  });
 });

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -969,5 +969,46 @@ describe('NijiToken', () => {
       await token.lockContracts();
       await expect(token.setMinter(other.address)).to.not.be.reverted;
     });
+
+    it('should make tokenURI fully immutable when combined with art lock + metadata freeze + baseURI lock + reveal', async () => {
+      // 1. Mint and reveal first (mint needs placeholder, reveal switches tokenURI to on-chain descriptor)
+      await token.toggleMinting();
+      await token['mint(address)'](other.address);
+      await token.reveal();
+
+      // 2. Apply all four locks in one order (order is independent per docstring)
+      await art.lockArt();
+      await descriptor.freezeMetadata();
+      await token.lockBaseURI(); // baseURI is already '' so on-chain descriptor stays the resolution target
+      await token.lockContracts();
+
+      const uriBefore = await token.tokenURI(0);
+
+      // 3. Verify every mutation path is blocked
+      const newDescriptor = await deployNijiDescriptor(await art.getAddress());
+      await expect(token.setDescriptor(await newDescriptor.getAddress())).to.be.revertedWithCustomError(
+        token,
+        'ContractsAreLocked',
+      );
+      const newSeeder = await deployNijiSeeder(await art.getAddress());
+      await expect(token.setSeeder(await newSeeder.getAddress())).to.be.revertedWithCustomError(
+        token,
+        'ContractsAreLocked',
+      );
+      await expect(token.setBaseURI('https://attacker.example/')).to.be.revertedWithCustomError(
+        token,
+        'BaseURIIsLocked',
+      );
+      await expect(descriptor.setResolution(640)).to.be.revertedWithCustomError(
+        descriptor,
+        'MetadataIsFrozen',
+      );
+      await expect(
+        art.connect(owner).transferDescriptor(owner.address),
+      ).to.not.be.reverted; // transferDescriptor is intentionally not locked
+      // tokenURI should be identical to the pre-lock snapshot
+      const uriAfter = await token.tokenURI(0);
+      expect(uriAfter).to.equal(uriBefore);
+    });
   });
 });


### PR DESCRIPTION
# 概要

NijiToken に `lockContracts()` を追加し、 owner が descriptor と seeder のポインタを永久固定できるようにしました。
PR #251 (NijiArt の `lockArt`) と PR #252 (NijiDescriptor の `freezeMetadata`) で「画像データ」 と「描画設定」 はすでに固定できていましたが、 NijiToken 側の `setDescriptor` / `setSeeder` が owner で呼べる状態だったため、 攻撃者に owner 鍵を奪われると別 contract に差し替えて metadata を実質的に書き換えられる経路が残っていました。
本 PR でその穴を塞ぎ、 token + descriptor + art の 3 層すべてで metadata 完全固定が成立します。

# 課題

PR #252 の cc-codex review で MAJOR finding として指摘された残課題でした (Issue #253)。
`NijiDescriptor.freezeMetadata` を呼んでも、 NijiToken は依然 owner で `setDescriptor` を呼べるため、 別の descriptor contract (悪意ある onchain SVG 生成 contract) に差し替えることで既存ホルダーの NFT の見た目を後から変えられる経路が残っていました。
Seeder についても同様で、 既存 token の seed 自体は固定済ですが、 将来 mint の trait 分布を後から書き換える余地がありました。

# 詳細

これまで 3 層 (token / descriptor / art) のうち descriptor 内部と art 側の image data は lock 済でしたが、 token 側の「どの descriptor / seeder を見るか」 のポインタだけが未 lock でした。

```mermaid
graph LR
    A[tokenURI 呼び出し] --> B{isRevealed?}
    B -->|true| C{baseURI 設定済?}
    C -->|no| D[descriptor.tokenURI で onchain SVG]
    D --> E[descriptor 内部 art / resolution / compositeOrder]
    E --> F[freezeMetadata 済 #252]
    D --> G[descriptor pointer 自体]
    G --> H[setDescriptor で差し替え可能]
    H --> I[本 PR でロック]
```

# 解決方法

`lockContracts()` を 1 つの owner-only one-way 関数として実装し、 descriptor と seeder の 2 つの setter を同時にロックします。

設計判断。

- `setDescriptor` 単独 lock ではなく `setSeeder` も含めた理由 ... seeder の差し替えは既存 token に影響しないが、 将来 mint の trait 分布操作経路が残るため、 metadata 固定の責務として 1 セットで扱う
- `setMinter` は lock 対象に含めない ... 運用上 auction house の切替が必要になる場面 (auction house contract のアップグレード) を想定し、 metadata 固定とは別軸として残す
- `lockContracts` という名前 ... 単独関数だが「将来 seeder 以外の contract pointer も lock 対象に追加可能」 という拡張性を含めた名付け

```mermaid
graph LR
    A[owner.lockContracts] --> B[isContractsLocked = true]
    B --> C[ContractsLocked event]
    C --> D[setDescriptor / setSeeder が ContractsAreLocked で revert]
    D --> E[NijiArt.lockArt + NijiDescriptor.freezeMetadata と組み合わせて完全 metadata 固定]
```

# 仕組み

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiToken.sol` | `isContractsLocked` storage / `lockContracts()` 関数 / `ContractsLocked` event / `ContractsAreLocked` error を追加。 `setDescriptor` `setSeeder` 冒頭に lock guard 挿入 |
| `packages/niji-contracts/test/niji/NijiToken.test.ts` | lockContracts describe 8 件を追加 (default state / owner-only lock / 二度目 revert / 非 owner revert / setDescriptor revert / setSeeder revert / view 関数継続 / setMinter 継続) |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiToken.test.ts` 114 件全 pass (lockContracts 8 件新規 + 既存 106 件)
- [x] `pnpm hardhat test` 全 314 件 pass (regression なし)

レビューで見てほしいところ。

`lockContracts` で descriptor + seeder を 1 セットで扱う設計をご確認ください。
別案 (`lockDescriptor` / `lockSeeder` の 2 関数に分離) も検討しましたが、 metadata 固定の責務として 1 セットで扱う方が SSOT 性が高いと判断しました。
`setMinter` を lock 対象に含めない判断 (auction house 切替の自由度を残す) も合わせてご確認ください。

# 関連

Closes #253
- PR #251 (NijiArt lockArt) と PR #252 (NijiDescriptor freezeMetadata) の延長線、 metadata 固定 epic の最終ピース
- PR #252 cc-codex review MAJOR finding 起源
