### PR TITLE
🐛 fix(niji-contracts): Phase 2 Sub 4 - Inflation + GasSnapshot test の tokenId hard-code + delegate 漏れ修正 (Issue #304)

### DIFF
--- a/packages/niji-contracts/test/foundry/governance/InflationHandling.t.sol
+++ b/packages/niji-contracts/test/foundry/governance/InflationHandling.t.sol
@@ -94,11 +94,15 @@ contract NijiDAOLogic3InflationHandling40TotalSupplyTest is NijiDAOLogicV3Inflat
     }
 
     function testRejectsIfProposingBelowThreshold() public {
-        // Give user1 2 tokens, proposal requires 3
+        // Give user1 2 tokens, proposal requires 3 (Niji ... tokenId 0 開始 + ERC721Votes 手動 delegate 必須)
         vm.startPrank(tokenHolder);
+        nounsToken.transferFrom(tokenHolder, user1, 0);
         nounsToken.transferFrom(tokenHolder, user1, 1);
-        nounsToken.transferFrom(tokenHolder, user1, 2);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        vm.prank(user1);
+        nounsToken.delegate(user1);
 
         vm.roll(block.number + 1);
 
@@ -109,12 +113,16 @@ contract NijiDAOLogic3InflationHandling40TotalSupplyTest is NijiDAOLogicV3Inflat
     }
 
     function testAllowsProposingIfAboveThreshold() public {
-        // Give user1 3 tokens, proposal requires 3
+        // Give user1 3 tokens, proposal requires 3 (Niji ... tokenId 0 開始 + ERC721Votes 手動 delegate 必須)
         vm.startPrank(tokenHolder);
+        nounsToken.transferFrom(tokenHolder, user1, 0);
         nounsToken.transferFrom(tokenHolder, user1, 1);
         nounsToken.transferFrom(tokenHolder, user1, 2);
-        nounsToken.transferFrom(tokenHolder, user1, 3);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        vm.prank(user1);
+        nounsToken.delegate(user1);
 
         vm.roll(block.number + 1);
 
@@ -133,23 +141,31 @@ abstract contract TotalSupply40WithAProposalState is NijiDAOLogicV3InflationHand
         setTotalSupply(40);
 
         vm.startPrank(tokenHolder);
-        // 3 votes to user1
+        // 3 votes to user1 (Niji ... tokenId 0 開始のため -1 offset)
+        nounsToken.transferFrom(tokenHolder, user1, 0);
         nounsToken.transferFrom(tokenHolder, user1, 1);
         nounsToken.transferFrom(tokenHolder, user1, 2);
-        nounsToken.transferFrom(tokenHolder, user1, 3);
 
         // 3 votes to user2
+        nounsToken.transferFrom(tokenHolder, user2, 10);
         nounsToken.transferFrom(tokenHolder, user2, 11);
         nounsToken.transferFrom(tokenHolder, user2, 12);
-        nounsToken.transferFrom(tokenHolder, user2, 13);
 
         // 5 votes to user3
+        nounsToken.transferFrom(tokenHolder, user3, 20);
         nounsToken.transferFrom(tokenHolder, user3, 21);
         nounsToken.transferFrom(tokenHolder, user3, 22);
         nounsToken.transferFrom(tokenHolder, user3, 23);
         nounsToken.transferFrom(tokenHolder, user3, 24);
-        nounsToken.transferFrom(tokenHolder, user3, 25);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(user1);
+        nounsToken.delegate(user1);
+        vm.prank(user2);
+        nounsToken.delegate(user2);
+        vm.prank(user3);
+        nounsToken.delegate(user3);
 
         vm.roll(block.number + 1);
 

--- a/packages/niji-contracts/test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol
+++ b/packages/niji-contracts/test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol
@@ -18,8 +18,13 @@ abstract contract NijiDAOLogic_GasSnapshot_propose is NijiDAOLogicSharedBaseTest
         vm.startPrank(minter);
         uint256 _tokenId = nounsToken.mint();
         nounsToken.transferFrom(minter, proposer, _tokenId);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposer);
+        nounsToken.delegate(proposer);
+
+        vm.roll(block.number + 1);
     }
 
     function test_propose_shortDescription() public {
@@ -65,8 +70,15 @@ abstract contract NijiDAOLogic_GasSnapshot_castVote is NijiDAOLogicSharedBaseTes
         nounsToken.transferFrom(minter, proposer, _tid1);
         uint256 _tid2 = nounsToken.mint();
         nounsToken.transferFrom(minter, nouner, _tid2);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposer);
+        nounsToken.delegate(proposer);
+        vm.prank(nouner);
+        nounsToken.delegate(nouner);
+
+        vm.roll(block.number + 1);
 
         givenProposal();
         vm.roll(block.number + daoProxy.votingDelay() + 1);
@@ -114,8 +126,15 @@ abstract contract NijiDAOLogic_GasSnapshot_castVoteDuringObjectionPeriod is Niji
         nounsToken.transferFrom(minter, proposer, _tid1);
         uint256 _tid2 = nounsToken.mint();
         nounsToken.transferFrom(minter, nouner, _tid2);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposer);
