### PR TITLE
🐛 fix(niji-contracts): Phase 2 Sub 1.5 - NijiDAOLogicSharedBase.mint helper に self-delegate 追加で 24 件 fail 解消 (Issue #306)

### DIFF
--- a/packages/niji-contracts/test/foundry/helpers/NijiDAOLogicSharedBase.t.sol
+++ b/packages/niji-contracts/test/foundry/helpers/NijiDAOLogicSharedBase.t.sol
@@ -7,6 +7,7 @@ import { DeployUtilsFork } from './DeployUtilsFork.sol';
 import { NijiDAOExecutor } from '../../../contracts/governance/NijiDAOExecutor.sol';
 import { INijiTokenForkLike } from '../../../contracts/governance/fork/newdao/governance/INijiTokenForkLike.sol';
 import { NijiTokenLike } from '../../../contracts/governance/NijiDAOInterfaces.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 import { Utils } from './Utils.sol';
 
 interface DAOLogicFork {
@@ -85,6 +86,13 @@ abstract contract NijiDAOLogicSharedBaseTest is Test, DeployUtilsFork {
             nounsToken.transferFrom(minter, to, tokenId);
         }
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        // (Niji 仕様 ... governance test の VotesBelowProposalThreshold 防御)
+        // NijiTokenLike に delegate 未公開のため NijiToken 直接 cast
+        vm.prank(to);
+        NijiToken(payable(address(nounsToken))).delegate(to);
+
         vm.roll(block.number + 1);
     }
 


### PR DESCRIPTION
# 概要

Phase 2 Sub-Issue 1.5 (Issue #306) の high-leverage fix PR。
NijiDAOLogicSharedBase.mint(to, amount) helper の末尾に self-delegate を追加、 governance test 全体に波及する VotesBelowProposalThreshold (48 件) を完全消滅させて全体 fail を 128 → 104 (-24 件) に削減。

# 課題

PR #309 (Sub 4) で Inflation / GasSnapshot に self-delegate を追加して 8 件解消したが、 残 governance test 48 件は `VotesBelowProposalThreshold()` で fail 継続。
root cause は共通 helper `NijiDAOLogicSharedBase.mint(to, amount)` が token mint + transferFrom 後の delegate 呼出を持たないこと、 OZ v5 ERC721Votes は token 受領で auto-delegate しない仕様 (Nouns 旧実装と異なる) のため受領者 to の getPriorVotes() = 0 を返し、 後続 propose で VotesBelowProposalThreshold revert を 48 件発生させていた。

# 詳細

NijiDAOLogicSharedBase.mint helper に self-delegate を追加。 NijiTokenLike interface に delegate 未公開のため NijiToken 直接 cast (import 追加)。

```diff
+import { NijiToken } from '../../../contracts/NijiToken.sol';

     function mint(address to, uint256 amount) internal {
         vm.startPrank(minter);
         for (uint256 i = 0; i < amount; i++) {
             uint256 tokenId = nounsToken.mint();
             nounsToken.transferFrom(minter, to, tokenId);
         }
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        // (Niji 仕様 ... governance test の VotesBelowProposalThreshold 防御)
+        // NijiTokenLike に delegate 未公開のため NijiToken 直接 cast
+        vm.prank(to);
+        NijiToken(payable(address(nounsToken))).delegate(to);
+
         vm.roll(block.number + 1);
     }
```

```mermaid
flowchart LR
  A[mint helper 呼出] --> B[minter prank で mint+transferFrom]
  B --> C{delegate?}
  C -->|未呼出 修正前| D[ERC721Votes votes 0]
  D --> E[propose で VotesBelowProposalThreshold revert 48 件]
  C -->|self-delegate 追加 修正後| F[ERC721Votes votes amount に反映]
  F --> G[propose 成功]
```

# 設計判断

## helper 内 self-delegate を default 化

mint helper は governance test の汎用 fixture、 受領者が直後に propose / castVote する前提。 OZ v5 仕様変更により delegate 明示が必須となったため、 helper level で fix し全 caller (CancelProposal / Propose / ProposeBySigs / UpdateProposal / Vote / Veto 全 state test) を一括解消。

## NijiToken 直接 cast

NijiTokenLike interface に delegate() を追加する代替案もあるが、 production code (NijiDAOInterfaces.sol) への変更は scope 拡大のため避けた。 test fixture 内 cast で完結、 production 影響なし。

# 完了条件

- [x] NijiDAOLogicSharedBase.mint helper に self-delegate 追加
- [x] VotesBelowProposalThreshold (48 件) → 0 件 完全消滅
- [x] 全体 fail 128 → 104 (-24 件)、 pass 483 → 507 (+24 件)
- [x] DAOLogic / governance test 全体に波及する high-leverage fix

# 残課題 (本 PR scope 外)

- EvmError: Revert (68 件) ... deeper logic (NijiDAOLogicV4.propose 内部 / forkEscrow address mismatch 等)、 別 root cause
- call reverted as expected (30 件) ... event spec drift
- ERC721InvalidReceiver / InsufficientApproval (各 14/12 件) ... OZ v5 safe receiver / approval check
- MustBeNounerOrPaySufficientFee (12 件) ... NijiDAOData Sub 3 scope (#303)
- 各 follow-up Sub-Issue で個別対応

# レビューで見てほしいところ

- self-delegate を helper level で default 化、 全 caller 一括解消の leverage 最大化
- NijiTokenLike → NijiToken cast は test fixture 内のみ、 production interface 変更なし
- VotesBelowProposalThreshold 48 件完全消滅は事実、 deeper logic 残 fail は別 root cause

# 関連

Issue #293 ... Phase 2 親 Issue
Issue #306 ... 本 PR の起点 Sub-Issue 1.5
PR #309 ... Sub 4 (Inflation + GasSnapshot self-delegate inline 適用)
PR #307 ... Sub 1 (DAOLogic tokenId hard-code)

Refs #306
