### PR TITLE
🔄 feat(niji-contracts): transfer-ownership-niji task で multisig 移譲を自動化 (Issue #41)

### DIFF
--- a/packages/niji-contracts/tasks/index.ts
+++ b/packages/niji-contracts/tasks/index.ts
@@ -3,6 +3,7 @@ export * from './create-proposal';
 export * from './descriptor-art-to-console';
 export * from './verify-etherscan-dao-v3';
 export * from './verify-niji';
+export * from './transfer-ownership-niji';
 export * from './deploy-niji-base-sepolia';
 export * from './deploy-niji-full';
 export * from './deploy-niji-smoke';

--- a/packages/niji-contracts/tasks/transfer-ownership-niji.ts
+++ b/packages/niji-contracts/tasks/transfer-ownership-niji.ts
@@ -1,0 +1,122 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { task } from 'hardhat/config';
+import { isAddress } from 'viem';
+
+interface DeploymentsSnapshot {
+  profile: 'full' | 'smoke';
+  network: string;
+  chainId: number;
+  timestamp: string;
+  deployer: string;
+  contracts: Record<string, string | null | undefined>;
+}
+
+// Contracts that follow the Ownable2Step pattern and should be transferred together when
+// rotating ownership to a multisig. The auction-house proxy intentionally uses a separate
+// owner / proxy-admin split; rotate it via the existing governance-side workflow if needed.
+const OWNED_CONTRACTS = [
+  { name: 'NijiArt', factory: 'NijiArt' },
+  { name: 'NijiDescriptor', factory: 'NijiDescriptor' },
+  { name: 'NijiSeeder', factory: 'NijiSeeder' },
+  { name: 'NijiToken', factory: 'NijiToken' },
+] as const;
+
+task(
+  'transfer-ownership-niji',
+  'Transfer Ownable2Step ownership of NijiArt / Descriptor / Seeder / Token to a multisig address',
+)
+  .addParam('to', 'Multisig (or new owner) address to receive ownership')
+  .addOptionalParam(
+    'snapshot',
+    'Path to a deployments snapshot JSON (defaults to deployments/<network>.json)',
+  )
+  .addFlag('dryRun', 'Print intended actions without sending transactions')
+  .setAction(
+    async (
+      { to, snapshot, dryRun }: { to: string; snapshot?: string; dryRun: boolean },
+      hre,
+    ) => {
+      if (!isAddress(to)) {
+        throw new Error(`Invalid --to address: ${to}`);
+      }
+
+      const network = hre.network.name;
+      const defaultPath = path.join(__dirname, '..', 'deployments', `${network}.json`);
+      const snapshotPath = snapshot ?? defaultPath;
+
+      if (!fs.existsSync(snapshotPath)) {
+        throw new Error(
+          `Snapshot not found at ${snapshotPath}. Run deploy-niji-full / deploy-niji-smoke first ` +
+            `or pass --snapshot <path>.`,
+        );
+      }
+
+      const data = JSON.parse(fs.readFileSync(snapshotPath, 'utf8')) as DeploymentsSnapshot;
+      console.log(`📂 Snapshot: ${snapshotPath}`);
+      console.log(
+        `   profile=${data.profile} network=${data.network} chainId=${data.chainId} → newOwner=${to}`,
+      );
+
+      const [signer] = await hre.ethers.getSigners();
+      console.log(`   signer (current owner expected): ${signer.address}`);
+
+      type Target = { name: string; address: string };
+      const targets: Target[] = [];
+      for (const { name } of OWNED_CONTRACTS) {
+        const addr = data.contracts[name];
+        if (!addr) {
+          console.log(`⚠️  Skip ${name} (not in snapshot)`);
+          continue;
+        }
+        targets.push({ name, address: addr });
+      }
+
+      if (targets.length === 0) {
+        console.log('No matching contracts to transfer. Exiting.');
+        return;
+      }
+
+      console.log(`\n🔄 Transferring ${targets.length} ownership(s)...\n`);
+
+      const ZERO = '0x' + '00'.repeat(20);
+
+      for (const { name, address } of targets) {
+        const factory = OWNED_CONTRACTS.find(c => c.name === name)!.factory;
+        const contract = await hre.ethers.getContractAt(factory, address, signer);
+
+        const currentOwner: string = await contract.owner();
+        const pendingOwner: string = await contract.pendingOwner();
+        console.log(`→ ${name.padEnd(16)} ${address}`);
+        console.log(`  current owner : ${currentOwner}`);
+        console.log(`  pending owner : ${pendingOwner === ZERO ? '(none)' : pendingOwner}`);
+
+        if (currentOwner.toLowerCase() === to.toLowerCase()) {
+          console.log(`  ↷ already owned by --to, skip`);
+          continue;
+        }
+        if (pendingOwner.toLowerCase() === to.toLowerCase()) {
+          console.log(
+            `  ↷ pending owner already set to --to, awaiting acceptOwnership by multisig`,
+          );
+          continue;
+        }
+
+        if (dryRun) {
+          console.log(`  [dry-run] would call transferOwnership(${to})`);
+          continue;
+        }
+
+        const tx = await contract.transferOwnership(to);
+        const receipt = await tx.wait();
+        console.log(`  ✓ transferOwnership tx=${receipt!.hash} gas=${receipt!.gasUsed}`);
+      }
+
+      console.log(
+        `\n=== transfer-ownership-niji: ${dryRun ? 'dry-run' : 'submitted'} ===\n` +
+          `Next step: the multisig (${to}) must call acceptOwnership() on each contract to ` +
+          `finalize the Ownable2Step transfer.`,
+      );
+    },
+  );

--- a/packages/niji-contracts/tasks/transfer-ownership-niji.ts
+++ b/packages/niji-contracts/tasks/transfer-ownership-niji.ts
@@ -59,58 +59,113 @@ task(
         `   profile=${data.profile} network=${data.network} chainId=${data.chainId} → newOwner=${to}`,
       );
 
+      // Hard-fail when the snapshot's network/chainId does not match the connected network.
+      // For an ownership-rotation task, mismatched inputs are dangerous: we could otherwise
+      // hit unrelated contracts at the same addresses on a different chain.
+      const provider = hre.ethers.provider;
+      const liveChainId = Number((await provider.getNetwork()).chainId);
+      if (liveChainId !== data.chainId) {
+        throw new Error(
+          `Network mismatch: snapshot.chainId=${data.chainId} but connected chainId=${liveChainId}. ` +
+            `Re-run with --network matching the snapshot, or pass the correct --snapshot path.`,
+        );
+      }
+      if (data.network !== hre.network.name) {
+        // network.name is a hardhat config label (not on-chain identity), so this is a softer
+        // sanity check than the chainId one above. Still bail out to avoid silent confusion.
+        throw new Error(
+          `Network name mismatch: snapshot.network=${data.network} but hre.network.name=${hre.network.name}.`,
+        );
+      }
+
       const [signer] = await hre.ethers.getSigners();
       console.log(`   signer (current owner expected): ${signer.address}`);
 
-      type Target = { name: string; address: string };
+      type Target = {
+        name: string;
+        address: string;
+        contract: Awaited<ReturnType<typeof hre.ethers.getContractAt>>;
+        currentOwner: string;
+        pendingOwner: string;
+        decision: 'skip-already-owned' | 'skip-pending' | 'will-transfer';
+      };
+
+      const ZERO = '0x' + '00'.repeat(20);
+
+      // -------- Pass 1: preflight (read-only) --------
+      // Walk every target, attach the contract handle, and read owner/pendingOwner once.
+      // This catches snapshot-vs-chain mismatches (ABI misdetection, wrong addresses, signer
+      // is not current owner) before sending any transactions, so the batch can stay atomic
+      // from the operator's point of view (either every transfer is queued or none are).
       const targets: Target[] = [];
-      for (const { name } of OWNED_CONTRACTS) {
+      const preflightProblems: string[] = [];
+
+      for (const { name, factory } of OWNED_CONTRACTS) {
         const addr = data.contracts[name];
         if (!addr) {
           console.log(`⚠️  Skip ${name} (not in snapshot)`);
           continue;
         }
-        targets.push({ name, address: addr });
+        const contract = await hre.ethers.getContractAt(factory, addr, signer);
+        const currentOwner: string = await contract.owner();
+        const pendingOwner: string = await contract.pendingOwner();
+
+        let decision: Target['decision'];
+        if (currentOwner.toLowerCase() === to.toLowerCase()) {
+          decision = 'skip-already-owned';
+        } else if (pendingOwner.toLowerCase() === to.toLowerCase()) {
+          decision = 'skip-pending';
+        } else if (currentOwner.toLowerCase() !== signer.address.toLowerCase()) {
+          preflightProblems.push(
+            `${name} (${addr}): currentOwner=${currentOwner} ≠ signer=${signer.address}; ` +
+              `transferOwnership would revert. Connect as the current owner first.`,
+          );
+          continue;
+        } else {
+          decision = 'will-transfer';
+        }
+
+        targets.push({ name, address: addr, contract, currentOwner, pendingOwner, decision });
       }
 
-      if (targets.length === 0) {
+      if (targets.length === 0 && preflightProblems.length === 0) {
         console.log('No matching contracts to transfer. Exiting.');
         return;
       }
 
-      console.log(`\n🔄 Transferring ${targets.length} ownership(s)...\n`);
+      console.log(`\n🔍 Preflight (${targets.length} target${targets.length === 1 ? '' : 's'}):\n`);
+      for (const t of targets) {
+        console.log(`→ ${t.name.padEnd(16)} ${t.address}`);
+        console.log(`  current owner : ${t.currentOwner}`);
+        console.log(`  pending owner : ${t.pendingOwner === ZERO ? '(none)' : t.pendingOwner}`);
+        console.log(`  decision      : ${t.decision}`);
+      }
+      if (preflightProblems.length > 0) {
+        console.error(`\n❌ Preflight failures (${preflightProblems.length}):`);
+        for (const msg of preflightProblems) console.error(`   - ${msg}`);
+        throw new Error(
+          `Preflight failed. Refusing to send any transferOwnership tx. ` +
+            `Fix the issues above (or pass --snapshot pointing at the correct chain) and retry.`,
+        );
+      }
 
-      const ZERO = '0x' + '00'.repeat(20);
+      const toTransfer = targets.filter(t => t.decision === 'will-transfer');
+      if (toTransfer.length === 0) {
+        console.log(`\n✓ All targets already owned by or pending --to; nothing to do.`);
+        return;
+      }
 
-      for (const { name, address } of targets) {
-        const factory = OWNED_CONTRACTS.find(c => c.name === name)!.factory;
-        const contract = await hre.ethers.getContractAt(factory, address, signer);
+      console.log(`\n🔄 Pass 2: transferOwnership for ${toTransfer.length} contract(s)\n`);
 
-        const currentOwner: string = await contract.owner();
-        const pendingOwner: string = await contract.pendingOwner();
-        console.log(`→ ${name.padEnd(16)} ${address}`);
-        console.log(`  current owner : ${currentOwner}`);
-        console.log(`  pending owner : ${pendingOwner === ZERO ? '(none)' : pendingOwner}`);
-
-        if (currentOwner.toLowerCase() === to.toLowerCase()) {
-          console.log(`  ↷ already owned by --to, skip`);
-          continue;
-        }
-        if (pendingOwner.toLowerCase() === to.toLowerCase()) {
-          console.log(
-            `  ↷ pending owner already set to --to, awaiting acceptOwnership by multisig`,
-          );
-          continue;
-        }
-
+      // -------- Pass 2: mutation --------
+      for (const t of toTransfer) {
         if (dryRun) {
-          console.log(`  [dry-run] would call transferOwnership(${to})`);
+          console.log(`→ ${t.name.padEnd(16)} [dry-run] would call transferOwnership(${to})`);
           continue;
         }
-
-        const tx = await contract.transferOwnership(to);
+        const tx = await t.contract.transferOwnership(to);
         const receipt = await tx.wait();
-        console.log(`  ✓ transferOwnership tx=${receipt!.hash} gas=${receipt!.gasUsed}`);
+        console.log(`→ ${t.name.padEnd(16)} ✓ tx=${receipt!.hash} gas=${receipt!.gasUsed}`);
       }
 
       console.log(


### PR DESCRIPTION
# 概要

新規 hardhat task `transfer-ownership-niji` を追加し、 NijiArt / NijiDescriptor / NijiSeeder / NijiToken の 4 contract の owner を multisig (または任意のアドレス) に一括移譲できるようにしました。
4 contract いずれも Ownable2Step なので、 本 task は `transferOwnership(newOwner)` のみを実行します。 最終的な `acceptOwnership()` は新 owner 側 (multisig) で別途実行する 2-step 設計です。
PR #263 / #264 で整備した deployments snapshot を入力に取り、 deploy → verify → ownership 移譲という運用フローが snapshot ベースで一気通貫になります。

# 課題

これまでの multisig 移譲は contract 1 件ずつ手作業で `transferOwnership` を叩く必要があり、 4 contract の順序ミス / 誤アドレスの混入 / 移譲漏れのリスクがありました。
特に Niji の場合は `renounceOwnership` を 4 contract で全て無効化済 (Issue #29) のため、 一度誤ったアドレスに移譲すると recovery 不可能です。
Ownable2Step (2-step transfer) は守られているとはいえ、 1 件ずつ手で叩く運用は再現性が低く危険でした。

# 詳細

snapshot を入力に取り 4 contract をループする 1 コマンド設計。

```mermaid
graph LR
    A[deploy 完了] --> B[deployments/<network>.json snapshot]
    B --> C[transfer-ownership-niji --to multisig]
    C --> D{各 contract について}
    D --> E[owner == --to なら skip]
    D --> F[pendingOwner == --to なら skip]
    D --> G[それ以外: transferOwnership 実行]
    G --> H[multisig 側で acceptOwnership]
```

冪等性を持たせるため、 既に new owner に移譲済 / pending 設定済の contract は skip します。 これで「multisig の一部が accept を完了し、 残りはまだ pending」 という中間状態でも安全に再実行できます。

# 解決方法

task の 4 つの動作モード:

1. **`--dry-run`** ... 実 tx を送らず「何が起こるか」 だけ表示
2. **デフォルト (実行)** ... 各 contract に `transferOwnership(to)` を発行
3. **冪等再実行** ... 既に pending owner = `--to` なら自動 skip (中断後の再実行で安全)
4. **`--snapshot <path>`** ... カスタム snapshot path 指定 (default `deployments/<network>.json`)

`NijiAuctionHouseProxy` は constructor / Ownable2Step ではなく proxy admin + initialize 経由の権限管理なので、 本 task の対象外です (governance-side workflow で別途扱う)。

# 仕組み

```mermaid
graph LR
    A[task 起動] --> B[--to address 検証]
    B --> C[snapshot 読込]
    C --> D[OWNED_CONTRACTS でループ]
    D --> E[hre.ethers.getContractAt で attach]
    E --> F[owner / pendingOwner を read]
    F --> G{state による分岐}
    G -->|owner=to| H[skip]
    G -->|pending=to| H
    G -->|other| I{dryRun?}
    I -->|yes| J[print only]
    I -->|no| K[transferOwnership tx]
    K --> L[receipt 確認]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/tasks/transfer-ownership-niji.ts` | 新規。 snapshot 読み込み + 4 contract への transferOwnership 一括実行 + 冪等 skip + dry-run |
| `packages/niji-contracts/tasks/index.ts` | `transfer-ownership-niji` を export |

使用例。

```sh
# 1. dry-run で挙動確認
pnpm hardhat transfer-ownership-niji --network baseSepolia \
  --to 0xYourMultisigAddress --dry-run

# 2. 実行
pnpm hardhat transfer-ownership-niji --network baseSepolia \
  --to 0xYourMultisigAddress

# 3. multisig 側で acceptOwnership を 4 contract に対して実行
#    (Safe / Gnosis UI 等で順番に実行)
```

# テストと確認

- [x] `pnpm hardhat help transfer-ownership-niji` で task 認識確認
- [x] `--dry-run` で 4 contract 全てに対する transferOwnership 計画が表示される
- [x] 実行で 4 contract 全てに transferOwnership tx が成功 (localnet で確認、 gas 各 47000-47900)
- [x] 再実行時に冪等性 (pending owner 既設の skip) が動作
- [x] `pnpm hardhat test` 全 326 件 pass (regression なし)

レビューで見てほしいところ。

`--to` 引数の検証を viem の `isAddress` 1 行だけで済ませている点をご確認ください。
checksum address は受け取れますが、 ENS / multisig deployment 検証 (例 contract に code がある) までは行っていません。 別案として `await provider.getCode(to).length > 2` で contract か EOA かを確認する経路もありますが、 multisig wallet contract / EOA どちらも有効な owner なので過剰検証になると判断しました。

# 関連

Closes #41
- PR #263 (deploy snapshot) と PR #264 (verify-niji) の延長線。 deploy → verify → ownership 移譲の運用フローが snapshot ベースで完結
