### PR TITLE
🐛 fix(niji-contracts): NijiDAOFork test の Nouns founder distribution 期待値修正で 7 件 fail 解消

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/NijiDAOFork.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/NijiDAOFork.t.sol
@@ -9,6 +9,7 @@ import { NijiDAOFork } from '../../../contracts/governance/fork/NijiDAOFork.sol'
 import { NijiDAOForkEscrow } from '../../../contracts/governance/fork/NijiDAOForkEscrow.sol';
 import { IERC721 } from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import { INijiDAOForkEscrow } from '../../../contracts/governance/NijiDAOInterfaces.sol';
+import { NijiToken } from '../../../contracts/NijiToken.sol';
 
 abstract contract DAOForkZeroState is NijiDAOLogicBaseTest {
     address tokenHolder = makeAddr('tokenHolder');
@@ -33,14 +34,19 @@ abstract contract DAOForkZeroState is NijiDAOLogicBaseTest {
         deal(address(timelock), 1000 ether);
         erc20Mock.mint(address(timelock), 300e18);
 
-        // Mint total of 20 tokens. 18 to token holder, 2 to nounders
+        // Mint total of 20 tokens, 全て tokenHolder へ (Niji ... founder distribution 廃止のため旧 2 件 nounders 経路なし)
         vm.startPrank(minter);
         while (nounsToken.totalSupply() < 20) {
             nounsToken.mint();
             nounsToken.transferFrom(minter, tokenHolder, nounsToken.totalSupply() - 1);
         }
         vm.stopPrank();
-        assertEq(dao.nouns().balanceOf(tokenHolder), 18);
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(tokenHolder);
+        NijiToken(payable(address(nounsToken))).delegate(tokenHolder);
+
+        assertEq(dao.nouns().balanceOf(tokenHolder), 20);
 
         escrow = dao.forkEscrow();
     }
@@ -61,7 +67,8 @@ contract DAOForkZeroStateTest is DAOForkZeroState {
         dao.escrowToFork(tokenIds, new uint256[](0), '');
         vm.stopPrank();
 
-        assertEq(dao.nouns().balanceOf(tokenHolder), 15);
+        // 20 - 3 = 17
+        assertEq(dao.nouns().balanceOf(tokenHolder), 17);
     }
 
     function test_escrowToForkEmitsEvent() public {
@@ -142,7 +149,8 @@ contract DAOForkSignaledUnderThresholdStateTest is DAOForkSignaledUnderThreshold
     }
 
     function test_unsignalFork_returnsTokens() public {
-        assertEq(dao.nouns().balanceOf(tokenHolder), 15);
+        // 20 - 3 = 17 (escrow 中)
+        assertEq(dao.nouns().balanceOf(tokenHolder), 17);
 
         tokenIds = [1, 2, 3];
 
@@ -151,7 +159,8 @@ contract DAOForkSignaledUnderThresholdStateTest is DAOForkSignaledUnderThreshold
         vm.prank(tokenHolder);
         dao.withdrawFromForkEscrow(tokenIds);
 
-        assertEq(dao.nouns().balanceOf(tokenHolder), 18);
+        // withdraw 後 20 件全戻し
+        assertEq(dao.nouns().balanceOf(tokenHolder), 20);
     }
 
     function test_unsignalForkWithDifferentTokens_reverts() public {


### PR DESCRIPTION
# 概要

NijiDAOFork.t.sol setUp の Nouns founder distribution 期待値 (18 / 15 / 18) を Niji 仕様 (全 20 件 tokenHolder = 20 / 17 / 20) に修正、 tokenHolder self-delegate 追加で 7 件 fail 解消、 全体 fail 54 → 47 / pass 668 → 703 (+35 副次効果含む)。

# 課題

NijiDAOFork.t.sol setUp は 20 件 mint で 18 件 tokenHolder / 2 件 nounders を旧 Nouns 仕様前提に hard-code (`assertEq(...balanceOf(tokenHolder), 18)`)。
Niji 仕様で founder distribution は廃止 (PR #317 で同 issue が ProposalRewards に対しても見つかった) のため全 20 件が tokenHolder へ、 期待値 18 と実 20 の不一致で `execution error` (assertion 失敗) revert。
更に tokenHolder への self-delegate 漏れで後続 propose / vote 経路で VotesBelowProposalThreshold revert も連鎖。

# 詳細

```diff
+import { NijiToken } from '../../../contracts/NijiToken.sol';

-        // Mint total of 20 tokens. 18 to token holder, 2 to nounders
+        // Mint total of 20 tokens, 全て tokenHolder へ (Niji ... founder distribution 廃止のため旧 2 件 nounders 経路なし)
         vm.startPrank(minter);
         while (nounsToken.totalSupply() < 20) {
             nounsToken.mint();
             nounsToken.transferFrom(minter, tokenHolder, nounsToken.totalSupply() - 1);
         }
         vm.stopPrank();
-        assertEq(dao.nouns().balanceOf(tokenHolder), 18);
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(tokenHolder);
+        NijiToken(payable(address(nounsToken))).delegate(tokenHolder);
+
+        assertEq(dao.nouns().balanceOf(tokenHolder), 20);
```

```diff
-        assertEq(dao.nouns().balanceOf(tokenHolder), 15);  // 18 - 3
+        // 20 - 3 = 17
+        assertEq(dao.nouns().balanceOf(tokenHolder), 17);
```

```mermaid
flowchart LR
  A[setUp] --> B[20 件 mint loop]
  B --> C{Nouns 仕様 18 / 2?}
  C -->|旧期待値 18 修正前| D[assertion 20 vs 18 失敗 → execution error]
  C -->|Niji 仕様 20 修正後| E[全 20 件 tokenHolder]
  E --> F{tokenHolder delegate?}
  F -->|漏れ 修正前| G[VotesBelowProposalThreshold]
  F -->|追加 修正後| H[propose / escrow 全 pass]
```

# 設計判断

## tokenIds = [1, 2, 3] は維持

escrow テストで使う tokenId hard-code [1, 2, 3] は tokenHolder が 0-19 を全保有のため valid、 0-based に変更しない (test 意図 ... 3 件分の escrow 動作確認、 番号自体に意味なし)。

## founder distribution 廃止コメントを残す

旧 Nouns の auto distribution 仕様を知らない future reader 向けに、 「founder distribution 廃止のため旧 2 件 nounders 経路なし」 コメントで意図を明示。

# 完了条件

- [x] balanceOf 期待値 18 → 20 / 15 → 17 / 18 → 20 / 15 → 17 (4 箇所)
- [x] tokenHolder self-delegate 追加
- [x] DAOForkZeroStateTest 6/6 pass + 他 fork state test 大半 pass
- [x] 全体 fail 54 → 47 (-7 件)、 pass 668 → 703 (+35 件)

# 残課題 (本 PR scope 外)

DAOForkSignaledOverThresholdStateTest.test_proposalThresholdIsLowered 1 件は deeper logic (proposalThreshold 計算)、 別 PR で対応。

# 関連

Issue #293 ... Phase 2 親 Issue
PR #317 ... ProposalRewards (同 pattern: Nouns founder distribution 残骸削除)

Refs #293
