### PR TITLE
🔧 fix(niji-webapp): Lingui 翻訳カタログ (.po) の Nouns/Noun を Niji に sweep

### DIFF
--- a/packages/niji-webapp/src/locales/en-US.po
+++ b/packages/niji-webapp/src/locales/en-US.po
@@ -79,10 +79,6 @@ msgstr "Review Streaming Payment Action"
 msgid "Proposal functions"
 msgstr "Proposal functions"
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "Proposal candidates must meet the required Nouns vote threshold."
-msgstr "Proposal candidates must meet the required Nouns vote threshold."
-
 #: src/components/Documentation/index.tsx
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
@@ -121,11 +117,6 @@ msgstr "Add Function Call Arguments"
 msgid "Treasury"
 msgstr "Treasury"
 
-#. placeholder {0}: i18n.number(availableVotes)
-#: src/components/VoteModal/index.tsx
-msgid "Voting with <0>{0}</0> Nouns"
-msgstr "Voting with <0>{0}</0> Nouns"
-
 #: src/pages/Vote/index.tsx
 msgid "Ended"
 msgstr "Ended"
@@ -138,10 +129,6 @@ msgstr "Select signatures"
 #: src/components/NavBar/index.tsx
 msgid "Candidates"
 msgstr "Candidates"
-
-#: src/components/CurrentDelegatePannel/index.tsx
-msgid "Noun votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Noun."
-msgstr "Noun votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Noun."
 
 #: src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
 msgid "Invalid Arguments"
@@ -171,6 +158,11 @@ msgstr "Nijis & Traits"
 #: src/components/ForkStatus/index.tsx
 msgid "In Escrow"
 msgstr "In Escrow"
+
+#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignals.tsx
+msgid "Niji voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
+msgstr "Niji voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 
 #: src/pages/EditProposal/index.tsx
 msgid "Proposal Candidate Created!"
@@ -280,14 +272,6 @@ msgstr "Consequently, the Niji Foundation anticipates being the steward of the v
 msgid "Bids for"
 msgstr "Bids for"
 
-#: src/pages/CreateCandidate/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal. "
-msgstr "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal. "
-
-#: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
-msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Go to playground"
 msgstr "Go to playground"
@@ -295,10 +279,6 @@ msgstr "Go to playground"
 #: src/components/Bid/index.tsx
 msgid "or more"
 msgstr "or more"
-
-#: src/pages/Playground/index.tsx
-msgid "Nouns Protocol"
-msgstr "Nouns Protocol"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
@@ -326,10 +306,6 @@ msgstr "Deploy Niji fork"
 #: src/components/ProposalHeader/index.tsx
 msgid "You have no votes."
 msgstr "You have no votes."
-
-#: src/components/CandidateSponsors/index.tsx
-msgid "Sponsoring a proposal requires at least one Noun vote"
-msgstr "Sponsoring a proposal requires at least one Noun vote"
 
 #: src/components/StreamWithdrawModal/index.tsx
 msgid "You've successfully withdrawn {withdrawAmount} {unitForDisplay} to your wallet"
@@ -399,6 +375,10 @@ msgstr "s"
 msgid "Queue"
 msgstr "Queue"
 
+#: src/components/CurrentDelegatePannel/index.tsx
+msgid "Niji votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Niji."
+msgstr "Niji votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Niji."
+
 #: src/components/Documentation/index.tsx
 msgid "CryptoPunks"
 msgstr "CryptoPunks"
@@ -416,10 +396,10 @@ msgstr "You can experiment with off-chain Niji generation at the {playgroundLink
 msgid "You've successfully voted on on prop {0}"
 msgstr "You've successfully voted on on prop {0}"
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
-msgid "Nouns voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
-msgstr "Nouns voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
+#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
+#: src/components/ProposalHeader/index.tsx
+msgid "Only Niji you owned or were delegated to you before {0} are eligible to vote."
+msgstr "Only Niji you owned or were delegated to you before {0} are eligible to vote."
 
 #: src/components/VoteModal/index.tsx
 msgid "Thank you for voting."
@@ -461,14 +441,16 @@ msgstr "Settlement of one auction kicks off the next."
 msgid "Ends {0}"
 msgstr "Ends {0}"
 
+#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
+#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
+#: src/pages/Fork/index.tsx
+msgid "More than {0} Niji ({1}% of the DAO) are required to pass the threshold"
+msgstr "More than {0} Niji ({1}% of the DAO) are required to pass the threshold"
+
 #: src/components/CreateProposalButton/index.tsx
 #: src/pages/CreateProposal/index.tsx
 msgid "Create Proposal"
 msgstr "Create Proposal"
-
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Noun: </0>"
-msgstr "<0>Delegated Noun: </0>"
 
 #: src/components/ProposalHeader/index.tsx
 msgid "You voted <0>For</0> this proposal"
@@ -500,13 +482,13 @@ msgstr "Governance"
 msgid "Cancel"
 msgstr "Cancel"
 
+#: src/components/CandidateSponsors/index.tsx
+msgid "Sponsoring a proposal requires at least one Niji vote"
+msgstr "Sponsoring a proposal requires at least one Niji vote"
+
 #: src/components/CandidateSponsors/SignatureForm.tsx
 msgid "Signature request"
 msgstr "Signature request"
-
-#: src/components/Proposals/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal."
-msgstr "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal."
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
@@ -730,12 +712,6 @@ msgstr "Delegation"
 msgid "Filename"
 msgstr "Filename"
 
-#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
-#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
-#: src/pages/Fork/index.tsx
-msgid "More than {0} Nouns ({1}% of the DAO) are required to pass the threshold"
-msgstr "More than {0} Nouns ({1}% of the DAO) are required to pass the threshold"
-
 #: src/components/Proposals/index.tsx
 msgid "About Proposal Candidates"
 msgstr "About Proposal Candidates"
@@ -764,6 +740,10 @@ msgstr "m"
 #: src/components/ForkingPeriodTimer/index.tsx
 msgid "minutes"
 msgstr "minutes"
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "This candidate has met the required threshold, but Niji voters can still add support until it’s put onchain."
+msgstr "This candidate has met the required threshold, but Niji voters can still add support until it’s put onchain."
 
 #: src/components/Proposals/index.tsx
 msgid "Candidates submitted by community members will appear here."
@@ -837,10 +817,6 @@ msgstr "Back"
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Nouns: </0>"
-msgstr "<0>Delegated Nouns: </0>"
-
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
 msgstr "Update Proposal Candidate"
@@ -853,6 +829,10 @@ msgstr "public domain"
 #: src/pages/TraitsPage.tsx
 msgid "License"
 msgstr "License"
+
+#: src/pages/TraitsPage.tsx
+msgid "Browse and download all available Niji traits."
+msgstr "Browse and download all available Niji traits."
 
 #: src/components/Proposals/index.tsx
 msgid "Connect wallet to make a proposal."
@@ -949,6 +929,11 @@ msgstr "Proposal Executed!"
 #: src/pages/EditProposal/index.tsx
 msgid "Note"
 msgstr "Note"
+
+#: src/components/ByLineHoverCard/index.tsx
+#: src/components/ByLineHoverCard/index.tsx
+msgid "<0>Delegated Niji: </0>"
+msgstr "<0>Delegated Niji: </0>"
 
 #: src/components/Documentation/index.tsx
 msgid "All Nijis are members of Niji DAO."
