### PR TITLE
📝 feat(niji-contracts): deploy snapshot を deployments/<network>.json に固定 path 出力 (Issue #40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ i18n.cache
 # niji deploy artifacts (deploy log JSON kept selectively, but render PNG / SVG / metadata are large)
 packages/niji-contracts/deploy/
 
+# deployments snapshots: keep mainnet / sepolia / base-sepolia tracked, ignore local dev snapshots
+packages/niji-contracts/deployments/localhost.json
+packages/niji-contracts/deployments/hardhat.json
+
 # generated test outputs / playwright traces / forge artifacts
 packages/niji-assets/test_output/
 packages/niji-webapp/test-results/

--- a/packages/niji-contracts/tasks/deploy-niji-full.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-full.ts
@@ -493,18 +493,27 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
     // Persist the latest addresses under deployments/<network>.json so downstream tools
     // (SDK / webapp / scripts) can read a stable path without scanning timestamped log files.
     // The timestamped log above is kept as the auditable history; this file is the latest snapshot.
-    const deploymentsDir = path.join(__dirname, '../deployments');
-    fs.mkdirSync(deploymentsDir, { recursive: true });
-    const latestPath = path.join(deploymentsDir, `${network.name}.json`);
-    const latestPayload = {
-      network: deployLog.network,
-      chainId: deployLog.chainId,
-      timestamp: deployLog.timestamp,
-      deployer: deployLog.deployer,
-      contracts: deployLog.contracts,
-    };
-    fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
-    console.log(`📝 Deployments snapshot: ${latestPath}`);
+    //
+    // Skip snapshot emission for partial deploys (--skipToken etc.) — otherwise the stable
+    // path could be overwritten with null/incomplete addresses on tracked networks
+    // (sepolia / base-sepolia / mainnet).
+    if (args.skipToken) {
+      console.log('\n⚠️  Skipping deployments/<network>.json snapshot (--skipToken partial run)');
+    } else {
+      const deploymentsDir = path.join(__dirname, '../deployments');
+      fs.mkdirSync(deploymentsDir, { recursive: true });
+      const latestPath = path.join(deploymentsDir, `${network.name}.json`);
+      const latestPayload = {
+        profile: 'full' as const,
+        network: deployLog.network,
+        chainId: deployLog.chainId,
+        timestamp: deployLog.timestamp,
+        deployer: deployLog.deployer,
+        contracts: deployLog.contracts,
+      };
+      fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
+      console.log(`📝 Deployments snapshot: ${latestPath}`);
+    }
 
     // chainId 31337 (anvil / hardhat) のときだけ SDK gen.ts の 31337 entry を実 deploy
     // address に書き換える。 wagmi.config.ts は mainnet/sepolia のみを宣言しており

--- a/packages/niji-contracts/tasks/deploy-niji-full.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-full.ts
@@ -490,6 +490,22 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
     fs.writeFileSync(logPath, JSON.stringify(deployLog, null, 2));
     console.log(`\n📝 Deploy log: ${logPath}`);
 
+    // Persist the latest addresses under deployments/<network>.json so downstream tools
+    // (SDK / webapp / scripts) can read a stable path without scanning timestamped log files.
+    // The timestamped log above is kept as the auditable history; this file is the latest snapshot.
+    const deploymentsDir = path.join(__dirname, '../deployments');
+    fs.mkdirSync(deploymentsDir, { recursive: true });
+    const latestPath = path.join(deploymentsDir, `${network.name}.json`);
+    const latestPayload = {
+      network: deployLog.network,
+      chainId: deployLog.chainId,
+      timestamp: deployLog.timestamp,
+      deployer: deployLog.deployer,
+      contracts: deployLog.contracts,
+    };
+    fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
+    console.log(`📝 Deployments snapshot: ${latestPath}`);
+
     // chainId 31337 (anvil / hardhat) のときだけ SDK gen.ts の 31337 entry を実 deploy
     // address に書き換える。 wagmi.config.ts は mainnet/sepolia のみを宣言しており
     // 31337 は test 用 patch entry のため、 deploy 結果と drift しないよう毎回同期する。

--- a/packages/niji-contracts/tasks/deploy-niji-smoke.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-smoke.ts
@@ -283,13 +283,18 @@ task('deploy-niji-smoke', 'Deploy Niji stack + 36 sample PNGs + mint 1 token (P6
 
     // Persist the latest contract addresses under deployments/<network>.json so downstream tools
     // (SDK / webapp / scripts) can read a stable path without scanning timestamped log files.
+    // smoke does not deploy auction / WETH, so the `profile` discriminator lets consumers tell
+    // which task produced the snapshot.
     const deploymentsDir = path.join(__dirname, '../deployments');
     if (!fs.existsSync(deploymentsDir)) fs.mkdirSync(deploymentsDir, { recursive: true });
     const latestPath = path.join(deploymentsDir, `${network.name}.json`);
     const latestPayload = {
+      profile: 'smoke' as const,
       network: deployLog.network,
       chainId: Number((await ethers.provider.getNetwork()).chainId),
-      timestamp: deployLog.timestamp,
+      // Use canonical raw ISO timestamp (deploy-niji-full uses the same format) instead of the
+      // filename-safe variant from `deployLog.timestamp`, so consumers can parse a single format.
+      timestamp: new Date().toISOString(),
       deployer: deployLog.deployer,
       contracts: deployLog.contracts,
     };

--- a/packages/niji-contracts/tasks/deploy-niji-smoke.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-smoke.ts
@@ -281,5 +281,20 @@ task('deploy-niji-smoke', 'Deploy Niji stack + 36 sample PNGs + mint 1 token (P6
     fs.writeFileSync(logPath, JSON.stringify(deployLog, null, 2));
     console.log(`\n[11] deploy log: ${logPath}`);
 
+    // Persist the latest contract addresses under deployments/<network>.json so downstream tools
+    // (SDK / webapp / scripts) can read a stable path without scanning timestamped log files.
+    const deploymentsDir = path.join(__dirname, '../deployments');
+    if (!fs.existsSync(deploymentsDir)) fs.mkdirSync(deploymentsDir, { recursive: true });
+    const latestPath = path.join(deploymentsDir, `${network.name}.json`);
+    const latestPayload = {
+      network: deployLog.network,
+      chainId: Number((await ethers.provider.getNetwork()).chainId),
+      timestamp: deployLog.timestamp,
+      deployer: deployLog.deployer,
+      contracts: deployLog.contracts,
+    };
+    fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
+    console.log(`[11] deployments snapshot: ${latestPath}`);
+
     console.log('\n=== SMOKE DEPLOY OK ===');
   });


### PR DESCRIPTION
# 概要

`deploy-niji-full.ts` と `deploy-niji-smoke.ts` の最後で `deployments/<network>.json` という固定 path に最新 deploy 結果のサマリーを書き出すようにしました。
これまでの `deploy/<network>-<timestamp>-*.json` (audit log) はそのまま残しつつ、 SDK / webapp / scripts が「最新の contract address」 を読みに行くときに timestamp スキャン不要で安定 path で参照できます。
mainnet / sepolia / base-sepolia の snapshot は git tracked にして team 共有、 localhost / hardhat の snapshot は dev local 専用で gitignore します。

# 課題

これまでの deploy script は `deploy/<network>-<timestamp>-{smoke,full}.json` 形式の timestamp 付きファイルを書き出すだけで、 downstream の利用者が「最新の deploy 結果」 を読むためには deploy/ ディレクトリ全件を `ls -t | head -1` する必要がありました。

- SDK の address 同期スクリプトが timestamp スキャンに依存
- mainnet / sepolia の正規 address を team 内で共有する仕組みがない (audit log は local 専用で git ignored)
- CI なしで運用しているため、 deploy 後に手動で address を貼り直す手順が消耗

# 詳細

audit log と latest snapshot を 2 系統に分ける設計。

```mermaid
graph LR
    A[deploy 実行] --> B[deploy/<network>-<ts>-full.json]
    A --> C[deployments/<network>.json]
    B --> D[audit log 履歴 git ignored]
    C --> E{network?}
    E -->|mainnet/sepolia| F[git tracked、 team 共有]
    E -->|localhost/hardhat| G[git ignored、 dev local]
```

# 解決方法

両 deploy task の末尾に snapshot 書き出しを追加。

```ts
const deploymentsDir = path.join(__dirname, '../deployments');
fs.mkdirSync(deploymentsDir, { recursive: true });
const latestPath = path.join(deploymentsDir, `${network.name}.json`);
const latestPayload = {
  network,
  chainId,
  timestamp,
  deployer,
  contracts: { NijiArt, NijiDescriptor, NijiSeeder, NijiToken, ...(full なら auction + WETH) },
};
fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
```

`.gitignore` で `deployments/localhost.json` と `deployments/hardhat.json` のみ ignore、 他 network (mainnet / sepolia / base-sepolia) の snapshot は default で git tracked になる構成。

# 仕組み

```mermaid
graph LR
    A[deploy 完了直前] --> B[既存 audit log 出力]
    B --> C[新 snapshot 出力]
    C --> D[deployments dir mkdirSync]
    D --> E[<network>.json 上書き]
    E --> F[SDK / webapp が固定 path で読み取り可能]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/tasks/deploy-niji-full.ts` | 既存 deploy log 出力の直後に snapshot 出力を追加 |
| `packages/niji-contracts/tasks/deploy-niji-smoke.ts` | 同上 (chainId は network から動的取得) |
| `.gitignore` | `deployments/localhost.json` と `deployments/hardhat.json` を ignore に追加 (他 network snapshot は tracked) |

# テストと確認

- [x] `pnpm hardhat deploy-niji-smoke --network localhost` で `deployments/localhost.json` が生成される
- [x] snapshot 内容に network / chainId / timestamp / deployer / contracts が含まれる
- [x] `pnpm hardhat test` 全 326 件 pass (regression なし)
- [x] `.gitignore` で localhost / hardhat 用 snapshot が ignore される確認

レビューで見てほしいところ。

`.gitignore` の network 別 ignore 列挙が静的なため、 将来 chain を追加した時に「dev local 用 snapshot を tracked に commit してしまう」 mistake のリスクがあります。
代替案 (例 `deployments/*.local.json` 命名規約) もありますが、 既存 hardhat の `network.name` が `localhost` / `hardhat` で確定しているため、 固定列挙の方が運用上シンプルと判断しました。

# 関連

Closes #40
