### PR TITLE
🔧 fix(niji-webapp): index.html / site.webmanifest / JSDoc に残った Nouns 表記を Niji に置換

### DIFF
--- a/packages/niji-webapp/index.html
+++ b/packages/niji-webapp/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.ico" />
-    <script defer data-domain="nouns.wtf" src="https://plausible.io/js/plausible.js"></script>
+    <script defer data-domain="niji.wtf" src="https://plausible.io/js/plausible.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="One Noun, every day, forever. Nouns DAO is an experiment on the Ethereum blockchain."
+      content="One Niji, every day, forever. Niji DAO is an experiment on the Ethereum blockchain."
     />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -27,7 +27,7 @@
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
     -->
-    <title>Nouns DAO</title>
+    <title>Niji DAO</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/packages/niji-webapp/public/site.webmanifest.json
+++ b/packages/niji-webapp/public/site.webmanifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Nouns DAO",
-  "short_name": "Nouns DAO",
+  "name": "Niji DAO",
+  "short_name": "Niji DAO",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",

--- a/packages/niji-webapp/src/utils/getAddressFromQueryParams.ts
+++ b/packages/niji-webapp/src/utils/getAddressFromQueryParams.ts
@@ -3,7 +3,7 @@ import { isAddress } from 'viem';
 /**
  * Get address from query param
  *
- * @param paramName query param name i.e. for the URL nouns.wtf/delegate?to=0xabv... to would be the paramName
+ * @param paramName query param name i.e. for the URL niji.wtf/delegate?to=0xabv... to would be the paramName
  * @param useLocationResult string returned by react-router-v5 useLocation
  */
 export const getAddressFromQueryParams = (


### PR DESCRIPTION
# 概要

ローカル dev server (http://localhost:2424) を立ち上げたところ、 タブタイトル / meta description / PWA manifest 名が "Nouns DAO" のまま残っていた。
過去 rename PR が src 内 component 文字列を更新したものの、 static file (index.html / site.webmanifest.json) + 一部 JSDoc コメントの拾い漏らしを補完する。

# 課題

```
$ curl -s http://localhost:2424 | grep -E 'title|description'
<title>Nouns DAO</title>
content="One Noun, every day, forever. Nouns DAO is an experiment..."
data-domain="nouns.wtf"
```

ブラウザタブ表示 + OS の Recent Apps + PWA install 名が Nouns 表記、 user 視点で branding 整合性が壊れていた。

# 解決方法

3 file 修正。

| ファイル | 変更 |
|---|---|
| `packages/niji-webapp/index.html` | `<title>` / meta description / Plausible `data-domain` を Niji 化 (`Nouns DAO` → `Niji DAO`、 `One Noun` → `One Niji`、 `nouns.wtf` → `niji.wtf`) |
| `packages/niji-webapp/public/site.webmanifest.json` | PWA manifest の `name` / `short_name` を `Niji DAO` に (`Nouns DAO` × 2 箇所) |
| `packages/niji-webapp/src/utils/getAddressFromQueryParams.ts` | JSDoc 例 URL `nouns.wtf/delegate` → `niji.wtf/delegate` |

# 仕組み

```mermaid
graph LR
    A[ブラウザ /<br/>OS] -->|GET /| B[index.html<br/>title / description]
    A -->|GET /site.webmanifest.json| C[PWA name]
    A -->|Plausible analytics| D[data-domain]
    B -.->|残置 残骸| E[Nouns DAO 表示]
    C -.->|残置 残骸| E
    D -.->|残置 残骸| F[nouns.wtf に計測送信]
```

問題点。

- title / manifest name が Nouns のままだとブラウザ tab + OS recent apps + PWA インストール時のショートカット名が "Nouns DAO" になる
- Plausible analytics の `data-domain` が `nouns.wtf` のままだと別 site の統計に混入する (本番反映時に重要)
- meta description が google 検索結果 snippet に出る

修正後。

```mermaid
graph LR
    A[ブラウザ /<br/>OS] -->|title| B[Niji DAO]
    A -->|PWA name| B
    A -->|data-domain| C[niji.wtf]
```

# 検証

`curl http://localhost:2424` 出力。

```
<title>Niji DAO</title>
content="One Niji, every day, forever. Niji DAO is an experiment on the Ethereum blockchain."
data-domain="niji.wtf"
```

vitest 52 件 PASS 維持 (本 PR の修正範囲外)。

# 残置の判断

`packages/niji-webapp/src/components/Documentation/index.tsx:185` の Proposal 727 link (`https://nouns.wtf/vote/727`) は **文脈的に元 Nouns DAO の Proposal 727 を参照** している記述 (Niji DUNA が Wyoming で Nouns DAO Proposal 727 に基づいて構築された歴史説明) のため残置。 link が Niji DAO 側に存在しない場合は branding 違反でなく事実引用。

`dist/` 配下の build 成果物 (dist/index.html / dist/site.webmanifest.json) は git ignore 対象、 次回 build 時に src の修正が伝播する。