### PR TITLE
✅ feat(niji-contracts): verify-niji task で snapshot 一括 Etherscan verify (Issue #39)

### DIFF
--- a/packages/niji-contracts/tasks/deploy-niji-full.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-full.ts
@@ -468,6 +468,20 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
     console.log(`║ ETH Spent:      ${ethers.formatEther(balance - balanceAfter)} ETH`);
     console.log('╚═══════════════════════════════════════════════════════════════╝');
 
+    // Constructor args captured per contract so the verify-niji task can reconstruct the
+    // arguments needed by hardhat-verify / Etherscan API. Includes only contracts whose
+    // verification we automate (NijiArt / Descriptor / Seeder / Token + AuctionHouse pair).
+    // null for contracts that were not deployed in this run (e.g. token skipped via --skipToken,
+    // auction skipped for non-localhost networks).
+    const constructorArgs: Record<string, unknown[] | null> = {
+      NijiArt: [deployer.address, TRAIT_DIRS.map(t => t.name)],
+      NijiDescriptor: [artAddr, RESOLUTION, COMPOSITE_ORDER],
+      NijiSeeder: [artAddr],
+      NijiToken: tokenAddrFinal ? ['Niji', 'NIJI', descAddrFinal, seederAddr, MAX_SUPPLY] : null,
+      NijiAuctionHouseProxy: null, // proxy uses initialize data, not constructor; verify separately
+      WETH: wethAddr ? [] : null,
+    };
+
     // Persist deploy log JSON for downstream sdk address sync
     const deployLog = {
       timestamp: new Date().toISOString(),
@@ -482,6 +496,7 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
         NijiAuctionHouseProxy: auctionProxyAddr,
         WETH: wethAddr,
       },
+      constructorArgs,
     };
     const deployLogDir = path.join(__dirname, '../deploy');
     fs.mkdirSync(deployLogDir, { recursive: true });
@@ -510,6 +525,7 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
         timestamp: deployLog.timestamp,
         deployer: deployLog.deployer,
         contracts: deployLog.contracts,
+        constructorArgs: deployLog.constructorArgs,
       };
       fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
       console.log(`📝 Deployments snapshot: ${latestPath}`);

--- a/packages/niji-contracts/tasks/deploy-niji-smoke.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-smoke.ts
@@ -297,6 +297,13 @@ task('deploy-niji-smoke', 'Deploy Niji stack + 36 sample PNGs + mint 1 token (P6
       timestamp: new Date().toISOString(),
       deployer: deployLog.deployer,
       contracts: deployLog.contracts,
+      // Constructor args captured per contract so verify-niji can reconstruct them.
+      constructorArgs: {
+        NijiArt: [deployer.address, NIJI_TRAITS.map(t => t.name)],
+        NijiDescriptor: [artAddr, NIJI_RESOLUTION, NIJI_COMPOSITE_ORDER],
+        NijiSeeder: [artAddr],
+        NijiToken: ['Niji', 'NIJI', descriptorAddr, seederAddr, 0],
+      } as Record<string, unknown[]>,
     };
     fs.writeFileSync(latestPath, JSON.stringify(latestPayload, null, 2) + '\n');
     console.log(`[11] deployments snapshot: ${latestPath}`);

--- a/packages/niji-contracts/tasks/index.ts
+++ b/packages/niji-contracts/tasks/index.ts
@@ -2,6 +2,7 @@ export * from './accounts';
 export * from './create-proposal';
 export * from './descriptor-art-to-console';
 export * from './verify-etherscan-dao-v3';
+export * from './verify-niji';
 export * from './deploy-niji-base-sepolia';
 export * from './deploy-niji-full';
 export * from './deploy-niji-smoke';

