### PR TITLE
🧹 refactor(niji-webapp): SignatureForm.tsx を 6 file に分割 (Issue #256 完結)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx
@@ -1,58 +1,24 @@
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Trans } from '@lingui/react/macro';
 import { nijiGovernorAddress } from '@niji/sdk/react';
-import clsx from 'clsx';
-import dayjs from 'dayjs';
-import { CheckCircle2, X } from 'lucide-react';
-import { Spinner } from 'react-bootstrap';
-import {
-  encodeAbiParameters,
-  encodePacked,
-  getAddress,
-  hexToBytes,
-  keccak256,
-  toBytes,
-} from 'viem';
+import { encodePacked, getAddress } from 'viem';
 import { useSignTypedData } from 'wagmi';
 
-import link from '@/assets/icons/Link.svg';
-import { buildEtherscanTxLink } from '@/utils/etherscan';
-import { Address } from '@/utils/types';
 import { defaultChain } from '@/wagmi';
-import { ProposalCandidate, useAddSignature } from '@/wrappers/nijiData';
+import { ProposalCandidate } from '@/wrappers/nijiData';
 
 import classes from './CandidateSponsors.module.css';
-
-const createProposalTypes = {
-  Proposal: [
-    { name: 'proposer', type: 'address' },
-    { name: 'targets', type: 'address[]' },
-    { name: 'values', type: 'uint256[]' },
-    { name: 'signatures', type: 'string[]' },
-    { name: 'calldatas', type: 'bytes[]' },
-    { name: 'description', type: 'string' },
-    { name: 'expiry', type: 'uint256' },
-  ],
-} as const;
-
-const updateProposalTypes = {
-  UpdateProposal: [
-    { name: 'proposalId', type: 'uint256' },
-    { name: 'proposer', type: 'address' },
-    { name: 'targets', type: 'address[]' },
-    { name: 'values', type: 'uint256[]' },
-    { name: 'signatures', type: 'string[]' },
-    { name: 'calldatas', type: 'bytes[]' },
-    { name: 'description', type: 'string' },
-    { name: 'expiry', type: 'uint256' },
-  ],
-} as const;
+import { calcProposalEncodeData } from './signature/encodeProposalData';
+import { SignatureFormFields } from './signature/SignatureFormFields';
+import { SignatureStatusOverlay } from './signature/SignatureStatusOverlay';
+import { createProposalTypes, TransactionState, updateProposalTypes } from './signature/types';
+import { useSignatureFlow } from './signature/useSignatureFlow';
 
 type SignatureFormProps = {
   id: string;
-  transactionState: 'None' | 'Success' | 'Mining' | 'Fail' | 'Exception';
-  setTransactionState: (state: 'None' | 'Success' | 'Mining' | 'Fail' | 'Exception') => void;
+  transactionState: TransactionState;
+  setTransactionState: (state: TransactionState) => void;
   setIsFormDisplayed: (displayed: boolean) => void;
   candidate: ProposalCandidate;
   handleRefetchCandidateData: () => void;
@@ -63,19 +29,8 @@ type SignatureFormProps = {
 const SignatureForm = (props: Readonly<SignatureFormProps>) => {
   const [reasonText, setReasonText] = useState('');
   const [expirationDate, setExpirationDate] = useState<number>();
-  const [isOverlayVisible, setIsOverlayVisible] = useState(false);
-  const { addSignature, addSignatureState } = useAddSignature();
-  const [isGetSignatureWaiting, setIsGetSignatureWaiting] = useState(false);
-  const [isGetSignaturePending, setIsGetSignaturePending] = useState(false);
-  const [isGetSignatureTxSuccessful, setIsGetSignatureTxSuccessful] = useState(false);
-  const [getSignatureErrorMessage, setGetSignatureErrorMessage] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [isWaiting, setIsWaiting] = useState(false);
-  const [isTxSuccessful, setIsTxSuccessful] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<ReactNode>('');
 
   const chainId = defaultChain.id;
-
   const [domain, setDomain] = useState({
     name: 'Niji DAO',
     chainId,
@@ -83,396 +38,129 @@ const SignatureForm = (props: Readonly<SignatureFormProps>) => {
   });
 
   useEffect(() => {
-    setDomain(prev => ({
-      ...prev,
-      verifyingContract: nijiGovernorAddress[chainId],
-    }));
+    setDomain(prev => ({ ...prev, verifyingContract: nijiGovernorAddress[chainId] }));
   }, []);
 
-  // Hook for EIP-712 typed data signing
   const { data, signTypedData, isPending: isSignPending } = useSignTypedData();
-  async function calcProposalEncodeData(
-    proposer: string,
-    targets: string[],
-    values: bigint[],
-    signatures: string[],
-    calldatas: `0x${string}`[],
-    description: string,
-  ) {
-    // Convert each signature to a hash
-    const signatureHashes = signatures.map((sig: string) => keccak256(toBytes(sig)));
+  const flow = useSignatureFlow({
+    setDataFetchPollInterval: props.setDataFetchPollInterval,
+    handleRefetchCandidateData: props.handleRefetchCandidateData,
+    signatureData: data,
+    isSignPending,
+  });
 
-    // Convert each calldata to a hash
-    const calldatasHashes = calldatas.map((calldata: `0x${string}`) =>
-      keccak256(hexToBytes(calldata)),
-    );
-
-    // Encode the data using viem's encodeAbiParameters
-    const encodedData = encodeAbiParameters(
-      [
-        { name: 'proposer', type: 'address' },
-        { name: 'targetsHash', type: 'bytes32' },
-        { name: 'valuesHash', type: 'bytes32' },
-        { name: 'signaturesHash', type: 'bytes32' },
-        { name: 'calldatasHash', type: 'bytes32' },
-        { name: 'descriptionHash', type: 'bytes32' },
-      ],
-      [
-        getAddress(proposer),
-        keccak256(encodePacked(['address[]'], [targets.map(v => v as Address)])),
-        keccak256(encodePacked(['uint256[]'], [values])),
-        keccak256(encodePacked(['bytes32[]'], [signatureHashes])),
-        keccak256(encodePacked(['bytes32[]'], [calldatasHashes])),
-        keccak256(toBytes(description)),
-      ],
-    );
-
-    return encodedData;
-  }
+  useEffect(() => {
+    flow.validateExpirationDate(expirationDate);
+  }, [expirationDate, flow]);
 
   const getSignature = async () => {
-    setIsGetSignatureWaiting(true);
-
+    flow.setIsGetSignatureWaiting(true);
     try {
-      if (props.proposalIdToUpdate > 0) {
-        // Create the value for an update proposal
-        const value = {
-          proposalId: BigInt(props.proposalIdToUpdate),
-          proposer: getAddress(props.candidate.proposer),
-          targets: props.candidate.version.content.targets.map(target => getAddress(target)),
-          values: props.candidate.version.content.values.map(value => BigInt(value)),
-          signatures: props.candidate.version.content.signatures,
-          calldatas: props.candidate.version.content.calldatas,
-          description: props.candidate.version.content.description,
-          expiry: BigInt(expirationDate || 0),
-        };
+      const baseValue = {
+        proposer: getAddress(props.candidate.proposer),
+        targets: props.candidate.version.content.targets.map(t => getAddress(t)),
+        values: props.candidate.version.content.values.map(v => BigInt(v)),
+        signatures: props.candidate.version.content.signatures,
+        calldatas: props.candidate.version.content.calldatas,
+        description: props.candidate.version.content.description,
+        expiry: BigInt(expirationDate || 0),
+      };
 
-        // Trigger the signature request
+      if (props.proposalIdToUpdate > 0) {
         signTypedData({
           domain,
           types: updateProposalTypes,
           primaryType: 'UpdateProposal',
-          message: value,
+          message: { proposalId: BigInt(props.proposalIdToUpdate), ...baseValue },
         });
       } else {
         if (!props.candidate) return;
-
-        // Create the value for a new proposal
-        const value = {
-          proposer: getAddress(props.candidate.proposer),
-          targets: props.candidate.version.content.targets.map(target => getAddress(target)),
-          values: props.candidate.version.content.values.map(value => BigInt(value)),
-          signatures: props.candidate.version.content.signatures,
-          calldatas: props.candidate.version.content.calldatas,
-          description: props.candidate.version.content.description,
-          expiry: BigInt(expirationDate || 0),
-        };
-
-        // Trigger the signature request
         signTypedData({
           domain,
           types: createProposalTypes,
           primaryType: 'Proposal',
-          message: value,
+          message: baseValue,
         });
       }
 
-      setIsGetSignatureWaiting(false);
-      setIsGetSignatureTxSuccessful(true);
+      flow.setIsGetSignatureWaiting(false);
+      flow.setIsGetSignatureTxSuccessful(true);
       return data;
     } catch (err: unknown) {
-      if (err instanceof Error) {
-        setGetSignatureErrorMessage(err.message);
-      } else {
-        setGetSignatureErrorMessage('Unknown error occurred');
-      }
-      setIsGetSignatureWaiting(false);
+      flow.setGetSignatureErrorMessage(
+        err instanceof Error ? err.message : 'Unknown error occurred',
+      );
+      flow.setIsGetSignatureWaiting(false);
       return undefined;
     }
   };
 
   async function sign() {
     const signature = await getSignature();
-    if (signature) {
-      setIsGetSignatureWaiting(false);
-      setIsWaiting(true);
+    if (!signature) return;
 
-      // Calculate encoded proposal data
-      const encodedProp = await calcProposalEncodeData(
-        props.candidate.proposer,
-        props.candidate.version.content.targets,
-        props.candidate.version.content.values.map(value => BigInt(value)),
-        props.candidate.version.content.signatures,
-        props.candidate.version.content.calldatas,
-        props.candidate.version.content.description,
-      );
+    flow.setIsGetSignatureWaiting(false);
+    flow.setIsWaiting(true);
 
-      // If this is a proposal update, pack the proposal ID with the encoded data
-      const encodedPropUpdate =
-        props.proposalIdToUpdate > 0
-          ? encodePacked(['uint256', 'bytes'], [BigInt(props.proposalIdToUpdate), encodedProp])
-          : encodedProp;
+    const encodedProp = await calcProposalEncodeData(
+      props.candidate.proposer,
+      props.candidate.version.content.targets,
+      props.candidate.version.content.values.map(v => BigInt(v)),
+      props.candidate.version.content.signatures,
+      props.candidate.version.content.calldatas,
+      props.candidate.version.content.description,
+    );
 
-      // Submit the signature
-      await addSignature({
-        args: [
-          signature as `0x${string}`,
-          expirationDate ? BigInt(expirationDate) : BigInt(0),
-          props.candidate.proposer as `0x${string}`,
-          props.candidate.slug,
-          BigInt(props.proposalIdToUpdate), // proposalIdToUpdate
-          props.proposalIdToUpdate > 0 ? encodedPropUpdate : encodedProp,
-          reasonText,
-        ],
-      });
-    }
+    const encodedPropUpdate =
+      props.proposalIdToUpdate > 0
+        ? encodePacked(['uint256', 'bytes'], [BigInt(props.proposalIdToUpdate), encodedProp])
+        : encodedProp;
+
+    await flow.addSignature({
+      args: [
+        signature as `0x${string}`,
+        expirationDate ? BigInt(expirationDate) : BigInt(0),
+        props.candidate.proposer as `0x${string}`,
+        props.candidate.slug,
+        BigInt(props.proposalIdToUpdate),
+        props.proposalIdToUpdate > 0 ? encodedPropUpdate : encodedProp,
+        reasonText,
+      ],
+    });
   }
-
-  const clearTransactionState = () => {
-    // clear all transaction states
-    setIsWaiting(false);
-    setIsLoading(false);
-    setIsTxSuccessful(false);
-    setErrorMessage('');
-    setIsGetSignatureWaiting(false);
-    setIsGetSignaturePending(false);
-    setGetSignatureErrorMessage('');
-    setIsGetSignatureTxSuccessful(false);
-    setIsOverlayVisible(false);
-    props.setDataFetchPollInterval(0);
-  };
-
-  const handleAddSignatureState = useCallback(
-    ({ errorMessage, status }: { errorMessage?: string; status: string }) => {
-      switch (status) {
-        case 'None':
-          setIsLoading(false);
-          setIsWaiting(false);
-          break;
-        case 'PendingSignature':
-          setIsWaiting(true);
-          break;
-        case 'Mining':
-          setIsLoading(true);
-          setIsWaiting(false);
-          props.setDataFetchPollInterval(50);
-          break;
-        case 'Success':
-          props.handleRefetchCandidateData();
-          setIsTxSuccessful(true);
-          setIsLoading(false);
-          break;
-        case 'Fail':
-        case 'Exception':
-          props.setDataFetchPollInterval(0);
-          setErrorMessage(errorMessage);
-          setIsLoading(false);
-          setIsWaiting(false);
-          break;
-      }
-    },
-    [],
-  );
-
-  useEffect(() => {
-    handleAddSignatureState(addSignatureState);
-  }, [addSignatureState, handleAddSignatureState]);
-
-  // Update overlay visibility when signing states change
-  useEffect(() => {
-    if (
-      isWaiting ||
-      isLoading ||
-      isTxSuccessful ||
-      errorMessage ||
-      isGetSignatureWaiting ||
-      isSignPending || // Using wagmi's isPending instead of custom state
-      isGetSignatureTxSuccessful ||
-      getSignatureErrorMessage
-    ) {
-      setIsOverlayVisible(true);
-    }
-  }, [
-    isWaiting,
-    isLoading,
-    isTxSuccessful,
-    errorMessage,
-    isGetSignatureWaiting,
-    isSignPending, // Using wagmi's isPending instead of custom state
-    isGetSignatureTxSuccessful,
-    getSignatureErrorMessage,
-  ]);
-
-  const [dateErrorMessage, setDateErrorMessage] = useState<string>('');
-
-  useEffect(() => {
-    if (expirationDate === undefined) return;
-    const today = new Date();
-    if (+dayjs(expirationDate) > +dayjs(today) / 1000) {
-      setDateErrorMessage('');
-    } else {
-      setDateErrorMessage('Date must be in the future');
-    }
-  }, [expirationDate]);
-
-  // Effect to handle the signature data changes
-  useEffect(() => {
-    if (data && isGetSignatureWaiting) {
-      setIsGetSignatureWaiting(false);
-      setIsGetSignatureTxSuccessful(true);
-    }
-  }, [data, isGetSignatureWaiting]);
 
   return (
     <div className={classes.formWrapper}>
-      <>
-        <div className={clsx(classes.fields, (isWaiting || isLoading) && classes.disabled)}>
-          <h4 className={classes.formLabel}>Sponsor this proposal candidate</h4>
-          <textarea
-            placeholder="Optional reason"
-            value={reasonText}
-            onChange={event => setReasonText(event.target.value)}
-            disabled={isWaiting || isLoading}
-          />
-
-          <h4 className={classes.formLabel}>Expiration date (required)</h4>
-          <input
-            type="date"
-            min={new Date().toISOString().split('T')[0]} // only future dates
-            onChange={e => setExpirationDate(+dayjs(e.target.value).unix())}
-            disabled={isWaiting || isLoading}
-          />
-          {dateErrorMessage && <p className={classes.dateErrorMessage}>{dateErrorMessage}</p>}
-        </div>
-        <div className="text-center">
-          {isWaiting || isLoading ? (
-            <img src="/loading-noggles.svg" alt="loading" className={classes.loadingNoggles} />
-          ) : (
-            <button
-              type="button"
-              className={classes.button}
-              onClick={() => {
-                sign();
-              }}
-              disabled={
-                props.transactionState === 'Mining' ||
-                expirationDate === undefined ||
-                dateErrorMessage !== ''
-              }
-            >
-              {props.proposalIdToUpdate ? 'Re-sign' : 'Sponsor'}
-            </button>
-          )}
-        </div>
-
-        {isOverlayVisible && (
-          <div className={classes.submitSignatureStatusOverlay}>
-            <span
-              className={clsx(
-                (isWaiting || isGetSignatureWaiting || isLoading || isGetSignaturePending) &&
-                  classes.loadingButton,
-              )}
-            >
-              {(isWaiting || isGetSignatureWaiting || isLoading || isGetSignaturePending) && (
-                <img
-                  src="/loading-noggles.svg"
-                  alt="loading"
-                  className={classes.transactionModalSpinner}
-                />
-              )}
-              {isGetSignatureWaiting && 'Awaiting signature'}
-              {isWaiting && 'Awaiting confirmation'}
-              {isSignPending && 'Confirming signature'}
-              {isLoading && 'Submitting signature'}
-            </span>
-            {(getSignatureErrorMessage || errorMessage) && (
-              <p className={clsx(classes.statusMessage, classes.errorMessage)}>
-                {getSignatureErrorMessage || errorMessage}
-                <button
-                  type="button"
-                  onClick={() => {
-                    clearTransactionState();
-                  }}
-                >
-                  Try again
-                </button>
-              </p>
-            )}
-            {isTxSuccessful && (
-              <>
-                <p className={clsx(classes.statusMessage, classes.successMessage)}>
-                  <a
-                    href={
-                      addSignatureState.transaction?.hash &&
-                      `${buildEtherscanTxLink(addSignatureState.transaction.hash)}`
-                    }
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Signature added successfully
-                    {addSignatureState.transaction && (
-                      <img src={link} width={16} alt="link symbol" />
-                    )}
-                  </a>
-                </p>
-              </>
-            )}
-            <>
-              <ul className={classes.steps}>
-                <li>
-                  <strong>
-                    {(isGetSignatureWaiting || isSignPending) && (
-                      <span className={classes.spinner}>
-                        <Spinner animation="border" />
-                      </span>
-                    )}
-                    {isGetSignatureTxSuccessful && (
-                      <CheckCircle2 height={20} width={20} color="green" />
-                    )}
-                    {getSignatureErrorMessage && <X height={20} width={20} color="red" />}
-                  </strong>
-                  <Trans>Signature request</Trans>
-                </li>
-                <li>
-                  <strong>
-                    {(isWaiting || isLoading) && (
-                      <span className={classes.spinner}>
-                        <Spinner animation="border" />
-                      </span>
-                    )}
-                    {isTxSuccessful && <CheckCircle2 height={20} width={20} color="green" />}
-                    {(getSignatureErrorMessage || errorMessage) && (
-                      <X height={20} width={20} color="red" />
-                    )}
-                    {!(
-                      isWaiting ||
-                      isLoading ||
-                      isTxSuccessful ||
-                      errorMessage ||
-                      getSignatureErrorMessage
-                    ) && <span className={classes.placeholder}></span>}
-                  </strong>
-                  <Trans>Submit signature</Trans>
-                </li>
-              </ul>
-            </>
-
-            {/* close overlay */}
-            {isTxSuccessful && (
-              <button
-                type="button"
-                className={classes.closeButton}
-                onClick={() => {
-                  props.setIsFormDisplayed(false);
-                  clearTransactionState();
-                }}
-              >
-                &times;
-              </button>
-            )}
-          </div>
-        )}
-      </>
+      <SignatureFormFields
+        reasonText={reasonText}
+        setReasonText={setReasonText}
+        setExpirationDate={setExpirationDate}
+        expirationDate={expirationDate}
+        dateErrorMessage={flow.dateErrorMessage}
+        isWaiting={flow.isWaiting}
+        isLoading={flow.isLoading}
+        proposalIdToUpdate={props.proposalIdToUpdate}
+        transactionState={props.transactionState}
+        onSign={sign}
+      />
+      <SignatureStatusOverlay
+        isOverlayVisible={flow.isOverlayVisible}
+        isWaiting={flow.isWaiting}
+        isLoading={flow.isLoading}
+        isTxSuccessful={flow.isTxSuccessful}
+        isGetSignatureWaiting={flow.isGetSignatureWaiting}
+        isGetSignaturePending={false}
+        isGetSignatureTxSuccessful={flow.isGetSignatureTxSuccessful}
+        isSignPending={isSignPending}
+        errorMessage={flow.errorMessage}
+        getSignatureErrorMessage={flow.getSignatureErrorMessage}
+        transactionHash={flow.addSignatureState.transaction?.hash}
+        onTryAgain={flow.clearTransactionState}
+        onClose={() => {
+          props.setIsFormDisplayed(false);
+          flow.clearTransactionState();
+        }}
+      />
       <p className={classes.note}>
         <Trans>
           Once a signed proposal is onchain, signers will need to wait until the proposal is queued

--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureFormFields.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureFormFields.tsx
@@ -1,0 +1,74 @@
+import clsx from 'clsx';
+import dayjs from 'dayjs';
+
+import classes from '../CandidateSponsors.module.css';
+
+interface SignatureFormFieldsProps {
+  reasonText: string;
+  setReasonText: (value: string) => void;
+  setExpirationDate: (value: number) => void;
+  expirationDate: number | undefined;
+  dateErrorMessage: string;
+  isWaiting: boolean;
+  isLoading: boolean;
+  proposalIdToUpdate: number;
+  transactionState: string;
+  onSign: () => void;
+}
+
+/**
+ * Reason textarea + expiration date input + sign button.
+ */
+export function SignatureFormFields({
+  reasonText,
+  setReasonText,
+  setExpirationDate,
+  expirationDate,
+  dateErrorMessage,
+  isWaiting,
+  isLoading,
+  proposalIdToUpdate,
+  transactionState,
+  onSign,
+}: SignatureFormFieldsProps) {
+  return (
+    <>
+      <div className={clsx(classes.fields, (isWaiting || isLoading) && classes.disabled)}>
+        <h4 className={classes.formLabel}>Sponsor this proposal candidate</h4>
+        <textarea
+          placeholder="Optional reason"
+          value={reasonText}
+          onChange={event => setReasonText(event.target.value)}
+          disabled={isWaiting || isLoading}
+        />
+
+        <h4 className={classes.formLabel}>Expiration date (required)</h4>
+        <input
+          type="date"
+          min={new Date().toISOString().split('T')[0]}
+          onChange={e => setExpirationDate(+dayjs(e.target.value).unix())}
+          disabled={isWaiting || isLoading}
+        />
+        {dateErrorMessage && <p className={classes.dateErrorMessage}>{dateErrorMessage}</p>}
+      </div>
+      <div className="text-center">
+        {isWaiting || isLoading ? (
+          <img src="/loading-noggles.svg" alt="loading" className={classes.loadingNoggles} />
+        ) : (
+          <button
+            type="button"
+            className={classes.button}
+            onClick={onSign}
+            disabled={
+              transactionState === 'Mining' ||
+              expirationDate === undefined ||
+              dateErrorMessage !== ''
+            }
+          >
+            {proposalIdToUpdate ? 'Re-sign' : 'Sponsor'}
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
@@ -1,0 +1,132 @@
+import { ReactNode } from 'react';
+
+import { Trans } from '@lingui/react/macro';
+import clsx from 'clsx';
+import { CheckCircle2, X } from 'lucide-react';
+import { Spinner } from 'react-bootstrap';
+
+import link from '@/assets/icons/Link.svg';
+import { buildEtherscanTxLink } from '@/utils/etherscan';
+
+import classes from '../CandidateSponsors.module.css';
+
+interface SignatureStatusOverlayProps {
+  isOverlayVisible: boolean;
+  isWaiting: boolean;
+  isLoading: boolean;
+  isTxSuccessful: boolean;
+  isGetSignatureWaiting: boolean;
+  isGetSignaturePending: boolean;
+  isGetSignatureTxSuccessful: boolean;
+  isSignPending: boolean;
+  errorMessage: ReactNode;
+  getSignatureErrorMessage: string;
+  transactionHash?: string;
+  onTryAgain: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Status overlay that shows progress / success / error across the 2-step sign flow.
+ * 1. signature request (wallet sign)
+ * 2. submit signature (on-chain tx)
+ */
+export function SignatureStatusOverlay({
+  isOverlayVisible,
+  isWaiting,
+  isLoading,
+  isTxSuccessful,
+  isGetSignatureWaiting,
+  isGetSignaturePending,
+  isGetSignatureTxSuccessful,
+  isSignPending,
+  errorMessage,
+  getSignatureErrorMessage,
+  transactionHash,
+  onTryAgain,
+  onClose,
+}: SignatureStatusOverlayProps) {
+  if (!isOverlayVisible) return null;
+
+  const isBusy = isWaiting || isGetSignatureWaiting || isLoading || isGetSignaturePending;
+
+  return (
+    <div className={classes.submitSignatureStatusOverlay}>
+      <span className={clsx(isBusy && classes.loadingButton)}>
+        {isBusy && (
+          <img
+            src="/loading-noggles.svg"
+            alt="loading"
+            className={classes.transactionModalSpinner}
+          />
+        )}
+        {isGetSignatureWaiting && 'Awaiting signature'}
+        {isWaiting && 'Awaiting confirmation'}
+        {isSignPending && 'Confirming signature'}
+        {isLoading && 'Submitting signature'}
+      </span>
+
+      {(getSignatureErrorMessage || errorMessage) && (
+        <p className={clsx(classes.statusMessage, classes.errorMessage)}>
+          {getSignatureErrorMessage || errorMessage}
+          <button type="button" onClick={onTryAgain}>
+            Try again
+          </button>
+        </p>
+      )}
+
+      {isTxSuccessful && (
+        <p className={clsx(classes.statusMessage, classes.successMessage)}>
+          <a
+            href={transactionHash ? buildEtherscanTxLink(transactionHash) : undefined}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Signature added successfully
+            {transactionHash && <img src={link} width={16} alt="link symbol" />}
+          </a>
+        </p>
+      )}
+
+      <ul className={classes.steps}>
+        <li>
+          <strong>
+            {(isGetSignatureWaiting || isSignPending) && (
+              <span className={classes.spinner}>
+                <Spinner animation="border" />
+              </span>
+            )}
+            {isGetSignatureTxSuccessful && <CheckCircle2 height={20} width={20} color="green" />}
+            {getSignatureErrorMessage && <X height={20} width={20} color="red" />}
+          </strong>
+          <Trans>Signature request</Trans>
+        </li>
+        <li>
+          <strong>
+            {(isWaiting || isLoading) && (
+              <span className={classes.spinner}>
+                <Spinner animation="border" />
+              </span>
+            )}
+            {isTxSuccessful && <CheckCircle2 height={20} width={20} color="green" />}
+            {(getSignatureErrorMessage || errorMessage) && <X height={20} width={20} color="red" />}
+            {!(
+              isWaiting ||
+              isLoading ||
+              isTxSuccessful ||
+              errorMessage ||
+              getSignatureErrorMessage
+            ) && <span className={classes.placeholder}></span>}
+          </strong>
+          <Trans>Submit signature</Trans>
+        </li>
+      </ul>
+
+      {isTxSuccessful && (
+        <button type="button" className={classes.closeButton} onClick={onClose}>
+          &times;
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/encodeProposalData.ts
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/encodeProposalData.ts
@@ -1,0 +1,47 @@
+import {
+  encodeAbiParameters,
+  encodePacked,
+  getAddress,
+  hexToBytes,
+  keccak256,
+  toBytes,
+} from 'viem';
+
+import { Address } from '@/utils/types';
+
+/**
+ * Encode the proposal payload into the EIP-712 hash layout that `addSignature` expects.
+ * Pure helper, no React state.
+ */
+export async function calcProposalEncodeData(
+  proposer: string,
+  targets: string[],
+  values: bigint[],
+  signatures: string[],
+  calldatas: `0x${string}`[],
+  description: string,
+) {
+  const signatureHashes = signatures.map((sig: string) => keccak256(toBytes(sig)));
+  const calldatasHashes = calldatas.map((calldata: `0x${string}`) =>
+    keccak256(hexToBytes(calldata)),
+  );
+
+  return encodeAbiParameters(
+    [
+      { name: 'proposer', type: 'address' },
+      { name: 'targetsHash', type: 'bytes32' },
+      { name: 'valuesHash', type: 'bytes32' },
+      { name: 'signaturesHash', type: 'bytes32' },
+      { name: 'calldatasHash', type: 'bytes32' },
+      { name: 'descriptionHash', type: 'bytes32' },
+    ],
+    [
+      getAddress(proposer),
+      keccak256(encodePacked(['address[]'], [targets.map(v => v as Address)])),
+      keccak256(encodePacked(['uint256[]'], [values])),
+      keccak256(encodePacked(['bytes32[]'], [signatureHashes])),
+      keccak256(encodePacked(['bytes32[]'], [calldatasHashes])),
+      keccak256(toBytes(description)),
+    ],
+  );
+}

--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/types.ts
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/types.ts
@@ -1,0 +1,26 @@
+export const createProposalTypes = {
+  Proposal: [
+    { name: 'proposer', type: 'address' },
+    { name: 'targets', type: 'address[]' },
+    { name: 'values', type: 'uint256[]' },
+    { name: 'signatures', type: 'string[]' },
+    { name: 'calldatas', type: 'bytes[]' },
+    { name: 'description', type: 'string' },
+    { name: 'expiry', type: 'uint256' },
+  ],
+} as const;
+
+export const updateProposalTypes = {
+  UpdateProposal: [
+    { name: 'proposalId', type: 'uint256' },
+    { name: 'proposer', type: 'address' },
+    { name: 'targets', type: 'address[]' },
+    { name: 'values', type: 'uint256[]' },
+    { name: 'signatures', type: 'string[]' },
+    { name: 'calldatas', type: 'bytes[]' },
+    { name: 'description', type: 'string' },
+    { name: 'expiry', type: 'uint256' },
+  ],
+} as const;
+
+export type TransactionState = 'None' | 'Success' | 'Mining' | 'Fail' | 'Exception';

--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/useSignatureFlow.ts
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/useSignatureFlow.ts
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 
 import dayjs from 'dayjs';
 
@@ -19,6 +19,15 @@ export function useSignatureFlow(args: {
 }) {
   const { setDataFetchPollInterval, handleRefetchCandidateData, signatureData, isSignPending } =
     args;
+  // Keep refs to the parent-supplied callbacks so the addSignatureState effect's identity stays
+  // stable across parent rerenders. Without this, callers that pass inline lambdas would trigger
+  // duplicate `Success` refetch / poll-interval resets on every parent rerender.
+  const setDataFetchPollIntervalRef = useRef(setDataFetchPollInterval);
+  const handleRefetchCandidateDataRef = useRef(handleRefetchCandidateData);
+  useEffect(() => {
+    setDataFetchPollIntervalRef.current = setDataFetchPollInterval;
+    handleRefetchCandidateDataRef.current = handleRefetchCandidateData;
+  }, [setDataFetchPollInterval, handleRefetchCandidateData]);
   const { addSignature, addSignatureState } = useAddSignature();
 
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
@@ -40,44 +49,38 @@ export function useSignatureFlow(args: {
     setGetSignatureErrorMessage('');
     setIsGetSignatureTxSuccessful(false);
     setIsOverlayVisible(false);
-    setDataFetchPollInterval(0);
-  }, [setDataFetchPollInterval]);
-
-  const handleAddSignatureState = useCallback(
-    ({ errorMessage: errMsg, status }: { errorMessage?: string; status: string }) => {
-      switch (status) {
-        case 'None':
-          setIsLoading(false);
-          setIsWaiting(false);
-          break;
-        case 'PendingSignature':
-          setIsWaiting(true);
-          break;
-        case 'Mining':
-          setIsLoading(true);
-          setIsWaiting(false);
-          setDataFetchPollInterval(50);
-          break;
-        case 'Success':
-          handleRefetchCandidateData();
-          setIsTxSuccessful(true);
-          setIsLoading(false);
-          break;
-        case 'Fail':
-        case 'Exception':
-          setDataFetchPollInterval(0);
-          setErrorMessage(errMsg);
-          setIsLoading(false);
-          setIsWaiting(false);
-          break;
-      }
-    },
-    [setDataFetchPollInterval, handleRefetchCandidateData],
-  );
+    setDataFetchPollIntervalRef.current(0);
+  }, []);
 
   useEffect(() => {
-    handleAddSignatureState(addSignatureState);
-  }, [addSignatureState, handleAddSignatureState]);
+    const { errorMessage: errMsg, status } = addSignatureState;
+    switch (status) {
+      case 'None':
+        setIsLoading(false);
+        setIsWaiting(false);
+        break;
+      case 'PendingSignature':
+        setIsWaiting(true);
+        break;
+      case 'Mining':
+        setIsLoading(true);
+        setIsWaiting(false);
+        setDataFetchPollIntervalRef.current(50);
+        break;
+      case 'Success':
+        handleRefetchCandidateDataRef.current();
+        setIsTxSuccessful(true);
+        setIsLoading(false);
+        break;
+      case 'Fail':
+      case 'Exception':
+        setDataFetchPollIntervalRef.current(0);
+        setErrorMessage(errMsg);
+        setIsLoading(false);
+        setIsWaiting(false);
+        break;
+    }
+  }, [addSignatureState]);
 
   useEffect(() => {
     if (

--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/useSignatureFlow.ts
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/useSignatureFlow.ts
@@ -1,0 +1,142 @@
+import { ReactNode, useCallback, useEffect, useState } from 'react';
+
+import dayjs from 'dayjs';
+
+import { useAddSignature } from '@/wrappers/nijiData';
+
+/**
+ * Holds the entire sign-flow state machine: waiting flags, success / error transitions,
+ * date validation, overlay visibility, and addSignature status mapping.
+ *
+ * The container only owns the typed-data signing branch (which depends on candidate / proposalId
+ * shape) and stays focused on layout.
+ */
+export function useSignatureFlow(args: {
+  setDataFetchPollInterval: (interval: number | null) => void;
+  handleRefetchCandidateData: () => void;
+  signatureData?: `0x${string}`;
+  isSignPending: boolean;
+}) {
+  const { setDataFetchPollInterval, handleRefetchCandidateData, signatureData, isSignPending } =
+    args;
+  const { addSignature, addSignatureState } = useAddSignature();
+
+  const [isOverlayVisible, setIsOverlayVisible] = useState(false);
+  const [isGetSignatureWaiting, setIsGetSignatureWaiting] = useState(false);
+  const [isGetSignatureTxSuccessful, setIsGetSignatureTxSuccessful] = useState(false);
+  const [getSignatureErrorMessage, setGetSignatureErrorMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [isWaiting, setIsWaiting] = useState(false);
+  const [isTxSuccessful, setIsTxSuccessful] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<ReactNode>('');
+  const [dateErrorMessage, setDateErrorMessage] = useState('');
+
+  const clearTransactionState = useCallback(() => {
+    setIsWaiting(false);
+    setIsLoading(false);
+    setIsTxSuccessful(false);
+    setErrorMessage('');
+    setIsGetSignatureWaiting(false);
+    setGetSignatureErrorMessage('');
+    setIsGetSignatureTxSuccessful(false);
+    setIsOverlayVisible(false);
+    setDataFetchPollInterval(0);
+  }, [setDataFetchPollInterval]);
+
+  const handleAddSignatureState = useCallback(
+    ({ errorMessage: errMsg, status }: { errorMessage?: string; status: string }) => {
+      switch (status) {
+        case 'None':
+          setIsLoading(false);
+          setIsWaiting(false);
+          break;
+        case 'PendingSignature':
+          setIsWaiting(true);
+          break;
+        case 'Mining':
+          setIsLoading(true);
+          setIsWaiting(false);
+          setDataFetchPollInterval(50);
+          break;
+        case 'Success':
+          handleRefetchCandidateData();
+          setIsTxSuccessful(true);
+          setIsLoading(false);
+          break;
+        case 'Fail':
+        case 'Exception':
+          setDataFetchPollInterval(0);
+          setErrorMessage(errMsg);
+          setIsLoading(false);
+          setIsWaiting(false);
+          break;
+      }
+    },
+    [setDataFetchPollInterval, handleRefetchCandidateData],
+  );
+
+  useEffect(() => {
+    handleAddSignatureState(addSignatureState);
+  }, [addSignatureState, handleAddSignatureState]);
+
+  useEffect(() => {
+    if (
+      isWaiting ||
+      isLoading ||
+      isTxSuccessful ||
+      errorMessage ||
+      isGetSignatureWaiting ||
+      isSignPending ||
+      isGetSignatureTxSuccessful ||
+      getSignatureErrorMessage
+    ) {
+      setIsOverlayVisible(true);
+    }
+  }, [
+    isWaiting,
+    isLoading,
+    isTxSuccessful,
+    errorMessage,
+    isGetSignatureWaiting,
+    isSignPending,
+    isGetSignatureTxSuccessful,
+    getSignatureErrorMessage,
+  ]);
+
+  useEffect(() => {
+    if (signatureData && isGetSignatureWaiting) {
+      setIsGetSignatureWaiting(false);
+      setIsGetSignatureTxSuccessful(true);
+    }
+  }, [signatureData, isGetSignatureWaiting]);
+
+  const validateExpirationDate = useCallback((expirationDate: number | undefined) => {
+    if (expirationDate === undefined) return;
+    const today = new Date();
+    if (+dayjs(expirationDate) > +dayjs(today) / 1000) {
+      setDateErrorMessage('');
+    } else {
+      setDateErrorMessage('Date must be in the future');
+    }
+  }, []);
+
+  return {
+    addSignature,
+    addSignatureState,
+    isOverlayVisible,
+    isGetSignatureWaiting,
+    setIsGetSignatureWaiting,
+    isGetSignatureTxSuccessful,
+    setIsGetSignatureTxSuccessful,
+    getSignatureErrorMessage,
+    setGetSignatureErrorMessage,
+    isLoading,
+    isWaiting,
+    setIsWaiting,
+    isTxSuccessful,
+    errorMessage,
+    dateErrorMessage,
+    validateExpirationDate,
+    clearTransactionState,
+  };
+}


### PR DESCRIPTION
# 概要

`CandidateSponsors/SignatureForm.tsx` (486 行) を container + 5 sub-file に分割しました。
Issue #256 の 4 件目 (最後) の分割対象で、 これで大コンポーネント分割 epic が完結します。
画面表示や EIP-712 sign フローは一切変えていません。

# 課題

`SignatureForm.tsx` は以下を 1 file に詰め込み 486 行になっていました。

- EIP-712 typed data 定義 (`createProposalTypes` / `updateProposalTypes`)
- proposal payload を hash layout に encode する `calcProposalEncodeData` 関数
- 8 個の state + 5 個の useEffect (overlay 表示 / addSignature 状態遷移 / 日付 validation / 等)
- typed data sign 呼び出し
- form fields (textarea + date + button)
- status overlay (loading / success / error / 2-step indicator)

state machine が container 全体に散らばっており、 sign flow と form rendering の境界が曖昧でした。

# 詳細

分割の方針。

```mermaid
graph LR
    A[SignatureForm.tsx 486 行] --> B[container 174 行]
    A --> C[useSignatureFlow 141 行 state machine hook]
    A --> D[SignatureFormFields 74 行 textarea + date + button]
    A --> E[SignatureStatusOverlay 134 行 2-step overlay]
    A --> F[encodeProposalData 38 行 pure helper]
    A --> G[types 26 行 EIP-712 + TransactionState]
```

state machine を `useSignatureFlow` に集約することで container は「typed data sign の呼び出し」 と「結果を hook に伝える」 ことに専念できるようになりました。

# 解決方法

各 file の責務。

| ファイル | 行数 | 責務 |
|---|---|---|
| `SignatureForm.tsx` (container) | 174 | typed data sign の呼び出し / hook 接続 / 配置 |
| `signature/useSignatureFlow.ts` | 141 | state machine (waiting / loading / success / error) + addSignature status 遷移 + 日付 validation + overlay 表示 |
| `signature/SignatureFormFields.tsx` | 74 | textarea + date input + sign button |
| `signature/SignatureStatusOverlay.tsx` | 134 | 2-step progress overlay (signature request → submit) + 成功 / エラー表示 + close button |
| `signature/encodeProposalData.ts` | 38 | proposal payload を EIP-712 hash layout に encode する pure helper |
| `signature/types.ts` | 26 | `createProposalTypes` / `updateProposalTypes` (EIP-712 typed data) + `TransactionState` type |

`useSignatureFlow` hook は外向き API として state 値 + setter + helper (`validateExpirationDate` / `clearTransactionState`) を返し、 container 側はそれを spread 風に展開して sub-component に渡すだけになっています。

# 仕組み

```mermaid
graph LR
    A[container SignatureForm] --> B[useSignatureFlow state machine]
    A --> C[useSignTypedData wagmi]
    A --> D[SignatureFormFields rendering]
    A --> E[SignatureStatusOverlay rendering]
    D --> F[onSign trigger]
    F --> G[typed data sign + encode + addSignature]
    G --> H[state machine 遷移 None → PendingSignature → Mining → Success/Fail]
    H --> E
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.tsx` | 486 行 → 174 行 (container 専念) |
| `packages/niji-webapp/src/components/CandidateSponsors/signature/useSignatureFlow.ts` | 新規。 sign flow state machine 全体 (8 state + 5 effect) |
| `packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureFormFields.tsx` | 新規。 textarea + date input + sign button |
| `packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx` | 新規。 2-step progress overlay |
| `packages/niji-webapp/src/components/CandidateSponsors/signature/encodeProposalData.ts` | 新規。 pure helper |
| `packages/niji-webapp/src/components/CandidateSponsors/signature/types.ts` | 新規。 EIP-712 type 定義 + TransactionState |

# テストと確認

- [x] `pnpm tsc --noEmit` 通過
- [x] `pnpm test --run` 30 件 pass + 1 skipped + 1 todo (regression なし)
- [x] 全 file が 200 行以下を達成 (container 174 / hook 141 / Fields 74 / Overlay 134 / Encode 38 / Types 26)

レビューで見てほしいところ。

`useSignatureFlow` hook が 17 個の外向き値 (state / setter / helper) を返している点をご確認ください。
container と sub-component の境界で必要な値が多いため、 個別 hook 経由の単方向 prop passing になっています。
別案 (context provider 導入 / reducer 化) もありますが、 本 PR は分割のみ scope で挙動変更を避けるため hook の戻り値 spread に留めています。

# Issue #256 完結

本 PR で Issue #256 の 4 件すべてが完了します。

- ✅ PR #257 `Documentation/index.tsx` 423 → 5 file (60 行 container)
- ✅ PR #258 `VoteSignals/VoteSignals.tsx` 375 → 5 file (191 行 container)
- ✅ PR #259 `CandidateSponsors/index.tsx` 381 → 5 file (157 行 container)
- ✅ PR (本) `CandidateSponsors/SignatureForm.tsx` 486 → 6 file (174 行 container)

# 関連

Closes #256
