### PR TITLE
🐛 fix(niji-contracts): NijiAuctionHouseV3.getPrices で nounId=0 対応 (production code + test 同期)

### DIFF
--- a/packages/niji-contracts/contracts/NijiAuctionHouseV3.sol
+++ b/packages/niji-contracts/contracts/NijiAuctionHouseV3.sol
@@ -456,15 +456,25 @@ contract NijiAuctionHouseV3 is
         uint256 actualCount = 0;
 
         SettlementState memory settlementState;
-        for (uint256 id = latestNounId; id > 0 && actualCount < auctionCount; --id) {
-            if (id <= 1820 && id % 10 == 0) continue; // Skip Nounder reward nouns
+        // Niji ... nounId=0 開始のため id=0 を loop に含める (旧 Nouns nounId=1 開始想定の `id > 0` を修正)
+        // Nounder skip 条件は Niji で founder distribution 廃止のため id != 0 ガードを追加 (id=0 は通常 auction)
+        for (uint256 id = latestNounId; actualCount < auctionCount; --id) {
+            if (id != 0 && id <= 1820 && id % 10 == 0) {
+                if (id == 0) break;
+                continue; // Skip Nounder reward nouns (Niji ... id=0 は対象外)
+            }
 
             settlementState = settlementHistory[id];
             require(settlementState.blockTimestamp > 1, 'Missing data');
-            if (settlementState.winner == address(0)) continue; // Skip auctions with no bids
+            if (settlementState.winner == address(0)) {
+                if (id == 0) break;
+                continue; // Skip auctions with no bids
+            }
 
             prices[actualCount] = uint64PriceToUint256(settlementState.amount);
             ++actualCount;
+
+            if (id == 0) break;
         }
 
         require(auctionCount == actualCount, 'Not enough history');

--- a/packages/niji-contracts/test/foundry/Phase1/NijiAuctionHouseV3.t.sol
+++ b/packages/niji-contracts/test/foundry/Phase1/NijiAuctionHouseV3.t.sol
@@ -106,9 +106,9 @@ contract NijiAuctionHouseV3Phase1Test is DeployUtils {
         assertEq(settlements.length, 0);
     }
 
-    /// TC-010: getPrices (history 空、 'Not enough history' revert)
+    /// TC-010: getPrices (history 空、 production code fix #322 で loop が id=0 含むため Missing data revert に変化)
     function test_TC010_getPrices_RevertsWhenHistoryEmpty() public {
-        vm.expectRevert(bytes('Not enough history'));
+        vm.expectRevert(bytes('Missing data'));
         auction.getPrices(10);
     }
 


### PR DESCRIPTION
# 概要

NijiAuctionHouseV3.getPrices の `id > 0` loop が nounId=0 を未処理だった production code bug を修正、 test 副作用 1 件を同期、 全体 fail 41 → 38 / pass 710 → 713。

# 課題

NijiAuctionHouseV3.getPrices (line 459) の loop は `id > 0 && actualCount < auctionCount` で id=0 を除外、 旧 Nouns 仕様 (nounId=1 開始) の名残。
Niji production NijiToken は `_currentTokenId = 0` 開始のため最初の auction が nounId=0、 getPrices(2) で 2 件期待しても loop は id=1 から開始 → 1 件しか取得できず 'Not enough history' revert。
更に Nounder skip 条件 `id <= 1820 && id % 10 == 0` も id=0 をマッチさせるため、 Niji の最初の auction を Nounder reward 経路で skip してしまっていた。

# 詳細

## production code 修正 (3 箇所)

```diff
-        for (uint256 id = latestNounId; id > 0 && actualCount < auctionCount; --id) {
-            if (id <= 1820 && id % 10 == 0) continue; // Skip Nounder reward nouns
+        // Niji ... nounId=0 開始のため id=0 を loop に含める (旧 Nouns nounId=1 開始想定の `id > 0` を修正)
+        // Nounder skip 条件は Niji で founder distribution 廃止のため id != 0 ガードを追加 (id=0 は通常 auction)
+        for (uint256 id = latestNounId; actualCount < auctionCount; --id) {
+            if (id != 0 && id <= 1820 && id % 10 == 0) {
+                if (id == 0) break;
+                continue; // Skip Nounder reward nouns (Niji ... id=0 は対象外)
+            }

             settlementState = settlementHistory[id];
             require(settlementState.blockTimestamp > 1, 'Missing data');
-            if (settlementState.winner == address(0)) continue; // Skip auctions with no bids
+            if (settlementState.winner == address(0)) {
+                if (id == 0) break;
+                continue; // Skip auctions with no bids
+            }

             prices[actualCount] = uint64PriceToUint256(settlementState.amount);
             ++actualCount;
+
+            if (id == 0) break;
         }
```

## test 副作用同期

Phase 1 test_TC010_getPrices_RevertsWhenHistoryEmpty の revert 期待値を変更:

```diff
-        vm.expectRevert(bytes('Not enough history'));
+        vm.expectRevert(bytes('Missing data'));
         auction.getPrices(10);
```

理由 ... loop が id=0 含むため auction 0 件状態で settlementHistory[0] が empty を引いて Missing data revert に変化 (loop が id=1 から始まり 1 件も loop しないと Not enough history だったが、 修正後は id=0 で 1 回 loop して Missing data)。

# 設計判断

## production code 直接修正 (test 側 workaround 不可能)

`id > 0` の loop condition は production 仕様変更追従、 test fixture では回避不可。 user 承認を得て production code に直接修正。

## Nounder skip 条件に id != 0 ガード追加

旧 Nouns で id=0 は token 番目 (`0 % 10 == 0`) で Nounder reward 想定だったが、 Niji で founder distribution 廃止のため id=0 も通常 auction。 skip 条件から id=0 を除外。

# 完了条件

- [x] getPrices loop で nounId=0 含むよう修正
- [x] Nounder skip 条件で id=0 除外
- [x] test_TC010 revert 期待値同期
- [x] 全体 fail 41 → 38 (-3 件)、 pass 710 → 713 (+3 件)

# 残課題

- test_getPrices_skipsNounderNiji 等の残 Not enough history は別 root cause (Nounder reward 経路 の test 期待値)、 別 PR で対応

# レビューで見てほしいところ

- production code 変更は test fixture 内で回避不可能な仕様変更追従、 影響範囲は getPrices 単独 (getSettlements 系は line 411 で既に id=0 含む実装)
- Nounder skip 条件は production semantics 影響あり、 Niji で founder distribution 廃止のため id=0 を Nounder 対象外とする変更が正当

# 関連

Issue #293 ... Phase 2 親 Issue

Refs #293
