### PR TITLE
🐛 fix(niji-contracts): 残 4 件 fail 修正 (signer delegate + ProposalRewardsUpdated rewardPerVote 同期)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOData.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOData.t.sol
@@ -888,6 +888,10 @@ contract NijiDAOData_CreateCandidateToUpdateProposalTest is NijiDAODataBaseTest 
         (signer, signerPK) = makeAddrAndKey('signerWithVote1');
         bidAndSettleAuction(auction, signer);
 
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(signer);
+        NijiToken(payable(address(nounsDao.nouns()))).delegate(signer);
+
         proposalId = proposeBySigs(
             notNouner,
             signer,

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/UpdateProposal.t.sol
@@ -69,6 +69,11 @@ contract UpdateProposalPermissionsTest is UpdateProposalBaseTest {
         // Niji ... proposer は tokenId=0 を保有 (0 開始)
         nounsToken.transferFrom(proposer, signer, 0);
         vm.stopPrank();
+
+        // ERC721Votes (OZ v5) self-delegate (signer の votes 反映)
+        vm.prank(signer);
+        NijiToken(payable(address(nounsToken))).delegate(signer);
+
         vm.roll(block.number + 1);
 
         uint256 expirationTimestamp = block.timestamp + 1234;

--- a/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -405,6 +405,7 @@ contract ProposalRewardsTest is BaseProposalRewardsTest {
         settleAuction();
         votingClientIds = [0];
 
+        // Niji ... rewardPerVote actual 3.75e15 (founder distribution 廃止反映)
         vm.expectEmit();
         emit Rewards.ProposalRewardsUpdated(
             1,
@@ -413,7 +414,7 @@ contract ProposalRewardsTest is BaseProposalRewardsTest {
             lastAuctionId,
             15 ether,
             0.075 ether,
-            4166666666666666
+            3750000000000000
         );
         rewards.updateRewardsForProposalWritingAndVoting({
             lastProposalId: proposalId,
@@ -439,6 +440,7 @@ contract ProposalRewardsTest is BaseProposalRewardsTest {
         settleAuction();
         votingClientIds = [0];
 
+        // Niji ... rewardPerVote actual 3.75e15
         vm.expectEmit();
         emit Rewards.ProposalRewardsUpdated(
             1,
@@ -447,7 +449,7 @@ contract ProposalRewardsTest is BaseProposalRewardsTest {
             lastAuctionId,
             15 ether,
             0.075 ether,
-            4166666666666666
+            3750000000000000
         );
         rewards.updateRewardsForProposalWritingAndVoting({
             lastProposalId: proposalId,


### PR DESCRIPTION
# 概要

3 file の修正で 4 件 fail 解消、 全体 fail 38 → 35 / pass 713 → 716。

# 課題

PR #323 後の残 fail のうち以下 4 件を機械的修正:
- NijiDAOData_CreateCandidateToUpdateProposalTest ... signer の delegate 漏れで MustProvideSignatures revert
- UpdateProposalPermissionsTest.test_givenPropWithSigners_reverts ... 同 signer delegate 漏れ
- ProposalRewards test_splitsRewardsBetweenEligibleProposals + test_givenClientIdAboveTotalSupply_skipsIt ... rewardPerVote 期待値が旧 Nouns 仕様 (4.166e15) で actual 3.75e15 と乖離

# 詳細

```diff
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(signer);
+        NijiToken(payable(address(nounsDao.nouns()))).delegate(signer);
```

```diff
-            4166666666666666
+            3750000000000000
```

# 完了条件

- [x] NijiDAOData_CreateCandidateToUpdateProposalTest setUp pass
- [x] UpdateProposalPermissionsTest.test_givenPropWithSigners_reverts pass
- [x] test_splitsRewardsBetweenEligibleProposals + test_givenClientIdAboveTotalSupply_skipsIt pass
- [x] 全体 fail 38 → 35 (-3 件)、 pass 713 → 716 (+3 件)

# 関連

Issue #293 ... Phase 2 親 Issue

Refs #293
