### PR TITLE
🔧 refactor(niji-webapp): any 型を generic 化 + console.log 格上げ (Issue #19 #21 subset)

### DIFF
--- a/packages/niji-webapp/src/components/ModalBottomButtonRow/index.tsx
+++ b/packages/niji-webapp/src/components/ModalBottomButtonRow/index.tsx
@@ -5,8 +5,8 @@ import NavBarButton, { NavBarButtonStyle } from '../NavBarButton';
 import classes from './ModalBottomButtonRow.module.css';
 
 export interface ModalBottomButtonRowProps {
-  onPrevBtnClick: (e?: any) => void;
-  onNextBtnClick: (e?: any) => void;
+  onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+  onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
   prevBtnText: React.ReactNode;
   nextBtnText: React.ReactNode;
   isNextBtnDisabled?: boolean;

--- a/packages/niji-webapp/src/components/VoteCard/index.tsx
+++ b/packages/niji-webapp/src/components/VoteCard/index.tsx
@@ -82,10 +82,7 @@ const VoteCard: React.FC<VoteCardProps> = props => {
         return;
       }
 
-      // viem PublicClient generic 型がチェーン縮小で wagmi 戻り値型と一致しないため as any で迂回
-      // (実体は同じ PublicClient、 単に型推論の問題)
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      lookupNNSOrENS(publicClient as any, delegateInfo.delegate)
+      lookupNNSOrENS(publicClient, delegateInfo.delegate)
         .then(name => {
           // Store data as mapping of address_Expiration => address or ENS
           if (name) {
@@ -99,7 +96,7 @@ const VoteCard: React.FC<VoteCardProps> = props => {
           }
         })
         .catch(error => {
-          console.log(`error resolving reverse ens lookup: `, error);
+          console.warn(`error resolving reverse ens lookup: `, error);
         });
     });
     setEnsCached(true);

--- a/packages/niji-webapp/src/utils/colorResponsiveUIUtils.ts
+++ b/packages/niji-webapp/src/utils/colorResponsiveUIUtils.ts
@@ -19,7 +19,7 @@ export const shouldUseStateBg = (location: { pathname: string }) => {
  * @param coolState  cool 背景時に返す値
  * @param warmState  warm 背景時に返す値
  */
-export const usePickByStateColor = (whiteState: any, coolState: any, warmState: any) => {
+export const usePickByStateColor = <T>(whiteState: T, coolState: T, warmState: T): T => {
   const location = useLocation();
   const useStateBg = shouldUseStateBg(location);
   const isCoolState = useAtomValue(isCoolBackgroundAtom);

--- a/packages/niji-webapp/src/utils/ensLookup.ts
+++ b/packages/niji-webapp/src/utils/ensLookup.ts
@@ -47,7 +47,7 @@ export const useReverseENSLookUp = (address: Address) => {
             }
           })
           .catch(error => {
-            console.log(`error resolving reverse ens lookup: `, error);
+            console.warn(`error resolving reverse ens lookup: `, error);
           });
       }
     }

--- a/packages/niji-webapp/src/utils/lookupNNSOrENS.ts
+++ b/packages/niji-webapp/src/utils/lookupNNSOrENS.ts
@@ -3,15 +3,29 @@ import { parseAbiItem } from 'viem';
 import { Address } from '@/utils/types';
 
 /**
+ * Minimum surface we need from viem's PublicClient. Avoids `any` while staying compatible
+ * with both wagmi v2 client types and stock viem clients (chain narrowing differences make
+ * the full PublicClient generic awkward to import here).
+ */
+type ReadContractClient = {
+  readContract: (args: {
+    address: Address;
+    abi: ReadonlyArray<ReturnType<typeof parseAbiItem>>;
+    functionName: 'resolve';
+    args: readonly [Address];
+  }) => Promise<unknown>;
+};
+
+/**
  * look up NNS or ENS (NNS first, ENS fallback).
- * viem の PublicClient 型は chains narrow で wagmi 戻り値型と衝突しがちなので
- * client は any 受けし readContract 経由で抽象化する。
- * @param client viem PublicClient (any 受け)
+ * @param client viem PublicClient compatible client (must expose `readContract`)
  * @param target wallet address
  * @returns name or null
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function lookupNNSOrENS(client: any, target: Address): Promise<string | null> {
+export async function lookupNNSOrENS(
+  client: ReadContractClient,
+  target: Address,
+): Promise<string | null> {
   // try NNS
   try {
     const name = await client.readContract({
@@ -20,7 +34,7 @@ export async function lookupNNSOrENS(client: any, target: Address): Promise<stri
       functionName: 'resolve',
       args: [target],
     });
-    if (name) return name;
+    if (typeof name === 'string' && name) return name;
   } catch {
     // no biggie, NNS miss
   }
@@ -33,7 +47,7 @@ export async function lookupNNSOrENS(client: any, target: Address): Promise<stri
       functionName: 'resolve',
       args: [target],
     });
-    return name || null;
+    return typeof name === 'string' && name ? name : null;
   } catch {
     return null;
   }

--- a/packages/niji-webapp/src/utils/moderation/containsBlockedText.ts
+++ b/packages/niji-webapp/src/utils/moderation/containsBlockedText.ts
@@ -14,7 +14,7 @@ export const containsBlockedText = (text: string, language: string) => {
   const regexesForLanguage = new Map(Object.entries(moderationRegexes)).get(language);
   // Default to letting the string through if the language is unsupported
   if (regexesForLanguage === undefined) {
-    console.log(`Unsupported language ${language} requested`);
+    console.warn(`Unsupported language ${language} requested`);
     return false;
   }
 

--- a/packages/niji-webapp/src/utils/pickByState.ts
+++ b/packages/niji-webapp/src/utils/pickByState.ts
@@ -1,6 +1,11 @@
 /**
- * Given state, picks the stateResult that corresponses to state
+ * Given a `state` value, returns the corresponding entry in `stateResults` by index lookup.
+ * Generic over the state type `S` and the result type `R` so call sites stop losing type info.
  */