@@ -1094,11 +1079,6 @@ msgstr "Review Function Call Action"
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 
-#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
-#: src/components/ProposalHeader/index.tsx
-msgid "Only Nouns you owned or were delegated to you before {0} are eligible to vote."
-msgstr "Only Nouns you owned or were delegated to you before {0} are eligible to vote."
-
 #: src/components/Bid/index.tsx
 msgid "Settled auction successfully!"
 msgstr "Settled auction successfully!"
@@ -1196,6 +1176,10 @@ msgstr "Bid was placed successfully!"
 msgid "Current Threshold"
 msgstr "Current Threshold"
 
+#: src/pages/Playground/index.tsx
+msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nounsSDKLink}."
+msgstr "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nounsSDKLink}."
+
 #: src/pages/TraitsPage.tsx
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
@@ -1214,10 +1198,6 @@ msgstr "No arguments required "
 msgid "Add Streaming Payment Action"
 msgstr "Add Streaming Payment Action"
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "This candidate has met the required threshold, but Nouns voters can still add support until it’s put onchain."
-msgstr "This candidate has met the required threshold, but Nouns voters can still add support until it’s put onchain."
-
 #. placeholder {0}: isForked ? ` #${id}` : ''
 #: src/pages/Fork/index.tsx
 msgid "Niji DAO Fork{0}"
@@ -1227,6 +1207,10 @@ msgstr "Niji DAO Fork{0}"
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr "{0} votes"
+
+#: src/components/Proposals/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal."
+msgstr "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal."
 
 #: src/pages/Vote/index.tsx
 msgid "Withdraw from Stream <0/>"
@@ -1281,6 +1265,7 @@ msgid "Will have"
 msgstr "Will have"
 
 #: src/components/DelegateHoverCard/index.tsx
+#: src/components/DelegateHoverCard/index.tsx
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
 msgstr "Voted with<0>{numVotesForProp}</0>Niji"
 
@@ -1301,6 +1286,11 @@ msgstr "Current Delegate"
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
 msgstr "Threshold"
+
+#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
+#: src/pages/CreateCandidate/index.tsx
+msgid "Submissions are free for Niji voters. Non-voters can submit for a {0} ETH fee."
+msgstr "Submissions are free for Niji voters. Non-voters can submit for a {0} ETH fee."
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Delegate Updated!"
@@ -1343,10 +1333,6 @@ msgstr "View on Etherscan"
 msgid "Vetoed"
 msgstr "Vetoed"
 
-#: src/components/AddNijisToForkModal/index.tsx
-msgid "Add as many or as few of your Nouns as you’d like. Additional Nouns can be added during the escrow and forking periods."
-msgstr "Add as many or as few of your Nouns as you’d like. Additional Nouns can be added during the escrow and forking periods."
-
 #: src/components/ProposalEditor/index.tsx
 msgid "Preview"
 msgstr "Preview"
@@ -1356,8 +1342,8 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 
 #: src/pages/Playground/index.tsx
-msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
-msgstr "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
+#~ msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
+#~ msgstr "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
@@ -1392,10 +1378,6 @@ msgstr "Updating..."
 msgid "Starting on"
 msgstr "Starting on"
 
-#: src/pages/TraitsPage.tsx
-msgid "Browse and download all available Noun traits."
-msgstr "Browse and download all available Noun traits."
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Colored Noggles"
 msgstr "Colored Noggles"
@@ -1409,6 +1391,10 @@ msgstr "Proposer has {0} vote{1}"
 #: src/components/Documentation/index.tsx
 msgid "On-Chain Artwork"
 msgstr "On-Chain Artwork"
+
+#: src/components/AddNijisToForkModal/index.tsx
+msgid "Add as many or as few of your Niji as you’d like. Additional Niji can be added during the escrow and forking periods."
+msgstr "Add as many or as few of your Niji as you’d like. Additional Niji can be added during the escrow and forking periods."
 
 #: src/components/Footer.tsx
 msgid "Descriptor"
@@ -1434,11 +1420,8 @@ msgstr "While settlement is most heavily incentivized for the winning bidder, it
 msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
 msgstr "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
 
-#: src/components/DelegateHoverCard/index.tsx
-msgid "Voted with<0>{numVotesForProp}</0>Nouns"
-msgstr "Voted with<0>{numVotesForProp}</0>Nouns"
-
 #. placeholder {0}: i18n.number(availableVotes)
+#: src/components/VoteModal/index.tsx
 #: src/components/VoteModal/index.tsx
 msgid "Voting with <0>{0}</0> Niji"
 msgstr "Voting with <0>{0}</0> Niji"
@@ -1463,14 +1446,13 @@ msgstr "Add Stream Date Details"
 msgid "Forks"
 msgstr "Forks"
 
-#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
-#: src/pages/CreateCandidate/index.tsx
-msgid "Submissions are free for Nouns voters. Non-voters can submit for a {0} ETH fee."
-msgstr "Submissions are free for Nouns voters. Non-voters can submit for a {0} ETH fee."
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Explore traits"
 msgstr "Explore traits"
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Niji voting against a prop, varying between Min Threshold and Max Threshold."
+msgstr "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Niji voting against a prop, varying between Min Threshold and Max Threshold."
 
 #: src/pages/Vote/index.tsx
 msgid "Transaction Successful!"
@@ -1561,6 +1543,10 @@ msgstr "Offending proposal{0}"
 msgid "at"
 msgstr "at"
 
+#: src/pages/CreateCandidate/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal. "
+msgstr "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal. "
+
 #: src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.tsx
 msgid "Review Transfer Funds Action"
 msgstr "Review Transfer Funds Action"
@@ -1622,6 +1608,10 @@ msgstr "Defeated"
 #: src/components/Documentation/index.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nounders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nounders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nounders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nounders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "Proposal candidates must meet the required Niji vote threshold."
+msgstr "Proposal candidates must meet the required Niji vote threshold."
 
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 msgid "Choose sponsors"
@@ -1778,3 +1768,7 @@ msgstr "EVERY DAY,"
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"
 msgstr "Learn more"
+
+#: src/pages/Playground/index.tsx
+msgid "Niji Protocol"
+msgstr "Niji Protocol"

--- a/packages/niji-webapp/src/locales/ja-JP.po
+++ b/packages/niji-webapp/src/locales/ja-JP.po
@@ -84,10 +84,6 @@ msgstr "ストリーミング支払いアクションを確認"
 msgid "Proposal functions"
 msgstr "提案機能"
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "Proposal candidates must meet the required Nouns vote threshold."
-msgstr "提案候補は、必要なNounsの投票閾値を満たす必要があります。"
-
 #: src/components/Documentation/index.tsx
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
@@ -126,11 +122,6 @@ msgstr "関数呼び出し引数を追加"
 msgid "Treasury"
 msgstr "トレジャリー"
 
-#. placeholder {0}: i18n.number(availableVotes)
-#: src/components/VoteModal/index.tsx
-msgid "Voting with <0>{0}</0> Nouns"
-msgstr "<0>{0}</0> Nounsで投票"
-
 #: src/pages/Vote/index.tsx
 msgid "Ended"
 msgstr "終了しました"
@@ -143,10 +134,6 @@ msgstr "署名を選択"
 #: src/components/NavBar/index.tsx
 msgid "Candidates"
 msgstr "候補者"
-
-#: src/components/CurrentDelegatePannel/index.tsx
-msgid "Noun votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Noun."
-msgstr "Nounの票は譲渡できませんが (Nounの売却にはそれに応じて票も移ります)、委任することができます。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
 msgid "Invalid Arguments"
@@ -176,6 +163,11 @@ msgstr ""
 #: src/components/ForkStatus/index.tsx
 msgid "In Escrow"
 msgstr "エスクロー中"
