### PR TITLE
🐛 fix(niji-contracts): NijiDAOLogicBaseTest.mintTo helper に self-delegate 追加で 8 件 fail 解消

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/NijiDAOLogicBaseTest.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/NijiDAOLogicBaseTest.sol
@@ -11,6 +11,7 @@ import { NijiDAOTypes, NijiTokenLike } from '../../../contracts/governance/NijiD
 import { IProxyRegistry } from '../../../contracts/external/opensea/IProxyRegistry.sol';
 import { NijiDAOExecutorV2 } from '../../../contracts/governance/NijiDAOExecutorV2.sol';
 import { NijiDAOForkEscrow } from '../../../contracts/governance/fork/NijiDAOForkEscrow.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 import { INijiDAOLogic } from '../../../contracts/interfaces/INijiDAOLogic.sol';
 
 abstract contract NijiDAOLogicBaseTest is Test, DeployUtilsV3, SigUtils {
@@ -88,6 +89,11 @@ abstract contract NijiDAOLogicBaseTest is Test, DeployUtilsV3, SigUtils {
         tokenID = nounsToken.mint();
         nounsToken.transferFrom(minter, to, tokenID);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(to);
+        NijiToken(payable(address(nounsToken))).delegate(to);
+
         vm.roll(block.number + 1);
     }
 


### PR DESCRIPTION
# 概要

NijiDAOLogicBaseTest.mintTo(to) helper に self-delegate を追加、 helper 経由で token を受領する receivers の delegate 漏れを解消、 VotesBelowProposalThreshold 18 → 4 件 (-14)、 全体 fail 62 → 54 (-8) / pass 655 → 668 (+13)。

# 課題

PR #312 (Sub 1.5) で NijiDAOLogicSharedBase.mint helper に self-delegate を追加したが、 NijiDAOLogicBaseTest には独立した mintTo(to) helper が存在し、 こちらは delegate 呼出未追加。
NijiDAOLogicBaseTest を継承する deeper test (NijiDAOLogicVotesTest / ProposalDataForRewardsTest 等) で getPriorVotes() = 0 を返し VotesBelowProposalThreshold revert を 14 件発生させていた。

# 詳細

```diff
+import { NijiToken } from '../../../contracts/NijiToken.sol';

     function mintTo(address to) internal returns (uint256 tokenID) {
         vm.startPrank(minter);
         tokenID = nounsToken.mint();
         nounsToken.transferFrom(minter, to, tokenID);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(to);
+        NijiToken(payable(address(nounsToken))).delegate(to);
+
         vm.roll(block.number + 1);
     }
```

```mermaid
flowchart LR
  A[mintTo 呼出] --> B[mint + transferFrom]
  B --> C{delegate?}
  C -->|未呼出 修正前| D[getPriorVotes 0 → VotesBelowProposalThreshold 14 件]
  C -->|self-delegate 追加 修正後| E[全 deeper test pass]
```

# 設計判断

## helper 1 箇所修正で 14 件解消

SharedBase.mint (PR #312) と同 pattern、 各 caller に inline 追加する代わりに helper level fix で leverage 最大化。 NijiDAOLogicBaseTest は別 base class (NijiDAOLogicSharedBase と派生関係なし) のため別途修正必要。

# 完了条件

- [x] mintTo helper に self-delegate 追加
- [x] VotesBelowProposalThreshold 18 → 4 件 (-14、 残 4 件は別 PR)
- [x] 全体 fail 62 → 54 (-8 件)、 pass 655 → 668 (+13 件)

# 残課題 (本 PR scope 外)

- 残 VotesBelowProposalThreshold 4 件 (ProposalRewards.t.sol test_votingClientIdsMustBe* deeper logic)
- 他 fail (execution error 18 / Not enough history 8 / event spec drift / 等) は別 root cause

# 関連

Issue #293 ... Phase 2 親 Issue
PR #312 ... Sub 1.5 (NijiDAOLogicSharedBase.mint helper self-delegate、 本 PR は別 base class の補完)

Refs #293
