### PR TITLE
🐛 fix(niji-contracts): test_rewardSplitBetweenTwoClients vote 数 9:1 比率に修正 (founder distribution 廃止反映)

### DIFF
--- a/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -687,29 +687,30 @@ contract VotesRewardsTest is BaseProposalRewardsTest {
     }
 
     function test_rewardSplitBetweenTwoClients() public {
-        // cast 8 votes
-        assertEq(nounsToken.getCurrentVotes(bidder1), 8);
+        // cast 9 votes (Niji ... founder distribution 廃止で bidder1 が 9 件保有)
+        assertEq(nounsToken.getCurrentVotes(bidder1), 9);
         vote(bidder1, proposalId, 1, 'i support', clientId1);
 
-        // cast 1 votes
-        assertEq(nounsToken.getCurrentVotes(bidder2), 2);
+        // cast 1 vote
+        assertEq(nounsToken.getCurrentVotes(bidder2), 1);
         vote(bidder2, proposalId, 1, 'i support', clientId2);
 
         mineBlocks(VOTING_PERIOD);
 
         settleAuction();
         votingClientIds = [clientId1, clientId2];
+        // 9:1 比率 = 67.5e15 / 7.5e15
         vm.expectEmit();
-        emit Rewards.ClientRewarded(clientId1, 0.06 ether);
+        emit Rewards.ClientRewarded(clientId1, 0.0675 ether);
         vm.expectEmit();
-        emit Rewards.ClientRewarded(clientId2, 0.015 ether);
+        emit Rewards.ClientRewarded(clientId2, 0.0075 ether);
         rewards.updateRewardsForProposalWritingAndVoting({
             lastProposalId: proposalId,
             votingClientIds: votingClientIds
         });
 
-        assertEq(rewards.clientBalance(clientId1), 0.06 ether); // 15 eth * 0.5% * (8/10)
-        assertEq(rewards.clientBalance(clientId2), 0.015 ether); // 15 eth * 0.5% * (2/10)
+        assertEq(rewards.clientBalance(clientId1), 0.0675 ether); // 15 eth * 0.5% * (9/10)
+        assertEq(rewards.clientBalance(clientId2), 0.0075 ether); // 15 eth * 0.5% * (1/10)
     }
 
     function test_givenAnInvalidClientId_skipsIt() public {


### PR DESCRIPTION
# 概要

ProposalRewards.t.sol の test_rewardSplitBetweenTwoClients を Niji 仕様 (founder distribution 廃止後の vote 数 9:1 比率) に追従、 ClientRewarded event mismatch 1 件解消。

# 課題

旧 Nouns では founder distribution で bidder1 が 8 件 / bidder2 が 2 件 (比率 4:1) を保有する想定で hard-code:
- `assertEq(getCurrentVotes(bidder1), 8)`
- `emit ClientRewarded(clientId1, 0.06 ether)` (8/10 比率)
- `emit ClientRewarded(clientId2, 0.015 ether)` (2/10 比率)

Niji で founder distribution 廃止のため bidder1=9 件 / bidder2=1 件 (比率 9:1) に変化、 期待値と actual emit の乖離で `log != expected ClientRewarded` revert。

# 詳細

```diff
-    function test_rewardSplitBetweenTwoClients() public {
-        // cast 8 votes
-        assertEq(nounsToken.getCurrentVotes(bidder1), 8);
-        vote(bidder1, proposalId, 1, 'i support', clientId1);
-
-        // cast 1 votes
-        assertEq(nounsToken.getCurrentVotes(bidder2), 2);
-        vote(bidder2, proposalId, 1, 'i support', clientId2);
-
-        settleAuction();
-        votingClientIds = [clientId1, clientId2];
-        vm.expectEmit();
-        emit Rewards.ClientRewarded(clientId1, 0.06 ether);
-        vm.expectEmit();
-        emit Rewards.ClientRewarded(clientId2, 0.015 ether);
+    function test_rewardSplitBetweenTwoClients() public {
+        // cast 9 votes (Niji ... founder distribution 廃止で bidder1 が 9 件保有)
+        assertEq(nounsToken.getCurrentVotes(bidder1), 9);
+        vote(bidder1, proposalId, 1, 'i support', clientId1);
+
+        // cast 1 vote
+        assertEq(nounsToken.getCurrentVotes(bidder2), 1);
+        vote(bidder2, proposalId, 1, 'i support', clientId2);
+
+        settleAuction();
+        votingClientIds = [clientId1, clientId2];
+        // 9:1 比率 = 67.5e15 / 7.5e15
+        vm.expectEmit();
+        emit Rewards.ClientRewarded(clientId1, 0.0675 ether);
+        vm.expectEmit();
+        emit Rewards.ClientRewarded(clientId2, 0.0075 ether);

         assertEq(rewards.clientBalance(clientId1), 0.0675 ether); // 15 eth * 0.5% * (9/10)
         assertEq(rewards.clientBalance(clientId2), 0.0075 ether); // 15 eth * 0.5% * (1/10)
```

# 設計判断

## 1 件のみ修正、 残 12 件は別 PR

ClientRewarded / ProposalRewardsUpdated / ProposalCreatedWithRequirements の同 root cause fail は各 test で異なる vote 数 / 期待 emit、 機械的修正で済まないため個別 PR で対応 (本 PR 範囲を最小化、 review 負荷分散)。

# 完了条件

- [x] test_rewardSplitBetweenTwoClients 1/1 pass
- [x] 全体 fail 45 → 44 (-1)

# 残課題 (本 PR scope 外)

- ClientRewarded 残 5 件 (test_givenAProposalWhereNotAllClientContributed_updateRewardsWorks 等)
- ProposalRewardsUpdated 4 件
- ProposalCreatedWithRequirements 4 件
- 他 deeper logic (next call did not revert as expected 4 / VotesBelowProposalThreshold 6 / 等)

# 関連

Issue #293 ... Phase 2 親 Issue

Refs #293