+
+#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignals.tsx
+msgid "Niji voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
+msgstr "Nijiの投票者は、保留中の提案の提案者に対して、どのように投票するつもりかのアイデアを提供し、提案の変更に関する有益なガイダンスを提供するために投票シグナルを送ることができます。"
 
 #: src/pages/EditProposal/index.tsx
 msgid "Proposal Candidate Created!"
@@ -285,14 +277,6 @@ msgstr ""
 msgid "Bids for"
 msgstr "入札"
 
-#: src/pages/CreateCandidate/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal. "
-msgstr "提案候補は誰でも作成できます。候補がNounsの投票者から十分な署名を受け取ると、提案に昇格することができます。"
-
-#: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
-msgstr "閾値（提案を通過させるために必要な賛成票の最小数）は、提案が受けた反対票の数に基づいて設定されます。これは、提案に反対するNounsの割合に応じて線形に増加し、最小閾値と最大閾値の間で変動します。"
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Go to playground"
 msgstr "プレイグラウンドに行く"
@@ -300,10 +284,6 @@ msgstr "プレイグラウンドに行く"
 #: src/components/Bid/index.tsx
 msgid "or more"
 msgstr "かそれ以上"
-
-#: src/pages/Playground/index.tsx
-msgid "Nouns Protocol"
-msgstr "Nounsプロトコル"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
@@ -331,10 +311,6 @@ msgstr ""
 #: src/components/ProposalHeader/index.tsx
 msgid "You have no votes."
 msgstr "投票がありません。"
-
-#: src/components/CandidateSponsors/index.tsx
-msgid "Sponsoring a proposal requires at least one Noun vote"
-msgstr "提案をスポンサーするには、少なくとも1つのNounの投票が必要です"
 
 #: src/components/StreamWithdrawModal/index.tsx
 msgid "You've successfully withdrawn {withdrawAmount} {unitForDisplay} to your wallet"
@@ -404,6 +380,10 @@ msgstr "秒"
 msgid "Queue"
 msgstr "キュー"
 
+#: src/components/CurrentDelegatePannel/index.tsx
+msgid "Niji votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Niji."
+msgstr "Nijiの票は譲渡できませんが (Nijiの売却にはそれに応じて票も移ります)、委任することができます。"
+
 #: src/components/Documentation/index.tsx
 msgid "CryptoPunks"
 msgstr "クリプトパンクス"
@@ -421,10 +401,10 @@ msgstr ""
 msgid "You've successfully voted on on prop {0}"
 msgstr "あなたは提案 {0} に投票することに成功しました。"
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
-msgid "Nouns voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
-msgstr "Nounsの投票者は、保留中の提案の提案者に対して、どのように投票するつもりかのアイデアを提供し、提案の変更に関する有益なガイダンスを提供するために投票シグナルを送ることができます。"
+#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
+#: src/components/ProposalHeader/index.tsx
+msgid "Only Niji you owned or were delegated to you before {0} are eligible to vote."
+msgstr "投票できるのは {0} 以前に所有していた、または委任されたNijiのみです。"
 
 #: src/components/VoteModal/index.tsx
 msgid "Thank you for voting."
@@ -466,14 +446,16 @@ msgstr "オークションの決済が１つ終わる度に次が始まります
 msgid "Ends {0}"
 msgstr "残り{0} で終了します"
 
+#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
+#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
+#: src/pages/Fork/index.tsx
+msgid "More than {0} Niji ({1}% of the DAO) are required to pass the threshold"
+msgstr "閾値を通過するには、{0}以上のNouns（DAOの{1}%）が必要です"
+
 #: src/components/CreateProposalButton/index.tsx
 #: src/pages/CreateProposal/index.tsx
 msgid "Create Proposal"
 msgstr "提案を作成"
-
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Noun: </0>"
-msgstr "委任Noun: "
 
 #: src/components/ProposalHeader/index.tsx
 msgid "You voted <0>For</0> this proposal"
@@ -505,13 +487,13 @@ msgstr "ガバナンス"
 msgid "Cancel"
 msgstr "キャンセル"
 
+#: src/components/CandidateSponsors/index.tsx
+msgid "Sponsoring a proposal requires at least one Niji vote"
+msgstr "提案をスポンサーするには、少なくとも1つのNounの投票が必要です"
+
 #: src/components/CandidateSponsors/SignatureForm.tsx
 msgid "Signature request"
 msgstr "署名リクエスト"
-
-#: src/components/Proposals/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal."
-msgstr "提案候補は誰でも作成できます。候補がNounsの投票者から十分な署名を受け取った場合、それは提案に昇格することができます。"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
@@ -735,12 +717,6 @@ msgstr "デリゲーション"
 msgid "Filename"
 msgstr ""
 
-#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
-#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
-#: src/pages/Fork/index.tsx
-msgid "More than {0} Nouns ({1}% of the DAO) are required to pass the threshold"
-msgstr "閾値を通過するには、{0}以上のNouns（DAOの{1}%）が必要です"
-
 #: src/components/Proposals/index.tsx
 msgid "About Proposal Candidates"
 msgstr "提案候補について"
@@ -769,6 +745,10 @@ msgstr "分"
 #: src/components/ForkingPeriodTimer/index.tsx
 msgid "minutes"
 msgstr "分"
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "This candidate has met the required threshold, but Niji voters can still add support until it’s put onchain."
+msgstr "この候補者は必要な閾値を満たしていますが、Nijiの投票者はオンチェーンに載るまでサポートを追加できます。"
 
 #: src/components/Proposals/index.tsx
 msgid "Candidates submitted by community members will appear here."
@@ -842,10 +822,6 @@ msgstr "戻る"
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr ""
 
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Nouns: </0>"
-msgstr "委任Noun: "
-
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
 msgstr "提案候補を更新"
@@ -858,6 +834,10 @@ msgstr "パブリックドメイン"
 #: src/pages/TraitsPage.tsx
 msgid "License"
 msgstr "ライセンス"
+
+#: src/pages/TraitsPage.tsx
+msgid "Browse and download all available Niji traits."
+msgstr "利用可能なすべての名詞の特性を閲覧してダウンロード。"
 
 #: src/components/Proposals/index.tsx
 msgid "Connect wallet to make a proposal."
@@ -954,6 +934,11 @@ msgstr "提案が実行されました！"
 #: src/pages/EditProposal/index.tsx
 msgid "Note"
 msgstr "注"
+
+#: src/components/ByLineHoverCard/index.tsx
+#: src/components/ByLineHoverCard/index.tsx
+msgid "<0>Delegated Niji: </0>"
+msgstr "委任Noun: "
 
 #: src/components/Documentation/index.tsx
 msgid "All Nijis are members of Niji DAO."
@@ -1099,11 +1084,6 @@ msgstr "関数呼び出しアクションのレビュー"
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr ""
 
-#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
-#: src/components/ProposalHeader/index.tsx
-msgid "Only Nouns you owned or were delegated to you before {0} are eligible to vote."
-msgstr "投票できるのは {0} 以前に所有していた、または委任されたNounsのみです。"
-
 #: src/components/Bid/index.tsx
 msgid "Settled auction successfully!"
 msgstr "オークションが正常に決済されました！"
@@ -1201,6 +1181,10 @@ msgstr "正常に入札されました！"
 msgid "Current Threshold"
 msgstr "現在の閾値"
 