+        nounsToken.delegate(proposer);
+        vm.prank(nouner);
+        nounsToken.delegate(nouner);
+
+        vm.roll(block.number + 1);
 
         givenProposal();
         vm.roll(block.number + daoProxy.votingDelay() + 1);


### PR DESCRIPTION
# 概要

Phase 2 Sub-Issue 4 (Issue #304) の fix PR。
InflationHandling.t.sol (3 test contract) + NijiDAOLogicV3GasSnapshot.t.sol (3 setUp) に 2 種類の post-rebrand 修正を適用、 全 8 件 fail を解消。

# 課題

PR #307 (Sub 1) で DAOLogic 系の tokenId hard-code を一部修正したが、 InflationHandling / GasSnapshot は依然 fail。
trace で 2 種類の独立した root cause を特定 ... (1) tokenHolder → user 転送の hard-code "1/2/3/11..." (旧 Nouns 1 開始) と (2) `getPriorVotes(user1, ...) = 0` (ERC721Votes OZ v5 で受領 auto-delegate 廃止)。

# 詳細

## 修正種別 1 ... tokenId hard-code を 0-based に

NijiToken `_currentTokenId = 0` 初期化のため、 setTotalSupply(40) で tokenHolder が tokenId 0-39 を保持する。 旧 hard-code "1/2/3" は ERC721NonexistentToken 経路ではなく setTotalSupply 経由で先に mint 済のため revert しないが、 votes count がずれていた。

```diff
-        nounsToken.transferFrom(tokenHolder, user1, 1);
-        nounsToken.transferFrom(tokenHolder, user1, 2);
-        nounsToken.transferFrom(tokenHolder, user1, 3);
+        nounsToken.transferFrom(tokenHolder, user1, 0);
+        nounsToken.transferFrom(tokenHolder, user1, 1);
+        nounsToken.transferFrom(tokenHolder, user1, 2);
```

## 修正種別 2 ... ERC721Votes 手動 delegate

OpenZeppelin v5 ERC721Votes は token 受領で auto-delegate しない仕様 (Nouns 旧実装と異なる)。 `getPriorVotes(user1, ...) = 0` が返るため `VotesBelowProposalThreshold()` revert。 transferFrom 後に self-delegate を明示。

```diff
         nounsToken.transferFrom(tokenHolder, user1, 2);
         vm.stopPrank();

+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        vm.prank(user1);
+        nounsToken.delegate(user1);
+
         vm.roll(block.number + 1);

         assertEq(nounsToken.getPriorVotes(user1, block.number - 1), 3);
```

```mermaid
flowchart LR
  A[setUp 開始] --> B[setTotalSupply 40<br/>tokenHolder に 40 件 mint]
  B --> C{tokenId hard-code 1?}
  C -->|YES 修正前| D[transfer 成功でも votes 0]
  C -->|NO 0-based| E[transfer 成功]
  E --> F{auto-delegate?}
  F -->|NO OZ v5 仕様| G[VotesBelowProposalThreshold revert]
  F -->|YES self-delegate 後| H[propose 成功]
```

# 設計判断

## delegate 経路を test 内に追加

production code では minter / auction house 経路で受領者が自分で `delegate(self)` を呼ぶ運用想定。 test fixture でも同等経路を simulate するため、 transferFrom 直後に self-delegate を追加。 helper 化 (`_delegateTo(user)`) するほどの呼出回数ではないため inline で。

## tokenId 0-based は確認のため hard-code 維持

ProposeBySigs / GasSnapshot (Sub 1 PR #307) では mint 戻り値経由に変更したが、 InflationHandling は setTotalSupply 経由で先に tokenHolder に大量 mint しているため戻り値経由が困難。 tokenHolder の保有範囲が 0-39 と判明している状況で hard-code -1 offset の方が読みやすい。

# 完了条件

- [x] InflationHandling.t.sol 10/10 pass (元 4 fail → 0 fail)
- [x] NijiDAOLogicV3GasSnapshot.t.sol 7/7 pass (元 4 fail → 0 fail)
- [x] 全体 fail 件数 137 → 129 (-8 件)、 pass 468 → 482 (+14 件)
- [x] `forge test --match-path 'test/foundry/governance/InflationHandling.t.sol|test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol'` で 0 fail

# レビューで見てほしいところ

- delegate 経路は test fixture 内 inline 追加 (helper 化保留)、 同 pattern が他 governance test に展開する場合は helper 抽出を検討
- tokenId 0-based 変換は -1 offset で機械的、 setTotalSupply(40) → tokenHolder 0-39 の範囲確認済
- gas snapshot 値は実測ベース更新なし (production code の gas usage 変化観測のため snapshot を意図的に固定値しない、 forge --gas-report で都度確認)

# 関連

Issue #293 ... Phase 2 親 Issue
Issue #304 ... 本 PR の起点 Sub-Issue 4
PR #307 ... Sub 1 (DAOLogic tokenId hard-code、 mint 戻り値経由)
PR #308 ... Sub 5 (kiwa-prefix placeholder)

Refs #304
