### PR TITLE
🐛 fix(niji-contracts): UpdateProposalBySigs hard-code i+1 loop を mint 戻り値経由 + 8 signer self-delegate に修正

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposalBySigs.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposalBySigs.t.sol
@@ -11,6 +11,7 @@ import { NijiDAOProxyV3 } from '../../../contracts/governance/NijiDAOProxyV3.sol
 import { NijiDAOTypes } from '../../../contracts/governance/NijiDAOInterfaces.sol';
 import { IProxyRegistry } from '../../../contracts/external/opensea/IProxyRegistry.sol';
 import { NijiDAOExecutor } from '../../../contracts/governance/NijiDAOExecutor.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 contract UpdateProposalBySigsTest is NijiDAOLogicBaseTest {
     address proposer = makeAddr('proposerWithVote');
@@ -30,12 +31,19 @@ contract UpdateProposalBySigsTest is NijiDAOLogicBaseTest {
             _signers.push(signer);
             _signerPKs.push(signerPK);
 
-            nounsToken.mint();
-            nounsToken.transferFrom(minter, signer, i + 1);
+            // Niji ... mint 戻り値経由 (旧 hard-code i+1 は 1 開始想定、 Niji は 0 開始)
+            uint256 _tokenId = nounsToken.mint();
+            nounsToken.transferFrom(minter, signer, _tokenId);
+        }
+        vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate (8 signer)
+        for (uint256 i = 0; i < 8; ++i) {
+            vm.prank(_signers[i]);
+            NijiToken(payable(address(nounsToken))).delegate(_signers[i]);
         }
 
         vm.roll(block.number + 1);
-        vm.stopPrank();
 
         (
             address[] memory signers,


### PR DESCRIPTION
# 概要

UpdateProposalBySigs.t.sol の 8 signer loop で hard-coded tokenId (i+1) + delegate 漏れを修正、 UpdateProposalBySigs 29/29 pass、 全体 fail 58 → 57 / pass 601 → 630 (+29 件副次効果含む)。

# 課題

8 signer loop の `nounsToken.transferFrom(minter, signer, i + 1)` が旧 Nouns 仕様 (tokenId=1 開始) を hard-code、 Niji production の `_currentTokenId = 0` 開始と不整合。
更に loop 内で signer に対する delegate 呼出が欠落、 ERC721Votes (OZ v5) auto-delegate 廃止仕様で全 signer の getPriorVotes() = 0、 propose で VotesBelowProposalThreshold revert。

# 詳細

```diff
+import { NijiToken } from '../../../contracts/NijiToken.sol';

         vm.startPrank(minter);
         for (uint256 i = 0; i < 8; ++i) {
             (address signer, uint256 signerPK) = makeAddrAndKey(...);
             _signers.push(signer);
             _signerPKs.push(signerPK);

-            nounsToken.mint();
-            nounsToken.transferFrom(minter, signer, i + 1);
+            // Niji ... mint 戻り値経由 (旧 hard-code i+1 は 1 開始想定、 Niji は 0 開始)
+            uint256 _tokenId = nounsToken.mint();
+            nounsToken.transferFrom(minter, signer, _tokenId);
         }
-
-        vm.roll(block.number + 1);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate (8 signer)
+        for (uint256 i = 0; i < 8; ++i) {
+            vm.prank(_signers[i]);
+            NijiToken(payable(address(nounsToken))).delegate(_signers[i]);
+        }
+
+        vm.roll(block.number + 1);
```

```mermaid
flowchart LR
  A[8 signer loop] --> B[mint 戻り値経由]
  B --> C[transferFrom signer]
  C --> D[2 段 loop で self-delegate]
  D --> E[getPriorVotes 反映]
  E --> F[propose 成功]
```

# 完了条件

- [x] hard-code i+1 を mint 戻り値経由に置換
- [x] 8 signer 全員の self-delegate 追加
- [x] UpdateProposalBySigs 29/29 全 pass
- [x] 全体 fail 58 → 57 (-1)、 pass 601 → 630 (+29 件副次効果)

# レビューで見てほしいところ

- 2 段 loop (mint+transfer / delegate) で順序保持、 _signers 配列経由で同一 signer 参照
- 同 pattern PR (#307 / #315) と整合、 機械的修正

# 関連

Issue #293 ... Phase 2 親 Issue
PR #315 ... forkEscrow nonce + 6 file self-delegate (本 PR の前提)

Refs #293