-export const usePickByState = (state: any, states: any[], stateResults: any[]): any => {
+export const usePickByState = <S, R>(
+  state: S,
+  states: readonly S[],
+  stateResults: readonly R[],
+): R => {
   return stateResults[states.indexOf(state)];
 };

--- a/packages/niji-webapp/src/utils/pickByState.ts
+++ b/packages/niji-webapp/src/utils/pickByState.ts
@@ -1,11 +1,13 @@
 /**
  * Given a `state` value, returns the corresponding entry in `stateResults` by index lookup.
  * Generic over the state type `S` and the result type `R` so call sites stop losing type info.
+ * @returns the matched result, or `undefined` if `state` is not in `states` or `stateResults`
+ *          is shorter than `states` (runtime-honest: `Array.indexOf(...)` can be `-1`).
  */
 export const usePickByState = <S, R>(
   state: S,
   states: readonly S[],
   stateResults: readonly R[],
-): R => {
+): R | undefined => {
   return stateResults[states.indexOf(state)];
 };

--- a/packages/niji-webapp/src/utils/pseudoRandomPredictableShuffle.ts
+++ b/packages/niji-webapp/src/utils/pseudoRandomPredictableShuffle.ts
@@ -7,18 +7,18 @@
  * @param seed random seed
  * @returns  elements in inputs pseudorandomly shuffled as a function of seed
  */
-export const pseudoRandomPredictableShuffle = (input: Array<any> = [], seed = 1) => {
-  input = [...input];
-  const output = [];
+export const pseudoRandomPredictableShuffle = <T>(input: readonly T[] = [], seed = 1): T[] => {
+  const remaining: T[] = [...input];
+  const output: T[] = [];
 
-  while (input.length) {
+  while (remaining.length) {
     if (seed === 0) seed++;
     // adapted from: https://stackoverflow.com/a/19303725
     let rand = Math.sin(seed++) * 10000;
     rand -= Math.floor(rand);
-    const index = Math.floor(input.length * rand);
-    output.push(input[index]);
-    input.splice(index, 1);
+    const index = Math.floor(remaining.length * rand);
+    output.push(remaining[index]);
+    remaining.splice(index, 1);
   }
 
   return output;

--- a/packages/niji-webapp/src/utils/svg2png.ts
+++ b/packages/niji-webapp/src/utils/svg2png.ts
@@ -38,7 +38,7 @@ export const svg2png = (
       try {
         resolve(png);
       } catch (e) {
-        console.log('Error converting SVG to PNG:', e);
+        console.error('Error converting SVG to PNG:', e);
         resolve(null);
       }
     };


### PR DESCRIPTION
# 概要

niji-webapp の TypeScript 厳密化 (Issue #19) と機械的なコード整理 (Issue #21) のサブセットをまとめて反映しました。
具体的には `any` 型を 5 箇所で generic / unknown / 具体型に置き換え、 不適切な `console.log` を `console.warn` または `console.error` に格上げしています。
両 Issue とも 6 ヶ月以上前の起票で、 当時の指摘箇所のうち既に解決済のもの (`@ts-expect-error` 5 → 2 箇所、 重複関数 `usePickByState` は #169 で別責務化済) を除き、 残った機械的に直せる範囲を 1 PR にまとめました。

# 課題

webapp の `src/utils/*.ts` と一部 `src/components/*` に `any` 型が点在しており、 リファクタリング時に型エラーで早期検出できる場面が失われていました。
特に `lookupNNSOrENS` の `client: any` 受けは「viem の PublicClient 型が wagmi 戻り値型と合わない」 という理由で意図的に置かれていましたが、 結果として呼び出し側でも `as any` を強いる連鎖になっていました。

# 詳細

各修正の意図。

```mermaid
graph LR
    A[any 型混入箇所] --> B[generic 化で型情報維持]
    A --> C[unknown + typeof narrow で安全な runtime check]
    A --> D[React 標準型に置換]
    B --> E[usePickByState / usePickByStateColor / pseudoRandomPredictableShuffle]
    C --> F[lookupNNSOrENS の readContract 返り値]
    D --> G[ModalBottomButtonRow の click handler]
```

`lookupNNSOrENS` は最小限の `ReadContractClient` interface を定義し、 viem PublicClient と wagmi 戻り値型の両方を受けられる shape を local に閉じ込めました。 読み出し結果は `Promise<unknown>` で受けて呼び出し側で `typeof name === 'string'` で narrow するため、 文字列以外が混じった時に runtime で気付けます。

# 解決方法

| 修正対象 | 変更前 | 変更後 |
|---|---|---|
| `usePickByState` | `(state: any, states: any[], stateResults: any[]): any` | `<S, R>(state: S, states: readonly S[], stateResults: readonly R[]): R` |
| `usePickByStateColor` | `(whiteState: any, coolState: any, warmState: any)` | `<T>(whiteState: T, coolState: T, warmState: T): T` |
| `pseudoRandomPredictableShuffle` | `(input: Array<any> = [], seed = 1)` | `<T>(input: readonly T[] = [], seed = 1): T[]` |
| `lookupNNSOrENS` | `(client: any, target: Address)` | `(client: ReadContractClient, target: Address)` |
| `ModalBottomButtonRow` | `onPrevBtnClick: (e?: any) => void` | `onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>` |
| `VoteCard` | `lookupNNSOrENS(publicClient as any, ...)` | `lookupNNSOrENS(publicClient, ...)` (as any 撤去) |

合わせて以下の `console.log` を意味に合った level に格上げしました。

| ファイル | 変更 |
|---|---|
| `src/utils/svg2png.ts` | catch 内の `console.log` → `console.error` |
| `src/utils/moderation/containsBlockedText.ts` | unsupported language `console.log` → `console.warn` |
| `src/utils/ensLookup.ts` | reverse lookup catch `console.log` → `console.warn` |
| `src/components/VoteCard/index.tsx` | 同上 |

`useChainPastAuctions` の `console.log` 2 件は `import.meta.env.DEV` ガード付きの dev only trace なので保持しています。 `TraitsPage` 等の `console.warn` / `console.error` も production error reporting で意味があるため保持。

# 仕組み

```mermaid
graph LR
    A[呼び出し側 publicClient] --> B[lookupNNSOrENS]
    B --> C[ReadContractClient interface]
    C --> D[readContract で resolve 呼び出し]
    D --> E[Promise unknown]
    E --> F[typeof name string narrow]
    F --> G[名前 or null]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/utils/pickByState.ts` | `any` を `<S, R>` generic 化 |
| `packages/niji-webapp/src/utils/colorResponsiveUIUtils.ts` | `any` を `<T>` generic 化 |
| `packages/niji-webapp/src/utils/pseudoRandomPredictableShuffle.ts` | `Array<any>` を `readonly T[]` 化、 input mutation を新変数に分離 |
| `packages/niji-webapp/src/utils/lookupNNSOrENS.ts` | `client: any` を `ReadContractClient` interface に。 戻り値を `typeof === 'string'` で narrow |
| `packages/niji-webapp/src/utils/svg2png.ts` | `console.log` → `console.error` |
| `packages/niji-webapp/src/utils/moderation/containsBlockedText.ts` | `console.log` → `console.warn` |
| `packages/niji-webapp/src/utils/ensLookup.ts` | `console.log` → `console.warn` |
| `packages/niji-webapp/src/components/ModalBottomButtonRow/index.tsx` | `(e?: any)` を `React.MouseEventHandler<HTMLDivElement>` に |
| `packages/niji-webapp/src/components/VoteCard/index.tsx` | `console.log` → `console.warn` + `lookupNNSOrENS(publicClient as any, ...)` の `as any` 撤去 |

# テストと確認

- [x] `pnpm tsc --noEmit` 通過
- [x] `pnpm test --run` 30 件 pass + 1 skipped + 1 todo (regression なし)
- [x] `pnpm -w lint` 対象 9 file で error 0 (warning は既存からあるもの)

レビューで見てほしいところ。

`lookupNNSOrENS` で定義した `ReadContractClient` interface の shape をご確認ください。
本来は viem の PublicClient を直接受けるべきですが、 chain narrowing で wagmi 戻り値型と衝突するため、 最小限の `readContract` shape を local に定義しています。
別案 (`@wagmi/core` の `Client` 型を直接 import) があればご指摘ください。

# scope 外 follow-up

両 Issue 起票時の指摘で本 PR に含めなかった作業 (継続課題)。

- Issue #19 の `unsafe as アサーション 20+ 箇所` の段階的修正
- Issue #19 の `nijiDao.ts` 残存 `@ts-expect-error` 1 箇所 (wagmi codegen 型深度問題、 別 Issue で要根本対応)
- Issue #21 の大コンポーネント分割 (CandidateSponsors / Documentation / VoteSignals)

これらは scope が大きく独立タスクとして必要と判断したため、 別 follow-up Issue 起票で対応します。

# 関連

Closes #19
Closes #21
