### PR TITLE
🐛 fix(niji-contracts): foundry test setUp で PlaceholderURI 未設定 fix (Issue #292)

### DIFF
--- a/packages/niji-contracts/test/foundry/helpers/DeployUtils.sol
+++ b/packages/niji-contracts/test/foundry/helpers/DeployUtils.sol
@@ -131,6 +131,7 @@ abstract contract DeployUtils is Test {
         NijiSeeder seeder = new NijiSeeder(address(art));
         token = new NijiToken('Niji', 'NIJI', address(descriptor), address(seeder), 0);
         token.setMintingActive(true);
+        token.setPlaceholderURI('ipfs://placeholder');
         if (minter != address(0)) {
             token.setMinter(minter);
         }


### PR DESCRIPTION
# 概要

Foundry 既存テスト 75 件が setUp 段階の `PlaceholderURINotSet()` revert で fail していた問題を修正する。
test helper の `DeployUtils.deployToken()` が NijiToken の placeholder URI を初期化せず、 token mint 経路で revert する状態だった。
deploy 直後に `setPlaceholderURI('ipfs://placeholder')` を 1 行追加することで解消する。

# 課題

`forge test` 実行時に 81 件が setUp の段階で fail し、 主要 contract test を回帰検証できない状態だった。
fail テストは NijiAuctionHouseV3 / NijiDAOData / NijiDAOLogic 全 state / governance / rewards / Inflation Handling 等の主要 contract を含む。
NijiToken `_mintTo()` は collection が `isRevealed=false` かつ `_placeholderURI` が空の場合に `PlaceholderURINotSet()` を revert する仕様で、 test helper が placeholder 設定を忘れていたことが原因。

# 詳細

NijiToken `_mintTo()` (`packages/niji-contracts/contracts/NijiToken.sol:298`) は次の判定で placeholder URI 必須化を強制する。

```solidity
function _mintTo(address to) internal returns (uint256) {
    if (!isRevealed && bytes(_placeholderURI).length == 0) revert PlaceholderURINotSet();
    // ...
}
```

test helper である `DeployUtils.deployToken()` (`packages/niji-contracts/test/foundry/helpers/DeployUtils.sol:126-137`) は token deploy 後に `setMintingActive(true)` と `setMinter(...)` のみ呼び、 `setPlaceholderURI(...)` を呼んでいなかった。
結果として全 test の setUp で auction `unpause()` が内部で `mint()` を呼び、 `_mintTo()` 内で revert していた。

```mermaid
flowchart TD
  A[setUp 開始] --> B[deployToken]
  B --> C[NijiToken deploy<br/>_placeholderURI = 空]
  C --> D[transferOwnership timelock]
  D --> E[auction.unpause]
  E --> F[NijiToken.mint]
  F --> G{isRevealed false<br/>かつ placeholder 空?}
  G -->|YES| H[PlaceholderURINotSet revert<br/>setUp fail]
  G -->|NO| I[mint 成功]
```

# 解決方法

`DeployUtils.deployToken()` で token deploy 直後に `token.setPlaceholderURI('ipfs://placeholder')` を 1 行追加する。
deploy 直後は token owner が `address(this)` のため onlyOwner gate を pass し、 後続の `transferOwnership(...)` 前に placeholder URI を確実に設定できる。

# 仕組み

修正後の流れ。

```mermaid
flowchart TD
  A[setUp 開始] --> B[deployToken]
  B --> C[NijiToken deploy<br/>owner = address this]
  C --> D[setMintingActive true]
  D --> E[setPlaceholderURI ipfs://placeholder<br/>NEW 修正箇所]
  E --> F[setMinter optional]
  F --> G[deployToken return]
  G --> H[caller が transferOwnership]
  H --> I[unpause → mint → _placeholderURI 非空で pass]
```

変更したファイルと内容。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-contracts/test/foundry/helpers/DeployUtils.sol` | `deployToken()` 内で token deploy 直後に `setPlaceholderURI('ipfs://placeholder')` を 1 行追加、 deploy 直後の onlyOwner pass を活用して全 test の setUp で placeholder を確実に初期化 |

```diff
         NijiSeeder seeder = new NijiSeeder(address(art));
         token = new NijiToken('Niji', 'NIJI', address(descriptor), address(seeder), 0);
         token.setMintingActive(true);
+        token.setPlaceholderURI('ipfs://placeholder');
         if (minter != address(0)) {
             token.setMinter(minter);
         }
```

# テストと確認

- [x] `forge test` 実行で PlaceholderURINotSet() による fail が 81 件 → 6 件に減少 (75 件解消)
- [x] 既存 pass テスト (NijiArtKiwaTest / NijiTokenKiwaTest / NijiSeederKiwaTest / NijiAuctionHouseV3KiwaTest / NijiFuzz 等 128 件 → 248 件に増加) は引き続き pass
- [ ] 残 6 件 (kiwa-prefix test 内部の独自 setup 経路) は本 PR scope 外、 Issue #293 で別途対応

レビューで見てほしいところ。
`'ipfs://placeholder'` という placeholder 値は test 用途のため任意文字列で十分だが、 将来 mainnet deploy script との衝突を避けたい場合は別 prefix (例 `test://placeholder`) への変更が望ましいかもしれない。
ただし `setPlaceholderURI` は `lockBaseURI` 前なら何度でも更新可能なため、 test 内で別 placeholder を再設定するパターンも問題なく動作する。

# 関連

Issue #293 ... 本 fix 適用後も残る 118 件 fail (post-rebrand test refresh) の対応 Issue (別途進める)

Closes #292