--- a/packages/niji-contracts/tasks/verify-niji.ts
+++ b/packages/niji-contracts/tasks/verify-niji.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { task } from 'hardhat/config';
+
+interface DeploymentsSnapshot {
+  profile: 'full' | 'smoke';
+  network: string;
+  chainId: number;
+  timestamp: string;
+  deployer: string;
+  contracts: Record<string, string | null | undefined>;
+  constructorArgs?: Record<string, unknown[] | null>;
+}
+
+// Some contracts share bytecode with their dependencies, so hardhat-verify needs the
+// fully-qualified contract path to disambiguate.
+const FULLY_QUALIFIED_NAMES: Record<string, string> = {
+  NijiArt: 'contracts/NijiArt.sol:NijiArt',
+  NijiDescriptor: 'contracts/NijiDescriptor.sol:NijiDescriptor',
+  NijiSeeder: 'contracts/NijiSeeder.sol:NijiSeeder',
+  NijiToken: 'contracts/NijiToken.sol:NijiToken',
+  WETH: 'contracts/test/WETH.sol:WETH',
+};
+
+task('verify-niji', 'Verify Niji contracts on Etherscan from a deployments/<network>.json snapshot')
+  .addOptionalParam(
+    'snapshot',
+    'Path to a deployments snapshot JSON (defaults to deployments/<network>.json)',
+  )
+  .setAction(async ({ snapshot }: { snapshot?: string }, hre) => {
+    const network = hre.network.name;
+    const defaultPath = path.join(__dirname, '..', 'deployments', `${network}.json`);
+    const snapshotPath = snapshot ?? defaultPath;
+
+    if (!fs.existsSync(snapshotPath)) {
+      throw new Error(
+        `Snapshot not found at ${snapshotPath}. Run deploy-niji-full / deploy-niji-smoke first ` +
+          `or pass --snapshot <path>.`,
+      );
+    }
+
+    const raw = fs.readFileSync(snapshotPath, 'utf8');
+    const data = JSON.parse(raw) as DeploymentsSnapshot;
+    console.log(`📂 Snapshot: ${snapshotPath}`);
+    console.log(`   profile=${data.profile} network=${data.network} chainId=${data.chainId}`);
+
+    const targets: { name: string; address: string; args: unknown[] }[] = [];
+    for (const [name, address] of Object.entries(data.contracts)) {
+      if (!address) continue;
+      // Skip the auction proxy — it uses initialize calldata, not a constructor; verify it
+      // separately via the legacy verify-etherscan-dao-v3 task if needed.
+      if (name === 'NijiAuctionHouseProxy') continue;
+      const args = data.constructorArgs?.[name];
+      if (!args) {
+        console.log(`⚠️  Skip ${name} (no constructorArgs in snapshot)`);
+        continue;
+      }
+      targets.push({ name, address, args });
+    }
+
+    console.log(`\n🔍 Verifying ${targets.length} contract(s)...\n`);
+
+    let okCount = 0;
+    let skipCount = 0;
+    let failCount = 0;
+    for (const { name, address, args } of targets) {
+      try {
+        console.log(`→ ${name.padEnd(16)} ${address}`);
+        await hre.run('verify:verify', {
+          address,
+          constructorArguments: args,
+          contract: FULLY_QUALIFIED_NAMES[name],
+        });
+        okCount += 1;
+        console.log(`  ✓ verified`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes('Already Verified') || message.includes('already verified')) {
+          skipCount += 1;
+          console.log(`  ↷ already verified (skip)`);
+          continue;
+        }
+        failCount += 1;
+        console.error(`  ✗ ${message}`);
+      }
+    }
+
+    console.log(`\n=== verify-niji: ok=${okCount} skipped=${skipCount} failed=${failCount} ===`);
+    if (failCount > 0) {
+      throw new Error(`${failCount} verification(s) failed`);
+    }
+  });


### PR DESCRIPTION
# 概要

新規 hardhat task `verify-niji` を追加し、 `deployments/<network>.json` snapshot から一括で Etherscan 検証を実行できるようにしました。
PR #263 (Issue #40) で導入した snapshot 経路と組み合わせて、 deploy 直後の検証作業がワンコマンドで完結します。
deploy script 側に `constructorArgs` を snapshot に書き出す処理を追加し、 verify task が address と一緒にコンストラクタ引数を読み取れる形にしてあります。

# 課題

これまでの Etherscan 検証は contract 1 件ずつ `hardhat verify` を手で叩く必要があり、 deploy 直後に 4-6 contract を順に検証する手順がエラーの温床でした。

