### PR TITLE
🎨 refactor(niji-webapp): 5 file を Tailwind 化 / module 削除 (Issue #23 sub-PR 2)

### DIFF
--- a/packages/niji-webapp/src/components/GrayCircle/GrayCircle.module.css
+++ b/packages/niji-webapp/src/components/GrayCircle/GrayCircle.module.css
@@ -1,4 +1,0 @@
-.wrapper {
-  height: 55px;
-  width: 55px;
-}

--- a/packages/niji-webapp/src/components/GrayCircle/index.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.tsx
@@ -3,8 +3,6 @@ import React from 'react';
 import LegacyNoun from '@/components/LegacyNoun';
 import { getGrayBackgroundSVG } from '@/utils/grayBackgroundSVG';
 
-import classes from './GrayCircle.module.css';
-
 import nounClasses from '@/components/LegacyNoun/Noun.module.css';
 
 interface GrayCircleProps {
@@ -13,7 +11,7 @@ interface GrayCircleProps {
 
 export const GrayCircle: React.FC<GrayCircleProps> = ({ isDelegateView }) => {
   return (
-    <div className={isDelegateView ? classes.wrapper : ''}>
+    <div className={isDelegateView ? 'h-[55px] w-[55px]' : ''}>
       <LegacyNoun
         imgPath={getGrayBackgroundSVG()}
         alt={''}

--- a/packages/niji-webapp/src/components/ModalBottomButtonRow/ModalBottomButtonRow.module.css
+++ b/packages/niji-webapp/src/components/ModalBottomButtonRow/ModalBottomButtonRow.module.css
@@ -1,5 +1,0 @@
-.buttonWrapper {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 2rem;
-}

--- a/packages/niji-webapp/src/components/ModalBottomButtonRow/index.tsx
+++ b/packages/niji-webapp/src/components/ModalBottomButtonRow/index.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import NavBarButton, { NavBarButtonStyle } from '../NavBarButton';
 
-import classes from './ModalBottomButtonRow.module.css';
-
 export interface ModalBottomButtonRowProps {
   onPrevBtnClick: (e?: any) => void;
   onNextBtnClick: (e?: any) => void;
@@ -22,7 +20,7 @@ const ModalBottomButtonRow: React.FC<ModalBottomButtonRowProps> = props => {
   } = props;
 
   return (
-    <div className={classes.buttonWrapper}>
+    <div className="mt-8 flex justify-between">
       <NavBarButton
         buttonText={prevBtnText}
         buttonStyle={NavBarButtonStyle.DELEGATE_BACK}

--- a/packages/niji-webapp/src/components/ModalTextPrimary/ModalTextPrimary.module.css
+++ b/packages/niji-webapp/src/components/ModalTextPrimary/ModalTextPrimary.module.css
@@ -1,6 +1,0 @@
-.text {
-  font-size: 22px;
-  font-weight: bold;
-  color: var(--brand-cool-dark-text);
-  margin-bottom: 0.5rem;
-}

--- a/packages/niji-webapp/src/components/ModalTextPrimary/index.tsx
+++ b/packages/niji-webapp/src/components/ModalTextPrimary/index.tsx
@@ -1,10 +1,10 @@
-import classes from './ModalTextPrimary.module.css';
-
 interface ModalTextPrimaryProps {
   children?: React.ReactNode;
 }
 
 const ModalTextPrimary = ({ children }: Readonly<ModalTextPrimaryProps>) => (
-  <div className={classes.text}>{children}</div>
+  <div className="mb-2 text-[22px] font-bold text-[color:var(--brand-cool-dark-text)]">
+    {children}
+  </div>
 );
 export default ModalTextPrimary;

--- a/packages/niji-webapp/src/layout/Section/Section.module.css
+++ b/packages/niji-webapp/src/layout/Section/Section.module.css
@@ -1,3 +1,0 @@
-.container {
-  padding: 2rem 0rem 0rem 0rem;
-}

--- a/packages/niji-webapp/src/layout/Section/index.tsx
+++ b/packages/niji-webapp/src/layout/Section/index.tsx
@@ -2,8 +2,6 @@ import { CSSProperties } from 'react';
 
 import { Container, Row } from 'react-bootstrap';
 
-import classes from './Section.module.css';
-
 const Section: React.FC<{
   fullWidth: boolean;
   className?: string;
@@ -12,7 +10,7 @@ const Section: React.FC<{
 }> = props => {
   const { fullWidth, className, children, style } = props;
   return (
-    <div className={`${classes.container} ${className}`} style={style}>
+    <div className={`pt-8 ${className ?? ''}`} style={style}>
       <Container fluid={fullWidth ? true : 'lg'}>
         <Row className="align-items-center">{children}</Row>
       </Container>

--- a/packages/niji-webapp/src/pages/NotFound/NotFound.module.css
+++ b/packages/niji-webapp/src/pages/NotFound/NotFound.module.css
@@ -1,5 +1,0 @@
-.heading {
-  display: inline-block;
-  font-weight: bold;
-  font-size: 3rem;
-}

--- a/packages/niji-webapp/src/pages/NotFound/index.tsx
+++ b/packages/niji-webapp/src/pages/NotFound/index.tsx
@@ -4,8 +4,6 @@ import { Col, Image } from 'react-bootstrap';
 import _404img from '../../assets/404noun.png';
 import Section from '../../layout/Section';
 
-import classes from './NotFound.module.css';
-
 const NotFoundPage = () => {
   return (
     <Section fullWidth={false}>
@@ -13,7 +11,7 @@ const NotFoundPage = () => {
         <Image src={_404img} fluid />
       </Col>
       <Col lg={8}>
-        <h1 className={classes.heading}>
+        <h1 className="inline-block text-5xl font-bold">
           <Trans>404: This is not the person, place, or thing you're looking for...</Trans>
         </h1>
       </Col>


### PR DESCRIPTION
# 概要

Issue #23 (CSS Modules → Tailwind 完全移行) の sub-PR 2。
3-6 行の薄い CSS module 5 file (Section / GrayCircle / ModalBottomButtonRow / NotFound / ModalTextPrimary) を Tailwind 化し module を削除する。
sub-PR 1 (PR #271) で確立した「等価変換 + module 削除 + test pass 維持」 パターンの 2 回目適用。

Refs #23

# 課題

sub-PR 1 で 5 file (合計 9 行 CSS) を整理した。 残 89 module のうち 3-6 行系がまだ多数残っており、 同パターンで継続できる候補が 5 file あった。 1 PR に詰め込み過ぎると review が辛くなるため、 sub-PR 1 と同じ 5 file 規模に揃える。

# 詳細

```mermaid
graph LR
    A[sub-PR 1<br/>5 file / 9 行 CSS] --> B[本 sub-PR 2<br/>5 file / 24 行 CSS]
    B --> C[sub-PR 3 以降<br/>残 84 file]
```

問題点。

- 8-15 行の中規模 module も等価変換可能だが review 負荷を踏まえて 5 file 単位を維持
- `var(--brand-*)` の CSS 変数は Tailwind の任意値構文 (`[color:var(--...)]`) で吸収

# 解決方法

5 file それぞれ 1-4 行の utility 置換に分解、 Tailwind utility ↔ CSS property の対応表を commit message + 本 body に明示する。

# 仕組み

Tailwind 置換対応表。

| 元 CSS | Tailwind 置換 |
|---|---|
| `Section.container { padding: 2rem 0 0 0 }` | `pt-8` |
| `GrayCircle.wrapper { height: 55px; width: 55px }` | `h-[55px] w-[55px]` |
| `ModalBottomButtonRow.buttonWrapper { display:flex; justify-content:space-between; margin-top:2rem }` | `mt-8 flex justify-between` |
| `NotFound.heading { display:inline-block; font-weight:bold; font-size:3rem }` | `inline-block text-5xl font-bold` |
| `ModalTextPrimary.text { font-size:22px; font-weight:bold; color:var(--brand-cool-dark-text); margin-bottom:0.5rem }` | `mb-2 text-[22px] font-bold text-[color:var(--brand-cool-dark-text)]` |

変更したファイル。

| ファイル | 何を変えたか |
|---|---|
| `src/layout/Section/index.tsx` | `classes.container` → `pt-8`、 `${className}` → `${className ?? ''}` で undefined fallback 明示 |
| `src/layout/Section/Section.module.css` | 削除 |
| `src/components/GrayCircle/index.tsx` | `classes.wrapper` → `h-[55px] w-[55px]` (任意値構文) |
| `src/components/GrayCircle/GrayCircle.module.css` | 削除 |
| `src/components/ModalBottomButtonRow/index.tsx` | `classes.buttonWrapper` → `mt-8 flex justify-between` |
| `src/components/ModalBottomButtonRow/ModalBottomButtonRow.module.css` | 削除 |
| `src/pages/NotFound/index.tsx` | `classes.heading` → `inline-block text-5xl font-bold` (3rem = text-5xl) |
| `src/pages/NotFound/NotFound.module.css` | 削除 |
| `src/components/ModalTextPrimary/index.tsx` | `classes.text` → `mb-2 text-[22px] font-bold text-[color:var(--brand-cool-dark-text)]` |
| `src/components/ModalTextPrimary/ModalTextPrimary.module.css` | 削除 |

# 検証

`pnpm test` で 35 件 PASS 維持 (regression なし、 既存 4 file fail は develop でも発生する `@heroicons/react/solid` 解決失敗で本 PR の影響外)。

# Issue #23 の進捗

| 指標 | sub-PR 1 前 | sub-PR 1 後 | sub-PR 2 (本 PR) 後 |
|---|---|---|---|
| CSS modules 数 | 94 | 89 | 84 |
| 削減累計 | 0 | -5 | -10 (10.6% 減) |

残 84 file は次の sub-PR (3-N) で進める。 候補は `Link.module.css` (8 行) / `StreamPaymentsReviewStep.module.css` (8 行) / `App.module.css` (12 行) / `MinBid.module.css` (13 行) 等。
