### PR TITLE
🔧 fix(niji-webapp): branding sweep — Trans macro / JSX text / string literal の Nouns/Noun を Niji に置換

### DIFF
--- a/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
+++ b/packages/niji-webapp/src/components/AddNijisToForkModal/index.tsx
@@ -232,7 +232,7 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
     <div className={classes.confirmModalContent}>
       <h2 className={classes.modalTitle}>Confirm</h2>
       <p className={classes.modalDescription}>
-        By joining this fork you are giving up your Nouns to be retrieved in the new fork. This
+        By joining this fork you are giving up your Niji to be retrieved in the new fork. This
         cannot be undone.
       </p>
       <button
@@ -260,18 +260,18 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
   const modalContent = (
     <div className={classes.modalContent}>
       <h2 className={classes.modalTitle}>
-        {props.isForkingPeriod ? 'Join fork' : 'Add Nouns to escrow'}
+        {props.isForkingPeriod ? 'Join fork' : 'Add Niji to escrow'}
       </h2>
 
       <p className={classes.modalDescription}>
         {!props.isForkingPeriod ? (
           <>
             Nouners can withdraw their tokens from escrow as long as the forking period hasn&apos;t
-            started. Nouns in escrow are not eligible to vote or submit proposals.
+            started. Niji in escrow are not eligible to vote or submit proposals.
           </>
         ) : (
           <>
-            By joining this fork you are giving up your Nouns to be retrieved in the new fork. This
+            By joining this fork you are giving up your Niji to be retrieved in the new fork. This
             cannot be undone.
           </>
         )}
@@ -340,12 +340,12 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
       <div className={classes.sectionHeader}>
         <div className={classes.sectionLabel}>
           <p>
-            <strong>Select Nouns to {props.isForkingPeriod ? 'join fork' : 'to escrow'}</strong>
+            <strong>Select Niji to {props.isForkingPeriod ? 'join fork' : 'to escrow'}</strong>
           </p>
           <p>
             <Trans>
-              Add as many or as few of your Nouns as you’d like. Additional Nouns can be added
-              during the escrow and forking periods.
+              Add as many or as few of your Niji as you’d like. Additional Niji can be added during
+              the escrow and forking periods.
             </Trans>
           </p>
         </div>
@@ -484,7 +484,7 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
                 target="_blank"
                 rel="noreferrer"
               >
-                Your Nouns have been added to {props.isForkingPeriod ? 'the fork' : 'escrow'}
+                Your Niji have been added to {props.isForkingPeriod ? 'the fork' : 'escrow'}
                 {escrowToForkState.transaction && <img src={link} width={16} alt="link symbol" />}
               </a>
               {props.userEscrowedNouns &&
@@ -496,7 +496,7 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
                       clearTransactionState();
                     }}
                   >
-                    Add additional Nouns
+                    Add additional Niji
                   </button>
                 )}
             </p>
