### PR TITLE
✨ feat(niji-webapp): webapp utils 続行 - 4 pure function に vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/utils/addressAndENSDisplayUtils.test.ts
+++ b/packages/niji-webapp/src/utils/addressAndENSDisplayUtils.test.ts
@@ -1,0 +1,85 @@
+import type { Address } from '@/utils/types';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  formatShortAddress,
+  shortENS,
+  veryShortAddress,
+  veryShortENS,
+} from './addressAndENSDisplayUtils';
+
+describe('veryShortENS', () => {
+  it('returns first char + "..." + last 3 chars', () => {
+    expect(veryShortENS('nouns.eth')).toBe('n...eth');
+    expect(veryShortENS('vitalik.eth')).toBe('v...eth');
+  });
+
+  it('handles single-character ENS', () => {
+    // 'a'.substring(0, 1) = 'a', 'a'.substring(-2) = 'a' (negative start clamped to 0)
+    expect(veryShortENS('a')).toBe('a...a');
+  });
+});
+
+describe('veryShortAddress', () => {
+  const addr = '0xabcdef1234567890abcdef1234567890abcdef12' as Address;
+
+  it('returns first 3 chars + "..." + last 1 char', () => {
+    expect(veryShortAddress(addr)).toBe('0xa...2');
+  });
+
+  it('returns empty string when address is undefined', () => {
+    expect(veryShortAddress(undefined)).toBe('');
+  });
+});
+
+describe('shortENS', () => {
+  let originalInnerWidth: number;
+
+  beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: originalInnerWidth,
+    });
+  });
+
+  const setWidth = (width: number) => {
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: width,
+    });
+  };
+
+  it('returns full ENS when length < 15', () => {
+    setWidth(400);
+    expect(shortENS('short.eth')).toBe('short.eth');
+  });
+
+  it('returns full ENS when window width > 480', () => {
+    setWidth(800);
+    expect(shortENS('verylongname.eth')).toBe('verylongname.eth');
+  });
+
+  it('truncates when length >= 15 and width <= 480', () => {
+    setWidth(400);
+    expect(shortENS('verylongname.eth')).toBe('very...name.eth');
+  });
+});
+
+describe('formatShortAddress', () => {
+  const addr = '0xabcdef1234567890abcdef1234567890abcdef12' as Address;
+
+  it('returns first 4 chars + "..." + last 4 chars (from index 38)', () => {
+    expect(formatShortAddress(addr)).toBe('0xab...ef12');
+  });
+
+  it('returns empty string when address is undefined', () => {
+    expect(formatShortAddress(undefined)).toBe('');
+  });
+});

--- a/packages/niji-webapp/src/utils/bidSorter.test.ts
+++ b/packages/niji-webapp/src/utils/bidSorter.test.ts
@@ -1,0 +1,45 @@
+import type { IBid } from '@/wrappers/subgraph';
+
+import { describe, expect, it } from 'vitest';
+
+import { compareBidsChronologically } from './bidSorter';
+
+describe('compareBidsChronologically', () => {
+  const makeBid = (blockTimestamp: number, txIndex = 0): IBid =>
+    ({
+      blockTimestamp: blockTimestamp.toString(),
+      txIndex,
+    }) as unknown as IBid;
+
+  it('returns positive when b is newer than a (sort descending)', () => {
+    const a = makeBid(1000);
+    const b = makeBid(2000);
+    expect(compareBidsChronologically(a, b)).toBeGreaterThan(0);
+  });
+
+  it('returns negative when a is newer than b', () => {
+    const a = makeBid(2000);
+    const b = makeBid(1000);
+    expect(compareBidsChronologically(a, b)).toBeLessThan(0);
+  });
+
+  it('returns 0 when timestamps and txIndex are identical', () => {
+    const a = makeBid(1000, 0);
+    const b = makeBid(1000, 0);
+    expect(compareBidsChronologically(a, b)).toBe(0);
+  });
+
+  it('uses txIndex as tiebreaker (same block)', () => {
+    const a = makeBid(1000, 0);
+    const b = makeBid(1000, 5);
+    expect(compareBidsChronologically(a, b)).toBeGreaterThan(0); // b is "later" (higher txIndex)
+  });
+
+  it('sorts array descending chronologically', () => {
+    const bids: IBid[] = [makeBid(100), makeBid(300), makeBid(200)];
+    const sorted = [...bids].sort(compareBidsChronologically);
+    expect((sorted[0] as IBid).blockTimestamp).toBe('300');
+    expect((sorted[1] as IBid).blockTimestamp).toBe('200');
+    expect((sorted[2] as IBid).blockTimestamp).toBe('100');
+  });
+});

