### PR TITLE
🐛 fix(niji-contracts): Phase 2 Sub 3 - NijiDAOData test setUp に self-delegate 追加で 7 件 fail 解消 (Issue #303)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOData.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOData.t.sol
@@ -12,6 +12,7 @@ import { NijiDAODataEvents } from '../../contracts/governance/data/NijiDAODataEv
 import { NijiDAODataProxy } from '../../contracts/governance/data/NijiDAODataProxy.sol';
 import { NijiDAOProposals } from '../../contracts/governance/NijiDAOProposals.sol';
 import { SigUtils } from './helpers/SigUtils.sol';
+import { NijiToken } from '../../contracts/NijiToken.sol';
 
 abstract contract NijiDAODataBaseTest is DeployUtilsV3, SigUtils, NijiDAODataEvents, AuctionHelpers {
     NijiDAODataProxy proxy;
@@ -44,6 +45,13 @@ abstract contract NijiDAODataBaseTest is DeployUtilsV3, SigUtils, NijiDAODataEve
 
         bidAndSettleAuction(auction, address(this));
         bidAndSettleAuction(auction, otherProposer);
+
+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        // (Niji 仕様 ... candidate test の MustBeNounerOrPaySufficientFee 防御)
+        NijiToken nijiToken = NijiToken(payable(address(nounsDao.nouns())));
+        nijiToken.delegate(address(this));
+        vm.prank(otherProposer);
+        nijiToken.delegate(otherProposer);
 
         vm.roll(block.number + 1);
     }


### PR DESCRIPTION
# 概要

Phase 2 Sub-Issue 3 (Issue #303) の fix PR。
NijiDAOData test の setUp に self-delegate を追加、 candidate creation 経路の MustBeNounerOrPaySufficientFee revert 12 件を完全消滅、 NijiDAOData 41 件 pass。

# 課題

NijiDAOData test の setUp は `bidAndSettleAuction(auction, address(this))` + `bidAndSettleAuction(auction, otherProposer)` で auction 経由 token 受領するが、 ERC721Votes (OZ v5) は受領で auto-delegate しない仕様のため getPriorVotes() = 0 を返す。
candidate creation 経路の `createProposalCandidate` で nouner 判定が失敗、 MustBeNounerOrPaySufficientFee revert を 12 件発生させていた。

# 詳細

setUp 末尾に address(this) / otherProposer の self-delegate を追加。 NijiToken import + cast 経由 (NijiTokenLike に delegate 未公開)。

```diff
+import { NijiToken } from '../../contracts/NijiToken.sol';

         bidAndSettleAuction(auction, address(this));
         bidAndSettleAuction(auction, otherProposer);
+
+        // ERC721Votes (OZ v5) は受領で auto-delegate しないため self-delegate 明示
+        // (Niji 仕様 ... candidate test の MustBeNounerOrPaySufficientFee 防御)
+        NijiToken nijiToken = NijiToken(payable(address(nounsDao.nouns())));
+        nijiToken.delegate(address(this));
+        vm.prank(otherProposer);
+        nijiToken.delegate(otherProposer);
+
         vm.roll(block.number + 1);
     }
```

```mermaid
flowchart LR
  A[setUp 開始] --> B[bidAndSettleAuction × 2]
  B --> C{delegate?}
  C -->|未呼出 修正前| D[getPriorVotes = 0]
  D --> E[createProposalCandidate で MustBeNounerOrPaySufficientFee 12 件]
  C -->|self-delegate 追加 修正後| F[getPriorVotes 反映]
  F --> G[candidate creation 成功]
```

# 設計判断

## test 内 inline delegate (helper 化保留)

Sub 1.5 (PR #312) で NijiDAOLogicSharedBase.mint helper level に self-delegate を追加したが、 NijiDAOData は別 base (DeployUtilsV3 + AuctionHelpers) を使用、 helper 共有なし。 setUp inline で完結させる方が試験 fixture の責務分離が明確。

## otherProposer のみ vm.prank 必要

address(this) は test contract 自身が caller (vm.prank なしで msg.sender = test contract)、 otherProposer は別 EOA のため vm.prank(otherProposer) で明示。

# 完了条件

- [x] NijiDAOData 41 件 pass (元 9 + 副次 setUp 通過 32 件)
- [x] MustBeNounerOrPaySufficientFee (12 件) → 0 件 完全消滅
- [x] 全体 fail 104 → 97 (-7 件)、 pass 507 → 514 (+7 件)
- [x] 残 1 件 (CreateCandidateToUpdateProposalTest の EvmError) は deeper logic 連鎖、 follow-up

# 残課題 (本 PR scope 外)

CreateCandidateToUpdateProposalTest setUp の EvmError: Revert は propose 内 forkEscrow address mismatch 連鎖、 Sub 1.5 deeper logic (#306 残部分) と同じ root cause。 別 follow-up Issue で対応。

# レビューで見てほしいところ

- setUp inline delegate は NijiDAOData fixture の責務、 helper 化保留妥当
- 12 件 fail 完全消滅 + 副次 32 件 pass の leverage
- 残 1 件 EvmError は別 root cause (deeper logic)、 本 PR scope 外

# 関連

Issue #293 ... Phase 2 親 Issue
Issue #303 ... 本 PR の起点 Sub-Issue 3
PR #312 ... Sub 1.5 (helper level self-delegate、 同 pattern)

Refs #303
