### PR TITLE
🐛 fix(niji-contracts): Phase 2 Sub 5 - kiwa-prefix test の setPlaceholderURI 追加で 4 件 fail 解消 (Issue #305)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiFuzz.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiFuzz.t.sol
@@ -75,6 +75,9 @@ contract NijiFuzz is Test {
 
         // Activate minting
         token.toggleMinting();
+
+        // placeholder URI 設定 (Niji 仕様 ... mint 前に必須)
+        token.setPlaceholderURI('ipfs://placeholder');
     }
 
     // =========================================================================

--- a/packages/niji-contracts/test/foundry/NijiTokenKiwaTest.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiTokenKiwaTest.t.sol
@@ -65,6 +65,10 @@ contract NijiTokenKiwaTest is Test {
         // mintingActive を true に
         vm.prank(owner);
         token.setMintingActive(true);
+
+        // placeholder URI 設定 (Niji 仕様 ... mint 前に必須)
+        vm.prank(owner);
+        token.setPlaceholderURI('ipfs://placeholder');
     }
 
     // ====================================================
@@ -104,6 +108,8 @@ contract NijiTokenKiwaTest is Test {
         capped.setMinter(minter);
         vm.prank(owner);
         capped.setMintingActive(true);
+        vm.prank(owner);
+        capped.setPlaceholderURI('ipfs://placeholder');
 
         vm.prank(minter);
         capped.mint(recipient); // 0


### PR DESCRIPTION
# 概要

Phase 2 Sub-Issue 5 (Issue #305) の fix PR。
NijiTokenKiwaTest / NijiFuzz の setUp + capped deploy 経路に setPlaceholderURI を追加、 mint 経路の PlaceholderURINotSet revert を解消。
全体 fail 件数 141 → 137 (-4)、 pass 464 → 468 (+4)。

# 課題

PR #294 で DeployUtils.deployToken() に setPlaceholderURI を追加したが、 これは DeployUtils 経由の test (NijiAuctionHouseV3 等 75 件) にしか効かない。
NijiTokenKiwaTest / NijiFuzz は独自 deploy 経路 (`new NijiToken(...)` 直接呼出) のため PR #294 の対象外、 setUp 後の mint 呼出で PlaceholderURINotSet() revert していた。

# 詳細

mint 経路で revert する 3 test を修正。

| file | 修正箇所 | 影響 test |
|---|---|---|
| test/foundry/NijiTokenKiwaTest.t.sol | setUp (1 箇所) | TC-010 burn_clearsOwnership |
| test/foundry/NijiTokenKiwaTest.t.sol | test_TC003_mint_maxSupply_reverts 内 capped deploy (1 箇所) | TC-003 mint_maxSupply_reverts |
| test/foundry/NijiFuzz.t.sol | setUp (1 箇所) | testFuzz_mintBatch_bounded |

```diff
         vm.prank(owner);
         token.setMintingActive(true);
+
+        // placeholder URI 設定 (Niji 仕様 ... mint 前に必須)
+        vm.prank(owner);
+        token.setPlaceholderURI('ipfs://placeholder');
     }
```

```mermaid
flowchart LR
  A[setUp 開始] --> B[NijiToken 直接 deploy]
  B --> C[setMinter setMintingActive]
  C --> D{setPlaceholderURI?}
  D -->|未設定 修正前| E[mint で PlaceholderURINotSet revert]
  D -->|設定済 修正後| F[mint 成功]
```

# 設計判断

## 独自 deploy 経路の解消は DeployUtils ではなく test 内で

NijiTokenKiwaTest / NijiFuzz は意図的に DeployUtils を経由せず自己完結 setup (mock seeder + stub descriptor) を使用、 NijiToken の単体動作を依存最小で verify する設計。 DeployUtils 経由に置換すると本旨が崩れるため、 test 内に setPlaceholderURI を直接追加した。

## TC-003 の capped deploy も独立に修正

TC-003 は maxSupply=2 の独自 token を deploy するため、 setUp の setPlaceholderURI 設定が効かない。 capped 用に別途 setPlaceholderURI を追加。

# 完了条件

- [x] NijiTokenKiwaTest 11/11 pass (修正前 8 pass / 3 fail → 11 pass / 0 fail)
- [x] NijiFuzz 6/6 pass (修正前 fuzz mintBatch 含む一部 fail → 全 pass)
- [x] 全体 fail 件数 141 → 137 (-4)、 pass 464 → 468 (+4)
- [x] `forge test --match-path 'test/foundry/NijiTokenKiwaTest.t.sol|test/foundry/NijiFuzz.t.sol'` で 0 fail

# レビューで見てほしいところ

- placeholder 値 `'ipfs://placeholder'` は test 用 default、 PR #294 / Phase 1 Sub-PR と同じ値を流用して整合性確保
- setUp + capped deploy の 2 箇所修正で全 affected test を cover、 他 kiwa-prefix test (NijiArtKiwaTest / NijiSeederKiwaTest / NijiAuctionHouseV3KiwaTest) は setPlaceholderURI grep 0 件で対象外
- 9 行 insertion のみ、 logic 変更なし

# 関連

Issue #293 ... Phase 2 親 Issue (post-rebrand test refresh)
Issue #305 ... 本 PR の起点 Sub-Issue 5
PR #294 ... DeployUtils fix (本 PR は DeployUtils 経由しない経路の補完)
PR #307 ... Phase 2 Sub 1 (DAOLogic tokenId fix、 前回 Phase 2 PR)

Refs #305
