### PR TITLE
🐛 fix(niji-contracts): Phase 2 Sub 1 - DAOLogic test の hard-coded tokenId を mint 戻り値経由に修正 (Issue #301)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposal.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposal.t.sol
@@ -44,10 +44,10 @@ abstract contract ProposalUpdatableState is ZeroState {
     function setUp() public virtual override {
         super.setUp();
 
-        // mint 1 noun to proposer
+        // mint 1 noun to proposer (Niji ... _currentTokenId 0 開始のため戻り値を受ける)
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposer, 1);
+        uint256 _tokenId = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposer, _tokenId);
         vm.roll(block.number + 1);
         vm.stopPrank();
 

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposalBySigs.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposalBySigs.t.sol
@@ -25,8 +25,8 @@ abstract contract ProposalUpdatableState is ZeroState {
         (signerWithVote, signerWithVotePK) = makeAddrAndKey('signerWithVote');
 
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, signerWithVote, 1);
+        uint256 _tokenId = nounsToken.mint();
+        nounsToken.transferFrom(minter, signerWithVote, _tokenId);
         vm.roll(block.number + 1);
         vm.stopPrank();
 

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol
@@ -13,8 +13,8 @@ abstract contract ExecutableProposalState is NijiDAOLogicBaseTest {
         super.setUp();
 
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, user, 1);
+        uint256 _tokenId = nounsToken.mint();
+        nounsToken.transferFrom(minter, user, _tokenId);
         vm.stopPrank();
         vm.roll(block.number + 1);
 

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/ProposeBySigs.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/ProposeBySigs.t.sol
@@ -34,12 +34,12 @@ contract ProposeBySigsTest is NijiDAOLogicBaseTest {
         dao._setProposalThresholdBPS(1_000);
 
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposerWithVote, 1);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, signerWithVote1, 2);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, signerWithVote2, 3);
+        uint256 _tid1 = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposerWithVote, _tid1);
+        uint256 _tid2 = nounsToken.mint();
+        nounsToken.transferFrom(minter, signerWithVote1, _tid2);
+        uint256 _tid3 = nounsToken.mint();
+        nounsToken.transferFrom(minter, signerWithVote2, _tid3);
         vm.roll(block.number + 1);
         vm.stopPrank();
     }

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
@@ -18,10 +18,10 @@ abstract contract UpdateProposalBaseTest is NijiDAOLogicBaseTest {
     function setUp() public override {
         super.setUp();
 
-        // mint 1 noun to proposer
+        // mint 1 noun to proposer (Niji ... tokenId は mint 戻り値経由、 0 開始)
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposer, 1);
+        uint256 _tokenId = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposer, _tokenId);
         vm.roll(block.number + 1);
         vm.stopPrank();
 

--- a/packages/niji-contracts/test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol
+++ b/packages/niji-contracts/test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol
@@ -16,8 +16,8 @@ abstract contract NijiDAOLogic_GasSnapshot_propose is NijiDAOLogicSharedBaseTest
         super.setUp();
 
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposer, 1);
+        uint256 _tokenId = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposer, _tokenId);
         vm.roll(block.number + 1);
         vm.stopPrank();
     }
@@ -61,10 +61,10 @@ abstract contract NijiDAOLogic_GasSnapshot_castVote is NijiDAOLogicSharedBaseTes
         super.setUp();
 
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposer, 1);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, nouner, 2);
+        uint256 _tid1 = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposer, _tid1);
+        uint256 _tid2 = nounsToken.mint();
+        nounsToken.transferFrom(minter, nouner, _tid2);
         vm.roll(block.number + 1);
         vm.stopPrank();
 
@@ -110,10 +110,10 @@ abstract contract NijiDAOLogic_GasSnapshot_castVoteDuringObjectionPeriod is Niji
         super.setUp();
 
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposer, 1);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, nouner, 2);
+        uint256 _tid1 = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposer, _tid1);
+        uint256 _tid2 = nounsToken.mint();
+        nounsToken.transferFrom(minter, nouner, _tid2);
         vm.roll(block.number + 1);
         vm.stopPrank();
 


### PR DESCRIPTION
# 概要