+#: src/pages/Playground/index.tsx
+msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nounsSDKLink}."
+msgstr ""
+
 #: src/pages/TraitsPage.tsx
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr "すべての特性は<0>CC0</0>（クリエイティブ・コモンズ・ゼロ）であり、パブリックドメインに属し、制限なくあらゆる目的で自由に使用できます。"
@@ -1219,10 +1203,6 @@ msgstr "引数は不要"
 msgid "Add Streaming Payment Action"
 msgstr "ストリーミング支払いアクションを追加"
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "This candidate has met the required threshold, but Nouns voters can still add support until it’s put onchain."
-msgstr "この候補者は必要な閾値を満たしていますが、Nounsの投票者はオンチェーンに載るまでサポートを追加できます。"
-
 #. placeholder {0}: isForked ? ` #${id}` : ''
 #: src/pages/Fork/index.tsx
 msgid "Niji DAO Fork{0}"
@@ -1232,6 +1212,10 @@ msgstr ""
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr "{0} 票"
+
+#: src/components/Proposals/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal."
+msgstr "提案候補は誰でも作成できます。候補がNijiの投票者から十分な署名を受け取った場合、それは提案に昇格することができます。"
 
 #: src/pages/Vote/index.tsx
 msgid "Withdraw from Stream <0/>"
@@ -1286,8 +1270,9 @@ msgid "Will have"
 msgstr "票になります"
 
 #: src/components/DelegateHoverCard/index.tsx
+#: src/components/DelegateHoverCard/index.tsx
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
-msgstr ""
+msgstr "<0>{numVotesForProp}</0>のNounで投票"
 
 #: src/components/VoteSignals/VoteSignals.tsx
 msgid "Pre-voting feedback"
@@ -1306,6 +1291,11 @@ msgstr "現在の代理人"
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
 msgstr "しきい値"
+
+#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
+#: src/pages/CreateCandidate/index.tsx
+msgid "Submissions are free for Niji voters. Non-voters can submit for a {0} ETH fee."
+msgstr "Nijiの投票者は提出が無料です。非投票者は{0} ETHの手数料で提出できます。"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Delegate Updated!"
@@ -1348,10 +1338,6 @@ msgstr "イーサスキャンで見る"
 msgid "Vetoed"
 msgstr "拒否"
 
-#: src/components/AddNijisToForkModal/index.tsx
-msgid "Add as many or as few of your Nouns as you’d like. Additional Nouns can be added during the escrow and forking periods."
-msgstr "お好きなだけ多くまたは少なくNounsを追加してください。追加のNounsはエスクロー期間とフォーク期間中に追加できます。"
-
 #: src/components/ProposalEditor/index.tsx
 msgid "Preview"
 msgstr "プレビュー"
@@ -1361,8 +1347,8 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr "あなたの<0>{availableVotes}</0>票が新しいアカウントに委任されました"
 
 #: src/pages/Playground/index.tsx
-msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
-msgstr ""
+#~ msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
+#~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
@@ -1397,10 +1383,6 @@ msgstr "更新"
 msgid "Starting on"
 msgstr "開始日"
 
-#: src/pages/TraitsPage.tsx
-msgid "Browse and download all available Noun traits."
-msgstr "利用可能なすべての名詞の特性を閲覧してダウンロード。"
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Colored Noggles"
 msgstr "カラーノグル"
@@ -1414,6 +1396,10 @@ msgstr "提案者は{0}票を持っています{1}"
 #: src/components/Documentation/index.tsx
 msgid "On-Chain Artwork"
 msgstr "オンチェーンアートワーク"
+
+#: src/components/AddNijisToForkModal/index.tsx
+msgid "Add as many or as few of your Niji as you’d like. Additional Niji can be added during the escrow and forking periods."
+msgstr "お好きなだけ多くまたは少なくNounsを追加してください。追加のNounsはエスクロー期間とフォーク期間中に追加できます。"
 
 #: src/components/Footer.tsx
 msgid "Descriptor"
@@ -1439,11 +1425,8 @@ msgstr ""
 msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
 msgstr "この提案にはUSDC資金移動アクションが含まれているため、TokenBuyer契約を補充するために追加のETHトランザクションを追加しました。このアクションにより、このような提案を資金提供するためにUSDCを信頼なく取得し続けることができます。"
 
-#: src/components/DelegateHoverCard/index.tsx
-msgid "Voted with<0>{numVotesForProp}</0>Nouns"
-msgstr "<0>{numVotesForProp}</0>のNounで投票"
-
 #. placeholder {0}: i18n.number(availableVotes)
+#: src/components/VoteModal/index.tsx
 #: src/components/VoteModal/index.tsx
 msgid "Voting with <0>{0}</0> Niji"
 msgstr ""
@@ -1468,14 +1451,13 @@ msgstr "ストリーム日付の詳細を追加"
 msgid "Forks"
 msgstr "フォーク"
 
-#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
-#: src/pages/CreateCandidate/index.tsx
-msgid "Submissions are free for Nouns voters. Non-voters can submit for a {0} ETH fee."
-msgstr "Nounsの投票者は提出が無料です。非投票者は{0} ETHの手数料で提出できます。"
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Explore traits"
 msgstr "特性を探索"
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Niji voting against a prop, varying between Min Threshold and Max Threshold."
+msgstr "閾値（提案を通過させるために必要な賛成票の最小数）は、提案が受けた反対票の数に基づいて設定されます。これは、提案に反対するNijiの割合に応じて線形に増加し、最小閾値と最大閾値の間で変動します。"
 
 #: src/pages/Vote/index.tsx
 msgid "Transaction Successful!"
@@ -1566,6 +1548,10 @@ msgstr "問題のある提案{0}"
 msgid "at"
 msgstr "の"
 
+#: src/pages/CreateCandidate/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal. "
+msgstr "提案候補は誰でも作成できます。候補がNijiの投票者から十分な署名を受け取ると、提案に昇格することができます。"
+
 #: src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.tsx
 msgid "Review Transfer Funds Action"
 msgstr "資金移動のアクションを確認"
@@ -1627,6 +1613,10 @@ msgstr "却下"
 #: src/components/Documentation/index.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nounders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nounders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr ""
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "Proposal candidates must meet the required Niji vote threshold."
+msgstr "提案候補は、必要なNijiの投票閾値を満たす必要があります。"
 
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 msgid "Choose sponsors"
@@ -1783,3 +1773,7 @@ msgstr "毎日"
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"
 msgstr "詳細はこちら"
+
+#: src/pages/Playground/index.tsx
+msgid "Niji Protocol"
+msgstr "Nijiプロトコル"

--- a/packages/niji-webapp/src/locales/pseudo.po
+++ b/packages/niji-webapp/src/locales/pseudo.po
@@ -79,10 +79,6 @@ msgstr ""
 msgid "Proposal functions"
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "Proposal candidates must meet the required Nouns vote threshold."
-msgstr ""
-
 #: src/components/Documentation/index.tsx
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
@@ -121,11 +117,6 @@ msgstr ""
 msgid "Treasury"
 msgstr ""
 
-#. placeholder {0}: i18n.number(availableVotes)
-#: src/components/VoteModal/index.tsx
-msgid "Voting with <0>{0}</0> Nouns"
-msgstr ""
-
 #: src/pages/Vote/index.tsx
 msgid "Ended"
 msgstr ""
@@ -137,10 +128,6 @@ msgstr ""
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "Candidates"
-msgstr ""
-
-#: src/components/CurrentDelegatePannel/index.tsx
-msgid "Noun votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Noun."
 msgstr ""
 
 #: src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
@@ -170,6 +157,11 @@ msgstr ""
 
 #: src/components/ForkStatus/index.tsx
 msgid "In Escrow"
+msgstr ""
+
+#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignals.tsx
+msgid "Niji voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 msgstr ""
 
 #: src/pages/EditProposal/index.tsx
