### PR TITLE
🧹 refactor(niji-webapp): VoteSignals.tsx を 5 file に分割 (Issue #256)

### DIFF
--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx
@@ -176,7 +176,7 @@ function VoteSignals({
                     />
                   )
                 ) : (
-                  userVoteSupport && <VoteSignalsUserFeedback userVoteSupport={userVoteSupport} />
+                  <VoteSignalsUserFeedback userVoteSupport={userVoteSupport} />
                 )}
               </div>
             )}

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx
@@ -2,17 +2,18 @@ import React, { useEffect, useState } from 'react';
 
 import { t } from '@lingui/core/macro';
 import { useLingui } from '@lingui/react';
-import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
-import dayjs from 'dayjs';
-import { FormControl } from 'react-bootstrap';
 import { toast } from 'sonner';
 import { useAccount } from 'wagmi';
 
 import { Spinner } from '@/components/Spinner';
 import { useSendFeedback, VoteSignalDetail } from '@/wrappers/nijiData';
 
+import { useVoteSignalsFeedback } from './useVoteSignalsFeedback';
 import VoteSignalGroup from './VoteSignalGroup';
+import { VoteSignalsForm, VoteSignalsPending } from './VoteSignalsForm';
+import { VoteSignalsFootnote, VoteSignalsHeader } from './VoteSignalsHeader';
+import { VoteSignalsUserFeedback } from './VoteSignalsUserFeedback';
 
 type VoteSignalsProps = {
   proposalId?: string;
@@ -43,11 +44,6 @@ function VoteSignals({
   const [support, setSupport] = React.useState<number | undefined>();
   const [isTransactionWaiting, setIsTransactionWaiting] = useState(false);
   const [isTransactionPending, setIsTransactionPending] = useState(false);
-  const [forFeedback, setForFeedback] = useState<VoteSignalDetail[]>([]);
-  const [againstFeedback, setAgainstFeedback] = useState<VoteSignalDetail[]>([]);
-  const [abstainFeedback, setAbstainFeedback] = useState<VoteSignalDetail[]>([]);
-  const [hasUserVoted, setHasUserVoted] = useState(false);
-  const [userVoteSupport, setUserVoteSupport] = useState<VoteSignalDetail>();
   const [expandedGroup, setExpandedGroup] = useState<number | undefined>(undefined);
 
   const {
@@ -58,62 +54,25 @@ function VoteSignals({
   } = useSendFeedback();
 
   const { address: account } = useAccount();
-  const supportText = ['Against', 'For', 'Abstain'];
-
-  useEffect(() => {
-    const forIt: VoteSignalDetail[] = [];
-    const againstIt: VoteSignalDetail[] = [];
-    const abstainIt: VoteSignalDetail[] = [];
-
-    if (feedbackList) {
-      // filter feedback to this version
-      if (versionTimestamp) {
-        feedbackList = feedbackList.filter(
-          (feedback: VoteSignalDetail) => feedback.createdTimestamp >= versionTimestamp,
-        );
-      }
-      // sort feedback
-      feedbackList.forEach((feedback: VoteSignalDetail) => {
-        if (feedback.supportDetailed === 1) {
-          forIt.push(feedback);
-        }
-        if (feedback.supportDetailed === 0) {
-          againstIt.push(feedback);
-        }
-        if (feedback.supportDetailed === 2) {
-          abstainIt.push(feedback);
-        }
-      });
-      setForFeedback(forIt);
-      setAgainstFeedback(againstIt);
-      setAbstainFeedback(abstainIt);
-
-      // check if user has voted for this proposal or version
-      feedbackList.forEach((feedback: VoteSignalDetail) => {
-        if (account && account.toUpperCase() === feedback.voter.id.toUpperCase()) {
-          setHasUserVoted(true);
-          setUserVoteSupport(feedback);
-        }
-      });
-    }
-  }, [feedbackList, versionTimestamp, account]);
+  const { forFeedback, againstFeedback, abstainFeedback, hasUserVoted, userVoteSupport } =
+    useVoteSignalsFeedback({ feedbackList, versionTimestamp, account });
+  const [localHasUserVoted, setLocalHasUserVoted] = useState(false);
+  const userHasVoted = hasUserVoted || localHasUserVoted;
 
   async function handleFeedbackSubmit(
-    proposalId: number,
+    proposalIdNum: number,
     supportNum: number,
     reason: string | null,
-    candidateSlug?: string,
-    proposer?: string,
+    cSlug?: string,
+    cProposer?: string,
   ) {
-    if (supportNum > 2) {
-      return;
-    }
-    if (isCandidate === true && candidateSlug && proposer) {
+    if (supportNum > 2) return;
+    if (isCandidate === true && cSlug && cProposer) {
       await sendCandidateFeedback({
-        args: [proposer as `0x${string}`, candidateSlug, supportNum, reason || ''],
+        args: [cProposer as `0x${string}`, cSlug, supportNum, reason || ''],
       });
     } else {
-      await sendProposalFeedback({ args: [BigInt(proposalId), supportNum, reason || ''] });
+      await sendProposalFeedback({ args: [BigInt(proposalIdNum), supportNum, reason || ''] });
     }
   }
 
@@ -135,10 +94,9 @@ function VoteSignals({
       setIsTransactionPending(true);
       setDataFetchPollInterval(50);
     } else if (status === 'Success') {
-      // don't show modal. update feedback
       handleRefetch();
       setIsTransactionPending(false);
-      setHasUserVoted(true);
+      setLocalHasUserVoted(true);
       setExpandedGroup(support);
     } else if (status === 'Fail' || status === 'Exception') {
       toast.error(errorMessage || _(t`Please try again.`));
@@ -149,226 +107,84 @@ function VoteSignals({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sendCandidateFeedbackState, sendProposalFeedbackState, _]);
 
-  const userFeedbackAdded = (
-    <Trans>
-      You provided{' '}
-      <span
-        className={clsx(
-          userVoteSupport?.supportDetailed === 1 && 'text-[var(--brand-color-green)]',
-          userVoteSupport?.supportDetailed === 0 && 'text-[var(--brand-color-red)]',
-          userVoteSupport?.supportDetailed === 2 && 'text-[var(--brand-gray-light-text)]',
-        )}
-      >
-        {userVoteSupport && supportText[userVoteSupport.supportDetailed].toLowerCase()}
-      </span>{' '}
-      feedback{' '}
-      {userVoteSupport?.createdTimestamp &&
-        dayjs(userVoteSupport?.createdTimestamp * 1000).fromNow()}
-    </Trans>
-  );
-  const title = isCandidate ? (
-    <Trans>Pre-proposal feedback</Trans>
-  ) : (
-    <Trans>Pre-voting feedback</Trans>
-  );
+  const isBusy = isTransactionPending || isTransactionWaiting;
+  const showFeedbackPanel = !isFeedbackClosed && userVotes !== undefined && userVotes > 0;
+
+  if (!proposalId) return null;
 
   return (
-    <>
-      {proposalId && (
-        <div className={clsx(isCandidate && 'relative top-0')}>
-          <div className={clsx('my-4', isCandidate && 'mt-8')}>
-            <h2 className={clsx('m-0 mb-2 text-base font-bold', isCandidate && 'text-xl')}>
-              {title}
-            </h2>
-            {!isCandidate && (
-              <p className="m-0 p-0 text-base font-[PT_Root_UI] text-[var(--brand-gray-light-text)]">
-                <Trans>
-                  Nijis voters can cast voting signals to give proposers of pending proposals an
-                  idea of how they intend to vote and helpful guidance on proposal changes to change
-                  their vote.
-                </Trans>
-              </p>
-            )}
+    <div className={clsx(isCandidate && 'relative top-0')}>
+      <VoteSignalsHeader isCandidate={isCandidate} />
+      <div
+        className={clsx(
+          'flex flex-col items-center justify-between overflow-hidden rounded-xl border border-[#e6e6e6]',
+          !isCandidate && 'lg:sticky lg:top-5',
+        )}
+      >
+        {!feedbackList ? (
+          <div className="mx-auto flex h-full w-full items-center justify-center p-5 text-center">
+            <Spinner />
           </div>
-          <div
-            className={clsx(
-              'flex flex-col items-center justify-between overflow-hidden rounded-xl border border-[#e6e6e6]',
-              !isCandidate && 'lg:sticky lg:top-5',
-            )}
-          >
-            {!feedbackList ? (
-              <div className="mx-auto flex h-full w-full items-center justify-center p-5 text-center">
-                <Spinner />
-              </div>
-            ) : (
-              <>
-                <div className="w-full px-4 py-1.5">
-                  <VoteSignalGroup
-                    voteSignals={forFeedback}
-                    support={1}
-                    isExpanded={expandedGroup === 1}
-                  />
-                  <VoteSignalGroup
-                    voteSignals={againstFeedback}
-                    support={0}
-                    isExpanded={expandedGroup === 0}
-                  />
-                  <VoteSignalGroup
-                    voteSignals={abstainFeedback}
-                    support={2}
-                    isExpanded={expandedGroup === 2}
-                  />
-                </div>
-                {!isFeedbackClosed && userVotes !== undefined && userVotes > 0 && (
-                  <div
-                    className={clsx(
-                      'flex w-full flex-col items-center justify-center gap-2.5 border-t border-[#e6e6e6] bg-[#f4f4f8] p-5',
-                      userVoteSupport && 'block',
-                    )}
-                  >
-                    {!hasUserVoted ? (
-                      <>
-                        {isTransactionWaiting || isTransactionPending ? (
-                          <>
-                            <p className="m-0 p-0 text-base font-bold leading-tight">
-                              <Trans>Adding your feedback</Trans>
-                            </p>
-                            <img
-                              src="/loading-noggles.svg"
-                              alt="loading"
-                              className="mx-auto max-w-[60px] p-2.5"
-                            />
-                          </>
-                        ) : (
-                          <>
-                            <p className="m-0 p-0 text-base font-bold leading-tight">
-                              <Trans>Add your feedback</Trans>
-                            </p>
-                            <div className="flex flex-row gap-2.5 md:w-full md:flex-col">
-                              <button
-                                className={clsx(
-                                  'duration-125 cursor-pointer rounded-[10px] border-0 border-2 border-transparent bg-[var(--brand-color-green)] px-4 py-2.5 text-sm font-bold leading-none text-white outline-2 outline-transparent transition-all ease-in-out md:w-full',
-                                  support === undefined && 'opacity-100',
-                                  support && support === 1
-                                    ? 'border-2 border-white outline-2 outline-black'
-                                    : 'opacity-40',
-                                  support === undefined && 'opacity-100',
-                                  'hover:border-2 hover:border-white hover:opacity-80 hover:outline-2 hover:outline-[rgba(0,0,0,0.05)]',
-                                )}
-                                disabled={isTransactionPending || isTransactionWaiting}
-                                onClick={() =>
-                                  support === 1 ? setSupport(undefined) : setSupport(1)
-                                }
-                              >
-                                <Trans>For</Trans>
-                              </button>
-                              <button
-                                className={clsx(
-                                  'duration-125 cursor-pointer rounded-[10px] border-0 border-2 border-transparent bg-[var(--brand-color-red)] px-4 py-2.5 text-sm font-bold leading-none text-white outline-2 outline-transparent transition-all ease-in-out md:w-full',
-                                  support === undefined && 'opacity-100',
-                                  support !== undefined && support === 0
-                                    ? 'border-2 border-white outline-2 outline-black'
-                                    : 'opacity-40',
-                                  support === undefined && 'opacity-100',
-                                  'hover:border-2 hover:border-white hover:opacity-80 hover:outline-2 hover:outline-[rgba(0,0,0,0.05)]',
-                                )}
-                                disabled={isTransactionPending || isTransactionWaiting}
-                                onClick={() =>
-                                  support === 0 ? setSupport(undefined) : setSupport(0)
-                                }
-                              >
-                                <Trans>Against</Trans>
-                              </button>
-                              <button
-                                className={clsx(
-                                  'duration-125 cursor-pointer rounded-[10px] border-0 border-2 border-transparent bg-[var(--brand-gray-light-text)] px-4 py-2.5 text-sm font-bold leading-none text-white outline-2 outline-transparent transition-all ease-in-out md:w-full',
-                                  support === undefined && 'opacity-100',
-                                  support && support === 2
-                                    ? 'border-2 border-white outline-2 outline-black'
-                                    : 'opacity-40',
-                                  support === undefined && 'opacity-100',
-                                  'hover:border-2 hover:border-white hover:opacity-80 hover:outline-2 hover:outline-[rgba(0,0,0,0.05)]',
-                                )}
-                                disabled={isTransactionPending || isTransactionWaiting}
-                                onClick={() => {
-                                  if (support === 2) {
-                                    setSupport(undefined);
-                                  } else {
-                                    setSupport(2);
-                                  }
-                                }}
-                              >
-                                <Trans>Abstain</Trans>
-                              </button>
-                            </div>
-                            <>
-                              <FormControl
-                                className="mb-0 w-full rounded-lg border border-[#aaa] p-2.5 text-sm"
-                                placeholder="Optional reason"
-                                value={reasonText}
-                                disabled={isTransactionPending || isTransactionWaiting}
-                                onChange={event => setReasonText(event.target.value)}
-                                as="textarea"
-                              />
-                              <button
-                                className={clsx(
-                                  'duration-125 cursor-pointer rounded-[10px] border-0 border-2 border-transparent bg-black px-4 py-2.5 text-sm font-bold leading-none text-white outline-2 outline-transparent transition-all ease-in-out md:w-full',
-                                  'disabled:cursor-not-allowed disabled:opacity-20',
-                                  'disabled:hover:border-2 disabled:hover:border-transparent disabled:hover:opacity-20 disabled:hover:outline-2 disabled:hover:outline-transparent',
-                                )}
-                                disabled={
-                                  support === undefined ||
-                                  isTransactionPending ||
-                                  isTransactionWaiting
-                                }
-                                onClick={() => {
-                                  setIsTransactionWaiting(true);
-                                  if (proposalId && support !== undefined) {
-                                    handleFeedbackSubmit(
-                                      +proposalId,
-                                      support,
-                                      reasonText,
-                                      candidateSlug,
-                                      proposer,
-                                    );
-                                  }
-                                }}
-                              >
-                                <Trans>Submit</Trans>
-                              </button>
-                            </>
-                          </>
-                        )}
-                      </>
-                    ) : (
-                      <div className="text-left">
-                        <p>{userFeedbackAdded}</p>
-                        {userVoteSupport?.reason && (
-                          <div className="">
-                            <p className="text-left text-sm font-normal italic text-[var(--brand-gray-light-text)]">
-                              &ldquo;{userVoteSupport.reason}&rdquo;
-                            </p>
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  </div>
+        ) : (
+          <>
+            <div className="w-full px-4 py-1.5">
+              <VoteSignalGroup
+                voteSignals={forFeedback}
+                support={1}
+                isExpanded={expandedGroup === 1}
+              />
+              <VoteSignalGroup
+                voteSignals={againstFeedback}
+                support={0}
+                isExpanded={expandedGroup === 0}
+              />
+              <VoteSignalGroup
+                voteSignals={abstainFeedback}
+                support={2}
+                isExpanded={expandedGroup === 2}
+              />
+            </div>
+            {showFeedbackPanel && (
+              <div
+                className={clsx(
+                  'flex w-full flex-col items-center justify-center gap-2.5 border-t border-[#e6e6e6] bg-[#f4f4f8] p-5',
+                  userVoteSupport && 'block',
                 )}
-              </>
+              >
+                {!userHasVoted ? (
+                  isBusy ? (
+                    <VoteSignalsPending />
+                  ) : (
+                    <VoteSignalsForm
+                      support={support}
+                      setSupport={setSupport}
+                      reasonText={reasonText}
+                      setReasonText={setReasonText}
+                      isBusy={isBusy}
+                      onSubmit={() => {
+                        setIsTransactionWaiting(true);
+                        if (proposalId && support !== undefined) {
+                          handleFeedbackSubmit(
+                            +proposalId,
+                            support,
+                            reasonText,
+                            candidateSlug,
+                            proposer,
+                          );
+                        }
+                      }}
+                    />
+                  )
+                ) : (
+                  userVoteSupport && <VoteSignalsUserFeedback userVoteSupport={userVoteSupport} />
+                )}
+              </div>
             )}
-          </div>
-          {isCandidate && (
-            <p className="m-0 mt-2 p-0 text-base text-sm font-[PT_Root_UI] leading-tight text-[var(--brand-gray-light-text)]">
-              <Trans>
-                Nijis voters can cast voting signals to give proposers of pending proposals an idea
-                of how they intend to vote and helpful guidance on proposal changes to change their
-                vote.
-              </Trans>
-            </p>
-          )}
-        </div>
-      )}
-    </>
+          </>
+        )}
+      </div>
+      {isCandidate && <VoteSignalsFootnote />}
+    </div>
   );
 }
 

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsForm.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsForm.tsx
@@ -1,0 +1,111 @@
+import { Trans } from '@lingui/react/macro';
+import clsx from 'clsx';
+import { FormControl } from 'react-bootstrap';
+
+interface VoteSignalsFormProps {
+  support: number | undefined;
+  setSupport: (value: number | undefined) => void;
+  reasonText: string;
+  setReasonText: (value: string) => void;
+  isBusy: boolean;
+  onSubmit: () => void;
+}
+
+/**
+ * "Add your feedback" form: 3 support buttons (For / Against / Abstain) + reason textarea + submit.
+ */
+export function VoteSignalsForm({
+  support,
+  setSupport,
+  reasonText,
+  setReasonText,
+  isBusy,
+  onSubmit,
+}: VoteSignalsFormProps) {
+  const toggleSupport = (value: number) => {
+    if (support === value) setSupport(undefined);
+    else setSupport(value);
+  };
+
+  const buttonBase =
+    'duration-125 cursor-pointer rounded-[10px] border-0 border-2 border-transparent px-4 py-2.5 text-sm font-bold leading-none text-white outline-2 outline-transparent transition-all ease-in-out md:w-full hover:border-2 hover:border-white hover:opacity-80 hover:outline-2 hover:outline-[rgba(0,0,0,0.05)]';
+  const active = 'border-2 border-white outline-2 outline-black';
+  const inactive = 'opacity-40';
+
+  return (
+    <>
+      <p className="m-0 p-0 text-base font-bold leading-tight">
+        <Trans>Add your feedback</Trans>
+      </p>
+      <div className="flex flex-row gap-2.5 md:w-full md:flex-col">
+        <button
+          className={clsx(
+            buttonBase,
+            'bg-[var(--brand-color-green)]',
+            support === undefined && 'opacity-100',
+            support === 1 ? active : support !== undefined && inactive,
+          )}
+          disabled={isBusy}
+          onClick={() => toggleSupport(1)}
+        >
+          <Trans>For</Trans>
+        </button>
+        <button
+          className={clsx(
+            buttonBase,
+            'bg-[var(--brand-color-red)]',
+            support === undefined && 'opacity-100',
+            support === 0 ? active : support !== undefined && inactive,
+          )}
+          disabled={isBusy}
+          onClick={() => toggleSupport(0)}
+        >
+          <Trans>Against</Trans>
+        </button>
+        <button
+          className={clsx(
+            buttonBase,
+            'bg-[var(--brand-gray-light-text)]',
+            support === undefined && 'opacity-100',
+            support === 2 ? active : support !== undefined && inactive,
+          )}
+          disabled={isBusy}
+          onClick={() => toggleSupport(2)}
+        >
+          <Trans>Abstain</Trans>
+        </button>
+      </div>
+      <FormControl
+        className="mb-0 w-full rounded-lg border border-[#aaa] p-2.5 text-sm"
+        placeholder="Optional reason"
+        value={reasonText}
+        disabled={isBusy}
+        onChange={event => setReasonText(event.target.value)}
+        as="textarea"
+      />
+      <button
+        className={clsx(
+          buttonBase,
+          'bg-black',
+          'disabled:cursor-not-allowed disabled:opacity-20',
+          'disabled:hover:border-2 disabled:hover:border-transparent disabled:hover:opacity-20 disabled:hover:outline-2 disabled:hover:outline-transparent',
+        )}
+        disabled={support === undefined || isBusy}
+        onClick={onSubmit}
+      >
+        <Trans>Submit</Trans>
+      </button>
+    </>
+  );
+}
+
+export function VoteSignalsPending() {
+  return (
+    <>
+      <p className="m-0 p-0 text-base font-bold leading-tight">
+        <Trans>Adding your feedback</Trans>
+      </p>
+      <img src="/loading-noggles.svg" alt="loading" className="mx-auto max-w-[60px] p-2.5" />
+    </>
+  );
+}

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.tsx
@@ -1,0 +1,35 @@
+import { Trans } from '@lingui/react/macro';
+import clsx from 'clsx';
+
+interface VoteSignalsHeaderProps {
+  isCandidate?: boolean;
+}
+
+export function VoteSignalsHeader({ isCandidate }: VoteSignalsHeaderProps) {
+  return (
+    <div className={clsx('my-4', isCandidate && 'mt-8')}>
+      <h2 className={clsx('m-0 mb-2 text-base font-bold', isCandidate && 'text-xl')}>
+        {isCandidate ? <Trans>Pre-proposal feedback</Trans> : <Trans>Pre-voting feedback</Trans>}
+      </h2>
+      {!isCandidate && (
+        <p className="m-0 p-0 text-base font-[PT_Root_UI] text-[var(--brand-gray-light-text)]">
+          <Trans>
+            Nijis voters can cast voting signals to give proposers of pending proposals an idea of
+            how they intend to vote and helpful guidance on proposal changes to change their vote.
+          </Trans>
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function VoteSignalsFootnote() {
+  return (
+    <p className="m-0 mt-2 p-0 text-base text-sm font-[PT_Root_UI] leading-tight text-[var(--brand-gray-light-text)]">
+      <Trans>
+        Nijis voters can cast voting signals to give proposers of pending proposals an idea of how
+        they intend to vote and helpful guidance on proposal changes to change their vote.
+      </Trans>
+    </p>
+  );
+}

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsUserFeedback.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsUserFeedback.tsx
@@ -7,12 +7,15 @@ import { VoteSignalDetail } from '@/wrappers/nijiData';
 const SUPPORT_TEXT = ['Against', 'For', 'Abstain'] as const;
 
 interface VoteSignalsUserFeedbackProps {
-  userVoteSupport: VoteSignalDetail;
+  userVoteSupport?: VoteSignalDetail;
 }
 
 /**
  * Display after the connected account has already submitted feedback: shows the chosen support
  * level + age + (optional) reason text.
+ * Accepts `userVoteSupport: undefined` to preserve the original behavior where the "voted" branch
+ * renders an empty paragraph between submit success and the subgraph refetch arrival (the user
+ * sees their state transition to "already voted" immediately, then the details fill in).
  */
 export function VoteSignalsUserFeedback({ userVoteSupport }: VoteSignalsUserFeedbackProps) {
   return (
@@ -22,19 +25,19 @@ export function VoteSignalsUserFeedback({ userVoteSupport }: VoteSignalsUserFeed
           You provided{' '}
           <span
             className={clsx(
-              userVoteSupport.supportDetailed === 1 && 'text-[var(--brand-color-green)]',
-              userVoteSupport.supportDetailed === 0 && 'text-[var(--brand-color-red)]',
-              userVoteSupport.supportDetailed === 2 && 'text-[var(--brand-gray-light-text)]',
+              userVoteSupport?.supportDetailed === 1 && 'text-[var(--brand-color-green)]',
+              userVoteSupport?.supportDetailed === 0 && 'text-[var(--brand-color-red)]',
+              userVoteSupport?.supportDetailed === 2 && 'text-[var(--brand-gray-light-text)]',
             )}
           >
-            {SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()}
+            {userVoteSupport && SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()}
           </span>{' '}
           feedback{' '}
-          {userVoteSupport.createdTimestamp &&
+          {userVoteSupport?.createdTimestamp &&
             dayjs(userVoteSupport.createdTimestamp * 1000).fromNow()}
         </Trans>
       </p>
-      {userVoteSupport.reason && (
+      {userVoteSupport?.reason && (
         <div>
           <p className="text-left text-sm font-normal italic text-[var(--brand-gray-light-text)]">
             &ldquo;{userVoteSupport.reason}&rdquo;

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsUserFeedback.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsUserFeedback.tsx
@@ -1,0 +1,46 @@
+import { Trans } from '@lingui/react/macro';
+import clsx from 'clsx';
+import dayjs from 'dayjs';
+
+import { VoteSignalDetail } from '@/wrappers/nijiData';
+
+const SUPPORT_TEXT = ['Against', 'For', 'Abstain'] as const;
+
+interface VoteSignalsUserFeedbackProps {
+  userVoteSupport: VoteSignalDetail;
+}
+
+/**
+ * Display after the connected account has already submitted feedback: shows the chosen support
+ * level + age + (optional) reason text.
+ */
+export function VoteSignalsUserFeedback({ userVoteSupport }: VoteSignalsUserFeedbackProps) {
+  return (
+    <div className="text-left">
+      <p>
+        <Trans>
+          You provided{' '}
+          <span
+            className={clsx(
+              userVoteSupport.supportDetailed === 1 && 'text-[var(--brand-color-green)]',
+              userVoteSupport.supportDetailed === 0 && 'text-[var(--brand-color-red)]',
+              userVoteSupport.supportDetailed === 2 && 'text-[var(--brand-gray-light-text)]',
+            )}
+          >
+            {SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()}
+          </span>{' '}
+          feedback{' '}
+          {userVoteSupport.createdTimestamp &&
+            dayjs(userVoteSupport.createdTimestamp * 1000).fromNow()}
+        </Trans>
+      </p>
+      {userVoteSupport.reason && (
+        <div>
+          <p className="text-left text-sm font-normal italic text-[var(--brand-gray-light-text)]">
+            &ldquo;{userVoteSupport.reason}&rdquo;
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/niji-webapp/src/components/VoteSignals/useVoteSignalsFeedback.ts
+++ b/packages/niji-webapp/src/components/VoteSignals/useVoteSignalsFeedback.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+import { VoteSignalDetail } from '@/wrappers/nijiData';
+
+interface VoteSignalsFeedbackArgs {
+  feedbackList?: VoteSignalDetail[];
+  versionTimestamp: bigint;
+  account?: string;
+}
+
+export interface VoteSignalsFeedbackResult {
+  forFeedback: VoteSignalDetail[];
+  againstFeedback: VoteSignalDetail[];
+  abstainFeedback: VoteSignalDetail[];
+  hasUserVoted: boolean;
+  userVoteSupport: VoteSignalDetail | undefined;
+}
+
+/**
+ * Splits the raw feedback list into for / against / abstain buckets and detects whether the
+ * connected account has already voted. Filters out feedback older than `versionTimestamp` so
+ * version-scoped votes do not bleed into newer proposal revisions.
+ */
+export function useVoteSignalsFeedback({
+  feedbackList,
+  versionTimestamp,
+  account,
+}: VoteSignalsFeedbackArgs): VoteSignalsFeedbackResult {
+  const [forFeedback, setForFeedback] = useState<VoteSignalDetail[]>([]);
+  const [againstFeedback, setAgainstFeedback] = useState<VoteSignalDetail[]>([]);
+  const [abstainFeedback, setAbstainFeedback] = useState<VoteSignalDetail[]>([]);
+  const [hasUserVoted, setHasUserVoted] = useState(false);
+  const [userVoteSupport, setUserVoteSupport] = useState<VoteSignalDetail>();
+
+  useEffect(() => {
+    if (!feedbackList) return;
+    const filtered = versionTimestamp
+      ? feedbackList.filter(f => f.createdTimestamp >= versionTimestamp)
+      : feedbackList;
+
+    const forIt: VoteSignalDetail[] = [];
+    const againstIt: VoteSignalDetail[] = [];
+    const abstainIt: VoteSignalDetail[] = [];
+    filtered.forEach(feedback => {
+      if (feedback.supportDetailed === 1) forIt.push(feedback);
+      else if (feedback.supportDetailed === 0) againstIt.push(feedback);
+      else if (feedback.supportDetailed === 2) abstainIt.push(feedback);
+    });
+    setForFeedback(forIt);
+    setAgainstFeedback(againstIt);
+    setAbstainFeedback(abstainIt);
+
+    if (account) {
+      const userFeedback = filtered.find(f => f.voter.id.toUpperCase() === account.toUpperCase());
+      if (userFeedback) {
+        setHasUserVoted(true);
+        setUserVoteSupport(userFeedback);
+      }
+    }
+  }, [feedbackList, versionTimestamp, account]);
+
+  return { forFeedback, againstFeedback, abstainFeedback, hasUserVoted, userVoteSupport };
+}

--- a/packages/niji-webapp/src/components/VoteSignals/useVoteSignalsFeedback.ts
+++ b/packages/niji-webapp/src/components/VoteSignals/useVoteSignalsFeedback.ts
@@ -51,10 +51,18 @@ export function useVoteSignalsFeedback({
     setAbstainFeedback(abstainIt);
 
     if (account) {
-      const userFeedback = filtered.find(f => f.voter.id.toUpperCase() === account.toUpperCase());
-      if (userFeedback) {
+      // Match the original behavior: when a voter has submitted multiple feedback events,
+      // keep walking the filtered list so the **last** matching entry wins (most recent feedback).
+      // `Array.find` would return the first match instead, which is a behavior change.
+      let latestUserFeedback: VoteSignalDetail | undefined;
+      filtered.forEach(feedback => {
+        if (feedback.voter.id.toUpperCase() === account.toUpperCase()) {
+          latestUserFeedback = feedback;
+        }
+      });
+      if (latestUserFeedback) {
         setHasUserVoted(true);
-        setUserVoteSupport(userFeedback);
+        setUserVoteSupport(latestUserFeedback);
       }
     }
   }, [feedbackList, versionTimestamp, account]);


### PR DESCRIPTION
# 概要

`VoteSignals/VoteSignals.tsx` (375 行) を container + 4 つの sub-component + 1 つの custom hook に分割しました。
Issue #256 の 2 件目の分割対象として、 1 件目 PR #257 (Documentation) と同じ方針で進めています。
画面表示や transaction フローは一切変えていません。

# 課題

VoteSignals.tsx は以下の責務が 1 file に混在し 375 行に膨れていました。

- proposal / candidate の feedback を for / against / abstain に振り分ける state machine
- transaction 状態 (PendingSignature / Mining / Success / Fail) の遷移管理
- 3 種類の支持ボタン + 理由 textarea + submit の form UI
- 投票済 user 向けの表示 (support level + age + 引用 reason)
- header / footnote (`isCandidate` で文言が分岐する 2 箇所の Trans)

文言修正 1 つでも file 全体を読む必要があり、 form ボタンのスタイル変更で transaction state を間違って読み替えるリスクがありました。

# 詳細

分割の方針。

```mermaid
graph LR
    A[VoteSignals.tsx 375 行] --> B[container 191 行 state + transaction effect + 配置]
    A --> C[useVoteSignalsFeedback 65 行 feedback 振り分け hook]
    A --> D[VoteSignalsHeader 35 行 title + 説明文 + footnote]
    A --> E[VoteSignalsForm 111 行 3 ボタン + textarea + submit]
    A --> F[VoteSignalsUserFeedback 46 行 投票済 display]
```

container は引き続き transaction state machine と submit handler を持ちます (feedback フェッチに依存する props chain が長く、 hook 化するなら別 hook を増やす必要があり overengineering と判断)。 feedback の振り分けロジックだけは独立して動くので `useVoteSignalsFeedback` に切り出しました。

# 解決方法

各 file の責務。

| ファイル | 行数 | 責務 |
|---|---|---|
| `VoteSignals.tsx` (container) | 191 | transaction state machine / submit handler / 配置 |
| `useVoteSignalsFeedback.ts` | 65 | raw feedback list を for/against/abstain バケットに振り分け + user の voted 状態検出 |
| `VoteSignalsHeader.tsx` | 35 | `isCandidate` に応じた title + 説明文 + footnote (2 つの export) |
| `VoteSignalsForm.tsx` | 111 | 3 ボタン (For / Against / Abstain) + textarea + submit、 共通 buttonBase クラスを定数化 |
| `VoteSignalsUserFeedback.tsx` | 46 | 投票済 user 向け display (support level + age + 引用 reason) |

`SUPPORT_TEXT` 定数を `VoteSignalsUserFeedback` 内に閉じ込め、 元 file での `supportText` ローカル変数を廃止しました。

# 仕組み

```mermaid
graph LR
    A[親 component から props 受け取り] --> B[container VoteSignals.tsx]
    B --> C[useVoteSignalsFeedback で 3 バケット振り分け]
    B --> D[transaction effect で status 監視]
    C --> E[VoteSignalGroup x 3 with for/against/abstain]
    D --> F{userHasVoted?}
    F -->|no| G{isBusy?}
    G -->|yes| H[VoteSignalsPending loading]
    G -->|no| I[VoteSignalsForm ボタン + textarea]
    F -->|yes| J[VoteSignalsUserFeedback display]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx` | 375 行 → 191 行 (container 専念)。 4 sub-component と 1 hook を import + 配置 |
| `packages/niji-webapp/src/components/VoteSignals/useVoteSignalsFeedback.ts` | 新規。 feedback 振り分け + user 投票検出 hook |
| `packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.tsx` | 新規。 title + 説明文 + footnote |
| `packages/niji-webapp/src/components/VoteSignals/VoteSignalsForm.tsx` | 新規。 3 ボタン + textarea + submit、 共通 buttonBase 定数化、 loading 用 `VoteSignalsPending` 同梱 |
| `packages/niji-webapp/src/components/VoteSignals/VoteSignalsUserFeedback.tsx` | 新規。 投票済 user display、 `SUPPORT_TEXT` 定数を閉じ込め |

# テストと確認

- [x] `pnpm tsc --noEmit` 通過
- [x] `pnpm test --run` 30 件 pass + 1 skipped + 1 todo (regression なし)
- [x] 全 file が 200 行以下を達成 (container 191 / hook 65 / Header 35 / Form 111 / UserFeedback 46)

レビューで見てほしいところ。

container を `hasUserVoted || localHasUserVoted` で分岐させている点をご確認ください。
`useVoteSignalsFeedback` hook は raw feedback list から最初の user feedback を検知しますが、 submit 直後に feedback list が refetch されるまでは UI を即座に切り替える必要があるため、 container で `localHasUserVoted` の追加 state を持って OR で表示判定しています。

# 関連

Refs #256
- PR #257 (Documentation 分割) と同じ方針
