### PR TITLE
✨ feat(niji-webapp): webapp Phase 1 Sub 3 - useProposalStatus + useKeyPress vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/hooks/useKeyPress.test.tsx
+++ b/packages/niji-webapp/src/hooks/useKeyPress.test.tsx
@@ -1,0 +1,61 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useKeyPress } from './useKeyPress';
+
+describe('useKeyPress', () => {
+  it('returns false initially', () => {
+    const { result } = renderHook(() => useKeyPress('a'));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when target key is pressed', () => {
+    const { result } = renderHook(() => useKeyPress('Enter'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when target key is released', () => {
+    const { result } = renderHook(() => useKeyPress('Escape'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('ignores non-target keys', () => {
+    const { result } = renderHook(() => useKeyPress('a'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b' }));
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('cleans up listeners on unmount', () => {
+    const { result, unmount } = renderHook(() => useKeyPress('x'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'x' }));
+    });
+    expect(result.current).toBe(true);
+
+    unmount();
+
+    // After unmount, dispatch should not affect state (no error)
+    expect(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'x' }));
+    }).not.toThrow();
+  });
+});

--- a/packages/niji-webapp/src/hooks/useProposalStatus.test.ts
+++ b/packages/niji-webapp/src/hooks/useProposalStatus.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { Proposal, ProposalState } from '@/wrappers/nijiDao';
+
+import { useProposalStatus } from './useProposalStatus';
+
+// useProposalStatus は pure function (Hook 風だが React hook なし)、 mock 不要
+describe('useProposalStatus', () => {
+  const baseProposal = (status: ProposalState): Proposal =>
+    ({
+      status,
+    }) as Proposal;
+
+  it('returns "success" for SUCCEEDED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.SUCCEEDED))).toBe('success');
+  });
+
+  it('returns "success" for EXECUTED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.EXECUTED))).toBe('success');
+  });
+
+  it('returns "success" for QUEUED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.QUEUED))).toBe('success');
+  });
+
+  it('returns "failure" for DEFEATED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.DEFEATED))).toBe('failure');
+  });
+
+  it('returns "failure" for VETOED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.VETOED))).toBe('failure');
+  });
+
+  it('returns "pending" for ACTIVE', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.ACTIVE))).toBe('pending');
+  });
+
+  it('returns "pending" for PENDING', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.PENDING))).toBe('pending');
+  });
+
+  it('returns "pending" for CANCELED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.CANCELED))).toBe('pending');
+  });
+
+  it('returns "pending" for EXPIRED', () => {
+    expect(useProposalStatus(baseProposal(ProposalState.EXPIRED))).toBe('pending');
+  });
+});


### PR DESCRIPTION
# 概要

webapp Phase 1 Sub 3 PR ... hooks layer に vitest 14 TC 追加 (useProposalStatus 9 + useKeyPress 5)、 全 vitest 45 → 59 件 pass。

# 課題

hooks layer (10 file) の test 未追加、 主要 logic (proposal status 判定 / key press detection) が回帰検証されていない。
今回 pure function + 軽量 React hook の 2 件から start。

# 詳細

## useProposalStatus (9 TC, pure function)

`Proposal.status` (ProposalState enum) を `success / failure / pending` 3 分類に map する pure function。
ProposalState 全 9 値を網羅:
- SUCCEEDED / EXECUTED / QUEUED → 'success'
- DEFEATED / VETOED → 'failure'
- ACTIVE / PENDING / CANCELED / EXPIRED → 'pending' (default)

mock 不要、 baseProposal helper で status のみ持つ minimal Proposal object を構築。

## useKeyPress (5 TC, React hook + window event)

target key 押下 / 解放 state を返す hook。
@testing-library/react `renderHook` + `act` で window.dispatchEvent simulation、 keydown/keyup state 遷移 + unmount cleanup を検証。

# 設計判断

## pure function は最小 mock で test

useProposalStatus は React hook ではなく pure function (Hook 風命名)、 React Testing Library 不要で直接呼出 + assertion。

## hooks layer の単純なものから着手

useChainPastAuctions / useSubgraphQuery は wagmi + TanStack Query + GraphQL 連携で mock 複雑、 まず pure function + window event hook で pattern 確立。 wagmi 連携 hooks は別 Sub-PR で個別対応。

# 完了条件

- [x] useProposalStatus 9 TC 全 pass
- [x] useKeyPress 5 TC 全 pass
- [x] 全 vitest 45 → 59 件 pass (+14 件)
- [x] 既存 45 件は regression なし

# 残課題

- useChainPastAuctions / useSubgraphQuery / useStreamPaymentTransactions (wagmi / GraphQL 連携)
- useBlockTimestamp / useBreakpointValues / useForkTreasuryBalance (chain RPC / window resize 連携)
- useScrollToLocation / useActivateLocale (DOM / atom 連携)
- 別 Sub-PR で個別対応

# 関連

Issue #327 ... webapp Phase 1 親 Issue
PR #328 ... Sub 1 (AuctionTimer + BidHistoryBtn components)
PR #329 ... Sub 2 (SelectProposalActionStep)

Refs #327