@@ -280,24 +272,12 @@ msgstr ""
 msgid "Bids for"
 msgstr ""
 
-#: src/pages/CreateCandidate/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal. "
-msgstr ""
-
-#: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
-msgstr ""
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Go to playground"
 msgstr ""
 
 #: src/components/Bid/index.tsx
 msgid "or more"
-msgstr ""
-
-#: src/pages/Playground/index.tsx
-msgid "Nouns Protocol"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
@@ -325,10 +305,6 @@ msgstr ""
 #: src/components/ProposalHeader/CandidateHeader.tsx
 #: src/components/ProposalHeader/index.tsx
 msgid "You have no votes."
-msgstr ""
-
-#: src/components/CandidateSponsors/index.tsx
-msgid "Sponsoring a proposal requires at least one Noun vote"
 msgstr ""
 
 #: src/components/StreamWithdrawModal/index.tsx
@@ -399,6 +375,10 @@ msgstr ""
 msgid "Queue"
 msgstr ""
 
+#: src/components/CurrentDelegatePannel/index.tsx
+msgid "Niji votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Niji."
+msgstr ""
+
 #: src/components/Documentation/index.tsx
 msgid "CryptoPunks"
 msgstr ""
@@ -416,9 +396,9 @@ msgstr ""
 msgid "You've successfully voted on on prop {0}"
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
-msgid "Nouns voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
+#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
+#: src/components/ProposalHeader/index.tsx
+msgid "Only Niji you owned or were delegated to you before {0} are eligible to vote."
 msgstr ""
 
 #: src/components/VoteModal/index.tsx
@@ -461,13 +441,15 @@ msgstr ""
 msgid "Ends {0}"
 msgstr ""
 
+#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
+#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
+#: src/pages/Fork/index.tsx
+msgid "More than {0} Niji ({1}% of the DAO) are required to pass the threshold"
+msgstr ""
+
 #: src/components/CreateProposalButton/index.tsx
 #: src/pages/CreateProposal/index.tsx
 msgid "Create Proposal"
-msgstr ""
-
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Noun: </0>"
 msgstr ""
 
 #: src/components/ProposalHeader/index.tsx
@@ -500,12 +482,12 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
-msgid "Signature request"
+#: src/components/CandidateSponsors/index.tsx
+msgid "Sponsoring a proposal requires at least one Niji vote"
 msgstr ""
 
-#: src/components/Proposals/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal."
+#: src/components/CandidateSponsors/SignatureForm.tsx
+msgid "Signature request"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
@@ -730,12 +712,6 @@ msgstr ""
 msgid "Filename"
 msgstr ""
 
-#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
-#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
-#: src/pages/Fork/index.tsx
-msgid "More than {0} Nouns ({1}% of the DAO) are required to pass the threshold"
-msgstr ""
-
 #: src/components/Proposals/index.tsx
 msgid "About Proposal Candidates"
 msgstr ""
@@ -763,6 +739,10 @@ msgstr ""
 
 #: src/components/ForkingPeriodTimer/index.tsx
 msgid "minutes"
+msgstr ""
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "This candidate has met the required threshold, but Niji voters can still add support until it’s put onchain."
 msgstr ""
 
 #: src/components/Proposals/index.tsx
@@ -837,10 +817,6 @@ msgstr ""
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr ""
 
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Nouns: </0>"
-msgstr ""
-
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
 msgstr ""
@@ -852,6 +828,10 @@ msgstr ""
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 #: src/pages/TraitsPage.tsx
 msgid "License"
+msgstr ""
+
+#: src/pages/TraitsPage.tsx
+msgid "Browse and download all available Niji traits."
 msgstr ""
 
 #: src/components/Proposals/index.tsx
@@ -948,6 +928,11 @@ msgstr ""
 #: src/pages/EditProposal/index.tsx
 #: src/pages/EditProposal/index.tsx
 msgid "Note"
+msgstr ""
+
+#: src/components/ByLineHoverCard/index.tsx
+#: src/components/ByLineHoverCard/index.tsx
+msgid "<0>Delegated Niji: </0>"
 msgstr ""
 
 #: src/components/Documentation/index.tsx
@@ -1094,11 +1079,6 @@ msgstr ""
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr ""
 
-#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
-#: src/components/ProposalHeader/index.tsx
-msgid "Only Nouns you owned or were delegated to you before {0} are eligible to vote."
-msgstr ""
-
 #: src/components/Bid/index.tsx
 msgid "Settled auction successfully!"
 msgstr ""
@@ -1196,6 +1176,10 @@ msgstr ""
 msgid "Current Threshold"
 msgstr ""
 
+#: src/pages/Playground/index.tsx
+msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nounsSDKLink}."
+msgstr ""
+
 #: src/pages/TraitsPage.tsx
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr ""
@@ -1214,10 +1198,6 @@ msgstr ""
 msgid "Add Streaming Payment Action"
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "This candidate has met the required threshold, but Nouns voters can still add support until it’s put onchain."
-msgstr ""
-
 #. placeholder {0}: isForked ? ` #${id}` : ''
 #: src/pages/Fork/index.tsx
 msgid "Niji DAO Fork{0}"
@@ -1226,6 +1206,10 @@ msgstr ""
 #. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
+msgstr ""
+
+#: src/components/Proposals/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal."
 msgstr ""
 
 #: src/pages/Vote/index.tsx
@@ -1281,6 +1265,7 @@ msgid "Will have"
 msgstr ""
 
 #: src/components/DelegateHoverCard/index.tsx
+#: src/components/DelegateHoverCard/index.tsx
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
 msgstr ""
 
@@ -1300,6 +1285,11 @@ msgstr ""
 #: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
+msgstr ""
+
+#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
+#: src/pages/CreateCandidate/index.tsx
+msgid "Submissions are free for Niji voters. Non-voters can submit for a {0} ETH fee."
 msgstr ""
 
 #: src/components/ChangeDelegatePanel/index.tsx
@@ -1343,10 +1333,6 @@ msgstr ""
 msgid "Vetoed"
 msgstr ""
 
-#: src/components/AddNijisToForkModal/index.tsx
-msgid "Add as many or as few of your Nouns as you’d like. Additional Nouns can be added during the escrow and forking periods."
-msgstr ""
-
 #: src/components/ProposalEditor/index.tsx
 msgid "Preview"
 msgstr ""
@@ -1356,8 +1342,8 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr ""
 
 #: src/pages/Playground/index.tsx
-msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
-msgstr ""
+#~ msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
+#~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
@@ -1392,10 +1378,6 @@ msgstr ""
 msgid "Starting on"
 msgstr ""
 
-#: src/pages/TraitsPage.tsx
-msgid "Browse and download all available Noun traits."
-msgstr ""
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Colored Noggles"
 msgstr ""
@@ -1408,6 +1390,10 @@ msgstr ""
 
 #: src/components/Documentation/index.tsx
 msgid "On-Chain Artwork"
+msgstr ""
+
+#: src/components/AddNijisToForkModal/index.tsx
+msgid "Add as many or as few of your Niji as you’d like. Additional Niji can be added during the escrow and forking periods."
 msgstr ""
 
 #: src/components/Footer.tsx
@@ -1434,11 +1420,8 @@ msgstr ""
 msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
 msgstr ""
 
-#: src/components/DelegateHoverCard/index.tsx
-msgid "Voted with<0>{numVotesForProp}</0>Nouns"
-msgstr ""
-
 #. placeholder {0}: i18n.number(availableVotes)
+#: src/components/VoteModal/index.tsx
 #: src/components/VoteModal/index.tsx
 msgid "Voting with <0>{0}</0> Niji"
 msgstr ""
