### PR TITLE
✨ feat(niji-webapp): webapp Phase 1 utils - 3 pure function に vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/utils/isMobile.test.ts
+++ b/packages/niji-webapp/src/utils/isMobile.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isMobileScreen } from './isMobile';
+
+describe('isMobileScreen', () => {
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  const setWidth = (width: number) => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: width,
+    });
+  };
+
+  it('returns true when window width is below 992', () => {
+    setWidth(800);
+    expect(isMobileScreen()).toBe(true);
+  });
+
+  it('returns true at boundary - 1 (991)', () => {
+    setWidth(991);
+    expect(isMobileScreen()).toBe(true);
+  });
+
+  it('returns false at boundary 992', () => {
+    setWidth(992);
+    expect(isMobileScreen()).toBe(false);
+  });
+
+  it('returns false when window width is above 992', () => {
+    setWidth(1200);
+    expect(isMobileScreen()).toBe(false);
+  });
+
+  it('handles very small width (mobile portrait)', () => {
+    setWidth(320);
+    expect(isMobileScreen()).toBe(true);
+  });
+
+  it('handles very large width (4K)', () => {
+    setWidth(3840);
+    expect(isMobileScreen()).toBe(false);
+  });
+});

--- a/packages/niji-webapp/src/utils/nounderNiji.test.ts
+++ b/packages/niji-webapp/src/utils/nounderNiji.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { isNounderNiji } from './nounderNiji';
+
+describe('isNounderNiji', () => {
+  it('returns true for nounId 0 (boundary, multiple of 10)', () => {
+    expect(isNounderNiji(0n)).toBe(true);
+  });
+
+  it('returns true for nounId 10', () => {
+    expect(isNounderNiji(10n)).toBe(true);
+  });
+
+  it('returns true for nounId 1820 (upper boundary)', () => {
+    expect(isNounderNiji(1820n)).toBe(true);
+  });
+
+  it('returns false for nounId 1 (not multiple of 10)', () => {
+    expect(isNounderNiji(1n)).toBe(false);
+  });
+
+  it('returns false for nounId 15 (not multiple of 10)', () => {
+    expect(isNounderNiji(15n)).toBe(false);
+  });
+
+  it('returns false for nounId 1830 (above upper boundary, multiple of 10)', () => {
+    expect(isNounderNiji(1830n)).toBe(false);
+  });
+
+  it('returns false for very large nounId (10000)', () => {
+    expect(isNounderNiji(10000n)).toBe(false);
+  });
+
+  it('handles middle Nounder ids (100, 500, 1000)', () => {
+    expect(isNounderNiji(100n)).toBe(true);
+    expect(isNounderNiji(500n)).toBe(true);
+    expect(isNounderNiji(1000n)).toBe(true);
+  });
+});

--- a/packages/niji-webapp/src/utils/numberUtils.test.ts
+++ b/packages/niji-webapp/src/utils/numberUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { countDecimals } from './numberUtils';
+
+describe('countDecimals', () => {
+  it('returns 0 for integer', () => {
+    expect(countDecimals(5)).toBe(0);
+    expect(countDecimals(0)).toBe(0);
+    expect(countDecimals(-42)).toBe(0);
+  });
+
+  it('returns 0 for whole number with decimal point (.0)', () => {
+    expect(countDecimals(5.0)).toBe(0);
+  });
+
+  it('returns 1 for single decimal', () => {
+    expect(countDecimals(5.5)).toBe(1);
+    expect(countDecimals(0.1)).toBe(1);
+  });
+
+  it('returns 2 for two decimals', () => {
+    expect(countDecimals(5.55)).toBe(2);
+    expect(countDecimals(0.01)).toBe(2);
+  });
+
+  it('returns multiple decimals correctly', () => {
+    expect(countDecimals(3.14159)).toBe(5);
+    expect(countDecimals(0.123456)).toBe(6);
+  });
+
+  it('handles negative decimals', () => {
+    expect(countDecimals(-5.5)).toBe(1);
+    expect(countDecimals(-3.14)).toBe(2);
+  });
+});


### PR DESCRIPTION
# 概要

webapp Phase 1 utils PR ... 3 pure function に vitest 20 TC 追加、 全 vitest 59 → 79 件 pass。

# 課題

utils layer 0 件 test だった領域に最小 mock で test 拡張、 主要 helper の boundary 動作を回帰検証。

# 詳細

3 file 20 TC:
- numberUtils.countDecimals (6 TC): integer/decimal/negative/multiple decimal
- isMobile.isMobileScreen (6 TC): boundary 991/992 + 320/4K
- nounderNiji.isNounderNiji (8 TC): boundary 0/1820/1830 + multiple of 10

# 完了条件

- [x] 3 file 20 TC 全 pass
- [x] 全 vitest 59 → 79 件 (+20 件)
- [x] 既存 59 件 regression なし

# 残課題

- etherscan (env / wagmi 連携) / addressAndENSDisplayUtils / bidSorter 等は別 PR

# 関連

Issue #327 ... webapp Phase 1 親 Issue
PR #328 / #329 / #330 ... Sub 1-3

Refs #327