Phase 2 Sub-Issue 1 (Issue #301) の部分 fix PR。
Nouns → Niji リブランド後の production code で NijiToken._currentTokenId は 0 開始だが、 既存 DAOLogic / governance test 6 file 12 箇所で旧 Nouns 仕様 (tokenId=1 開始) を前提に hard-code されていたため、 mint() 後の transferFrom(...,1) が ERC721NonexistentToken(1) で revert していた。
本 PR で全 hard-coded tokenId を mint() 戻り値経由に修正、 setUp 段階の早期 revert を解消した部分 fix (root cause analysis の 1 段階目)。

# 課題

Phase 1 PR #294 PlaceholderURI fix 適用後の DAOLogic 系 30+ 件 fail のうち主因は test 内 hard-coded tokenId、 production NijiToken の `_currentTokenId = 0` 仕様変更 (mint 連番開始位置) を test 期待値が追従していない状態。
fail の trace を確認したところ、 `nounsToken.mint(); nounsToken.transferFrom(...,1)` という pattern (mint 戻り値を捨てて hard-code "1" を渡す) が 12 箇所、 production code が tokenId=0 を返却するため transferFrom が `ERC721NonexistentToken(1)` で revert していた。

# 詳細

修正 file と箇所。

| file | 箇所数 | 修正内容 |
|---|---|---|
| test/foundry/NijiDAOLogic/CancelProposal.t.sol | 1 | `transferFrom(minter, proposer, 1)` → `transferFrom(minter, proposer, _tokenId)` |
| test/foundry/NijiDAOLogic/CancelProposalBySigs.t.sol | 1 | 同上 (signerWithVote) |
| test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol | 1 | 同上 (user) |
| test/foundry/NijiDAOLogic/UpdateProposal.t.sol | 1 | 同上 (proposer) |
| test/foundry/NijiDAOLogic/ProposeBySigs.t.sol | 3 | 連続 mint で _tid1/2/3 変数化 |
| test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol | 5 | 同上、 propose / vote / voteDuringObjectionPeriod の 3 setUp 内 5 箇所 |

```diff
         vm.startPrank(minter);
-        nounsToken.mint();
-        nounsToken.transferFrom(minter, proposer, 1);
+        uint256 _tokenId = nounsToken.mint();
+        nounsToken.transferFrom(minter, proposer, _tokenId);
         vm.roll(block.number + 1);
         vm.stopPrank();
```

```mermaid
flowchart LR
  A[setUp 開始] --> B[mint 経由<br/>戻り値捨てる]
  B --> C[transferFrom hard-code 1]
  C --> D{NijiToken<br/>tokenId=0 始まり?}
  D -->|YES Niji 仕様| E[ERC721NonexistentToken 1 revert]
  D -->|NO 旧 Nouns 仕様| F[OK]

  A --> G[修正後<br/>mint 戻り値受ける]
  G --> H[transferFrom tokenId 変数]
  H --> I[OK 全 token id 正しく解決]
```

# 設計判断

## hard-code "1" → "0" ではなく mint() 戻り値経由を選択

最も safe な fix は mint() 戻り値を変数で受ける経路。 hard-code "1" → "0" でも fix 可能だが、 将来 setUp で先に別 mint (例 auction unpause で tokenId=0 mint) が発生した場合に再度ずれる brittleness を避けるため、 戻り値経由で抽象化。

## 連続 mint の変数命名

ProposeBySigs / GasSnapshot で 2-3 連続 mint がある場合は _tid1 / _tid2 / _tid3 と naming (auto-increment を反映)、 readability を保ちつつ test 順序依存を明示。

# 完了条件

- [x] 6 file 12 箇所の hard-coded tokenId 修正完了
- [x] setUp 段階の ERC721NonexistentToken(1) revert が解消
- [x] forge test --match-path 'test/foundry/NijiDAOLogic/**|test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol' で setUp 通過件数が増加 (pass 463 → 464)
- [x] deeper logic revert (numTokensOwnedByDAO / forkEscrow address) は本 PR scope 外、 follow-up Issue #306 で対応

# 注意 (fail 数 118 → 141 への一時的増加)

setUp 通過後の deeper logic で別 revert が新たに顕在化し fail 数は 118 → 141 と 23 件増加。 これは Phase 1 PR #294 (PlaceholderURI fix で 81 → 118) と同じ root cause analysis pattern。
進捗 ... setUp 早期 revert の主因 (tokenId hard-code) を解消、 deeper logic (NijiDAOLogicV4.propose 内の numTokensOwnedByDAO call / NijiDAOForkEscrow address mismatch) は次層として可視化。 follow-up Issue #306 (Phase 2 Sub-Issue 1.5) で deployDAOProxy / NijiDAOForkEscrow 経路を見直す。

# レビューで見てほしいところ

- 全 12 箇所が同 pattern (mint() 戻り値 → transferFrom) で機械的修正、 logic 変更なし
- ProposeBySigs / GasSnapshot の連続 mint は _tid1 / _tid2 / _tid3 命名でずれを防止、 順序依存は production code と同じ
- fail 件数の一時的増加は root cause analysis の 1 段階目 (Phase 1 PlaceholderURI fix と同 pattern)、 progress として正当

# 関連

Issue #293 ... Phase 2 親 Issue (post-rebrand test refresh)
Issue #301 ... 本 PR の起点 Sub-Issue 1
Issue #306 ... follow-up Sub-Issue 1.5 (deployDAOProxy / NijiDAOForkEscrow deeper fix)

Refs #301