@@ -1463,13 +1446,12 @@ msgstr ""
 msgid "Forks"
 msgstr ""
 
-#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
-#: src/pages/CreateCandidate/index.tsx
-msgid "Submissions are free for Nouns voters. Non-voters can submit for a {0} ETH fee."
-msgstr ""
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Explore traits"
+msgstr ""
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Niji voting against a prop, varying between Min Threshold and Max Threshold."
 msgstr ""
 
 #: src/pages/Vote/index.tsx
@@ -1561,6 +1543,10 @@ msgstr ""
 msgid "at"
 msgstr ""
 
+#: src/pages/CreateCandidate/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal. "
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.tsx
 msgid "Review Transfer Funds Action"
 msgstr ""
@@ -1621,6 +1607,10 @@ msgstr ""
 
 #: src/components/Documentation/index.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nounders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nounders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
+msgstr ""
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "Proposal candidates must meet the required Niji vote threshold."
 msgstr ""
 
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
@@ -1777,4 +1767,8 @@ msgstr ""
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"
+msgstr ""
+
+#: src/pages/Playground/index.tsx
+msgid "Niji Protocol"
 msgstr ""

--- a/packages/niji-webapp/src/locales/zh-CN.po
+++ b/packages/niji-webapp/src/locales/zh-CN.po
@@ -79,10 +79,6 @@ msgstr "审核流支付操作"
 msgid "Proposal functions"
 msgstr "提案功能"
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "Proposal candidates must meet the required Nouns vote threshold."
-msgstr "候选提案必须达到所需的 Noun 投票门槛。"
-
 #: src/components/Documentation/index.tsx
 #: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
@@ -121,11 +117,6 @@ msgstr "添加函数调用参数"
 msgid "Treasury"
 msgstr "金库"
 
-#. placeholder {0}: i18n.number(availableVotes)
-#: src/components/VoteModal/index.tsx
-msgid "Voting with <0>{0}</0> Nouns"
-msgstr "使用 <0>{0}</0> 个 Nouns 投票"
-
 #: src/pages/Vote/index.tsx
 msgid "Ended"
 msgstr "已结束"
@@ -138,10 +129,6 @@ msgstr "选择签名"
 #: src/components/NavBar/index.tsx
 msgid "Candidates"
 msgstr "候选提案"
-
-#: src/components/CurrentDelegatePannel/index.tsx
-msgid "Noun votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Noun."
-msgstr "Noun 投票不可转让，但可<0>委托</0>，只要拥有 Noun，就可将投票权委托给他人。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.tsx
 msgid "Invalid Arguments"
@@ -171,6 +158,11 @@ msgstr ""
 #: src/components/ForkStatus/index.tsx
 msgid "In Escrow"
 msgstr "托管中"
+
+#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignals.tsx
+msgid "Niji voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
+msgstr "Niji 投票者可以发出投票信号，这既能让待定提案的提出者预估到他们的投票倾向，也能为提案修改提供宝贵指引，以争取（或引导）投票者转变其最终投票。"
 
 #: src/pages/EditProposal/index.tsx
 msgid "Proposal Candidate Created!"
@@ -280,14 +272,6 @@ msgstr ""
 msgid "Bids for"
 msgstr "竞拍记录："
 
-#: src/pages/CreateCandidate/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal. "
-msgstr "任何人都可创建提案候选。若候选人获得足够的 Noun 投票签名，即可升级为正式提案。"
-
-#: src/components/DynamicQuorumInfoModal/index.tsx
-msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Nouns voting against a prop, varying between Min Threshold and Max Threshold."
-msgstr "门槛（通过提案所需的最少支持票数）取决于提案的反对票数。它会随反对比例线性增加，介于最小门槛与最大门槛之间。"
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Go to playground"
 msgstr "前往游乐场"
@@ -295,10 +279,6 @@ msgstr "前往游乐场"
 #: src/components/Bid/index.tsx
 msgid "or more"
 msgstr "或以上"
-
-#: src/pages/Playground/index.tsx
-msgid "Nouns Protocol"
-msgstr "Nouns 协议"
 
 #: src/components/Documentation/index.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
@@ -326,10 +306,6 @@ msgstr ""
 #: src/components/ProposalHeader/index.tsx
 msgid "You have no votes."
 msgstr "您没有可投的票。"
-
-#: src/components/CandidateSponsors/index.tsx
-msgid "Sponsoring a proposal requires at least one Noun vote"
-msgstr "赞助提案至少需要一个 Noun 投票"
 
 #: src/components/StreamWithdrawModal/index.tsx
 msgid "You've successfully withdrawn {withdrawAmount} {unitForDisplay} to your wallet"
@@ -399,6 +375,10 @@ msgstr "秒"
 msgid "Queue"
 msgstr "排队"
 
+#: src/components/CurrentDelegatePannel/index.tsx
+msgid "Niji votes are not transferable, but are <0>delegatable</0>, which means you can assign your vote to someone else as long as you own your Niji."
+msgstr "Noun 投票不可转让，但可<0>委托</0>，只要拥有 Noun，就可将投票权委托给他人。"
+
 #: src/components/Documentation/index.tsx
 msgid "CryptoPunks"
 msgstr "CryptoPunks"
@@ -416,10 +396,10 @@ msgstr ""
 msgid "You've successfully voted on on prop {0}"
 msgstr "您已成功对提案 {0} 进行投票"
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
-msgid "Nouns voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
-msgstr "Nouns 投票者可以发出投票信号，这既能让待定提案的提出者预估到他们的投票倾向，也能为提案修改提供宝贵指引，以争取（或引导）投票者转变其最终投票。"
+#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
+#: src/components/ProposalHeader/index.tsx
+msgid "Only Niji you owned or were delegated to you before {0} are eligible to vote."
+msgstr "只有您在 {0} 之前拥有或被委托的 Niji 才可投票。"
 
 #: src/components/VoteModal/index.tsx
 msgid "Thank you for voting."
@@ -461,14 +441,16 @@ msgstr "一次拍卖结算后，下一次拍卖随即开始。"
 msgid "Ends {0}"
 msgstr "结束于 {0}"
 
+#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
+#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
+#: src/pages/Fork/index.tsx
+msgid "More than {0} Niji ({1}% of the DAO) are required to pass the threshold"
+msgstr "需要超过 {0} 个 Noun（占 DAO 的 {1}%）才能通过门槛"
+
 #: src/components/CreateProposalButton/index.tsx
 #: src/pages/CreateProposal/index.tsx
 msgid "Create Proposal"
 msgstr "创建提案"
-
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Noun: </0>"
-msgstr "<0>已委托 Noun：</0>"
 
 #: src/components/ProposalHeader/index.tsx
 msgid "You voted <0>For</0> this proposal"
@@ -500,13 +482,13 @@ msgstr "治理"
 msgid "Cancel"
 msgstr "取消"
 
+#: src/components/CandidateSponsors/index.tsx
+msgid "Sponsoring a proposal requires at least one Niji vote"
+msgstr "赞助提案至少需要一个 Noun 投票"
+
 #: src/components/CandidateSponsors/SignatureForm.tsx
 msgid "Signature request"
 msgstr "签名请求"
-
-#: src/components/Proposals/index.tsx
-msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal."
-msgstr "任何人都可创建提案候选。若候选获得足够签名，即可成为正式提案。"
 
 #: src/components/Documentation/index.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
@@ -730,12 +712,6 @@ msgstr "委托"
 msgid "Filename"
 msgstr ""
 
