### PR TITLE
🐛 fix(niji-contracts): ProposalRewards setUp の Nouns founder distribution + delegate 漏れ修正で 26 件 fail 解消

### DIFF
--- a/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -7,6 +7,7 @@ import { Rewards } from '../../../contracts/client-incentives/Rewards.sol';
 import { INijiAuctionHouseV2 } from '../../../contracts/interfaces/INijiAuctionHouseV2.sol';
 import { NijiAuctionHouseProxy } from '../../../contracts/proxies/NijiAuctionHouseProxy.sol';
 import { RewardsDeployer } from '../../../script/Rewards/RewardsDeployer.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 import 'forge-std/Test.sol';
 
 abstract contract BaseProposalRewardsTest is NijiDAOLogicBaseTest {
@@ -42,8 +43,15 @@ abstract contract BaseProposalRewardsTest is NijiDAOLogicBaseTest {
             bidAndSettleAuction({ bidAmount: 1 ether });
         }
 
-        vm.prank(makeAddr('noundersDAO'));
-        nounsToken.transferFrom(makeAddr('noundersDAO'), bidder2, 0);
+        // Niji ... 旧 Nouns で noundersDAO に 10 件毎 (tokenId 0/10/20...) 自動 distribute されていた
+        // 想定で noundersDAO → bidder2 への transferFrom が必要だったが、
+        // Niji 仕様で founder distribution は廃止、 該当 transferFrom は不要 (削除)。
+
+        // ERC721Votes (OZ v5) self-delegate (bidder1 / bidder2 が token 受領済)
+        vm.prank(bidder1);
+        NijiToken(payable(address(nounsToken))).delegate(bidder1);
+        vm.prank(bidder2);
+        NijiToken(payable(address(nounsToken))).delegate(bidder2);
 
         rewards = RewardsDeployer.deployRewards(dao, admin, minter, address(erc20Mock), address(0));
 


### PR DESCRIPTION
# 概要

ProposalRewards.t.sol setUp の旧 Nouns 仕様残骸 (noundersDAO founder distribution 経由 transferFrom) を削除 + bidder1 / bidder2 self-delegate を追加、 ERC721InsufficientApproval 12 件 + ERC721InvalidReceiver 14 件の **計 26 件 完全消滅**、 ProposalRewards setUp 通過分が 25 件 pass。

# 課題

ProposalRewards setUp で `vm.prank(makeAddr('noundersDAO')); nounsToken.transferFrom(makeAddr('noundersDAO'), bidder2, 0)` を呼んでいたが、 これは旧 Nouns 仕様で noundersDAO に 10 件毎 (tokenId 0/10/20...) 自動 distribute される前提。
Niji 仕様で founder distribution は廃止のため noundersDAO は tokenId 0 を保有しておらず、 transferFrom が `ERC721InsufficientApproval(noundersDAO, 0)` で revert していた。
更に bidAndSettleAuction 経由で受領した bidder1 / bidder2 への self-delegate 漏れで後続 propose が VotesBelowProposalThreshold revert していた。

# 詳細

```diff
+import { NijiToken } from '../../../contracts/NijiToken.sol';

         while (nounsToken.totalSupply() < 10) {
             bidAndSettleAuction({ bidAmount: 1 ether });
         }

-        vm.prank(makeAddr('noundersDAO'));
-        nounsToken.transferFrom(makeAddr('noundersDAO'), bidder2, 0);
+        // Niji ... 旧 Nouns で noundersDAO に 10 件毎 (tokenId 0/10/20...) 自動 distribute されていた
+        // 想定で noundersDAO → bidder2 への transferFrom が必要だったが、
+        // Niji 仕様で founder distribution は廃止、 該当 transferFrom は不要 (削除)。
+
+        // ERC721Votes (OZ v5) self-delegate (bidder1 / bidder2 が token 受領済)
+        vm.prank(bidder1);
+        NijiToken(payable(address(nounsToken))).delegate(bidder1);
+        vm.prank(bidder2);
+        NijiToken(payable(address(nounsToken))).delegate(bidder2);
```

```mermaid
flowchart LR
  A[setUp] --> B[bidAndSettleAuction × N で bidder1/2 が token 受領]
  B --> C{noundersDAO transferFrom?}
  C -->|旧 Nouns 想定 修正前| D[noundersDAO が tokenId 0 保有していない → InsufficientApproval revert]
  C -->|Niji 仕様 修正後| E[削除 founder distribution 廃止]
  E --> F{bidder1/2 delegate?}
  F -->|漏れ 修正前| G[VotesBelowProposalThreshold]
  F -->|追加 修正後| H[propose 成功]
```

# 設計判断

## founder distribution 関連 transferFrom を削除

旧 Nouns の自動 distribution は production code 仕様変更で廃止、 setUp で noundersDAO 保有を試行する経路は意味を失っている。 削除 + コメントで理由を残す。

## ERC721InvalidReceiver も副次解消

setUp が早期 revert していたため後続の test 内 transferFrom (ERC721InvalidReceiver 経路) まで到達せず、 setUp 解消で副次的に 14 件 pass。

# 完了条件

- [x] ERC721InsufficientApproval 12 件 → 0 件
- [x] ERC721InvalidReceiver 14 件 → 0 件 (副次)
- [x] ProposalRewards setUp 通過分が 25 件 pass
- [x] 全体 fail 57 → 62 (+5、 setUp 通過後の deeper logic 顕在化)、 pass 630 → 655 (+25)

# 残課題 (本 PR scope 外)

残 fail 62 件 ... VotesBelowProposalThreshold (18 deeper test 内 delegate 漏れ) / execution error (18) / Not enough history (8) / event spec drift (ClientRewarded / ProposalRewardsUpdated 等) は別 root cause、 別 PR で対応。

# レビューで見てほしいところ

- noundersDAO transferFrom 削除は production 仕様変更追従、 旧 Nouns auto distribution の名残除去
- 副次効果で ERC721InvalidReceiver 14 件解消 (setUp 早期 revert 連鎖の解消)
- 同 pattern PR (#313 NijiDAOData setUp self-delegate) と整合

# 関連

Issue #293 ... Phase 2 親 Issue
PR #313 ... NijiDAOData setUp self-delegate (同 pattern、 別 file)

Refs #293