--- a/packages/niji-webapp/src/utils/compareBids.test.ts
+++ b/packages/niji-webapp/src/utils/compareBids.test.ts
@@ -1,0 +1,37 @@
+import type { Bid } from './types';
+
+import { describe, expect, it } from 'vitest';
+
+import { compareBids } from './compareBids';
+
+describe('compareBids', () => {
+  const makeBid = (timestamp: bigint, transactionIndex = 0): Bid =>
+    ({
+      timestamp,
+      transactionIndex,
+    }) as Bid;
+
+  it('returns positive when b is newer than a (descending sort)', () => {
+    const a = makeBid(1000n);
+    const b = makeBid(2000n);
+    expect(compareBids(a, b)).toBeGreaterThan(0);
+  });
+
+  it('returns negative when a is newer than b', () => {
+    const a = makeBid(2000n);
+    const b = makeBid(1000n);
+    expect(compareBids(a, b)).toBeLessThan(0);
+  });
+
+  it('returns 0 for identical scores', () => {
+    const a = makeBid(1000n, 0);
+    const b = makeBid(1000n, 0);
+    expect(compareBids(a, b)).toBe(0);
+  });
+
+  it('uses transactionIndex as tiebreaker', () => {
+    const a = makeBid(1000n, 1);
+    const b = makeBid(1000n, 3);
+    expect(compareBids(a, b)).toBeGreaterThan(0); // b higher index = newer
+  });
+});

--- a/packages/niji-webapp/src/utils/pickByState.test.ts
+++ b/packages/niji-webapp/src/utils/pickByState.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { usePickByState } from './pickByState';
+
+describe('usePickByState', () => {
+  it('returns matching result by index', () => {
+    const states = ['a', 'b', 'c'];
+    const results = [1, 2, 3];
+    expect(usePickByState('a', states, results)).toBe(1);
+    expect(usePickByState('b', states, results)).toBe(2);
+    expect(usePickByState('c', states, results)).toBe(3);
+  });
+
+  it('returns undefined when state is not in states array', () => {
+    expect(usePickByState('z', ['a', 'b'], [1, 2])).toBeUndefined();
+  });
+
+  it('returns undefined when stateResults is shorter than states', () => {
+    expect(usePickByState('c', ['a', 'b', 'c'], [1, 2])).toBeUndefined();
+  });
+
+  it('works with enum-like numeric states', () => {
+    enum Status {
+      PENDING,
+      ACTIVE,
+      DONE,
+    }
+    const results = ['pending', 'active', 'done'];
+    expect(
+      usePickByState(Status.ACTIVE, [Status.PENDING, Status.ACTIVE, Status.DONE], results),
+    ).toBe('active');
+  });
+
+  it('works with complex object results', () => {
+    const states = [1, 2];
+    const results = [{ label: 'one' }, { label: 'two' }];
+    expect(usePickByState(2, states, results)).toEqual({ label: 'two' });
+  });
+});


### PR DESCRIPTION
# 概要

webapp utils 続行 ... 4 pure function に vitest 23 TC 追加、 全 vitest 79 → 102 件 (100 件突破)。

# 詳細

- addressAndENSDisplayUtils (9 TC): veryShortENS / veryShortAddress / shortENS / formatShortAddress (window.innerWidth boundary)
- bidSorter.compareBidsChronologically (5 TC): descending sort + txIndex tiebreaker
- compareBids (4 TC): bigint score + transactionIndex tiebreaker
- pickByState.usePickByState (5 TC): 配列 index lookup + undefined + enum / object 結果

全 pure function、 mock 最小。 linter import 順序整理 (vitest builtin → 内部 / 内部 import の type 先頭) を反映。

# 完了条件

- [x] 4 file 23 TC pass
- [x] 全 vitest 79 → 102 件 (+23)
- [x] 既存 79 件 regression なし

# 残課題

- 残 utils file (etherscan / candidateURL / colorResponsiveUIUtils / 他 25+ 件) は別 PR

# 関連

Issue #327 ... webapp Phase 1 親 Issue
PR #331 ... 前回 utils 3 file (numberUtils / isMobile / nounderNiji)

Refs #327
