### PR TITLE
📦 refactor(niji-api): ponder.config を SDK address map 経由に統一 (Issue #53)

### DIFF
--- a/packages/niji-api/ponder.config.ts
+++ b/packages/niji-api/ponder.config.ts
@@ -1,8 +1,14 @@
-import { nounsAuctionHouseAbi } from '@niji/sdk/auction-house';
-import { nounsTokenAbi } from '@niji/sdk/token';
-import { nounsGovernorAbi } from '@niji/sdk/governor';
-import { nounsStreamFactoryAbi } from '@niji/sdk/stream-factory';
-import { nounsStreamAbi } from '@niji/sdk/stream';
+import {
+  nounsAuctionHouseAbi,
+  nounsAuctionHouseAddress,
+} from '@niji/sdk/auction-house';
+import { nijiTokenAbi, nijiTokenAddress } from '@niji/sdk/token';
+import { nounsGovernorAbi, nounsGovernorAddress } from '@niji/sdk/governor';
+import {
+  nijiStreamFactoryAbi,
+  nijiStreamFactoryAddress,
+} from '@niji/sdk/stream-factory';
+import { nijiStreamAbi } from '@niji/sdk/stream';
 import { createConfig, factory } from 'ponder';
 import { getAbiItem } from 'viem';
 import dotenv from 'dotenv';
@@ -16,37 +22,37 @@ const mainnetConfig = createConfig({
   contracts: {
     NounsAuctionHouseV2: {
       chain: 'mainnet',
-      address: '0x830BD73E4184ceF73443C15111a1DF14e495C706',
+      address: nounsAuctionHouseAddress[1],
       abi: nounsAuctionHouseAbi,
       startBlock: 12985451,
     },
     NounsToken: {
       chain: 'mainnet',
-      address: '0x9C8fF314C9Bc7F6e59A9d9225Fb22946427eDC03',
-      abi: nounsTokenAbi,
+      address: nijiTokenAddress[1],
+      abi: nijiTokenAbi,
       startBlock: 12985438,
     },
     NounsDAOV4: {
       chain: 'mainnet',
-      address: '0x6f3E6272A167e8AcCb32072d08E0957F9c79223d',
+      address: nounsGovernorAddress[1],
       abi: nounsGovernorAbi,
       startBlock: 12985453,
     },
     StreamFactory: {
       chain: 'mainnet',
-      address: '0x0fd206FC7A7dBcD5661157eDCb1FFDD0D02A61ff',
-      abi: nounsStreamFactoryAbi,
+      address: nijiStreamFactoryAddress[1],
+      abi: nijiStreamFactoryAbi,
       startBlock: 16576500,
     },
 
     Stream: {
       chain: 'mainnet',
       address: factory({
-        address: '0x0fd206FC7A7dBcD5661157eDCb1FFDD0D02A61ff',
-        event: getAbiItem({ abi: nounsStreamFactoryAbi, name: 'StreamCreated' }),
-        parameter: getAbiItem({ abi: nounsStreamFactoryAbi, name: 'StreamCreated' }).inputs[7].name,
+        address: nijiStreamFactoryAddress[1],
+        event: getAbiItem({ abi: nijiStreamFactoryAbi, name: 'StreamCreated' }),
+        parameter: getAbiItem({ abi: nijiStreamFactoryAbi, name: 'StreamCreated' }).inputs[7].name,
       }),
-      abi: nounsStreamAbi,
+      abi: nijiStreamAbi,
       startBlock: 16576500,
     },
   },
@@ -63,37 +69,37 @@ const sepoliaConfig = createConfig({
   contracts: {
     NounsAuctionHouseV2: {
       chain: 'sepolia',
-      address: '0x488609b7113FCf3B761A05956300d605E8f6BcAf',
+      address: nounsAuctionHouseAddress[11155111],
       abi: nounsAuctionHouseAbi,
       startBlock: 3594847,
     },
     NounsToken: {
       chain: 'sepolia',
-      address: '0x4C4674bb72a096855496a7204962297bd7e12b85',
-      abi: nounsTokenAbi,
+      address: nijiTokenAddress[11155111],
+      abi: nijiTokenAbi,
       startBlock: 3594846,
     },
     NounsDAOV4: {
       chain: 'sepolia',
-      address: '0x35d2670d7C8931AACdd37C89Ddcb0638c3c44A57',
+      address: nounsGovernorAddress[11155111],
       abi: nounsGovernorAbi,
       startBlock: 3594849,
     },
     StreamFactory: {
       chain: 'sepolia',
-      address: '0xb78ccF3BD015f209fb9B2d3d132FD8784Df78DF5',
-      abi: nounsStreamFactoryAbi,
+      address: nijiStreamFactoryAddress[11155111],
+      abi: nijiStreamFactoryAbi,
       startBlock: 2564095,
     },
 
     Stream: {
       chain: 'sepolia',
       address: factory({
-        address: '0xb78ccF3BD015f209fb9B2d3d132FD8784Df78DF5',
-        event: getAbiItem({ abi: nounsStreamFactoryAbi, name: 'StreamCreated' }),
-        parameter: getAbiItem({ abi: nounsStreamFactoryAbi, name: 'StreamCreated' }).inputs[7].name,
+        address: nijiStreamFactoryAddress[11155111],
+        event: getAbiItem({ abi: nijiStreamFactoryAbi, name: 'StreamCreated' }),
+        parameter: getAbiItem({ abi: nijiStreamFactoryAbi, name: 'StreamCreated' }).inputs[7].name,
       }),
-      abi: nounsStreamAbi,
+      abi: nijiStreamAbi,
       startBlock: 2564095,
     },
   },


### PR DESCRIPTION
# 概要

niji-api パッケージの ponder.config.ts に hardcode されていた contract address を、 SDK の address map 経由参照に統一する refactor。
同時に旧 `nouns*` import 名から新 `niji*` 名への rename を合わせて適用し型エラーを解消する。
外部の動きは変わらず、 ponder の indexing 対象 address は SDK の SSOT と完全一致する状態になる。

Closes #53

# 課題

ponder.config.ts は `0x830BD73E4184ceF73443C15111a1DF14e495C706` のような contract address を直接 hardcode していた。
SDK 側には `nounsAuctionHouseAddress` などの address map が既に存在しており、 同じ address を 2 箇所で管理する SSOT 二重化が発生していた。
さらに `nounsTokenAbi` / `nounsStreamFactoryAbi` / `nounsStreamAbi` の旧名 import が SDK 側 rename (`niji*` への移行) と同期されておらず、 ponder.config.ts は TypeScript 型エラーで build 不能な状態だった。

# 詳細

現状の依存構造。

```mermaid
graph LR
    A[ponder.config.ts] -->|hardcoded 0x830B...| B[mainnet address]
    A -->|hardcoded 0x4886...| C[sepolia address]
    A -->|nounsTokenAbi import| D[SDK token.gen.ts]
    D -.->|rename 済| E[nijiTokenAbi]
```

問題点。

- ponder.config.ts と SDK で同じ address を 2 箇所管理 (一方を変更しても他方に追随しない drift リスク)
- SDK の rename 進行 (`nouns*` → `niji*`) に ponder.config.ts が追随できておらず型エラーで build 不能
- contract address の最新性は SDK の wagmi codegen が SSOT、 ponder.config.ts の hardcode はその瞬間の snapshot にすぎない

# 解決方法

ponder.config.ts の hardcode address を SDK の address map (`nounsAuctionHouseAddress[1]` 等) 経由参照に置換した。
SDK 側 rename と同期するために `nounsToken*` / `nounsStreamFactory*` / `nounsStream*` の旧名 import を `niji*` 新名に変更した。
factory pattern (Stream contract の dynamic resolution) もそのまま維持し外部挙動は不変。

# 仕組み

整理後の依存構造。

```mermaid
graph LR
    A[ponder.config.ts] -->|nounsAuctionHouseAddress 1| B[SDK auction-house.gen.ts]
    A -->|nounsAuctionHouseAddress 11155111| B
    A -->|nijiTokenAddress 1| C[SDK token.gen.ts]
    A -->|nijiStreamFactoryAddress 1| D[SDK stream-factory.gen.ts]
    B -.->|wagmi codegen| E[on-chain SSOT]
    C -.->|wagmi codegen| E
    D -.->|wagmi codegen| E
```

改善点。

- address SSOT は SDK 1 箇所に統一、 ponder.config.ts は import 経由で常に最新
- 旧 `nouns*` / 新 `niji*` rename の不整合を ponder.config.ts 側で解消し型エラー除去
- wagmi codegen で SDK address が更新されると ponder.config.ts も自動追随

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-api/ponder.config.ts` | 5 contract × 2 chain の hardcoded address を SDK address map 経由参照に置換、 同時に `nouns*` 旧名 import を `niji*` 新名へ rename |

# 検証

- `pnpm exec tsc --noEmit` (packages/niji-api) ... pass (出力なし)
- `pnpm exec ponder codegen` (packages/niji-api) ... success (`Wrote ponder-env.d.ts`)
- `pnpm -w lint packages/niji-api/ponder.config.ts` ... ignore 対象 (config file は eslint scope 外)
- niji-sdk の型エラーは本 PR の修正範囲外 (`@wagmi/core` d.ts 由来 + tsconfig include 漏れ、 develop branch でも同状態)

# Issue #53 の残作業

本 PR は #53 の「contract address を SDK に一元化」 部分を達成。
「lint/prettier 設定をルートに集約」 は既に develop で完了済 (`eslint.config.mjs` / `prettier.config.js` が root に集約済、 個別 package に `.eslintrc` / `.prettierrc` なし) のため本 PR では扱わない。
これにより Issue #53 の両 AC が満たされる。