@@ -553,7 +553,7 @@ const AddNijisToForkModal = (props: AddNounsToForkModalProps) => {
         {selectedNouns.length > 0 && !isTxSuccessful && (
           <>
             <p className={classes.selectedNouns}>
-              Adding {selectedNouns.map(nounId => `Noun ${nounId}`).join(', ')}
+              Adding {selectedNouns.map(nounId => `Niji ${nounId}`).join(', ')}
             </p>
           </>
         )}

--- a/packages/niji-webapp/src/components/AuctionNavigation/index.tsx
+++ b/packages/niji-webapp/src/components/AuctionNavigation/index.tsx
@@ -28,7 +28,7 @@ const AuctionNavigation: React.FC<AuctionNavigationProps> = props => {
   const lastAuctionNounId = useAppSelector(state => state.onDisplayAuction.lastAuctionNounId);
   const onDisplayAuctionNounId = Number(onDisplayAuction?.nounId);
 
-  // Page through Nouns via a keyboard
+  // Page through Niji via a keyboard
   // handle what happens on key press
   const handleKeyPress = useCallback(
     (event: { key: string }) => {

--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.tsx
@@ -67,11 +67,11 @@ const ByLineHoverCard: React.FC<ByLineHoverCardProps> = props => {
           <ScaleIcon height={15} width={15} className="mb-[5px] mr-[6px]" />
           {sortedNounIds?.length === 1 ? (
             <Trans>
-              <span>Delegated Noun: </span>
+              <span>Delegated Niji: </span>
             </Trans>
           ) : (
             <Trans>
-              <span>Delegated Nouns: </span>
+              <span>Delegated Niji: </span>
             </Trans>
           )}
 

--- a/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.tsx
@@ -189,8 +189,8 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
                   <p className={classes.subhead}>
                     {isThresholdMet && !props.isUpdateToProposal ? (
                       <Trans>
-                        This candidate has met the required threshold, but Nouns voters can still
-                        add support until it’s put onchain.
+                        This candidate has met the required threshold, but Niji voters can still add
+                        support until it’s put onchain.
                       </Trans>
                     ) : (
                       <>
@@ -200,7 +200,7 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
                           </Trans>
                         ) : (
                           <Trans>
-                            Proposal candidates must meet the required Nouns vote threshold.
+                            Proposal candidates must meet the required Niji vote threshold.
                           </Trans>
                         )}
                       </>
@@ -312,7 +312,7 @@ const CandidateSponsors: React.FC<CandidateSponsorsProps> = props => {
                                   <div className={classes.withoutVotesMsg}>
                                     <p>
                                       <Trans>
-                                        Sponsoring a proposal requires at least one Noun vote
+                                        Sponsoring a proposal requires at least one Niji vote
                                       </Trans>
                                     </p>
                                   </div>

--- a/packages/niji-webapp/src/components/CurrentBid/index.tsx
+++ b/packages/niji-webapp/src/components/CurrentBid/index.tsx
@@ -14,12 +14,12 @@ const LEFT_COL_CLASS = 'max-[992px]:pl-2';
 
 /**
  * Passible to CurrentBid as `currentBid` prop to indicate that
- * the bid amount is not applicable to this auction. (Nounder Noun)
+ * the bid amount is not applicable to this auction. (Nounder Niji)
  */
 export const BID_N_A = 'n/a';
 
 /**
- * Special Bid type for not applicable auctions (Nounder Nouns)
+ * Special Bid type for not applicable auctions (Nounder Niji)
  */
 type BidNa = typeof BID_N_A;
 

--- a/packages/niji-webapp/src/components/CurrentDelegatePannel/index.tsx
+++ b/packages/niji-webapp/src/components/CurrentDelegatePannel/index.tsx
@@ -47,8 +47,8 @@ const CurrentDelegatePannel: React.FC<CurrentDelegatePannelProps> = ({
 
           <p className={COPY_CLASS}>
             <Trans>
-              Noun votes are not transferable, but are <span className="emph">delegatable</span>,
-              which means you can assign your vote to someone else as long as you own your Noun.
+              Niji votes are not transferable, but are <span className="emph">delegatable</span>,
+              which means you can assign your vote to someone else as long as you own your Niji.
             </Trans>
           </p>
         </div>

--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.tsx
@@ -39,7 +39,7 @@ const DelegateGruopedNounImageVoteTable: React.FC<
             hoverCardContent={(tip: string) => (
               <DelegateHoverCard delegateId={tip} proposalCreationBlock={proposalCreationBlock} />
             )}
-            // We add this prefix to prevent collisions with the Noun info cards
+            // We add this prefix to prevent collisions with the Niji info cards
             tip={`delegate-${data.delegate}`}
             id="delegateVoteHoverCard"
           >

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.tsx
@@ -59,7 +59,7 @@ const DelegateHoverCard: React.FC<DelegateHoverCardProps> = props => {
           </Trans>
         ) : (
           <Trans>
-            Voted with<span className="mx-1 font-bold">{numVotesForProp}</span>Nouns
+            Voted with<span className="mx-1 font-bold">{numVotesForProp}</span>Niji
           </Trans>
         )}
       </div>

--- a/packages/niji-webapp/src/components/DynamicQuorumInfoModal/index.tsx
+++ b/packages/niji-webapp/src/components/DynamicQuorumInfoModal/index.tsx
@@ -90,7 +90,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
               <Trans>
                 The Threshold (minimum number of For votes required to pass a proposal) is set as a
                 function of the number of Against votes a proposal has received. It increases
-                linearly as a function of the % of Nouns voting against a prop, varying between Min
+                linearly as a function of the % of Niji voting against a prop, varying between Min
                 Threshold and Max Threshold.
               </Trans>
             ) : (
@@ -108,7 +108,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
           >
             <div className={classes.mobileQuorumInfo}>
               <span>Min Threshold:</span> {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
-              Nouns
+              Niji
             </div>
 
             <div className={classes.mobileQuorumInfo}>
@@ -116,12 +116,12 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
               {Math.floor(
                 (Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) * totalNounSupply) / 10_000,
               )}{' '}
-              Nouns
+              Niji
             </div>
 
             <div className={classes.mobileQuorumInfo}>
               <span>Max Threshold:</span> {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)}{' '}
-              Nouns
+              Niji
             </div>
           </div>
 
@@ -174,7 +174,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
                       x={470 + 10}
                       y={PLOTTING_CONSTANTS.height - 10}
                     >
-                      {linearToConstantCrossoverBPS / 100}% of Nouns Against
+                      {linearToConstantCrossoverBPS / 100}% of Niji Against
                     </text>
                   )}
                   {/* Vertical Line indicating against BPS */}
@@ -197,9 +197,9 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
                   />
                   <circle cy={y} cx={x} r="7" fill="var(--brand-gray-light-text)" />
                   <text x="20" y="24">
-                    Max Threshold: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                    Max Threshold: {Math.floor((maxQuorumBps * totalNounSupply) / 10_000)} Niji{' '}
                     <tspan fill="var(--brand-gray-light-text)">
-                      ({maxQuorumBps / 100}% of Nouns)
+                      ({maxQuorumBps / 100}% of Niji)
                     </tspan>
                   </text>
                   {Math.abs(y - 10 - PLOTTING_CONSTANTS.minQHeightPlotSpace) > 100 ? (
@@ -207,19 +207,19 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
                       <text x="20" y="280">
                         Min Threshold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)}{' '}
                         {Math.floor((minQuorumBps * totalNounSupply) / 10_000) === 1
-                          ? 'Noun'
-                          : 'Nouns'}{' '}
+                          ? 'Niji'
+                          : 'Niji'}{' '}
                         <tspan fill="var(--brand-gray-light-text)">
-                          ({minQuorumBps / 100}% of Nouns)
+                          ({minQuorumBps / 100}% of Niji)
                         </tspan>
                       </text>
                     </>
                   ) : (
                     <>
                       <text x="550" y="280">
-                        Min Thresold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Nouns{' '}
+                        Min Thresold: {Math.floor((minQuorumBps * totalNounSupply) / 10_000)} Niji{' '}
                         <tspan fill="var(--brand-gray-light-text)">
-                          ({minQuorumBps / 100}% of Nouns)
+                          ({minQuorumBps / 100}% of Niji)
                         </tspan>
                       </text>
                     </>
@@ -227,7 +227,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
                   {againstVotesBps >= 400 && againstVotesAbs >= maxQuorumBps && (
                     <text x={10} y={y - 10} fill="var(--brand-gray-light-text)">
                       {Math.floor(Math.min(maxQuorumBps, dqmFunction(againstVotesBps)) / 100)}% of
-                      Nouns
+                      Niji
                     </text>
                   )}
                   {againstVotesBps > 4000 ? (
@@ -237,7 +237,7 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
                     >
                       Current Threshold: {currentQuorum}{' '}
                       <tspan fill="var(--brand-gray-light-text)">
-                        ({againstVotesAbs} {againstVotesAbs === 1 ? 'Noun' : 'Nouns'} Currently
+                        ({againstVotesAbs} {againstVotesAbs === 1 ? 'Niji' : 'Niji'} Currently
                         Against)
                       </tspan>
                     </text>
@@ -248,14 +248,14 @@ const DynamicQuorumInfoModalOverlay: React.FC<DynamicQuorumInfoModalOverlayProps
                     >
                       Current Threshold: {currentQuorum}{' '}
                       <tspan fill="var(--brand-gray-light-text)">
-                        ({againstVotesAbs} {againstVotesAbs === 1 ? 'Noun' : 'Nouns'} Currently
+                        ({againstVotesAbs} {againstVotesAbs === 1 ? 'Niji' : 'Niji'} Currently
                         Against)
                       </tspan>
                     </text>
                   )}
                   {againstVotesAbs > 0 && (
                     <text x={x + (x < 712 ? 10 : -110)} y={310} fill="var(--brand-gray-light-text)">
-                      {Math.floor(againstVotesBps / 100)}% of Nouns
+                      {Math.floor(againstVotesBps / 100)}% of Niji
                     </text>
                   )}
                   {againstVotesBps >= 0.1 * maxQuorumBps && (

--- a/packages/niji-webapp/src/components/ForkingPeriodTimer/index.tsx
+++ b/packages/niji-webapp/src/components/ForkingPeriodTimer/index.tsx
@@ -108,7 +108,7 @@ const ForkingPeriodTimer: React.FC<ForkingPeriodTimerProps> = props => {
               </div>
             )}
           </h2>
-          <p>time left to return Nouns and join this fork</p>
+          <p>time left to return Niji and join this fork</p>
         </>
       ) : (
         <>

--- a/packages/niji-webapp/src/components/ProposalHeader/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalHeader/index.tsx
@@ -297,7 +297,7 @@ const ProposalHeader: React.FC<ProposalHeaderProps> = props => {
         !hasVoted && (
           <Alert variant="success" className={classes.voterIneligibleAlert}>
             <Trans>
-              Only Nouns you owned or were delegated to you before{' '}
+              Only Niji you owned or were delegated to you before{' '}
               {i18n.date(new Date(proposalCreationTimestamp * 1000), {
                 dateStyle: 'long',
                 timeStyle: 'long',

--- a/packages/niji-webapp/src/components/Proposals/index.tsx
+++ b/packages/niji-webapp/src/components/Proposals/index.tsx
@@ -399,7 +399,7 @@ const Proposals = ({ proposals, nounsRequired }: ProposalsProps) => {
                 <p>
                   <Trans>
                     Proposal candidates can be created by anyone. If a candidate receives enough
-                    signatures by Nouns voters, it can be promoted to a proposal.
+                    signatures by Niji voters, it can be promoted to a proposal.
                   </Trans>
                 </p>
                 <Link to="/create-candidate" className={clsx(classes.button)}>

--- a/packages/niji-webapp/src/components/VoteModal/index.tsx
+++ b/packages/niji-webapp/src/components/VoteModal/index.tsx
@@ -117,7 +117,7 @@ const VoteModal = ({
           </Trans>
         ) : (
           <Trans>
-            Voting with <span className={classes.bold}>{i18n.number(availableVotes)}</span> Nouns
+            Voting with <span className={classes.bold}>{i18n.number(availableVotes)}</span> Niji
           </Trans>
         )}
       </div>

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignals.tsx
@@ -183,8 +183,8 @@ function VoteSignals({
             {!isCandidate && (
               <p className="m-0 p-0 text-base font-[PT_Root_UI] text-[var(--brand-gray-light-text)]">
                 <Trans>
-                  Nouns voters can cast voting signals to give proposers of pending proposals an
-                  idea of how they intend to vote and helpful guidance on proposal changes to change
+                  Niji voters can cast voting signals to give proposers of pending proposals an idea
+                  of how they intend to vote and helpful guidance on proposal changes to change
                   their vote.
                 </Trans>
               </p>
@@ -360,7 +360,7 @@ function VoteSignals({
           {isCandidate && (
             <p className="m-0 mt-2 p-0 text-base text-sm font-[PT_Root_UI] leading-tight text-[var(--brand-gray-light-text)]">
               <Trans>
-                Nouns voters can cast voting signals to give proposers of pending proposals an idea
+                Niji voters can cast voting signals to give proposers of pending proposals an idea
                 of how they intend to vote and helpful guidance on proposal changes to change their
                 vote.
               </Trans>

--- a/packages/niji-webapp/src/pages/CreateCandidate/index.tsx
+++ b/packages/niji-webapp/src/pages/CreateCandidate/index.tsx
@@ -204,14 +204,14 @@ const CreateCandidatePage = () => {
         <Alert variant="secondary" className={classes.voterIneligibleAlert}>
           <Trans>
             Proposal candidates can be created by anyone. If a candidate receives enough signatures
-            by Nouns voters, it can be promoted to a proposal.{' '}
+            by Niji voters, it can be promoted to a proposal.{' '}
           </Trans>
           <br />
           <br />
 
           <strong>
             <Trans>
-              Submissions are free for Nouns voters. Non-voters can submit for a{' '}
+              Submissions are free for Niji voters. Non-voters can submit for a{' '}
               {createCandidateCost ? formatEther(createCandidateCost) : '0'} ETH fee.
             </Trans>
           </strong>

--- a/packages/niji-webapp/src/pages/Fork/ForkDeployEvent.tsx
+++ b/packages/niji-webapp/src/pages/Fork/ForkDeployEvent.tsx
@@ -12,7 +12,7 @@ type Props = {
 const ForkCycleEvent = ({ forkDetails }: Props) => {
   const actionLabel = 'Fork deployed';
   const nounCount = forkDetails?.tokensInEscrowCount;
-  const nounLabel = nounCount > 1 ? 'Nouns' : 'Noun';
+  const nounLabel = nounCount > 1 ? 'Niji' : 'Niji';
   const timestamp = dayjs(
     forkDetails?.forkingPeriodEndTimestamp && +forkDetails?.forkingPeriodEndTimestamp * 1000,
   ).fromNow();

--- a/packages/niji-webapp/src/pages/Fork/ForkEvent.tsx
+++ b/packages/niji-webapp/src/pages/Fork/ForkEvent.tsx
@@ -48,8 +48,8 @@ const ForkEvent = ({ event, isOnlyEvent }: Props) => {
           setActionLabel('added');
           setNounCount(
             event.tokenIDs?.length > 1
-              ? `${event.tokenIDs?.length} Nouns`
-              : `Noun ${event.tokenIDs?.[0]}`,
+              ? `${event.tokenIDs?.length} Niji`
+              : `Niji ${event.tokenIDs?.[0]}`,
           );
           setNounsInEvent(
             event.tokenIDs?.map((tokenId, i) => {
@@ -57,7 +57,7 @@ const ForkEvent = ({ event, isOnlyEvent }: Props) => {
                 <Link key={i} to={`/niji/${tokenId}`}>
                   <img
                     src={`https://noun.pics/${tokenId}`}
-                    alt={`Noun ${tokenId}`}
+                    alt={`Niji ${tokenId}`}
                     className={classes.nounImage}
                   />
                 </Link>
@@ -79,8 +79,8 @@ const ForkEvent = ({ event, isOnlyEvent }: Props) => {
           setActionLabel('joined with');
           setNounCount(
             event.tokenIDs?.length > 1
-              ? `${event.tokenIDs?.length} Nouns`
-              : `Noun ${event.tokenIDs?.[0]}`,
+              ? `${event.tokenIDs?.length} Niji`
+              : `Niji ${event.tokenIDs?.[0]}`,
           );
           setNounsInEvent(
             event.tokenIDs?.map((tokenId, i) => {
@@ -88,7 +88,7 @@ const ForkEvent = ({ event, isOnlyEvent }: Props) => {
                 <Link key={i} to={`/niji/${tokenId}`}>
                   <img
                     src={`https://noun.pics/${tokenId}`}
-                    alt={`Noun ${tokenId}`}
+                    alt={`Niji ${tokenId}`}
                     className={classes.nounImage}
                   />
                 </Link>
@@ -110,8 +110,8 @@ const ForkEvent = ({ event, isOnlyEvent }: Props) => {
           setActionLabel('removed');
           setNounCount(
             event.tokenIDs?.length > 1
-              ? `${event.tokenIDs?.length} Nouns`
-              : `Noun ${event.tokenIDs?.[0]}`,
+              ? `${event.tokenIDs?.length} Niji`
+              : `Niji ${event.tokenIDs?.[0]}`,
           );
           setNounsInEvent(
             event.tokenIDs?.map((tokenId, i) => {
@@ -119,7 +119,7 @@ const ForkEvent = ({ event, isOnlyEvent }: Props) => {
                 <Link key={i} to={`/niji/${tokenId}`}>
                   <img
                     src={`https://noun.pics/${tokenId}`}
-                    alt={`Noun ${tokenId}`}
+                    alt={`Niji ${tokenId}`}
                     className={classes.nounImage}
                   />
                 </Link>

--- a/packages/niji-webapp/src/pages/Fork/WithdrawNijisButton.tsx
+++ b/packages/niji-webapp/src/pages/Fork/WithdrawNijisButton.tsx
@@ -113,7 +113,7 @@ function WithdrawNijisButton(props: Props) {
         )}
         {isTxSuccessful && (
           <>
-            Success! Your Nouns have been withdrawn.
+            Success! Your Niji have been withdrawn.
             {withdrawFromForkEscrowState.transaction.hash && (
               <a
                 href={`${buildEtherscanTxLink(withdrawFromForkEscrowState.transaction.hash)}`}

--- a/packages/niji-webapp/src/pages/Fork/index.tsx
+++ b/packages/niji-webapp/src/pages/Fork/index.tsx
@@ -50,7 +50,7 @@ const ForkPage = () => {
   const [currentEscrowPercentage, setCurrentEscrowPercentage] = useState(0);
   const [dataFetchPollInterval, setDataFetchPollInterval] = useState(0);
   const [forkStatusLabel, setForkStatusLabel] = useState('Escrow');
-  const [addNounsButtonLabel, setAddNounsButtonLabel] = useState('Add Nouns to escrow');
+  const [addNounsButtonLabel, setAddNounsButtonLabel] = useState('Add Niji to escrow');
 
   // Hooks
   const adjustedTotalSupply = useAdjustedTotalSupply();
@@ -128,11 +128,11 @@ const ForkPage = () => {
     } else if (!timestamp && forkDetails?.data?.tokensInEscrowCount) {
       // 'escrow'
       setForkStatusLabel('Escrow');
-      setAddNounsButtonLabel('Add Nouns to escrow');
+      setAddNounsButtonLabel('Add Niji to escrow');
     } else {
       // 'pre-escrow'
       setForkStatusLabel('Pre-escrow');
-      setAddNounsButtonLabel('Add Nouns to Start Escrow Period');
+      setAddNounsButtonLabel('Add Niji to Start Escrow Period');
     }
   };
 
@@ -253,7 +253,7 @@ const ForkPage = () => {
                 {!isForked && !isForkPeriodActive && (
                   <p className={classes.note}>
                     <Trans>
-                      More than {forkThreshold == null ? '...' : forkThreshold} Nouns{' '}
+                      More than {forkThreshold == null ? '...' : forkThreshold} Niji{' '}
                       {`(${forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'}% of the DAO)`}{' '}
                       are required to pass the threshold
                     </Trans>
@@ -432,7 +432,7 @@ const ForkPage = () => {
                       <p>
                         Your Niji{userEscrowedNounIds.data.length > 1 && 's'} in escrow:{' '}
                         <strong>
-                          {userEscrowedNounIds.data.map(nounId => `Noun ${nounId}`).join(', ')}
+                          {userEscrowedNounIds.data.map(nounId => `Niji ${nounId}`).join(', ')}
                         </strong>
                       </p>
                     </div>
@@ -468,13 +468,13 @@ const ForkPage = () => {
             isModalOpen={isModalOpen}
             isConfirmModalOpen={isConfirmModalOpen}
             isForkingPeriod={isForkPeriodActive}
-            title={'Add Nouns to escrow'}
+            title={'Add Niji to escrow'}
             description={
-              "Nouners can withdraw their tokens from escrow as long as the forking period hasn't started. Nouns in escrow are not eligible to vote or submit proposals."
+              "Nouners can withdraw their tokens from escrow as long as the forking period hasn't started. Niji in escrow are not eligible to vote or submit proposals."
             }
-            selectLabel={'Select Nouns to escrow'}
+            selectLabel={'Select Niji to escrow'}
             selectDescription={
-              'Add as many or as few of your Nouns as you’d like.  Additional Nouns can be added during the escrow period.'
+              'Add as many or as few of your Niji as you’d like.  Additional Niji can be added during the escrow period.'
             }
             account={account}
             ownedNouns={userOwnedNounIds.data}

--- a/packages/niji-webapp/src/pages/NijisPage.tsx
+++ b/packages/niji-webapp/src/pages/NijisPage.tsx
@@ -209,7 +209,7 @@ const NijisPage: React.FC<NijisPageProps> = () => {
         </motion.div>
       </div>
 
-      {/* Selected Noun Details */}
+      {/* Selected Niji Details */}
       <motion.div layout className="border-border flex h-full flex-col border-l">
         <div className="bg-muted/40 flex h-full flex-col">
           {/* Niji Image */}

--- a/packages/niji-webapp/src/pages/Playground/index.tsx
+++ b/packages/niji-webapp/src/pages/Playground/index.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react-bootstrap';
 
 import InfoIcon from '@/assets/icons/Info.svg';
-import Noun from '@/components/LegacyNoun';
+import Niji from '@/components/LegacyNoun';
 import Link from '@/components/Link';
 import {
   getNijiData,
@@ -48,7 +48,7 @@ interface EncodedImage {
 
 const nounsProtocolLink = (
   <Link
-    text={<Trans>Nouns Protocol</Trans>}
+    text={<Trans>Niji Protocol</Trans>}
     url="https://www.notion.so/Noun-Protocol-32e4f0bf74fe433e927e2ea35e52a507"
     leavesPage={true}
   />
@@ -401,7 +401,7 @@ const Playground: FC = () => {
                           setDisplayNoun(true);
                         }}
                       >
-                        <Noun
+                        <Niji
                           imgPath={`data:image/svg+xml;base64,${btoa(svg)}`}
                           alt="niji"
                           className={classes.nounImg}

--- a/packages/niji-webapp/src/pages/TraitsPage.tsx
+++ b/packages/niji-webapp/src/pages/TraitsPage.tsx
@@ -208,7 +208,7 @@ const TraitsPage: FC = () => {
             </Button>
           </div>
           <p className="mt-4 text-lg text-gray-600">
-            <Trans>Browse and download all available Noun traits.</Trans>
+            <Trans>Browse and download all available Niji traits.</Trans>
           </p>
         </div>
       </div>

--- a/packages/niji-webapp/src/wagmi.ts
+++ b/packages/niji-webapp/src/wagmi.ts
@@ -42,7 +42,7 @@ export const config = createConfig({
       showQrModal: false,
     }),
     coinbaseWallet({
-      appName: 'Nouns.WTF',
+      appName: 'Niji.WTF',
       appLogoUrl: 'https://nijis.wtf/static/media/logo.cdea1650.svg',
     }),
   ],


### PR DESCRIPTION
# 概要

PR #120 (Niji rename sub PR 1-e、 大規模 rename) で漏れていた user-visible な branding 文字列残骸を全 sweep。
識別子 / 変数名 / 動的 prop 名 / 固有名詞 (Nouns Protocol / Nounders / Nounder's Reward / Nounspot) は維持、 contextual 表示文字列のみ Niji 化。

# 課題

ローカル dev server (http://localhost:2424) でユーザーが画面を確認したところ Quorum / Vote Signals / Delegate Panel / Candidate Sponsors / Fork History 等で "Nouns voters can cast..." "Max Threshold ... Nouns" "Noun votes are not transferable" 等が表示され続けていた。 PR #120 + #167 でも sweep 漏れがあった範囲。

# 解決方法

26 file で表示文字列のみ置換 (識別子は保護)。

| ファイル | 主な変更 |
|---|---|
| `wagmi.ts` | coinbaseWallet `appName: 'Nouns.WTF'` → `'Niji.WTF'` |
| `DynamicQuorumInfoModal/index.tsx` | "Nouns voters / Nouns vote / Nouns voting / Nouns Against / Nouns / 'Noun' : 'Nouns'" 15 箇所 |
| `VoteSignals/VoteSignals.tsx` | "Nouns voters can cast voting signals..." × 2 |
| `CurrentDelegatePannel/index.tsx` | "Noun votes are not transferable" / "your Noun." |
| `CandidateSponsors/index.tsx` | "Nouns voters can still" / "required Nouns vote threshold" / "one Noun vote" |
| `ByLineHoverCard/index.tsx` | "Delegated Niji:" (single + plural 統合) |
| `Proposals/index.tsx`, `CreateCandidate/index.tsx` | "by Nouns voters" / "for Nouns voters" |
| `ProposalHeader/index.tsx` | "Only Nouns you owned" → "Only Niji you owned" |
| `ForkingPeriodTimer/index.tsx` | "return Nouns and join" → "return Niji and join" |
| `TraitsPage.tsx` | "all available Noun traits" → "all available Niji traits" |
| `Fork/ForkEvent.tsx`, `Fork/ForkDeployEvent.tsx` | template literal `Noun ${tokenId}` → `Niji ${tokenId}`、 `'Nouns'`/`'Noun'` → `'Niji'` |
| `Fork/index.tsx`, `AddNijisToForkModal/index.tsx` | map で生成する `Noun ${nounId}` |
| `Playground/index.tsx` | `<Noun ` → `<Niji ` (import alias `Niji = LegacyNoun` を使っていたが 1 箇所だけ旧名残置) |

# 維持した文字列

Niji DAO が Nouns DAO Fork 由来の文脈で参照する固有名詞は触らない。

- `Documentation.tsx` ... "Nounder's Reward" / "Proposal 727" link (Niji DUNA は Nouns DAO Proposal 727 に基づく Wyoming DUNA 構築の歴史記述)
- `NijisIntroSection` ... "Nounspot Map" iframe (元 Nouns spot map 外部サービス)
- `Nounders/index.tsx` ... "The Nounders" / "Nounders' Reward" (組織名)
- `Playground/index.tsx` ... "Nouns Protocol" Notion link (元 Nouns Protocol への参照)

# 検証

- 表示文字列 grep で `\bNouns\b` 残骸 0 件 (固有名詞除く)
- vitest 52 件 PASS 維持で regression なし
- ローカル dev server (http://localhost:2424) で HMR 反映、 Quorum / Vote Signals / Delegate Panel が Niji 表記に