- 各 contract のコンストラクタ引数 (NijiArt なら traitNames 配列、 NijiDescriptor なら resolution + compositeOrder 等) を手元で組み立て直す必要があった
- 失敗した時の「これだけ verify、 残りはまた」 のリトライ運用が地味に手間
- 既存 `verify-etherscan-dao-v3` は DAO v3 専用、 Niji 基本 contract には未対応

# 詳細

snapshot に `constructorArgs` を追加することで、 verify task は snapshot 1 ファイルだけ読めば 4 contract をすべて検証できます。

```mermaid
graph LR
    A[deploy-niji-full / smoke] --> B[deployments network json snapshot]
    B --> C[contracts: address 一覧]
    B --> D[constructorArgs: 各 contract 引数]
    A2[verify-niji task] --> E[snapshot 読み込み]
    E --> F[各 contract を hardhat verify に渡す]
    F --> G[ok / already verified / failed カウント]
```

# 解決方法

3 つの実装を追加。

1. **`tasks/verify-niji.ts` 新規** ... `--snapshot <path>` でカスタム JSON も指定可能、 default は `deployments/<network>.json`。 `Already Verified` は skip、 失敗は最終的に exit 1。
2. **`deploy-niji-full.ts` 改修** ... snapshot 出力に `constructorArgs` field を追加 (NijiArt / Descriptor / Seeder / Token 各引数を文字列 / 配列で保存)。 token が deploy されなかった場合は `null` で skip 可能。
3. **`deploy-niji-smoke.ts` 改修** ... 同様に constructorArgs を snapshot に追加。

`NijiAuctionHouseProxy` は constructor ではなく initialize calldata で初期化されるため、 verify-niji 内で skip し、 必要なら既存 `verify-etherscan-dao-v3` task を別途使う前提です。

# 仕組み

```mermaid
graph LR
    A[snapshot 読込] --> B[各 contract を loop]
    B --> C{constructorArgs ある?}
    C -->|no| D[warn 表示で skip]
    C -->|yes| E[hardhat verify verify]
    E --> F{Already Verified?}
    F -->|yes| G[↷ skip count++]
    F -->|no| H[ok count++ or fail count++]
    B --> I[loop 終了 → 集計表示]
    I --> J{failed 0?}
    J -->|no| K[exit 1]
    J -->|yes| L[exit 0]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/tasks/verify-niji.ts` | 新規。 snapshot から一括 Etherscan verify。 fully-qualified contract path / Already Verified skip / 集計 / exit code |
| `packages/niji-contracts/tasks/index.ts` | `verify-niji` を export |
| `packages/niji-contracts/tasks/deploy-niji-full.ts` | snapshot に `constructorArgs` field を追加 |
| `packages/niji-contracts/tasks/deploy-niji-smoke.ts` | 同上 |

使用例。

```sh
# deploy 直後 (Base Sepolia)
pnpm hardhat deploy-niji-full --network baseSepolia
pnpm hardhat verify-niji --network baseSepolia
# カスタム snapshot を指定したい場合
pnpm hardhat verify-niji --network baseSepolia --snapshot ./other-snapshot.json
```

# テストと確認

- [x] `pnpm hardhat compile` 通過
- [x] `pnpm hardhat help verify-niji` で task 認識確認
- [x] `pnpm hardhat deploy-niji-smoke --network localhost` で snapshot に `constructorArgs` が含まれることを確認
- [x] `pnpm hardhat verify-niji --network localhost` で snapshot 読込 → 各 contract に対して `verify:verify` が呼ばれることを確認 (anvil は etherscan 未対応のため期待通り 4 件 fail で task としては正常起動)
- [x] `pnpm hardhat test` 全 326 件 pass (regression なし)

レビューで見てほしいところ。

snapshot の `constructorArgs` を JSON で素直に書き出している点 (BigInt → number / address → string 等の型扱い) をご確認ください。
NijiToken の maxSupply は smoke で `0`、 full で `MAX_SUPPLY` (int) なので JSON.stringify でそのまま number になります。 `BigInt` を含む場合は serialization が必要ですが、 現在は number / string / array のみで serialization 問題は発生していません。

# 関連

Closes #39
- PR #263 (Issue #40 deploy snapshot) と pair で運用ツール整備が完成
