### PR TITLE
✨ feat(niji-webapp): webapp Phase 1 Sub 2 - SelectProposalActionStep vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.test.tsx
@@ -1,0 +1,157 @@
+import { screen } from '@testing-library/dom';
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ProposalActionCreationStep, ProposalActionType } from '../..';
+
+import SelectProposalActionStep from './index';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../BrandDropdown', () => ({
+  default: ({
+    value,
+    onChange,
+    children,
+  }: {
+    value: string;
+    onChange: (e: { target: { value: string } }) => void;
+    children: React.ReactNode;
+  }) => (
+    <select data-testid="action-dropdown" value={value} onChange={onChange}>
+      {children}
+    </select>
+  ),
+}));
+
+vi.mock('../../../ModalBottomButtonRow', () => ({
+  default: ({
+    prevBtnText,
+    onPrevBtnClick,
+    nextBtnText,
+    onNextBtnClick,
+  }: {
+    prevBtnText: React.ReactNode;
+    onPrevBtnClick: () => void;
+    nextBtnText: React.ReactNode;
+    onNextBtnClick: () => void;
+  }) => (
+    <div>
+      <button data-testid="prev-btn" onClick={onPrevBtnClick}>
+        {prevBtnText}
+      </button>
+      <button data-testid="next-btn" onClick={onNextBtnClick}>
+        {nextBtnText}
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('../../../ModalSubtitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="subtitle">{children}</div>
+  ),
+}));
+
+vi.mock('../../../ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="title">{children}</div>
+  ),
+}));
+
+describe('SelectProposalActionStep', () => {
+  const setupProps = (overrides = {}) => ({
+    onPrevBtnClick: vi.fn(),
+    onNextBtnClick: vi.fn(),
+    state: {
+      actionType: ProposalActionType.LUMP_SUM,
+      address: '0x0000000000000000000000000000000000000000',
+      amount: '0',
+    },
+    setState: vi.fn(),
+    ...overrides,
+  });
+
+  it('renders title and dropdown with 3 action options', () => {
+    render(<SelectProposalActionStep {...setupProps()} />);
+    expect(screen.getByTestId('title')).toHaveTextContent('Add Proposal Action');
+    expect(screen.getByTestId('action-dropdown')).toBeInTheDocument();
+    expect(screen.getByText('Transfer Funds')).toBeInTheDocument();
+    expect(screen.getByText('Stream Funds')).toBeInTheDocument();
+    expect(screen.getByText('Function Call')).toBeInTheDocument();
+  });
+
+  it('calls onPrevBtnClick when Close button clicked', () => {
+    const onPrevBtnClick = vi.fn();
+    render(<SelectProposalActionStep {...setupProps({ onPrevBtnClick })} />);
+    fireEvent.click(screen.getByTestId('prev-btn'));
+    expect(onPrevBtnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onNextBtnClick with next step when Add Action Details clicked (LUMP_SUM)', () => {
+    const onNextBtnClick = vi.fn();
+    render(<SelectProposalActionStep {...setupProps({ onNextBtnClick })} />);
+    fireEvent.click(screen.getByTestId('next-btn'));
+    expect(onNextBtnClick).toHaveBeenCalledWith(ProposalActionCreationStep.LUMP_SUM_DETAILS);
+  });
+
+  it('calls setState with STREAM actionType when Stream Funds selected', () => {
+    const setState = vi.fn();
+    render(<SelectProposalActionStep {...setupProps({ setState })} />);
+    fireEvent.change(screen.getByTestId('action-dropdown'), {
+      target: { value: 'Stream Funds' },
+    });
+    expect(setState).toHaveBeenCalled();
+  });
+
+  it('calls setState with FUNCTION_CALL actionType when Function Call selected', () => {
+    const setState = vi.fn();
+    render(<SelectProposalActionStep {...setupProps({ setState })} />);
+    fireEvent.change(screen.getByTestId('action-dropdown'), {
+      target: { value: 'Function Call' },
+    });
+    expect(setState).toHaveBeenCalled();
+  });
+
+  it('routes to STREAM_PAYMENT_PAYMENT_DETAILS when Stream Funds initial state', () => {
+    const onNextBtnClick = vi.fn();
+    render(
+      <SelectProposalActionStep
+        {...setupProps({
+          onNextBtnClick,
+          state: {
+            actionType: ProposalActionType.STREAM,
+            address: '0x0000000000000000000000000000000000000000',
+            amount: '0',
+          },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('next-btn'));
+    expect(onNextBtnClick).toHaveBeenCalledWith(
+      ProposalActionCreationStep.STREAM_PAYMENT_PAYMENT_DETAILS,
+    );
+  });
+
+  it('routes to FUNCTION_CALL_SELECT_FUNCTION when Function Call initial state', () => {
+    const onNextBtnClick = vi.fn();
+    render(
+      <SelectProposalActionStep
+        {...setupProps({
+          onNextBtnClick,
+          state: {
+            actionType: ProposalActionType.FUNCTION_CALL,
+            address: '0x0000000000000000000000000000000000000000',
+            amount: '0',
+          },
+        })}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('next-btn'));
+    expect(onNextBtnClick).toHaveBeenCalledWith(
+      ProposalActionCreationStep.FUNCTION_CALL_SELECT_FUNCTION,
+    );
+  });
+});


### PR DESCRIPTION
# 概要

webapp Phase 1 Sub 2 PR ... SelectProposalActionStep に vitest 7 TC 追加、 全 vitest 38 → 45 件 pass。

# 課題

ProposalActionsModal の sub steps (9 件) のうち test 追加済は FunctionCallReviewStep のみ、 残 8 件は未 cover。
今回 routing logic を持つ SelectProposalActionStep を最初に追加 (dropdown → next step 判定経路を回帰検証)。

# 詳細

7 TC で routing pattern を網羅:

- title / dropdown 3 options render
- prev btn (Close) handler
- next btn の 3 経路 routing (LUMP_SUM → LUMP_SUM_DETAILS / STREAM → STREAM_PAYMENT_PAYMENT_DETAILS / FUNCTION_CALL → FUNCTION_CALL_SELECT_FUNCTION)
- setState 呼出 (actionType 変更)

mock 経路 ... BrandDropdown / ModalBottomButtonRow / ModalSubtitle / ModalTitle / @lingui/react/macro Trans を stub。 BrandDropdown は select element に置換、 dropdown event を fireEvent.change で simulate。

# 設計判断

## routing logic 中心に test

UI rendering より step 遷移 logic (proposalActionTypeToProposalActionCreationStep helper) の網羅を優先、 ProposalActionsModal の動線が正しいか継続検証。

## 既存 FunctionCallReviewStep pattern と一貫

mock 経路と describe / it 構造を既存 test に揃え、 webapp 全体の test style 統一。

# 完了条件

- [x] SelectProposalActionStep test 7 TC 全 pass
- [x] 全 vitest 38 → 45 件 pass (+7 件)
- [x] 既存 38 件は regression なし

# 残課題

- FunctionCallEnterArgsStep / FunctionCallSelectFunctionStep / StreamPayments*Step / TransferFunds*Step (残 7 step)
- Issue #327 配下 Sub 3-5 (hooks / wrappers / pages)

# 関連

Issue #327 ... webapp Phase 1 親 Issue
PR #328 ... Sub 1 (AuctionTimer + BidHistoryBtn)

Refs #327
