### PR TITLE
🧹 refactor(niji-webapp): CandidateSponsors/index.tsx を 5 file に分割 (Issue #256)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.tsx
@@ -1,0 +1,75 @@
+import { AnimatePresence, motion } from 'motion/react';
+
+import { ProposalCandidate } from '@/wrappers/nijiData';
+
+import classes from './CandidateSponsors.module.css';
+import SignatureForm from './SignatureForm';
+
+type TransactionState = 'None' | 'Success' | 'Mining' | 'Fail' | 'Exception';
+
+interface SponsorsFormOverlayProps {
+  isFormDisplayed: boolean;
+  candidate: ProposalCandidate;
+  id: string;
+  transactionState: TransactionState;
+  setTransactionState: (state: TransactionState) => void;
+  setIsFormDisplayed: (value: boolean) => void;
+  handleRefetchCandidateData: () => void;
+  setDataFetchPollInterval: (interval: number | null) => void;
+  proposalIdToUpdate: number;
+}
+
+/**
+ * Overlay panel that hosts the SignatureForm with motion enter/exit. Closing the overlay also
+ * stops the fast-poll loop the parent had started during sign-in.
+ */
+export function SponsorsFormOverlay({
+  isFormDisplayed,
+  candidate,
+  id,
+  transactionState,
+  setTransactionState,
+  setIsFormDisplayed,
+  handleRefetchCandidateData,
+  setDataFetchPollInterval,
+  proposalIdToUpdate,
+}: SponsorsFormOverlayProps) {
+  return (
+    <AnimatePresence>
+      {transactionState === 'Success' && (
+        <div className="transactionStatus success">
+          <p>Success!</p>
+        </div>
+      )}
+      {isFormDisplayed && (
+        <motion.div
+          className={classes.formOverlay}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          <button
+            className={classes.closeButton}
+            onClick={() => {
+              setIsFormDisplayed(false);
+              setDataFetchPollInterval(0);
+            }}
+          >
+            &times;
+          </button>
+          <SignatureForm
+            id={id}
+            transactionState={transactionState}
+            setTransactionState={setTransactionState}
+            setIsFormDisplayed={setIsFormDisplayed}
+            candidate={candidate}
+            handleRefetchCandidateData={handleRefetchCandidateData}
+            setDataFetchPollInterval={setDataFetchPollInterval}
+            proposalIdToUpdate={proposalIdToUpdate}
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsHeader.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsHeader.tsx
@@ -1,0 +1,81 @@
+import { Trans } from '@lingui/react/macro';
+
+import { Proposal } from '@/wrappers/nijiDao';
+import { ProposalCandidate } from '@/wrappers/nijiData';
+
+import classes from './CandidateSponsors.module.css';
+
+interface SponsorsHeaderProps {
+  candidate: ProposalCandidate;
+  isUpdateToProposal?: boolean;
+  isThresholdMet: boolean;
+  originalProposal?: Proposal;
+}
+
+/**
+ * Header + subhead for the candidate sponsors panel. Switches text between the "new candidate"
+ * flow and the "update to existing proposal" flow.
+ */
+export function SponsorsHeader({
+  candidate,
+  isUpdateToProposal,
+  isThresholdMet,
+  originalProposal,
+}: SponsorsHeaderProps) {
+  return (
+    <>
+      <h4 className={classes.header}>
+        <strong>
+          {isUpdateToProposal ? (
+            <>
+              {candidate.voteCount >= 0 ? candidate.voteCount : '...'} of{' '}
+              {originalProposal?.signers.length || '...'} original signed votes
+            </>
+          ) : (
+            <NewCandidateHeader candidate={candidate} />
+          )}
+        </strong>
+      </h4>
+      {candidate.proposerVotes > 0 && !isUpdateToProposal && (
+        <p className={classes.proposerVotesLabel}>
+          <Trans>
+            Proposer has {candidate.proposerVotes} vote
+            {candidate.proposerVotes > 1 ? 's' : ''}
+          </Trans>
+        </p>
+      )}
+      <p className={classes.subhead}>
+        {isThresholdMet && !isUpdateToProposal ? (
+          <Trans>
+            This candidate has met the required threshold, but Nijis voters can still add support
+            until it’s put onchain.
+          </Trans>
+        ) : isUpdateToProposal ? (
+          <Trans>Update proposal candidates must be re-signed by the original signers.</Trans>
+        ) : (
+          <Trans>Proposal candidates must meet the required Nijis vote threshold.</Trans>
+        )}
+      </p>
+    </>
+  );
+}
+
+function NewCandidateHeader({ candidate }: { candidate: ProposalCandidate }) {
+  const proposerOversaturated = candidate.proposerVotes > candidate.requiredVotes;
+  if (candidate.voteCount === 0 && proposerOversaturated) {
+    return <Trans>No sponsored votes needed</Trans>;
+  }
+  return (
+    <>
+      {candidate.voteCount >= 0 ? candidate.voteCount : '...'} of{' '}
+      {proposerOversaturated ? (
+        <em className={classes.naVotesLabel}>n/a</em>
+      ) : candidate.requiredVotes != undefined ? (
+        <>{candidate.requiredVotes}</>
+      ) : (
+        <>...</>
+      )}{' '}
+      sponsored votes
+    </>
+  );
+}

--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.tsx
@@ -1,0 +1,200 @@
+import { Trans } from '@lingui/react/macro';
+import { Link } from 'react-router';
+
+import { Proposal } from '@/wrappers/nijiDao';
+import { ProposalCandidate } from '@/wrappers/nijiData';
+
+import classes from './CandidateSponsors.module.css';
+import OriginalSignature from './OriginalSignature';
+import Signature from './Signature';
+
+interface SignerVoteCountMap {
+  id: string;
+  nijiRepresented?: ReadonlyArray<unknown>;
+}
+
+interface SponsorsListProps {
+  candidate: ProposalCandidate;
+  isUpdateToProposal?: boolean;
+  isParentProposalUpdatable: boolean;
+  isProposer: boolean;
+  isAccountSigner: boolean;
+  isOriginalSigner: boolean;
+  isThresholdMet: boolean;
+  account?: string;
+  activePendingProposers: unknown;
+  originalProposal?: Proposal;
+  originalSignersDelegates?: SignerVoteCountMap[];
+  connectedAccountNounVotes: number;
+  setIsAccountSigner: (value: boolean) => void;
+  setDataFetchPollInterval: (interval: number | null) => void;
+  handleRefetchCandidateData: () => void;
+  onOpenSubmitModal: () => void;
+  onOpenUpdateModal: () => void;
+  onOpenForm: () => void;
+}
+
+/**
+ * Renders the list of sponsor signatures + placeholder slots + the action button (submit-onchain
+ * for proposers / sponsor button for voters / inactive notice for old updates).
+ */
+export function SponsorsList({
+  candidate,
+  isUpdateToProposal,
+  isParentProposalUpdatable,
+  isProposer,
+  isAccountSigner,
+  isOriginalSigner,
+  isThresholdMet,
+  account,
+  activePendingProposers,
+  originalProposal,
+  originalSignersDelegates,
+  connectedAccountNounVotes,
+  setIsAccountSigner,
+  setDataFetchPollInterval,
+  handleRefetchCandidateData,
+  onOpenSubmitModal,
+  onOpenUpdateModal,
+  onOpenForm,
+}: SponsorsListProps) {
+  const signatures = candidate.version.content.contentSignatures;
+  const signers = signatures?.map(signature => signature.signer.id.toLowerCase());
+
+  return (
+    <ul className={classes.sponsorsList}>
+      {signatures.map(signature => {
+        const sigVoteCount = signature.signer.voteCount || 0;
+        if (!sigVoteCount || !activePendingProposers) return null;
+        if (signature.canceled) return null;
+        return (
+          <Signature
+            key={signature.signer.id}
+            reason={signature.reason}
+            voteCount={sigVoteCount}
+            expirationTimestamp={signature.expirationTimestamp}
+            signer={signature.signer.id}
+            isAccountSigner={signature.signer.id.toLowerCase() === account?.toLowerCase()}
+            sig={signature.sig}
+            setDataFetchPollInterval={setDataFetchPollInterval}
+            signerHasActiveOrPendingProposal={signature.signer.activeOrPendingProposal}
+            isUpdateToProposal={isUpdateToProposal}
+            isParentProposalUpdatable={isParentProposalUpdatable}
+            handleRefetchCandidateData={handleRefetchCandidateData}
+            setIsAccountSigner={setIsAccountSigner}
+            handleSignatureRemoved={handleRefetchCandidateData}
+          />
+        );
+      })}
+      {isUpdateToProposal
+        ? originalProposal?.signers.map((ogSigner, i) => {
+            const sigVoteCount = originalSignersDelegates?.find(d => d.id === ogSigner.id)
+              ?.nijiRepresented?.length;
+            if (signers?.includes(ogSigner.id.toLowerCase())) return null;
+            if (!sigVoteCount || !activePendingProposers) return null;
+            return (
+              <OriginalSignature
+                key={i}
+                signer={ogSigner.id}
+                voteCount={sigVoteCount}
+                isParentProposalUpdatable={isParentProposalUpdatable}
+              />
+            );
+          })
+        : candidate.requiredVotes > candidate.voteCount &&
+          Array(candidate.requiredVotes - candidate.voteCount)
+            .fill('')
+            .map((_s, i) => (
+              <li className={classes.placeholder} key={i}>
+                {' '}
+              </li>
+            ))}
+      <SponsorActionButton
+        candidate={candidate}
+        isUpdateToProposal={isUpdateToProposal}
+        isParentProposalUpdatable={isParentProposalUpdatable}
+        isProposer={isProposer}
+        isAccountSigner={isAccountSigner}
+        isOriginalSigner={isOriginalSigner}
+        isThresholdMet={isThresholdMet}
+        originalProposal={originalProposal}
+        connectedAccountNounVotes={connectedAccountNounVotes}
+        onOpenSubmitModal={onOpenSubmitModal}
+        onOpenUpdateModal={onOpenUpdateModal}
+        onOpenForm={onOpenForm}
+      />
+    </ul>
+  );
+}
+
+interface SponsorActionButtonProps {
+  candidate: ProposalCandidate;
+  isUpdateToProposal?: boolean;
+  isParentProposalUpdatable: boolean;
+  isProposer: boolean;
+  isAccountSigner: boolean;
+  isOriginalSigner: boolean;
+  isThresholdMet: boolean;
+  originalProposal?: Proposal;
+  connectedAccountNounVotes: number;
+  onOpenSubmitModal: () => void;
+  onOpenUpdateModal: () => void;
+  onOpenForm: () => void;
+}
+
+function SponsorActionButton({
+  candidate,
+  isUpdateToProposal,
+  isParentProposalUpdatable,
+  isProposer,
+  isAccountSigner,
+  isOriginalSigner,
+  isThresholdMet,
+  originalProposal,
+  connectedAccountNounVotes,
+  onOpenSubmitModal,
+  onOpenUpdateModal,
+  onOpenForm,
+}: SponsorActionButtonProps) {
+  if (isUpdateToProposal && !isParentProposalUpdatable) {
+    return (
+      <p className={classes.inactiveCandidate}>
+        <strong>
+          <Link to={`/vote/${originalProposal?.id}`}>Proposal {originalProposal?.id}</Link>
+        </strong>{' '}
+        is no longer updatable
+      </p>
+    );
+  }
+
+  if (isProposer && isThresholdMet) {
+    return (
+      <button
+        className={classes.button}
+        onClick={() => (isUpdateToProposal ? onOpenUpdateModal() : onOpenSubmitModal())}
+      >
+        Submit onchain
+      </button>
+    );
+  }
+
+  const canSignNewCandidate = !isUpdateToProposal && !isAccountSigner && !candidate.isProposal;
+  const canResign = isUpdateToProposal && isOriginalSigner && !isAccountSigner;
+  if (!canSignNewCandidate && !canResign) return null;
+
+  if (isProposer || connectedAccountNounVotes <= 0) {
+    return (
+      <div className={classes.withoutVotesMsg}>
+        <p>
+          <Trans>Sponsoring a proposal requires at least one Niji vote</Trans>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <button className={classes.button} onClick={onOpenForm}>
+      {isUpdateToProposal ? 'Re-sign' : 'Sponsor'}
+    </button>
+  );
+}

--- a/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
-import { Trans } from '@lingui/react/macro';
 import clsx from 'clsx';
 import { CheckCircle2 } from 'lucide-react';
-import { AnimatePresence, motion } from 'motion/react';
-import { Link } from 'react-router';
 import { useAccount } from 'wagmi';
 
 import { Proposal, ProposalState, useActivePendingUpdatableProposers } from '@/wrappers/nijiDao';
@@ -12,11 +9,12 @@ import { ProposalCandidate } from '@/wrappers/nijiData';
 import { useDelegateNounsAtBlockQuery, useUserVotes } from '@/wrappers/nijiToken';
 
 import classes from './CandidateSponsors.module.css';
-import OriginalSignature from './OriginalSignature';
 import SelectSponsorsToPropose from './SelectSponsorsToPropose';
-import Signature from './Signature';
-import SignatureForm from './SignatureForm';
+import { SponsorsFormOverlay } from './SponsorsFormOverlay';
+import { SponsorsHeader } from './SponsorsHeader';
+import { SponsorsList } from './SponsorsList';
 import SubmitUpdateProposal from './SubmitUpdateProposal';
+import { useCandidateSponsorState } from './useCandidateSponsorState';
 
 interface CandidateSponsorsProps {
   candidate: ProposalCandidate;
@@ -39,80 +37,39 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
   const [isFormDisplayed, setIsFormDisplayed] = React.useState<boolean>(false);
-  const [isAccountSigner, setIsAccountSigner] = React.useState<boolean>(false);
-  const [isOriginalSigner, setIsOriginalSigner] = useState<boolean>(false);
-  const [isThresholdMet, setIsThresholdMet] = React.useState<boolean>(false);
+  const [addSignatureTransactionState, setAddSignatureTransactionState] = useState<
+    'None' | 'Success' | 'Mining' | 'Fail' | 'Exception'
+  >('None');
+
   const { address: account } = useAccount();
   const activePendingProposers = useActivePendingUpdatableProposers(props.blockNumber);
   const connectedAccountNounVotes = useUserVotes() || 0;
+
+  const { isThresholdMet, isAccountSigner, isOriginalSigner, setIsAccountSigner } =
+    useCandidateSponsorState({
+      candidate: props.candidate,
+      originalProposal: props.originalProposal,
+      account,
+    });
+
   const originalSigners = props.originalProposal?.signers.map(signer => signer.id.toLowerCase());
   const originalSignersDelegateSnapshot = useDelegateNounsAtBlockQuery(
     originalSigners ?? [],
     BigInt(props.blockNumber ?? 0),
   );
-  const signatures = props.candidate.version.content.contentSignatures;
-  const signers = signatures?.map(signature => signature.signer.id.toLowerCase());
   const isParentProposalUpdatable = props.originalProposal?.status === ProposalState.UPDATABLE;
-
-  useEffect(() => {
-    // set relevant vars from fetched candidate data
-    (() => {
-      if (
-        props.candidate.proposerVotes + props.candidate.voteCount >=
-        props.candidate.requiredVotes
-      ) {
-        setIsThresholdMet(true);
-      } else {
-        setIsThresholdMet(false);
-      }
-      if (props.originalProposal?.signers) {
-        setIsThresholdMet(signatures.length >= props.originalProposal?.signers?.length);
-      }
-    })();
-  }, [props.candidate, props.originalProposal?.signers, signatures]);
-
-  useEffect(() => {
-    (() => {
-      if (props.originalProposal && props.originalProposal.signers && account) {
-        if (originalSigners && originalSigners.includes(account.toLowerCase())) {
-          setIsOriginalSigner(true);
-        } else {
-          setIsOriginalSigner(false);
-        }
-      }
-    })();
-  }, [props.originalProposal, account, originalSigners]);
-
-  useEffect(() => {
-    if (signatures && account) {
-      const isAccountSigner = signatures.find(
-        signature => signature.signer.id.toLowerCase() === account?.toLowerCase(),
-      );
-      if (isAccountSigner) {
-        setIsAccountSigner(true);
-      } else {
-        setIsAccountSigner(false);
-      }
-    }
-  }, [signatures, account]);
-
-  const [addSignatureTransactionState, setAddSignatureTransactionState] = useState<
-    'None' | 'Success' | 'Mining' | 'Fail' | 'Exception'
-  >('None');
+  const signatures = props.candidate.version.content.contentSignatures;
 
   const refetchData = () => {
     props.handleRefetchCandidateData();
   };
 
-  const handleSignatureRemoved = () => {
-    refetchData();
-  };
   return (
     <>
       <SelectSponsorsToPropose
         isModalOpen={isModalOpen}
         setIsModalOpen={setIsModalOpen}
-        signatures={props.candidate.version.content.contentSignatures}
+        signatures={signatures}
         requiredVotes={props.candidate.requiredVotes}
         candidate={props.candidate}
         blockNumber={props.blockNumber}
@@ -123,7 +80,7 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
         <SubmitUpdateProposal
           isModalOpen={isUpdateModalOpen}
           setIsModalOpen={setIsUpdateModalOpen}
-          signatures={props.candidate.version.content.contentSignatures}
+          signatures={signatures}
           candidate={props.candidate}
           setDataFetchPollInterval={props.setDataFetchPollInterval}
           handleRefetchCandidateData={props.handleRefetchCandidateData}
@@ -140,231 +97,48 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
           className={clsx(classes.interiorWrapper, isFormDisplayed && classes.formOverlayVisible)}
         >
           {signatures ? (
-            <>
-              {!isFormDisplayed ? (
-                <>
-                  <h4 className={classes.header}>
-                    <strong>
-                      {props.isUpdateToProposal ? (
-                        <>
-                          {props.candidate.voteCount >= 0 ? props.candidate.voteCount : '...'} of{' '}
-                          {props.originalProposal?.signers.length || '...'} original signed votes
-                        </>
-                      ) : (
-                        <>
-                          {props.candidate.voteCount === 0 &&
-                          props.candidate.proposerVotes > props.candidate.requiredVotes ? (
-                            <>
-                              <Trans>No sponsored votes needed</Trans>
-                            </>
-                          ) : (
-                            <>
-                              {props.candidate.voteCount >= 0 ? props.candidate.voteCount : '...'}{' '}
-                              of{' '}
-                              {(() => {
-                                if (props.candidate.proposerVotes > props.candidate.requiredVotes) {
-                                  return <em className={classes.naVotesLabel}>n/a</em>;
-                                } else if (props.candidate.requiredVotes != undefined) {
-                                  return <>{props.candidate.requiredVotes}</>;
-                                } else {
-                                  return <>...</>;
-                                }
-                              })()}{' '}
-                              sponsored votes
-                            </>
-                          )}
-                        </>
-                      )}
-                    </strong>
-                  </h4>
-                  {props.candidate.proposerVotes > 0 && !props.isUpdateToProposal && (
-                    <p className={classes.proposerVotesLabel}>
-                      <Trans>
-                        Proposer has {props.candidate.proposerVotes} vote
-                        {props.candidate.proposerVotes > 1 ? 's' : ''}
-                      </Trans>
-                    </p>
-                  )}
-                  <p className={classes.subhead}>
-                    {isThresholdMet && !props.isUpdateToProposal ? (
-                      <Trans>
-                        This candidate has met the required threshold, but Nijis voters can still
-                        add support until it’s put onchain.
-                      </Trans>
-                    ) : (
-                      <>
-                        {props.isUpdateToProposal ? (
-                          <Trans>
-                            Update proposal candidates must be re-signed by the original signers.
-                          </Trans>
-                        ) : (
-                          <Trans>
-                            Proposal candidates must meet the required Nijis vote threshold.
-                          </Trans>
-                        )}
-                      </>
-                    )}
-                  </p>
-                  <ul className={classes.sponsorsList}>
-                    {signatures.map(signature => {
-                      const sigVoteCount = signature.signer.voteCount || 0;
-                      if (!sigVoteCount || !activePendingProposers) return null;
-                      if (signature.canceled) return null;
-                      return (
-                        <Signature
-                          key={signature.signer.id}
-                          reason={signature.reason}
-                          voteCount={sigVoteCount}
-                          expirationTimestamp={signature.expirationTimestamp}
-                          signer={signature.signer.id}
-                          isAccountSigner={
-                            signature.signer.id.toLowerCase() === account?.toLowerCase()
-                          }
-                          sig={signature.sig}
-                          setDataFetchPollInterval={props.setDataFetchPollInterval}
-                          signerHasActiveOrPendingProposal={
-                            signature.signer.activeOrPendingProposal
-                          }
-                          isUpdateToProposal={props.isUpdateToProposal}
-                          isParentProposalUpdatable={isParentProposalUpdatable}
-                          handleRefetchCandidateData={refetchData}
-                          setIsAccountSigner={setIsAccountSigner}
-                          handleSignatureRemoved={handleSignatureRemoved}
-                        />
-                      );
-                    })}
-                    {props.isUpdateToProposal ? (
-                      <>
-                        {props.originalProposal?.signers.map((ogSigner, i) => {
-                          const sigVoteCount =
-                            originalSignersDelegateSnapshot.data?.delegates?.find(
-                              delegate => delegate.id === ogSigner.id,
-                            )?.nijiRepresented.length;
-                          if (signers?.includes(ogSigner.id.toLowerCase())) return null;
-                          if (!sigVoteCount || !activePendingProposers) return null;
-                          return (
-                            <OriginalSignature
-                              key={i}
-                              signer={ogSigner.id}
-                              voteCount={sigVoteCount}
-                              isParentProposalUpdatable={isParentProposalUpdatable}
-                            />
-                          );
-                        })}
-                      </>
-                    ) : (
-                      <>
-                        {props.candidate.requiredVotes > props.candidate.voteCount &&
-                          Array(props.candidate.requiredVotes - props.candidate.voteCount)
-                            .fill('')
-                            .map((_s, i) => (
-                              <li className={classes.placeholder} key={i}>
-                                {' '}
-                              </li>
-                            ))}
-                      </>
-                    )}
-                    {props.isUpdateToProposal && !isParentProposalUpdatable ? (
-                      <p className={classes.inactiveCandidate}>
-                        <strong>
-                          <Link to={`/vote/${props.originalProposal?.id}`}>
-                            Proposal {props.originalProposal?.id}
-                          </Link>
-                        </strong>{' '}
-                        is no longer updatable
-                      </p>
-                    ) : (
-                      <>
-                        {props.isProposer && isThresholdMet ? (
-                          <>
-                            {/* no sign button for proposers */}
-                            <button
-                              className={classes.button}
-                              onClick={() => {
-                                if (props.isUpdateToProposal) {
-                                  setIsUpdateModalOpen(true);
-                                } else {
-                                  setIsModalOpen(true);
-                                }
-                              }}
-                            >
-                              Submit onchain
-                            </button>
-                          </>
-                        ) : (
-                          <>
-                            {((!props.isUpdateToProposal &&
-                              !isAccountSigner &&
-                              !props.candidate.isProposal) ||
-                              (props.isUpdateToProposal &&
-                                isOriginalSigner &&
-                                !isAccountSigner)) && (
-                              <>
-                                {!props.isProposer && connectedAccountNounVotes > 0 ? (
-                                  <button
-                                    className={classes.button}
-                                    onClick={() => setIsFormDisplayed(!isFormDisplayed)}
-                                  >
-                                    {props.isUpdateToProposal ? 'Re-sign' : 'Sponsor'}
-                                  </button>
-                                ) : (
-                                  <div className={classes.withoutVotesMsg}>
-                                    <p>
-                                      <Trans>
-                                        Sponsoring a proposal requires at least one Niji vote
-                                      </Trans>
-                                    </p>
-                                  </div>
-                                )}
-                              </>
-                            )}
-                          </>
-                        )}
-                      </>
-                    )}
-                  </ul>
-                </>
-              ) : (
-                <AnimatePresence>
-                  {addSignatureTransactionState === 'Success' && (
-                    <div className="transactionStatus success">
-                      <p>Success!</p>
-                    </div>
-                  )}
-                  {isFormDisplayed ? (
-                    <motion.div
-                      className={classes.formOverlay}
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      transition={{ duration: 0.15 }}
-                    >
-                      <button
-                        className={classes.closeButton}
-                        onClick={() => {
-                          setIsFormDisplayed(false);
-                          props.setDataFetchPollInterval(0);
-                        }}
-                      >
-                        &times;
-                      </button>
-                      <SignatureForm
-                        id={props.id}
-                        transactionState={addSignatureTransactionState}
-                        setTransactionState={setAddSignatureTransactionState}
-                        setIsFormDisplayed={setIsFormDisplayed}
-                        candidate={props.candidate}
-                        handleRefetchCandidateData={props.handleRefetchCandidateData}
-                        setDataFetchPollInterval={props.setDataFetchPollInterval}
-                        proposalIdToUpdate={
-                          props.originalProposal?.id ? +props.originalProposal?.id : 0
-                        }
-                      />
-                    </motion.div>
-                  ) : null}
-                </AnimatePresence>
-              )}
-            </>
+            !isFormDisplayed ? (
+              <>
+                <SponsorsHeader
+                  candidate={props.candidate}
+                  isUpdateToProposal={props.isUpdateToProposal}
+                  isThresholdMet={isThresholdMet}
+                  originalProposal={props.originalProposal}
+                />
+                <SponsorsList
+                  candidate={props.candidate}
+                  isUpdateToProposal={props.isUpdateToProposal}
+                  isParentProposalUpdatable={isParentProposalUpdatable}
+                  isProposer={props.isProposer}
+                  isAccountSigner={isAccountSigner}
+                  isOriginalSigner={isOriginalSigner}
+                  isThresholdMet={isThresholdMet}
+                  account={account}
+                  activePendingProposers={activePendingProposers}
+                  originalProposal={props.originalProposal}
+                  originalSignersDelegates={originalSignersDelegateSnapshot.data?.delegates}
+                  connectedAccountNounVotes={connectedAccountNounVotes}
+                  setIsAccountSigner={setIsAccountSigner}
+                  setDataFetchPollInterval={props.setDataFetchPollInterval}
+                  handleRefetchCandidateData={refetchData}
+                  onOpenSubmitModal={() => setIsModalOpen(true)}
+                  onOpenUpdateModal={() => setIsUpdateModalOpen(true)}
+                  onOpenForm={() => setIsFormDisplayed(!isFormDisplayed)}
+                />
+              </>
+            ) : (
+              <SponsorsFormOverlay
+                isFormDisplayed={isFormDisplayed}
+                candidate={props.candidate}
+                id={props.id}
+                transactionState={addSignatureTransactionState}
+                setTransactionState={setAddSignatureTransactionState}
+                setIsFormDisplayed={setIsFormDisplayed}
+                handleRefetchCandidateData={props.handleRefetchCandidateData}
+                setDataFetchPollInterval={props.setDataFetchPollInterval}
+                proposalIdToUpdate={props.originalProposal?.id ? +props.originalProposal?.id : 0}
+              />
+            )
           ) : (
             <img
               src="/loading-noggles.svg"

--- a/packages/niji-webapp/src/components/CandidateSponsors/useCandidateSponsorState.ts
+++ b/packages/niji-webapp/src/components/CandidateSponsors/useCandidateSponsorState.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+import { Proposal } from '@/wrappers/nijiDao';
+import { ProposalCandidate } from '@/wrappers/nijiData';
+
+interface UseCandidateSponsorStateArgs {
+  candidate: ProposalCandidate;
+  originalProposal?: Proposal;
+  account?: string;
+}
+
+export interface CandidateSponsorState {
+  isThresholdMet: boolean;
+  isAccountSigner: boolean;
+  isOriginalSigner: boolean;
+  setIsAccountSigner: (value: boolean) => void;
+}
+
+/**
+ * Derives signer / threshold / original-signer flags from the candidate + original proposal +
+ * connected account. Extracted from the container so the rendering tree stays focused on layout.
+ */
+export function useCandidateSponsorState({
+  candidate,
+  originalProposal,
+  account,
+}: UseCandidateSponsorStateArgs): CandidateSponsorState {
+  const [isThresholdMet, setIsThresholdMet] = useState(false);
+  const [isAccountSigner, setIsAccountSigner] = useState(false);
+  const [isOriginalSigner, setIsOriginalSigner] = useState(false);
+
+  const signatures = candidate.version.content.contentSignatures;
+  const originalSigners = originalProposal?.signers.map(signer => signer.id.toLowerCase());
+
+  useEffect(() => {
+    if (candidate.proposerVotes + candidate.voteCount >= candidate.requiredVotes) {
+      setIsThresholdMet(true);
+    } else {
+      setIsThresholdMet(false);
+    }
+    if (originalProposal?.signers) {
+      setIsThresholdMet(signatures.length >= originalProposal.signers.length);
+    }
+  }, [candidate, originalProposal?.signers, signatures]);
+
+  useEffect(() => {
+    if (!originalProposal?.signers || !account) return;
+    setIsOriginalSigner(
+      Boolean(originalSigners && originalSigners.includes(account.toLowerCase())),
+    );
+  }, [originalProposal, account, originalSigners]);
+
+  useEffect(() => {
+    if (!signatures || !account) return;
+    const accountIsSigner = signatures.some(
+      sig => sig.signer.id.toLowerCase() === account.toLowerCase(),
+    );
+    setIsAccountSigner(accountIsSigner);
+  }, [signatures, account]);
+
+  return { isThresholdMet, isAccountSigner, isOriginalSigner, setIsAccountSigner };
+}


### PR DESCRIPTION
# 概要

`CandidateSponsors/index.tsx` (381 行) を container + 3 sub-component + 1 custom hook に分割しました。
Issue #256 の 3 件目の分割対象として、 PR #257 (Documentation) と PR #258 (VoteSignals) と同じ方針で進めています。
画面表示や transaction フローは一切変えていません。

# 課題

`CandidateSponsors/index.tsx` は以下を 1 file に詰め込み 381 行になっていました。

- 3 つの `useEffect` (threshold / original signer / account signer の検出)
- header / subhead の文言切替 (`isUpdateToProposal` で 2 通り)
- signature list の renderer + 元 signer の placeholder + 不足署名分の空 li
- 「submit onchain」 / 「sponsor」 / 「re-sign」 / 「no longer updatable」 の action button 4 分岐
- form overlay (motion enter/exit + close button + SignatureForm)
- 2 つの modal (SelectSponsorsToPropose / SubmitUpdateProposal)

button のロジックが 4 重ネスト ternary になっており、 どの条件で何が表示されるかの追跡が困難でした。

# 詳細

分割の方針。

```mermaid
graph LR
    A[CandidateSponsors/index.tsx 381 行] --> B[container 157 行]
    A --> C[useCandidateSponsorState 62 行 effect hook]
    A --> D[SponsorsHeader 81 行 header + subhead]
    A --> E[SponsorsList 200 行 list + action button]
    A --> F[SponsorsFormOverlay 75 行 motion overlay]
```

action button の 4 分岐は `SponsorActionButton` という file 内 sub-component に切り出し、 early-return 形式で書き換えました。 4 重ネスト ternary が消えて、 条件と表示の対応が直線的に読めるようになっています。

# 解決方法

各 file の責務。

| ファイル | 行数 | 責務 |
|---|---|---|
| `index.tsx` (container) | 157 | state / 配置 / refetch handler |
| `useCandidateSponsorState.ts` | 62 | threshold / original signer / account signer の 3 effect を 1 hook に集約 |
| `SponsorsHeader.tsx` | 81 | header + subhead の文言切替 + `NewCandidateHeader` 内部 helper |
| `SponsorsList.tsx` | 200 | 署名 list + 元 signer placeholder + 不足署名空 li + `SponsorActionButton` (action 4 分岐) |
| `SponsorsFormOverlay.tsx` | 75 | motion overlay + close button + SignatureForm wrapper |

action button の 4 分岐は以下の優先順序で early-return:

1. `isUpdateToProposal && !isParentProposalUpdatable` → 「no longer updatable」 link
2. `isProposer && isThresholdMet` → 「Submit onchain」 button
3. 署名できない状態 (new candidate ですでに自分が signer / update でも oryginal signer ではない 等) → null
4. proposer または vote 0 → 「Sponsoring a proposal requires at least one Niji vote」 message
5. それ以外 → 「Sponsor」 / 「Re-sign」 button

# 仕組み

```mermaid
graph LR
    A[親 component から props] --> B[container CandidateSponsors]
    B --> C[useCandidateSponsorState で threshold / signer 検出]
    B --> D{isFormDisplayed?}
    D -->|false| E[SponsorsHeader + SponsorsList]
    E --> F[SponsorActionButton 4 分岐 early-return]
    D -->|true| G[SponsorsFormOverlay motion + SignatureForm]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/components/CandidateSponsors/index.tsx` | 381 行 → 157 行 (container 専念)。 3 sub-component と 1 hook を import + 配置 |
| `packages/niji-webapp/src/components/CandidateSponsors/useCandidateSponsorState.ts` | 新規。 3 effect を 1 hook に集約 |
| `packages/niji-webapp/src/components/CandidateSponsors/SponsorsHeader.tsx` | 新規。 header + subhead 文言 + `NewCandidateHeader` helper |
| `packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.tsx` | 新規。 list rendering + action button (4 分岐 early-return) |
| `packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.tsx` | 新規。 motion overlay + SignatureForm wrapper |

# テストと確認

- [x] `pnpm tsc --noEmit` 通過
- [x] `pnpm test --run` 30 件 pass + 1 skipped + 1 todo (regression なし)
- [x] 全 file が 200 行以下を達成 (container 157 / hook 62 / Header 81 / List 200 / FormOverlay 75)

レビューで見てほしいところ。

`SponsorsList.tsx` の `SignerVoteCountMap` 型を `nijiRepresented?: ReadonlyArray<unknown>` で受けている点をご確認ください。
本来は `useDelegateNounsAtBlockQuery` が返す codegen 型 (`{ id, nijiRepresented: { __typename, id }[] }`) を直接受けるべきですが、 list 内で `nijiRepresented.length` だけ参照するため、 minimum surface に絞って unknown を許容しています。
別案 (codegen 型を直接 import) があればご指摘ください。

# 関連

Refs #256
- PR #257 (Documentation 分割) / PR #258 (VoteSignals 分割) と同じ方針
