### PR TITLE
🐛 fix(niji-contracts): test_proposalThresholdIsLowered で someone self-delegate 追加

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/NijiDAOFork.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/NijiDAOFork.t.sol
@@ -313,6 +313,11 @@ contract DAOForkSignaledOverThresholdStateTest is DAOForkSignaledOverThresholdSt
         nounsToken.transferFrom(tokenHolder, someone, 13);
         vm.prank(tokenHolder);
         nounsToken.transferFrom(tokenHolder, someone, 14);
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(someone);
+        NijiToken(payable(address(nounsToken))).delegate(someone);
+
         vm.roll(block.number + 1);
         propose(someone, address(0), 0, '', '', '');
     }


### PR DESCRIPTION
# 概要

test_proposalThresholdIsLowered の someone self-delegate 漏れ 1 件修正、 全体 fail 35 → 34 / pass 716 → 717。

# 課題

`tokenHolder → someone` への transferFrom 後の self-delegate 漏れで `getPriorVotes(someone, 1) = 0` を返し、 後続 propose 内で VotesBelowProposalThreshold revert。
ERC721Votes (OZ v5) は受領で auto-delegate しない仕様 (Niji 全 fix の root cause)。

# 詳細

```diff
         nounsToken.transferFrom(tokenHolder, someone, 14);
+
+        // ERC721Votes (OZ v5) self-delegate
+        vm.prank(someone);
+        NijiToken(payable(address(nounsToken))).delegate(someone);
+
         vm.roll(block.number + 1);
         propose(someone, address(0), 0, '', '', '');
```

# 完了条件

- [x] test_proposalThresholdIsLowered 1/1 pass
- [x] 全体 fail 35 → 34 (-1)、 pass 716 → 717 (+1)

# 関連

Issue #293 ... Phase 2 親 Issue

Refs #293
