### PR TITLE
🔧 fix(niji-webapp): vite.config.ts の dev port を 2424 + strictPort に修正 (Refs #156)

### DIFF
--- a/packages/niji-webapp/vite.config.ts
+++ b/packages/niji-webapp/vite.config.ts
@@ -39,7 +39,8 @@ export default defineConfig({
     }),
   ],
   server: {
-    port: 3000,
+    port: 2424,
+    strictPort: true,
     hmr: {
       overlay: true,
     },


### PR DESCRIPTION
# 概要

CLAUDE.md で「dev server on port 2424 (strictPort: true、 3000 fallback なし)」 と確定しているが、 `packages/niji-webapp/vite.config.ts` は `port: 3000` のままで `strictPort` 不在だった。 結果 `pnpm dev` が 3000 で起動してしまう状態。
`server.port` を 2424 に変更し `strictPort: true` を追加して 3000 fallback を遮断する。

Refs #156

# 課題

CLAUDE.md と Issue #156 (PR #157 open) の方針 ... 「dev port 3000 → 2424 移行」 のうち、 PR #157 は webapp 内 wagmi NetworkAlert を扱うが vite.config.ts の port 同期が抜けていた。
- ローカル開発時 `pnpm dev` で実際は port 3000 に bind
- CLAUDE.md 記載と挙動が乖離
- portman 管理外 port (3000) が使われ続ける

# 解決方法

`packages/niji-webapp/vite.config.ts` の `server.port` を 2424 に変更、 `strictPort: true` を追加。

```diff
   server: {
-    port: 3000,
+    port: 2424,
+    strictPort: true,
     hmr: {
       overlay: true,
     },
   },
```

`strictPort` を true にすることで port 2424 が使用中の場合は `EADDRINUSE` で即時 fail、 silent fallback 3000 が起きない。

# 検証

`pnpm dev` で `http://localhost:2424` が HTTP 200 を返すこと確認済 (本セッション実機検証)。

# 関連

- PR #157 (NetworkAlert wagmi useSwitchChain + dev port 3000 → 2424、 open) と並走、 本 PR で vite.config 側を合わせる