### PR TITLE
🐛 fix(niji-contracts): Phase 2 Sub 2 - rewards AuctionRewardsUpdated event の firstNounId hard-code を 0-based に (Issue #302)

### DIFF
--- a/packages/niji-contracts/test/foundry/rewards/Rewards.t.sol
+++ b/packages/niji-contracts/test/foundry/rewards/Rewards.t.sol
@@ -177,8 +177,9 @@ contract AuctionRewards is RewardsBaseTest {
     }
 
     function test_emitsAuctionRewardsUpdatedEvent() public {
+        // Niji ... mint 連番 0 開始のため最初の auction reward 更新 firstNounId は 0
         vm.expectEmit();
-        emit Rewards.AuctionRewardsUpdated(1, nounId);
+        emit Rewards.AuctionRewardsUpdated(0, nounId);
         rewards.updateRewardsForAuctions(nounId);
     }
 


### PR DESCRIPTION
# 概要

Phase 2 Sub-Issue 2 (Issue #302) の部分 fix PR。
rewards/Rewards.t.sol の AuctionRewardsUpdated event mismatch (1 件) を解消、 rewards 全 48 件 pass。
AuctionV3.t.sol の settlement / prices test 群 (40+ 箇所の nounId hard-code 修正必要) は規模上 follow-up Issue #310 に scope-out。

# 課題

PR #309 (Sub 4) 後の baseline で rewards/Rewards.t.sol の `test_emitsAuctionRewardsUpdatedEvent` が `log != expected AuctionRewardsUpdated` で fail。
trace で `emit Rewards.AuctionRewardsUpdated(1, nounId)` の firstNounId=1 が旧 Nouns 仕様 (mint 連番 1 開始) 想定、 Niji production code は mint 連番 0 開始のため最初の auction reward 更新 firstNounId は 0。

# 詳細

```diff
     function test_emitsAuctionRewardsUpdatedEvent() public {
+        // Niji ... mint 連番 0 開始のため最初の auction reward 更新 firstNounId は 0
         vm.expectEmit();
-        emit Rewards.AuctionRewardsUpdated(1, nounId);
+        emit Rewards.AuctionRewardsUpdated(0, nounId);
         rewards.updateRewardsForAuctions(nounId);
     }
```

```mermaid
flowchart LR
  A[setUp] --> B[bidAndSettleAuction × N]
  B --> C[updateRewardsForAuctions]
  C --> D{firstNounId 期待値}
  D -->|1 旧 Nouns 仕様| E[log != expected]
  D -->|0 Niji 仕様| F[pass]
```

# 設計判断

## Sub 2 scope を rewards に絞り、 AuctionV3 settlement は別 Sub-Issue

Sub 2 の原 scope は AuctionV3 7 + rewards 5 件想定だったが、 PR #294 PlaceholderURI fix の波及で rewards 5 → 1 件、 AuctionV3 7 件は nounId hard-code 修正が 40+ 箇所に散在する規模 (settlement / prices history 全 view path)。
本 PR は rewards 1 件のみ解消し、 AuctionV3 settlement test 群は follow-up Issue #310 で個別対応する。

# 完了条件

- [x] rewards/Rewards.t.sol 48/48 pass (元 14 pass / 1 fail → 15 pass / 0 fail、 + 副次 setUp 通過 33 件)
- [x] 全体 fail 件数 129 → 128 (-1)、 pass 482 → 483 (+1)
- [x] AuctionV3 settlement test 群は follow-up Issue #310 起票済

# レビューで見てほしいところ

- nounId 0-based は Niji 仕様の根拠 (NijiToken `_currentTokenId = 0` 初期化) と一致
- AuctionV3 settlement test の scope-out 判断 ... 40+ 箇所 hard-code 修正は本 PR 内に詰めると review 困難、 別 Sub-Issue で扱う

# 関連

Issue #293 ... Phase 2 親 Issue
Issue #302 ... 本 PR の起点 Sub-Issue 2
Issue #310 ... follow-up Sub 2.5 (AuctionV3 settlement / prices test refresh)
PR #309 ... Sub 4 (Inflation + GasSnapshot)

Refs #302
