### PR TITLE
🐛 fix(niji-contracts): Phase 2 - _deployDAOV3WithParams forkEscrow nonce 修正 + 6 file self-delegate で 39 件 fail 解消 (Issue #314)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposal.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposal.t.sol
@@ -5,6 +5,7 @@ import 'forge-std/Test.sol';
 import { NijiDAOLogicBaseTest } from './NijiDAOLogicBaseTest.sol';
 import { NijiDAOTypes } from '../../../contracts/governance/NijiDAOInterfaces.sol';
 import { NijiDAOProposals } from '../../../contracts/governance/NijiDAOProposals.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 abstract contract ZeroState is NijiDAOLogicBaseTest {
     address proposer = makeAddr('proposer');
@@ -48,8 +49,13 @@ abstract contract ProposalUpdatableState is ZeroState {
         vm.startPrank(minter);
         uint256 _tokenId = nounsToken.mint();
         nounsToken.transferFrom(minter, proposer, _tokenId);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposer);
+        NijiToken(payable(address(nounsToken))).delegate(proposer);
+
+        vm.roll(block.number + 1);
 
         proposalId = propose(proposer, target, 0, '', '', '');
         vm.roll(block.number + 1);

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposalBySigs.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/CancelProposalBySigs.t.sol
@@ -5,6 +5,7 @@ import 'forge-std/Test.sol';
 import { NijiDAOLogicBaseTest } from './NijiDAOLogicBaseTest.sol';
 import { NijiDAOTypes } from '../../../contracts/governance/NijiDAOInterfaces.sol';
 import { NijiDAOProposals } from '../../../contracts/governance/NijiDAOProposals.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 abstract contract ZeroState is NijiDAOLogicBaseTest {
     address proposer = makeAddr('proposer');
@@ -27,8 +28,13 @@ abstract contract ProposalUpdatableState is ZeroState {
         vm.startPrank(minter);
         uint256 _tokenId = nounsToken.mint();
         nounsToken.transferFrom(minter, signerWithVote, _tokenId);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(signerWithVote);
+        NijiToken(payable(address(nounsToken))).delegate(signerWithVote);
+
+        vm.roll(block.number + 1);
 
         NijiDAOProposals.ProposalTxs memory txs = makeTxs(makeAddr('target'), 0, '', '');
         uint256 expirationTimestamp = block.timestamp + 1234;

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.15;
 import 'forge-std/Test.sol';
 import { NijiDAOLogicBaseTest } from './NijiDAOLogicBaseTest.sol';
 import { NijiDAOProposals } from '../../../contracts/governance/NijiDAOProposals.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 abstract contract ExecutableProposalState is NijiDAOLogicBaseTest {
     address user = makeAddr('user');
@@ -16,6 +17,11 @@ abstract contract ExecutableProposalState is NijiDAOLogicBaseTest {
         uint256 _tokenId = nounsToken.mint();
         nounsToken.transferFrom(minter, user, _tokenId);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(user);
+        NijiToken(payable(address(nounsToken))).delegate(user);
+
         vm.roll(block.number + 1);
 
         // prep an executable proposal

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/ProposeBySigs.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/ProposeBySigs.t.sol
@@ -10,6 +10,7 @@ import { NijiDAOProxyV3 } from '../../../contracts/governance/NijiDAOProxyV3.sol
 import { NijiDAOTypes } from '../../../contracts/governance/NijiDAOInterfaces.sol';
 import { IProxyRegistry } from '../../../contracts/external/opensea/IProxyRegistry.sol';
 import { NijiDAOExecutor } from '../../../contracts/governance/NijiDAOExecutor.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 contract ProposeBySigsTest is NijiDAOLogicBaseTest {
     address proposerWithVote;
@@ -40,8 +41,17 @@ contract ProposeBySigsTest is NijiDAOLogicBaseTest {
         nounsToken.transferFrom(minter, signerWithVote1, _tid2);
         uint256 _tid3 = nounsToken.mint();
         nounsToken.transferFrom(minter, signerWithVote2, _tid3);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposerWithVote);
+        NijiToken(payable(address(nounsToken))).delegate(proposerWithVote);
+        vm.prank(signerWithVote1);
+        NijiToken(payable(address(nounsToken))).delegate(signerWithVote1);
+        vm.prank(signerWithVote2);
+        NijiToken(payable(address(nounsToken))).delegate(signerWithVote2);
+
+        vm.roll(block.number + 1);
     }
 
     function test_givenNoSigs_reverts() public {

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
@@ -8,6 +8,7 @@ import { SigUtils, ERC1271Stub } from '../helpers/SigUtils.sol';
 import { NijiDAOProposals } from '../../../contracts/governance/NijiDAOProposals.sol';
 import { NijiDAOProxyV3 } from '../../../contracts/governance/NijiDAOProxyV3.sol';
 import { NijiDAOTypes } from '../../../contracts/governance/NijiDAOInterfaces.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 import { IProxyRegistry } from '../../../contracts/external/opensea/IProxyRegistry.sol';
 import { NijiDAOExecutor } from '../../../contracts/governance/NijiDAOExecutor.sol';
 
@@ -22,8 +23,13 @@ abstract contract UpdateProposalBaseTest is NijiDAOLogicBaseTest {
         vm.startPrank(minter);
         uint256 _tokenId = nounsToken.mint();
         nounsToken.transferFrom(minter, proposer, _tokenId);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposer);
+        NijiToken(payable(address(nounsToken))).delegate(proposer);
+
+        vm.roll(block.number + 1);
 
         proposalId = propose(proposer, makeAddr('target'), 0, '', '', '');
         vm.roll(block.number + 1);

--- a/packages/niji-contracts/test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol
+++ b/packages/niji-contracts/test/foundry/governance/NijiDAOLogicV3GasSnapshot.t.sol
@@ -8,6 +8,7 @@ import { INijiDAOLogic } from '../../../contracts/interfaces/INijiDAOLogic.sol';
 import { DeployUtilsV3 } from '../helpers/DeployUtilsV3.sol';
 import { NijiDAOProxyV3 } from '../../../contracts/governance/NijiDAOProxyV3.sol';
 import { NijiDAOTypes } from '../../../contracts/governance/NijiDAOInterfaces.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 abstract contract NijiDAOLogic_GasSnapshot_propose is NijiDAOLogicSharedBaseTest {
     address immutable target = makeAddr('target');
@@ -22,7 +23,7 @@ abstract contract NijiDAOLogic_GasSnapshot_propose is NijiDAOLogicSharedBaseTest
 
         // ERC721Votes (OZ v5) self-delegate
         vm.prank(proposer);
-        nounsToken.delegate(proposer);
+        NijiToken(payable(address(nounsToken))).delegate(proposer);
 
         vm.roll(block.number + 1);
     }

--- a/packages/niji-contracts/test/foundry/helpers/DeployUtilsV3.sol
+++ b/packages/niji-contracts/test/foundry/helpers/DeployUtilsV3.sol
@@ -118,7 +118,10 @@ abstract contract DeployUtilsV3 is DeployUtils {
             FORK_DAO_QUORUM_VOTES_BPS
         );
 
-        address predictedForkEscrowAddress = computeCreateAddress(address(this), vm.getNonce(address(this)) + 2);
+        // forkEscrow は NijiDAOProxyV3 deploy 直後 (nonce+1) に deploy される
+        // 旧 +2 は daoLogicImplementation を引数評価で deploy する想定だったが、
+        // line 107 で先に deploy 済のため実 deploy 順序は ProxyV3 (N) → ForkEscrow (N+1)
+        address predictedForkEscrowAddress = computeCreateAddress(address(this), vm.getNonce(address(this)) + 1);
 
         INijiDAOLogic dao = INijiDAOLogic(
             payable(


### PR DESCRIPTION
# 概要

Phase 2 high-leverage fix PR (Issue #314)。
`_deployDAOV3WithParams` の forkEscrow address 予測 nonce ずれ (+2 → +1) と各 file の独自 mint+transferFrom 経路の self-delegate 漏れを同 PR で修正、 全体 fail 97 → 58 (-39 件) / pass 514 → 601 (+87 件) を達成。

# 課題

PR #312 (Sub 1.5) で NijiDAOLogicSharedBase.mint helper level に self-delegate を追加して 24 件解消したが、 各 file で独自 mint+transferFrom している test (CancelProposal / UpdateProposal 等) は helper 経路を通らないため delegate 漏れ継続。
更に trace で deeper logic として `_deployDAOV3WithParams` 内 `predictedForkEscrowAddress = computeCreateAddress(address(this), vm.getNonce(address(this)) + 2)` が実 deploy 順序とずれており、 SanctionsOracle address (nonce+2) が forkEscrow と取り違えられて propose 内 `numTokensOwnedByDAO()` が SanctionsOracle に対して呼ばれ revert していた。

# 詳細

## 修正 1 ... forkEscrow nonce 計算

`_deployDAOV3WithParams` 内の実 deploy 順序を逆算:

- 現 nonce N (line 121 時点)
- N ... `new NijiDAOProxyV3(...)` (line 125)
- N+1 ... `new NijiDAOForkEscrow(...)` (line 150)
- N+2 ... `new ChainalysisSanctionsListMock()` (line 152)

旧 `+ 2` は daoLogicImplementation を引数評価で deploy する想定だったが、 line 107 で `address daoLogicImplementation = address(new NijiDAOLogicV4())` で先 deploy 済のため deploy 順序から外れる。

```diff
-        address predictedForkEscrowAddress = computeCreateAddress(address(this), vm.getNonce(address(this)) + 2);
+        // forkEscrow は NijiDAOProxyV3 deploy 直後 (nonce+1) に deploy される
+        // 旧 +2 は daoLogicImplementation を引数評価で deploy する想定だったが、
+        // line 107 で先に deploy 済のため実 deploy 順序は ProxyV3 (N) → ForkEscrow (N+1)
+        address predictedForkEscrowAddress = computeCreateAddress(address(this), vm.getNonce(address(this)) + 1);
```

## 修正 2 ... 6 file の独自 mint+transferFrom 経路に self-delegate 追加

各 file (CancelProposal / UpdateProposal / CancelProposalBySigs / ForkBlocksProposalExecution / ProposeBySigs / GasSnapshot) の setUp に NijiToken import + self-delegate を追加。 NijiTokenLike interface に delegate 未公開のため NijiToken 直接 cast。

```diff
+import { NijiToken } from '../../../contracts/NijiToken.sol';

         vm.startPrank(minter);
         uint256 _tokenId = nounsToken.mint();
         nounsToken.transferFrom(minter, proposer, _tokenId);
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(proposer);
+        NijiToken(payable(address(nounsToken))).delegate(proposer);
+
+        vm.roll(block.number + 1);
```

```mermaid
flowchart TD
  A[setUp 開始] --> B[deployToken via DeployUtilsV3]
  B --> C[_deployDAOV3WithParams]
  C --> D{forkEscrow nonce 計算}
  D -->|+2 修正前| E[SanctionsOracle と address 取違え]
  E --> F[propose 内 numTokensOwnedByDAO で SanctionsOracle に call → revert]
  D -->|+1 修正後| G[forkEscrow address 正解]
  G --> H[mint + transferFrom]
  H --> I{self-delegate?}
  I -->|漏れ 修正前| J[VotesBelowProposalThreshold]
  I -->|追加 修正後| K[propose 成功]
```

# 設計判断

## forkEscrow nonce 修正は test fixture 内のみ

production code (NijiDAOProxyV3 constructor の forkEscrow 引数) には触らず、 test fixture (DeployUtilsV3) の nonce 計算のみ修正。 production deploy script は別経路 (実 forkEscrow address を渡す) で本問題は test fixture 限定。

## 各 file の self-delegate を helper 化しない

Sub 1.5 (PR #312) は NijiDAOLogicSharedBase.mint helper level で抽象化したが、 本 PR の対象 file は SharedBase helper 経由ではなく独自 setUp で mint+transferFrom する責務 (signer 個別の private key 管理 / 連続 mint 等)、 helper 化すると flexibility が損なわれる。 setUp inline 追加で完結。

# 完了条件

- [x] `_deployDAOV3WithParams` の nonce 計算が production deploy 順序と一致
- [x] 6 file (CancelProposal / UpdateProposal / CancelProposalBySigs / ForkBlocksProposalExecution / ProposeBySigs / GasSnapshot) で self-delegate 追加
- [x] EvmError: Revert (68 件) 大半解消、 全体 fail 97 → 58 (-39 件)、 pass 514 → 601 (+87 件)
- [x] ProposalActiveStateTest 等 governance test 全体 pass

# 残課題 (本 PR scope 外)

- UpdateProposalBySigs.t.sol の hard-code `i + 1` (8 件 loop) は別 PR
- AuctionV3 settlement test (Issue #310 scope、 40+ 箇所 nounId hard-code)
- OZ v5 ERC721InvalidReceiver / InsufficientApproval (26 件) safe receiver / approval 修正
- 他 deeper logic / event spec drift

# レビューで見てほしいところ

- forkEscrow nonce 計算 +2 → +1 は実 deploy 順序の数え直し、 production code 影響なし (test fixture 内のみ)
- 各 file の self-delegate inline 追加は同 pattern、 機械的修正で logic 影響なし
- fail 97 → 58 (-39 件) の中で forkEscrow nonce fix が大半 (15 件) + 各 file delegate 追加が残 (24 件)、 副次効果含む

# 関連

Issue #293 ... Phase 2 親 Issue
Issue #314 ... 本 PR の起点
PR #312 ... Sub 1.5 (helper level self-delegate、 本 PR は file level 補完)
PR #307 ... Sub 1 (DAOLogic tokenId hard-code、 同 file の前提修正)

Refs #314
