### PR TITLE
📝 docs(niji-docs): architecture + deploy-guide を新規追加 (Issue #24)

### DIFF
--- a/packages/niji-docs/content/protocol/architecture.mdx
+++ b/packages/niji-docs/content/protocol/architecture.mdx
@@ -1,0 +1,128 @@
+---
+title: Architecture
+description: Niji DAO contract architecture and module relationships
+---
+
+# Architecture
+
+Niji DAO の on-chain アーキテクチャを構成要素ごとに整理する。
+各 contract は単一責務で組み合わせて稼働する。
+コードは [`packages/niji-contracts/contracts/`](https://github.com/Niji-DAO/niji-monorepo/tree/develop/packages/niji-contracts/contracts) を参照。
+
+## 全体像
+
+Niji の core 構成は 5 系統 (Token / AuctionHouse / Descriptor / Seeder / Art) に分かれ、 ユーザー / DAO governance / 入札者の 3 アクターと相互作用する。
+
+```mermaid
+graph TD
+    subgraph "Core contracts"
+        Token[NijiToken<br/>ERC721]
+        Auction[NijiAuctionHouseV3]
+        Descriptor[NijiDescriptor]
+        Seeder[NijiSeeder]
+        Art[NijiArt]
+        SVG[SVGRenderer]
+        Inflator[Inflator]
+    end
+
+    subgraph "Governance"
+        DAO[NijiDAOLogic V4]
+        Executor[NijiDAOExecutorV2]
+        Data[NijiDAOData]
+    end
+
+    User["ユーザー / 入札者"] -->|入札 / mint claim| Auction
+    Auction -->|新規 Niji を mint| Token
+    Token -->|tokenURI 要求| Descriptor
+    Descriptor -->|trait 抽選| Seeder
+    Descriptor -->|画像データ取得| Art
+    Art -->|画像 RLE 展開| Inflator
+    Descriptor -->|SVG 組み立て| SVG
+    DAO -->|権限委譲| Executor
+    Executor -->|admin 操作| Token
+    Executor -->|admin 操作| Auction
+    Data -->|提案管理| DAO
+```
+
+## Core 5 系統の責務
+
+### NijiToken
+
+ERC721 実装で個別 Niji NFT の所有権を管理する。
+[`packages/niji-contracts/contracts/NijiToken.sol`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/contracts/NijiToken.sol) が SSOT。
+
+```solidity
+contract NijiToken is INijiToken, Ownable, ERC721Checkpointable {
+    function mint() public onlyMinter returns (uint256) {
+        // ...
+        return _mintTo(minter, _currentNijiId++);
+    }
+}
+```
+
+`mint()` は AuctionHouse からのみ呼ばれ、 新しい token id を発行して seed を Seeder で抽選する。 `tokenURI(tokenId)` を呼ばれると Descriptor 経由で SVG を build して data URI を返す。
+
+### NijiAuctionHouseV3
+
+Niji の英国式オークション (English auction、 上昇式) を実装する。
+[`packages/niji-contracts/contracts/NijiAuctionHouseV3.sol`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/contracts/NijiAuctionHouseV3.sol) が SSOT。
+
+1 日 1 体ペースで auction が開かれる仕組みで、 終了時刻直前の入札があれば自動延長 (`timeBuffer`) する。 落札後の wei は DAO Treasury (`NijiDAOExecutorV2`) に送金される。
+
+### NijiDescriptor
+
+`tokenURI()` の中身を生成する責務を持つ。
+[`packages/niji-contracts/contracts/NijiDescriptor.sol`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/contracts/NijiDescriptor.sol) が SSOT。
+
+trait 抽選結果から Art に保存された圧縮画像を取得し、 Inflator で RLE 展開、 SVGRenderer で SVG 文字列を組み立てる。 全工程が完全 on-chain で external storage に依存しない。
+
+### NijiSeeder
+
+5 trait (background / body / accessory / head / glasses) のランダム抽選を実装する。
+[`packages/niji-contracts/contracts/NijiSeeder.sol`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/contracts/NijiSeeder.sol) が SSOT。
+
+block 情報 + token id + chainid + 回転 salt から seed を生成し、 trait ごとの個数で剰余を取って index を決定する (詳細は [Issue #34](https://github.com/Niji-DAO/niji-monorepo/issues/34) で確定した規約)。
+
+### NijiArt
+
+trait 別の圧縮画像データを on-chain に保管する。
+[`packages/niji-contracts/contracts/NijiArt.sol`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/contracts/NijiArt.sol) が SSOT。
+
+palette + body parts + accessory parts + head parts + glasses parts を SSTORE2 経由で書き込み、 trait index 別に参照する。 mintBatch に 50 件上限 ([Issue #32](https://github.com/Niji-DAO/niji-monorepo/issues/32)) が掛かっており 1 tx あたりのガス消費を予測可能に抑えている。
+
+## Governance 系統
+
+### NijiDAOLogic V4
+
+提案 / 投票 / queue / execute の governance 全体を司る。 提案を作るには `proposalThreshold` 以上の voting power が必要、 投票期間は `votingDelay` + `votingPeriod` で制御される。
+
+### NijiDAOExecutorV2
+
+DAO 提案が可決された後に実 action を実行する Timelock コントロール。 全 admin 操作 (mint 設定変更 / descriptor 差し替え / treasury 出金等) はこの Executor 経由で行われる仕様。
+
+### NijiDAOData
+
+提案候補 (Proposal Candidate) / signature / feedback の保管を担当する。 governance の周辺機能 (投票前のフィードバック収集、 candidate からの formalize) を切り出したもの。
+
+## 補助系統
+
+| 系統 | 役割 |
+|---|---|
+| StreamFactory + Stream | 給与 / vesting の継続支払いを on-chain で管理 |
+| Payer + TokenBuyer | USDC / DAI / wei の換金を Treasury 経由で実行 |
+| Rewards | proposal author / voter / referrer への ETH reward を分配 |
+| ForkEscrow + ForkDAODeployer | DAO Fork (分岐) 機能を実装 |
+
+各補助 contract のアドレスは [Deployments](/protocol/deployments) を参照。
+
+## 完全 on-chain の意義
+
+Niji は 画像 / metadata / governance / treasury の全てを on-chain に置く設計を採用する。
+IPFS / off-chain server に依存しないため、 token 保有者は contract が存在する限り永続的に画像を取得できる。
+SVG レンダリングのガス消費は `SVGRenderer` の最適化で 数百万 gas 程度に収まる ([NijiGas test](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/test/niji/NijiGas.test.ts) でベンチマーク済)。
+
+## 関連
+
+- [Deployments](/protocol/deployments) ... mainnet / sepolia の実 contract address 一覧
+- [Forks](/protocol/forks) ... DAO Fork 機能の解説
+- [Governance Parameters](/governance/proposals) ... 提案 / 投票パラメータの SSOT

--- a/packages/niji-docs/content/protocol/deploy-guide.mdx
+++ b/packages/niji-docs/content/protocol/deploy-guide.mdx
@@ -1,0 +1,118 @@
+---
+title: Deploy Guide
+description: Niji contracts のデプロイ手順 (smoke / full / verify / transfer ownership)
+---
+
+# Deploy Guide
+
+Niji contracts をローカル / testnet / mainnet にデプロイする手順をまとめる。
+SSOT は [`packages/niji-contracts/tasks/`](https://github.com/Niji-DAO/niji-monorepo/tree/develop/packages/niji-contracts/tasks) の hardhat task 実装。
+
+## 前提
+
+| 項目 | 値 |
+|---|---|
+| node | 16.x 以上 (monorepo は 18 / 20 推奨) |
+| pnpm | 10.10.0 以上 |
+| ツール | `pnpm install` で hardhat / foundry / ethers v6 が揃う |
+| RPC | mainnet / sepolia / baseSepolia 用の `.env` (`packages/niji-contracts/.env`) |
+| 鍵 | deployer の private key (`DEPLOYER_PRIVATE_KEY`) と etherscan API key (`ETHERSCAN_API_KEY`) |
+
+`.env` は [`packages/niji-contracts/.env.example`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/.env.example) を写してから埋める。
+
+## 全体フロー
+
+```mermaid
+graph LR
+    Start[ローカル smoke] --> Smoke[smoke deploy<br/>36 画像]
+    Smoke --> Mint[mint smoke で<br/>tokenURI 確認]
+    Mint --> Testnet[baseSepolia / sepolia<br/>へ smoke]
+    Testnet --> Full[full deploy<br/>561 画像]
+    Full --> Verify[verify-niji で<br/>Etherscan verify]
+    Verify --> Transfer[transfer-ownership-niji<br/>multisig 移譲]
+```
+
+## Step 1. ローカル smoke deploy
+
+最も軽量な確認経路。 NijiArt / NijiDescriptor / NijiSeeder / NijiToken を hardhat localhost に deploy し、 36 画像 (trait 別 3 個ずつ) を seed して 1 体 mint する。
+
+```bash
+cd packages/niji-contracts
+pnpm install
+pnpm exec hardhat deploy-niji-smoke --network hardhat
+```
+
+出力は `deploy/hardhat-{timestamp}-smoke.json` に書かれる。
+contract address / gas used / 画像 hash が記録され reproducible。
+tokenURI を返す JSON に SVG が embed されていれば smoke は成功扱い。
+
+## Step 2. baseSepolia への smoke deploy
+
+testnet で同じ smoke を実行して入金 / ガス見積もりを確認する。
+
+```bash
+pnpm exec hardhat deploy-niji-base-sepolia --network baseSepolia
+```
+
+baseSepolia の RPC + chain id は `hardhat.config.ts` で `cancun` hardfork pin 済 (EIP-7825 の 16M tx gas cap を回避)。
+deploy 後に `block_gas_limit` 300M を活用した大規模 SSTORE2 書き込みも問題なく通る。
+
+## Step 3. full deploy (561 画像)
+
+本番想定の full deploy で全 561 画像を 12 trait category に分けて on-chain に書き込む。
+
+```bash
+pnpm exec hardhat deploy-niji-full --network sepolia
+```
+
+mintBatch は 50 件上限で実行される ([Issue #32](https://github.com/Niji-DAO/niji-monorepo/issues/32))。
+ガス消費は trait あたり 数百万 gas 程度、 全体で約 5-15 ETH 相当 (mainnet 想定)。
+
+## Step 4. snapshot 出力
+
+deploy 結果は固定 path に snapshot される ([Issue #40](https://github.com/Niji-DAO/niji-monorepo/issues/40))。
+
+```bash
+pnpm exec hardhat snapshot-niji --network sepolia
+```
+
+出力は `deployments/{network}.json` に書かれ、 全 contract address + abi hash + block number が永続化される。
+
+## Step 5. Etherscan verify
+
+snapshot から一括 verify を実行する ([Issue #39](https://github.com/Niji-DAO/niji-monorepo/issues/39))。
+
+```bash
+pnpm exec hardhat verify-niji --network sepolia
+```
+
+`deployments/{network}.json` を読んで全 contract を順次 `npx hardhat verify` する。
+失敗した contract は標準エラーに出力され、 reproducible に retry 可能。
+
+## Step 6. multisig へ ownership 移譲
+
+deployer EOA から multisig wallet (例 Safe) に owner 移譲する ([Issue #41](https://github.com/Niji-DAO/niji-monorepo/issues/41))。
+
+```bash
+pnpm exec hardhat transfer-ownership-niji --network sepolia --to <safe-address>
+```
+
+NijiToken / NijiAuctionHouseV3 / NijiDescriptor の 3 contract が順次 `transferOwnership(safe)` を呼ぶ。
+Safe 側で `acceptOwnership` を承認すれば 2-step 移譲 (`Ownable2Step` 経路) が完了する。
+
+## チェックリスト
+
+- [ ] `.env` に `DEPLOYER_PRIVATE_KEY` + `ETHERSCAN_API_KEY` を設定済
+- [ ] `hardhat deploy-niji-smoke --network hardhat` で local smoke が pass
+- [ ] testnet (baseSepolia / sepolia) で smoke deploy が pass
+- [ ] full deploy で 561 画像が on-chain に書き込まれた (`deployments/{network}.json` 出力済)
+- [ ] `verify-niji` で全 contract が Etherscan verify 済
+- [ ] `transfer-ownership-niji` で multisig に owner 移譲済
+- [ ] [Deployments](/protocol/deployments) ページに address を反映
+
+## 関連
+
+- [Architecture](/protocol/architecture) ... contract 間の責務と相互作用
+- [Deployments](/protocol/deployments) ... 確定済 mainnet / sepolia address
+- [`tasks/deploy-niji-smoke.ts`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/tasks/deploy-niji-smoke.ts)
+- [`tasks/deploy-niji-full.ts`](https://github.com/Niji-DAO/niji-monorepo/blob/develop/packages/niji-contracts/tasks/deploy-niji-full.ts)


### PR DESCRIPTION
# 概要

Niji DAO の contract アーキテクチャと deploy 手順を docs site (niji-docs) に整備する。
NatSpec コメントは既に充実しているため本 PR では追加せず、 不足していた architecture / deploy-guide の 2 ページを新規作成して Issue #24 の docs 側 AC を満たす。
公開先は niji-docs (Next.js + Nextra) で、 既存の `protocol/` セクション配下に並列追加する。

Closes #24

# 課題

Issue #24 の AC は 3 つ。

- NatSpec コメント充実
- アーキテクチャドキュメント
- デプロイ手順書

`packages/niji-contracts/contracts/NijiToken.sol` / `NijiAuctionHouseV3.sol` 等の主要 contract で NatSpec (`/// @title` / `@notice` / `@dev` / `@param`) は既に整備済 (Niji rename 過程で追加済) で本 PR では再整備不要。
一方、 docs site (`packages/niji-docs/`) には `protocol/deployments.mdx` (アドレス一覧) は存在するが、 contract 間の関係と deploy 手順をまとめた文書がなく、 外部開発者が Niji DAO の構造を追えない状態だった。

# 詳細

現状の niji-docs `protocol/` 構成。

```mermaid
graph LR
    A[protocol/deployments.mdx] -->|アドレス一覧のみ| Z[読み手]
    B[protocol/forks.mdx] -->|fork 機能解説| Z
    C[現状欠落: architecture] -.->|構造解説なし| Z
    D[現状欠落: deploy-guide] -.->|手順書なし| Z
```

問題点。

- アドレスはあるが「どの contract がどう繋がっているか」 が docs にない
- deploy task (smoke / full / verify / transfer-ownership-niji) は実装済 (Issue #34/#39/#40/#41 で完成) だが手順書化されていない
- 外部開発者が読むべき docs の順序が示されていない

# 解決方法

niji-docs の `content/protocol/` 配下に 2 ページを新規追加する。

- `architecture.mdx` ... contract 全体図 (mermaid) + core 5 系統 + governance 系統 + 補助系統の責務を文章で解説
- `deploy-guide.mdx` ... 6 step フロー (smoke → testnet smoke → full → snapshot → verify → transfer-ownership) を mermaid 図 + コマンド例 + チェックリストで提示

NatSpec は既存実装を尊重する。 確認は `grep -E '^\s*///|^\s*/\*\*' packages/niji-contracts/contracts/NijiToken.sol` で `@title` / `@notice` / `@param` 等が網羅されていることをチェック済。

# 仕組み

更新後の niji-docs `protocol/` 構成。

```mermaid
graph LR
    A[architecture.mdx<br/>新規] -->|contract 構造図| Z[読み手]
    B[deployments.mdx] -->|アドレス一覧| Z
    C[deploy-guide.mdx<br/>新規] -->|6 step フロー| Z
    D[forks.mdx] -->|fork 機能| Z
    A -->|相互参照| C
    A -->|相互参照| B
    C -->|相互参照| B
```

architecture.mdx は core 5 系統と governance 系統を分けて mermaid graph で示し、 各 contract の SSOT ファイル path を GitHub link で添える。
deploy-guide.mdx は前提環境 (`.env` 設定 / 鍵) → ローカル smoke → testnet smoke → full deploy → snapshot → Etherscan verify → multisig 移譲の順に並べ、 各 step に hardhat task 名と引数例を記載する。

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-docs/content/protocol/architecture.mdx` | 新規追加。 Niji の contract 全体図 + core 5 系統 (Token / AuctionHouse / Descriptor / Seeder / Art) + governance 系統 (DAOLogic / Executor / Data) + 補助系統 (Stream / Payer / Rewards / Fork) の責務を mermaid + Solidity 抜粋付きで解説 |
| `packages/niji-docs/content/protocol/deploy-guide.mdx` | 新規追加。 smoke / full / verify / transfer-ownership-niji の 6 step フローを mermaid + コマンド例 + チェックリストで提示、 関連 Issue (#32 / #34 / #39 / #40 / #41) へリンク |

# 検証

- `niji-docs` の build は既存 develop でも `proposals.mdx` / `contributing.mdx` で「Error compiling」 (Playwright browser 未 install による mermaid 図の skip エラー) が出ており、 本 PR の追加 mdx 2 ファイルも同種 (`browserType.launch: Executable doesn't exist`) で扱いは既存と同等。 これは env setup (`pnpm exec playwright install chromium`) 課題で本 PR の修正範囲外
- mdx 構文は既存 protocol ページ (`deployments.mdx` / `forks.mdx`) と同じ Nextra 4 syntax を踏襲、 frontmatter (title + description) + heading 階層 + mermaid code fence + table を使用
- 内部 link (`[Deployments](/protocol/deployments)`) は既存 path に対する相対リンクで切れない

# Issue #24 の残作業

| AC | 状態 |
|---|---|
| NatSpec コメント充実 | ✅ 既存実装で充実済 (本 PR 対象外、 確認のみ) |
| アーキテクチャドキュメント | ✅ 本 PR で `architecture.mdx` を新規追加 |
| デプロイ手順書 | ✅ 本 PR で `deploy-guide.mdx` を新規追加 |

これで Issue #24 の 3 AC を全て満たす状態となる。
