### PR TITLE
📏 feat(niji-contracts): mintBatch に上限 50 を設定 (Issue #32)

### DIFF
--- a/packages/niji-contracts/contracts/NijiToken.sol
+++ b/packages/niji-contracts/contracts/NijiToken.sol
@@ -72,6 +72,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @notice Thrown when mint is attempted before the placeholder URI is set (pre-reveal mint safety)
     error PlaceholderURINotSet();
 
+    /// @notice Thrown when mintBatch quantity exceeds the per-call upper bound (gas safety)
+    error MintBatchQuantityExceedsLimit(uint256 requested, uint256 limit);
+
     /// @notice Thrown when baseURI is modified after being locked
     error BaseURIIsLocked();
 
@@ -137,6 +140,11 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     // =============================================================
     //                           STORAGE
     // =============================================================
+
+    /// @notice Maximum number of tokens allowed in a single mintBatch call (gas-safety cap)
+    /// @dev Hard-coded constant since per-batch gas usage scales roughly linearly with the count;
+    ///      50 keeps the call well below typical block gas limits even with on-chain seed generation.
+    uint256 public constant MAX_MINT_BATCH_SIZE = 50;
 
     /// @notice The Niji descriptor contract for generating tokenURI
     NijiDescriptor public descriptor;
@@ -266,6 +274,9 @@ contract NijiToken is ERC721Enumerable, ERC721Votes, Ownable2Step, ReentrancyGua
     /// @return tokenIds Array of minted token IDs
     function mintBatch(address to, uint256 quantity) external onlyMinter nonReentrant returns (uint256[] memory) {
         if (!isMintingActive) revert MintingNotActive();
+        if (quantity > MAX_MINT_BATCH_SIZE) {
+            revert MintBatchQuantityExceedsLimit(quantity, MAX_MINT_BATCH_SIZE);
+        }
         if (maxSupply > 0 && _currentTokenId + quantity > maxSupply) revert MaxSupplyReached();
 
         uint256[] memory tokenIds = new uint256[](quantity);

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -157,6 +157,30 @@ describe('NijiToken', () => {
       await token.mintBatch(other.address, 3);
       expect(await token.balanceOf(other.address)).to.equal(3);
     });
+
+    it('should expose MAX_MINT_BATCH_SIZE = 50', async () => {
+      expect(await token.MAX_MINT_BATCH_SIZE()).to.equal(50);
+    });
+
+    it('should allow mintBatch at the upper bound (quantity = 50)', async () => {
+      // Use an unlimited-supply token so the 50-mint batch can run without hitting maxSupply.
+      const unlimited = await deployNijiToken(
+        'Niji',
+        'NIJI',
+        await descriptor.getAddress(),
+        await seeder.getAddress(),
+        0,
+      );
+      await unlimited.toggleMinting();
+      await unlimited.mintBatch(other.address, 50);
+      expect(await unlimited.balanceOf(other.address)).to.equal(50);
+    });
+
+    it('should revert mintBatch when quantity exceeds MAX_MINT_BATCH_SIZE', async () => {
+      await expect(token.mintBatch(other.address, 51))
+        .to.be.revertedWithCustomError(token, 'MintBatchQuantityExceedsLimit')
+        .withArgs(51, 50);
+    });
   });
 
   describe('tokenURI', () => {

--- a/packages/niji-contracts/test/niji/NijiToken.test.ts
+++ b/packages/niji-contracts/test/niji/NijiToken.test.ts
@@ -162,7 +162,7 @@ describe('NijiToken', () => {
       expect(await token.MAX_MINT_BATCH_SIZE()).to.equal(50);
     });
 
-    it('should allow mintBatch at the upper bound (quantity = 50)', async () => {
+    it('should allow mintBatch at the upper bound (quantity = 50) within mainnet block gas limit (≤30M)', async () => {
       // Use an unlimited-supply token so the 50-mint batch can run without hitting maxSupply.
       const unlimited = await deployNijiToken(
         'Niji',
@@ -172,7 +172,14 @@ describe('NijiToken', () => {
         0,
       );
       await unlimited.toggleMinting();
-      await unlimited.mintBatch(other.address, 50);
+
+      const tx = await unlimited.mintBatch(other.address, 50);
+      const receipt = await tx.wait();
+      expect(receipt).to.not.be.null;
+      // Mainnet's block gas limit is ~30M. Assert the 50-mint batch fits well under that bound
+      // (test net Hardhat's 300M block limit hides regression by default; this guard surfaces it).
+      const MAINNET_BLOCK_GAS_LIMIT = 30_000_000n;
+      expect(receipt!.gasUsed).to.be.lessThan(MAINNET_BLOCK_GAS_LIMIT);
       expect(await unlimited.balanceOf(other.address)).to.equal(50);
     });
 


### PR DESCRIPTION
# 概要

NijiToken の `mintBatch` に 1 回あたりの上限 50 を設定しました。
on-chain seed 生成と SSTORE2 image lookup を伴う関数のため、 1 batch あたりのガス消費が線形に増加します。 50 個までに制限することで、 通常の block gas limit 内に確実に収まる設計にします。
既存の auction house は 1 mint 単位なので、 本変更の影響を受けるのは `mintBatch` を直接叩く運用者のみです。

# 課題

これまでの `mintBatch(address to, uint256 quantity)` は `quantity` に上限がなく、 攻撃者または運用者が誤って 1000+ を指定すると以下が起こりえました。

- 1 transaction が block gas limit を超えて常時 revert する状態 (実害は revert で済む)
- 中途半端な数まで mint が進んで state が壊れる risk (今回は `_currentTokenId` を `unchecked` で増やしているため worst case でも整合は保たれるが、 future change で壊れる risk が残る)
- gas 見積もり時の RPC が timeout する操作ミス

数値の決定根拠を contract docstring に書き残し、 将来「なぜ 50 なのか」 が消失しないようにしています。

# 詳細

`mintBatch` の本処理は `_mintTo` 経由で seed 生成 (NijiSeeder の keccak ベース乱数) + storage write (`seeds[tokenId] = seed`) + `_mint` (ERC721Enumerable / ERC721Votes の hook) を毎件実行します。 1 件あたり概ね 200-300k gas、 50 件で約 10-15M gas 程度を想定し、 30M block gas limit に対して半分以下を確保します。

```mermaid
graph LR
    A[mintBatch quantity] --> B{quantity > MAX_MINT_BATCH_SIZE?}
    B -->|yes| C[MintBatchQuantityExceedsLimit revert]
    B -->|no| D{minting active && supply ok?}
    D -->|no| E[既存 revert]
    D -->|yes| F[1 件ずつ _mintTo 実行]
```

# 解決方法

- `MAX_MINT_BATCH_SIZE = 50` を `public constant` で公開 (off-chain から read 可能、 dApp 側で UI 制限を出せる)
- `mintBatch` 冒頭で `quantity > MAX_MINT_BATCH_SIZE` を検査し `MintBatchQuantityExceedsLimit(requested, limit)` で revert
- error は requested と limit の両方を payload に含めて off-chain 側でユーザー向け表示を組み立てやすくしている

# 仕組み

```mermaid
graph LR
    A[caller] --> B[mintBatch to, quantity]
    B --> C[quantity 上限チェック]
    C --> D[既存の minting active + supply check]
    D --> E[for ループで _mintTo]
    E --> F[tokenIds 返却]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/contracts/NijiToken.sol` | `MAX_MINT_BATCH_SIZE` public constant 追加、 `MintBatchQuantityExceedsLimit(uint256 requested, uint256 limit)` error 追加、 `mintBatch` 冒頭に上限ガード |
| `packages/niji-contracts/test/niji/NijiToken.test.ts` | 3 件追加 (定数値 50 の確認 / 50 件 mint が成功する / 51 件で revert) |

# テストと確認

- [x] `pnpm hardhat test test/niji/NijiToken.test.ts` 118 件全 pass (mintBatch 3 件新規 + 既存 115 件)
- [x] `pnpm hardhat test` 全 318 件 pass (regression なし)
- [x] 50 件 mintBatch の実 gas を確認 (test 中の 50 件 mint が問題なく完了)

レビューで見てほしいところ。

上限値 50 の妥当性をご確認ください。
現状の `_mintTo` 1 件あたり概ね 200-300k gas で、 50 件で 10-15M gas 程度。 30M block gas limit (mainnet) / 300M (hardhat local) のいずれにも収まる安全マージンとしての 50 です。
auction house が 1 mint 単位で動く現運用では本変更の影響は 0、 mintBatch を直接叩く運用 (テストネット / 検証 deploy) のみが影響範囲です。

# 関連

Closes #32
