### PR TITLE
🔧 fix(niji-webapp): sub-PR 8 で削除した module への dangling import 2 件を Tailwind 化 + 1 test 修正 (Issue #274 sub-PR 16)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionNavigation/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionNavigation/index.test.tsx
@@ -185,8 +185,10 @@ describe('AuctionNavigation Component', () => {
     const prevButton = screen.getByText('←');
     const nextButton = screen.getByText('→');
 
-    // Since we mocked isCool to be true
-    expect(prevButton.className).toContain('leftArrowCool');
-    expect(nextButton.className).toContain('rightArrowCool');
+    // Since we mocked isCool to be true, both buttons share the cool Tailwind variant
+    expect(prevButton.className).toContain('bg-[color:var(--brand-cool-accent)]');
+    expect(nextButton.className).toContain('bg-[color:var(--brand-cool-accent)]');
+    // Right arrow keeps the ml-[0.3rem] margin variant
+    expect(nextButton.className).toContain('ml-[0.3rem]');
   });
 });

--- a/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.tsx
@@ -1,13 +1,11 @@
 import { NijiImage } from '@/components/Niji';
 
-import classes from './CandidateSponsors.module.css';
-
 type CandidateSponsorImageProps = {
   nounId: bigint;
 };
 
 const CandidateSponsorImage = ({ nounId }: CandidateSponsorImageProps) => (
-  <div className={classes.sponsorAvatar}>
+  <div className="h-8 w-8 [&_img]:block [&_img]:w-full [&_img]:rounded-full">
     <NijiImage nounId={nounId} />
   </div>
 );

--- a/packages/niji-webapp/src/components/Proposals/index.tsx
+++ b/packages/niji-webapp/src/components/Proposals/index.tsx
@@ -35,7 +35,8 @@ import { useNounTokenBalance, useUserVotes } from '@/wrappers/nijiToken';
 
 import classes from './Proposals.module.css';
 
-import proposalStatusClasses from '@/components/ProposalStatus/ProposalStatus.module.css';
+const PROPOSAL_STATUS_CLASS =
+  "rounded-lg border-2 border-transparent px-[0.65rem] py-[0.36rem] font-['PT_Root_UI'] text-sm font-bold text-white";
 
 dayjs.extend(relativeTime);
 
@@ -283,12 +284,7 @@ const Proposals = ({ proposals, nounsRequired }: ProposalsProps) => {
 
                   const countdownPill = (
                     <div className={classes.proposalStatusWrapper}>
-                      <div
-                        className={clsx(
-                          proposalStatusClasses.proposalStatus,
-                          classes.countdownPill,
-                        )}
-                      >
+                      <div className={clsx(PROPOSAL_STATUS_CLASS, classes.countdownPill)}>
                         <div className={classes.countdownPillContentWrapper}>
                           <span className={classes.countdownPillClock}>
                             <ClockIcon height={16} width={16} />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,7 +435,7 @@ importers:
         version: 2.3.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
+        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
       dotenv:
         specifier: 'catalog:'
         version: 16.5.0
@@ -564,7 +564,7 @@ importers:
         version: 6.6.3
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
+        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
       abitype:
         specifier: ^1.0.8
         version: 1.0.8(typescript@5.9.2)(zod@3.25.76)
@@ -782,9 +782,6 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.0.0
         version: 4.0.18(bufferutil@4.0.9)(playwright@1.54.1)(utf-8-validate@5.0.7)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@4.0.18)
-      '@wagmi/cli':
-        specifier: 'catalog:'
-        version: 2.3.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -12440,6 +12437,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   precinct@11.0.5:


### PR DESCRIPTION
# 概要

ローカル dev server を立ち上げたところ、 sub-PR 8 (PR #279) で削除した CSS module を grep 漏れで参照し続けていた 2 file が Vite import-analysis エラーを出していたため修正。
合わせて、 過去 dev 環境で `@heroicons/react/solid` 等が unresolved で skip されていた test が `pnpm install -F @niji/webapp` 後に走るようになり、 sub-PR 13 で update し忘れていた AuctionNavigation の test 1 件も Tailwind class 確認に書換。

Refs #274

# 課題

```
[plugin:vite:import-analysis] Failed to resolve import "@/components/ProposalStatus/ProposalStatus.module.css" from "src/components/Proposals/index.tsx"
[plugin:vite:import-analysis] Failed to resolve import "./CandidateSponsors.module.css" from "src/components/CandidateCard/CandidateSponsorImage.tsx"
```

- sub-PR 8 の grep は `proposalStatusClasses` 名前で `Proposals/index.tsx` を、 `./CandidateSponsors.module.css` 相対 path を拾い損ねていた
- AuctionNavigation の test (`toContain('leftArrowCool')`) は sub-PR 13 (PR #284) の Tailwind 化で stale 化、 過去は test file が unresolved 依存で skip されていたため気づかれず

# 解決方法

3 file 修正。

| ファイル | 変更 |
|---|---|
| `src/components/Proposals/index.tsx` | `proposalStatusClasses` import を除去、 sub-PR 8 と同形の `PROPOSAL_STATUS_CLASS` 定数 (`rounded-lg border-2 border-transparent px-[0.65rem] py-[0.36rem] font-['PT_Root_UI'] text-sm font-bold text-white`) を file 内で再定義 |
| `src/components/CandidateCard/CandidateSponsorImage.tsx` | 相対 path `./CandidateSponsors.module.css` import を除去、 `classes.sponsorAvatar` (w/h 32px + img w-full + rounded-full + block) を子セレクタ `h-8 w-8 [&_img]:block [&_img]:w-full [&_img]:rounded-full` に置換 |
| `src/components/AuctionNavigation/index.test.tsx` | `toContain('leftArrowCool' / 'rightArrowCool')` を `toContain('bg-[color:var(--brand-cool-accent)]')` + `toContain('ml-[0.3rem]')` に書換、 sub-PR 13 の ARROW_BASE_CLASS / ARROW_COOL_CLASS と整合 |

# 検証

- 全 .tsx / .ts ファイルから `.module.css` import を抽出、 file system 上の存在を再帰確認 ... missing 0 件
- `pnpm test` (webapp) ... **52 件 PASS** + 1 skipped + 1 todo (sub-PR 13 までの 35 件から +17 件、 依存解決で過去 skip された test が走る)
- Vite import-analysis overlay 消滅、 `http://localhost:2424` 正常応答

pnpm-lock.yaml は同セッションで `pnpm install -F @niji/webapp` を実行した際の lockfile 自動更新 (依存 symlink 復旧で hash 変動)、 install 後の確定状態を含む。