-#. placeholder {0}: forkThreshold == null ? '...' : forkThreshold
-#. placeholder {1}: forkThresholdBPS != null ? forkThresholdBPS / 100 : '...'
-#: src/pages/Fork/index.tsx
-msgid "More than {0} Nouns ({1}% of the DAO) are required to pass the threshold"
-msgstr "需要超过 {0} 个 Noun（占 DAO 的 {1}%）才能通过门槛"
-
 #: src/components/Proposals/index.tsx
 msgid "About Proposal Candidates"
 msgstr "关于提案候选"
@@ -764,6 +740,10 @@ msgstr "分钟"
 #: src/components/ForkingPeriodTimer/index.tsx
 msgid "minutes"
 msgstr "分钟"
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "This candidate has met the required threshold, but Niji voters can still add support until it’s put onchain."
+msgstr "此候选（方案/提案）已满足了必要的支持门槛，但在其最终被部署到链上之前，Niji 的投票者们依然有机会为其追加支持"
 
 #: src/components/Proposals/index.tsx
 msgid "Candidates submitted by community members will appear here."
@@ -837,10 +817,6 @@ msgstr "返回"
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr ""
 
-#: src/components/ByLineHoverCard/index.tsx
-msgid "<0>Delegated Nouns: </0>"
-msgstr "<0>委托的 Nouns：</0>"
-
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
 msgstr "更新提案候选"
@@ -853,6 +829,10 @@ msgstr "公共领域"
 #: src/pages/TraitsPage.tsx
 msgid "License"
 msgstr "许可证"
+
+#: src/pages/TraitsPage.tsx
+msgid "Browse and download all available Niji traits."
+msgstr "浏览并下载所有可用的名词特征。"
 
 #: src/components/Proposals/index.tsx
 msgid "Connect wallet to make a proposal."
@@ -949,6 +929,11 @@ msgstr "提案已执行！"
 #: src/pages/EditProposal/index.tsx
 msgid "Note"
 msgstr "注意"
+
+#: src/components/ByLineHoverCard/index.tsx
+#: src/components/ByLineHoverCard/index.tsx
+msgid "<0>Delegated Niji: </0>"
+msgstr "<0>委托的 Nouns：</0>"
 
 #: src/components/Documentation/index.tsx
 msgid "All Nijis are members of Niji DAO."
@@ -1094,11 +1079,6 @@ msgstr "审核函数调用操作"
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr ""
 
-#. placeholder {0}: i18n.date(new Date(proposalCreationTimestamp * 1000), { dateStyle: 'long', timeStyle: 'long', })
-#: src/components/ProposalHeader/index.tsx
-msgid "Only Nouns you owned or were delegated to you before {0} are eligible to vote."
-msgstr "只有您在 {0} 之前拥有或被委托的 Nouns 才可投票。"
-
 #: src/components/Bid/index.tsx
 msgid "Settled auction successfully!"
 msgstr "成功结算拍卖！"
@@ -1196,6 +1176,10 @@ msgstr "出价成功！"
 msgid "Current Threshold"
 msgstr "当前门槛"
 
+#: src/pages/Playground/index.tsx
+msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nijiAssetsLink} and rendered using the {nounsSDKLink}."
+msgstr ""
+
 #: src/pages/TraitsPage.tsx
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr "所有特征均为<0>CC0</0>（知识共享零协议），这意味着它们属于公共领域，可以自由用于任何目的，无需限制。"
@@ -1214,10 +1198,6 @@ msgstr "无需参数 "
 msgid "Add Streaming Payment Action"
 msgstr "添加流支付操作"
 
-#: src/components/CandidateSponsors/index.tsx
-msgid "This candidate has met the required threshold, but Nouns voters can still add support until it’s put onchain."
-msgstr "此候选（方案/提案）已满足了必要的支持门槛，但在其最终被部署到链上之前，Nouns 的投票者们依然有机会为其追加支持"
-
 #. placeholder {0}: isForked ? ` #${id}` : ''
 #: src/pages/Fork/index.tsx
 msgid "Niji DAO Fork{0}"
@@ -1227,6 +1207,10 @@ msgstr ""
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr "{0} 票"
+
+#: src/components/Proposals/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal."
+msgstr "任何人都可创建提案候选。若候选获得足够签名，即可成为正式提案。"
 
 #: src/pages/Vote/index.tsx
 msgid "Withdraw from Stream <0/>"
@@ -1281,8 +1265,9 @@ msgid "Will have"
 msgstr "将拥有"
 
 #: src/components/DelegateHoverCard/index.tsx
+#: src/components/DelegateHoverCard/index.tsx
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
-msgstr ""
+msgstr "使用<0>{numVotesForProp}</0>个 Niji 进行投票"
 
 #: src/components/VoteSignals/VoteSignals.tsx
 msgid "Pre-voting feedback"
@@ -1301,6 +1286,11 @@ msgstr "当前委托人"
 #: src/pages/Vote/index.tsx
 msgid "Threshold"
 msgstr "门槛"
+
+#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
+#: src/pages/CreateCandidate/index.tsx
+msgid "Submissions are free for Niji voters. Non-voters can submit for a {0} ETH fee."
+msgstr "Niji 投票者提交是免费的。非投票者可以支付 {0} ETH 的费用提交。"
 
 #: src/components/ChangeDelegatePanel/index.tsx
 msgid "Delegate Updated!"
@@ -1343,10 +1333,6 @@ msgstr "在 Etherscan 上查看"
 msgid "Vetoed"
 msgstr "已否决"
 
-#: src/components/AddNijisToForkModal/index.tsx
-msgid "Add as many or as few of your Nouns as you’d like. Additional Nouns can be added during the escrow and forking periods."
-msgstr "根据您的喜好添加任意数量的 Nouns。在托管和分叉期间可以添加更多的 Nouns。"
-
 #: src/components/ProposalEditor/index.tsx
 msgid "Preview"
 msgstr "预览"
@@ -1356,8 +1342,8 @@ msgid "Your <0>{availableVotes}</0> votes have been delegated to a new account."
 msgstr "您的 <0>{availableVotes}</0> 票已委托给一个新账户。"
 
 #: src/pages/Playground/index.tsx
-msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
-msgstr ""
+#~ msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
+#~ msgstr ""
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
@@ -1392,10 +1378,6 @@ msgstr "更新中..."
 msgid "Starting on"
 msgstr "开始于"
 
-#: src/pages/TraitsPage.tsx
-msgid "Browse and download all available Noun traits."
-msgstr "浏览并下载所有可用的名词特征。"
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Colored Noggles"
 msgstr "彩色眼镜"
@@ -1409,6 +1391,10 @@ msgstr "提案者拥有 {0} 票{1}"
 #: src/components/Documentation/index.tsx
 msgid "On-Chain Artwork"
 msgstr "链上艺术品"
+
+#: src/components/AddNijisToForkModal/index.tsx
+msgid "Add as many or as few of your Niji as you’d like. Additional Niji can be added during the escrow and forking periods."
+msgstr "根据您的喜好添加任意数量的 Nouns。在托管和分叉期间可以添加更多的 Nouns。"
 
 #: src/components/Footer.tsx
 msgid "Descriptor"
@@ -1434,11 +1420,8 @@ msgstr ""
 msgid "Because this proposal contains a USDC fund transfer action we've added an additional additional ETH transaction to refill the TokenBuyer contract. This action allows to continue to trustlessly acquire USDC to fund proposals like this."
 msgstr "由于此提案包含 USDC 资金转移操作，我们添加了一个额外的 ETH 交易以补充 TokenBuyer 合约。此操作允许继续无信任地获取 USDC 以资助此类提案。"
 
