### PR TITLE
🐛 fix(niji-contracts): 残 fail 3 件 tokenId 0-based + nounId underflow 修正

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiAuctionHouseV3.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiAuctionHouseV3.t.sol
@@ -61,8 +61,11 @@ contract NijiAuctionHouseV3Test is NijiAuctionHouseV3TestBase {
     function test_createBid_revertsGivenWrongNounId() public {
         uint128 nounId = auction.auction().nounId;
 
-        vm.expectRevert('Noun not up for auction');
-        auction.createBid(nounId - 1);
+        // Niji ... nounId=0 開始のため nounId-1 は uint underflow、 nounId>0 の場合のみ前 nounId 試行
+        if (nounId > 0) {
+            vm.expectRevert('Noun not up for auction');
+            auction.createBid(nounId - 1);
+        }
 
         vm.expectRevert('Noun not up for auction');
         auction.createBid(nounId + 1);

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/ForkBlocksProposalExecution.t.sol
@@ -52,8 +52,9 @@ abstract contract ExecutableProposalWithActiveForkState is ExecutableProposalSta
         super.setUp();
 
         vm.startPrank(user);
-        tokenIds = [1];
-        nounsToken.approve(address(dao), 1);
+        // Niji ... mintTo(user) は tokenId=0 を受領するため 0-based
+        tokenIds = [0];
+        nounsToken.approve(address(dao), 0);
         dao.escrowToFork(tokenIds, new uint256[](0), '');
         vm.stopPrank();
 

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
@@ -66,7 +66,8 @@ contract UpdateProposalPermissionsTest is UpdateProposalBaseTest {
         dao.cancel(proposalId);
 
         (address signer, uint256 signerPK) = makeAddrAndKey('signer');
-        nounsToken.transferFrom(proposer, signer, 1);
+        // Niji ... proposer は tokenId=0 を保有 (0 開始)
+        nounsToken.transferFrom(proposer, signer, 0);
         vm.stopPrank();
         vm.roll(block.number + 1);
 


### PR DESCRIPTION
# 概要

残 fail の小規模 3 件 (tokenId 0-based + nounId underflow) を機械的修正、 全体 fail 47 → 45 / pass 703 → 706。

# 課題

各 file で異なる hard-code パターンが Niji 0-based 仕様と不整合:

1. ExecutableProposalWithActiveForkState ... tokenIds = [1] + approve(1) (mintTo(user) は tokenId=0)
2. UpdateProposalPermissionsTest ... transferFrom(proposer, signer, 1) (proposer 保有 tokenId=0)
3. NijiAuctionHouseV3Test.test_createBid_revertsGivenWrongNounId ... nounId=0 開始で nounId-1 が uint underflow → 期待 'Noun not up for auction' と実 panic 不一致

# 詳細

```diff
-        tokenIds = [1];
-        nounsToken.approve(address(dao), 1);
+        tokenIds = [0];
+        nounsToken.approve(address(dao), 0);
```

```diff
-        nounsToken.transferFrom(proposer, signer, 1);
+        nounsToken.transferFrom(proposer, signer, 0);
```

```diff
-        vm.expectRevert('Noun not up for auction');
-        auction.createBid(nounId - 1);
+        if (nounId > 0) {
+            vm.expectRevert('Noun not up for auction');
+            auction.createBid(nounId - 1);
+        }
```

# 完了条件

- [x] 3 file の tokenId / nounId 修正
- [x] 全体 fail 47 → 45 (-2)、 pass 703 → 706 (+3)

# 関連

Issue #293 ... Phase 2 親 Issue
Refs #293