-#: src/components/DelegateHoverCard/index.tsx
-msgid "Voted with<0>{numVotesForProp}</0>Nouns"
-msgstr "使用<0>{numVotesForProp}</0>个 Nouns 进行投票"
-
 #. placeholder {0}: i18n.number(availableVotes)
+#: src/components/VoteModal/index.tsx
 #: src/components/VoteModal/index.tsx
 msgid "Voting with <0>{0}</0> Niji"
 msgstr ""
@@ -1463,14 +1446,13 @@ msgstr "添加流支付日期详情"
 msgid "Forks"
 msgstr "分叉"
 
-#. placeholder {0}: createCandidateCost ? formatEther(createCandidateCost) : '0'
-#: src/pages/CreateCandidate/index.tsx
-msgid "Submissions are free for Nouns voters. Non-voters can submit for a {0} ETH fee."
-msgstr "Nouns 投票者提交是免费的。非投票者可以支付 {0} ETH 的费用提交。"
-
 #: src/pages/BrandAssets/BrandAssetsPage.tsx
 msgid "Explore traits"
 msgstr "探索特征"
+
+#: src/components/DynamicQuorumInfoModal/index.tsx
+msgid "The Threshold (minimum number of For votes required to pass a proposal) is set as a function of the number of Against votes a proposal has received. It increases linearly as a function of the % of Niji voting against a prop, varying between Min Threshold and Max Threshold."
+msgstr "门槛（通过提案所需的最少支持票数）取决于提案的反对票数。它会随反对比例线性增加，介于最小门槛与最大门槛之间。"
 
 #: src/pages/Vote/index.tsx
 msgid "Transaction Successful!"
@@ -1561,6 +1543,10 @@ msgstr "有问题的提案{0}"
 msgid "at"
 msgstr "于"
 
+#: src/pages/CreateCandidate/index.tsx
+msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Niji voters, it can be promoted to a proposal. "
+msgstr "任何人都可创建提案候选。若候选人获得足够的 Noun 投票签名，即可升级为正式提案。"
+
 #: src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.tsx
 msgid "Review Transfer Funds Action"
 msgstr "审查转账操作"
@@ -1622,6 +1608,10 @@ msgstr "不通过"
 #: src/components/Documentation/index.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nounders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nounders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr ""
+
+#: src/components/CandidateSponsors/index.tsx
+msgid "Proposal candidates must meet the required Niji vote threshold."
+msgstr "候选提案必须达到所需的 Noun 投票门槛。"
 
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 msgid "Choose sponsors"
@@ -1778,3 +1768,7 @@ msgstr "每一天，"
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"
 msgstr "了解更多"
+
+#: src/pages/Playground/index.tsx
+msgid "Niji Protocol"
+msgstr "Niji 协议"


### PR DESCRIPTION
# 概要

PR #290 で src の `<Trans>` macro を Niji 化したが、 **Lingui の翻訳カタログ (.po) の msgid + msgstr が古い Nouns 表記のまま**で、 runtime で `i18n._()` が msgid (= 古い英語文字列) を返して画面に表示されてしまっていた。
ユーザー視点で「全然 niji になってない」 問題の真因。 src 修正と catalog 修正は別 layer、 catalog 反映には extract + compile が必要だった。

# 課題

```
$ grep -c 'Nouns\|Noun ' packages/niji-webapp/src/locales/en-US.po
36
```

src の `<Trans>...</Trans>` を Niji 化しても、 Lingui の挙動。

1. msgid (= `<Trans>` 内文字列) が src 側で更新されると、 次回 `pnpm i18n:extract` で .po の旧 msgid が obsolete (`#~` prefix) 化、 新 msgid が active 化
2. msgstr (翻訳文字列) は msgid に対応する翻訳がなければ未翻訳扱い、 runtime は msgid を fallback として表示
3. extract 走らせるまで .po は古い Nouns msgid を持ち続け、 compile 済 .js も古いまま

つまり src で `<Trans>One Noun, every day</Trans>` → `<Trans>One Niji, every day</Trans>` に書き換えても、 .po に古い `msgid "One Noun..."` と `msgstr "One Noun..."` が残り、 catalog からは旧表記が引き続き返される。

# 解決方法

.po の msgid + msgstr を Niji 化 → extract で src と同期 → compile で .js 再生成。

3 段階。

1. python script で 4 file (.po) の Nouns/Noun を Niji に一括置換 (src の `<Trans>` と同じ規則)
2. `pnpm i18n:extract` で msgid が src と一致することを確認 (active な Nouns 残骸 0、 obsolete 化されない)
3. `pnpm i18n:compile` で en-US.js / ja-JP.js / zh-CN.js / pseudo.js 再生成、 runtime catalog 更新

# 仕組み

```mermaid
graph LR
    A[src tsx<br/>Trans macro 内 Niji 化済] --> B[i18n:extract]
    B --> C[.po msgid Niji 化]
    C --> D[i18n:compile]
    D --> E[.js compile 済 catalog]
    E --> F[runtime i18n._]
    F --> G[ブラウザ表示]

    A2[本 PR 修正] --> C
    A2 --> D
```

本 PR では .po を直接 sweep してから extract + compile を実行 (src + .po + .js の 3 層を一気に同期)。

# 仕組み (置換ルール詳細)

| 元 (Nouns / Noun) | 置換後 (Niji) |
|---|---|
| `Nouns voters` / `Nouns vote` / `Nouns voting` / `Nouns Against` / `of Nouns` / `Nouns)` / `Nouns Currently` | `Niji voters` 等 |
| `Delegated Nouns:` / `Delegated Noun:` | `Delegated Niji:` |
| `Only Nouns` / `by Nouns` / `for Nouns` | `Only Niji` 等 |
| `your Noun.` / `own your Noun` / `Noun votes` / `Noun trait` | `your Niji.` 等 |
| `return Nouns` / `{0}</0> Nouns` / `More than {0} Nouns` / `one Noun vote` / `</0>Nouns` | `return Niji` 等 |
| 日本語 `Nounsの投票` / `Nouns投票` / `Nounsの` / `Nounsで` / `Nounプロトコル` / `Nounの票` / `Nounの` / `Nounを` / `Nounが` / `Nounは` | `Nijiの投票` 等 |

# 維持した固有名詞

- `Nounspot` (元 Nouns spot map 外部サービス、 NijisIntroSection で iframe 参照)
- `Nounders` (組織名)
- `Nounder's Reward` (歴史的記述)

# 変更したファイル

| ファイル | 件数 (sweep 前 → 後) |
|---|---|
| `src/locales/en-US.po` | 36 → 1 (Nounspot のみ) |
| `src/locales/ja-JP.po` | 31 → 0 |
| `src/locales/zh-CN.po` | 同パターン |
| `src/locales/pseudo.po` | 同パターン |

(`*.js` は git ignore 対象で commit 不要、 各環境で `pnpm i18n:compile` 走らせる)

# 検証

- `pnpm i18n:extract` で msgid と src の <Trans> 文字列が同期 (en-US 396 total)、 obsolete 化されない
- `pnpm i18n:compile` で en-US.js 再生成、 Nouns 件数 1 件 (Nounspot のみ)
- ローカル dev server (http://localhost:2424) HMR 反映、 Quorum Modal / Vote Signals / Delegate Panel 等が Niji 表記に
- vitest 52 件 PASS 維持で regression なし

# 残作業 (本 PR 対象外)

ja-JP / zh-CN catalog の **未翻訳 73 件** は元から未翻訳で本 PR 対象外。 default locale (en) で動作する限り問題なし。 i18n 完成度向上は別 Issue で扱う。