### PR TITLE
✨ feat(niji-webapp): webapp utils part 2 - 5 pure function に vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/utils/candidateURL.test.ts
+++ b/packages/niji-webapp/src/utils/candidateURL.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCandidateSlug } from './candidateURL';
+
+describe('buildCandidateSlug', () => {
+  it('lowercases address and joins with slug', () => {
+    expect(buildCandidateSlug('0xABCDEF', 'my-proposal')).toBe('0xabcdef-my-proposal');
+  });
+
+  it('replaces spaces in slug with hyphens', () => {
+    expect(buildCandidateSlug('0xabc', 'my new proposal')).toBe('0xabc-my-new-proposal');
+  });
+
+  it('lowercases slug', () => {
+    expect(buildCandidateSlug('0xabc', 'MyProposal')).toBe('0xabc-myproposal');
+  });
+
+  it('handles multiple consecutive spaces', () => {
+    expect(buildCandidateSlug('0xabc', 'a  b   c')).toBe('0xabc-a-b-c');
+  });
+
+  it('handles empty slug', () => {
+    expect(buildCandidateSlug('0xABC', '')).toBe('0xabc-');
+  });
+});

--- a/packages/niji-webapp/src/utils/grayBackgroundSVG.test.ts
+++ b/packages/niji-webapp/src/utils/grayBackgroundSVG.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { getGrayBackgroundSVG } from './grayBackgroundSVG';
+
+describe('getGrayBackgroundSVG', () => {
+  it('returns a data URI string starting with the SVG prefix', () => {
+    const result = getGrayBackgroundSVG();
+    expect(result.startsWith('data:image/svg+xml;base64,')).toBe(true);
+  });
+
+  it('is non-empty', () => {
+    expect(getGrayBackgroundSVG().length).toBeGreaterThan(30);
+  });
+
+  it('returns the same value on multiple calls (pure constant)', () => {
+    expect(getGrayBackgroundSVG()).toBe(getGrayBackgroundSVG());
+  });
+});

--- a/packages/niji-webapp/src/utils/processProposalDescriptionText.test.ts
+++ b/packages/niji-webapp/src/utils/processProposalDescriptionText.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { processProposalDescriptionText } from './processProposalDescriptionText';
+
+describe('processProposalDescriptionText', () => {
+  it('removes first occurrence of title from description', () => {
+    expect(processProposalDescriptionText('Title\nBody text', 'Title')).toBe('\nBody text');
+  });
+
+  it('only removes the first occurrence', () => {
+    expect(processProposalDescriptionText('Title some Title here', 'Title')).toBe(
+      ' some Title here',
+    );
+  });
+
+  it('returns description unchanged when title not found', () => {
+    expect(processProposalDescriptionText('No match here', 'Title')).toBe('No match here');
+  });
+
+  it('handles empty description', () => {
+    expect(processProposalDescriptionText('', 'Title')).toBe('');
+  });
+
+  it('handles empty title (returns description unchanged)', () => {
+    // empty string replace matches at position 0 and removes nothing
+    expect(processProposalDescriptionText('description', '')).toBe('description');
+  });
+});

--- a/packages/niji-webapp/src/utils/pseudoRandomPredictableShuffle.test.ts
+++ b/packages/niji-webapp/src/utils/pseudoRandomPredictableShuffle.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { pseudoRandomPredictableShuffle } from './pseudoRandomPredictableShuffle';
+
+describe('pseudoRandomPredictableShuffle', () => {
+  it('returns same length array as input', () => {
+    const input = [1, 2, 3, 4, 5];
+    expect(pseudoRandomPredictableShuffle(input).length).toBe(input.length);
+  });
+
+  it('contains the same elements as input (permutation)', () => {
+    const input = [1, 2, 3, 4, 5];
+    const output = pseudoRandomPredictableShuffle(input);
+    expect([...output].sort()).toEqual([...input].sort());
+  });
+
+  it('produces deterministic output for same seed', () => {
+    const input = [1, 2, 3, 4, 5];
+    expect(pseudoRandomPredictableShuffle(input, 42)).toEqual(
+      pseudoRandomPredictableShuffle(input, 42),
+    );
+  });
+
+  it('produces different order for different seeds (usually)', () => {
+    const input = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const a = pseudoRandomPredictableShuffle(input, 1);
+    const b = pseudoRandomPredictableShuffle(input, 100);
+    expect(a).not.toEqual(b);
+  });
+
+  it('handles empty input', () => {
+    expect(pseudoRandomPredictableShuffle([])).toEqual([]);
+  });
+
+  it('handles single-element input', () => {
+    expect(pseudoRandomPredictableShuffle([42])).toEqual([42]);
+  });
+
+  it('uses default seed = 1 when not provided', () => {
+    const input = [1, 2, 3];
+    expect(pseudoRandomPredictableShuffle(input)).toEqual(pseudoRandomPredictableShuffle(input, 1));
+  });
+});

--- a/packages/niji-webapp/src/utils/usdcUtils.test.ts
+++ b/packages/niji-webapp/src/utils/usdcUtils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { contract2humanUSDCFormat, human2ContractUSDCFormat } from './usdcUtils';
+
+describe('human2ContractUSDCFormat', () => {
+  it('converts whole number to 6 decimal places contract format', () => {
+    expect(human2ContractUSDCFormat('100')).toBe('100000000');
+    expect(human2ContractUSDCFormat(100)).toBe('100000000');
+  });
+
+  it('handles decimal input', () => {
+    expect(human2ContractUSDCFormat('1.5')).toBe('1500000');
+    expect(human2ContractUSDCFormat('0.001')).toBe('1000');
+  });
+
+  it('handles zero', () => {
+    expect(human2ContractUSDCFormat('0')).toBe('0');
+  });
+
+  it('rounds fractional contract micro-USDC', () => {
+    expect(human2ContractUSDCFormat('1.0000001')).toBe('1000000');
+  });
+});
+
+describe('contract2humanUSDCFormat', () => {
+  it('converts contract format to human format with 3 decimal default', () => {
+    expect(contract2humanUSDCFormat('100000000')).toBe('100.000');
+    expect(contract2humanUSDCFormat('1500000')).toBe('1.500');
+  });
+
+  it('returns all decimals when allDecimals=true', () => {
+    expect(contract2humanUSDCFormat('1000001', true)).toBe('1.000001');
+  });
+
+  it('handles zero', () => {
+    expect(contract2humanUSDCFormat('0')).toBe('0.000');
+  });
+});


### PR DESCRIPTION
# 概要

webapp utils part 2 ... 5 pure function に vitest 27 TC 追加、 全 vitest 102 → 129 件 pass。

# 詳細

- usdcUtils (7 TC): 6 桁 USDC 変換 (human ↔ contract) + allDecimals option
- candidateURL.buildCandidateSlug (5 TC): address lowercase + 空白→hyphen
- processProposalDescriptionText (5 TC): title 先頭除去 + empty 経路
- grayBackgroundSVG (3 TC): data URI prefix + pure constant
- pseudoRandomPredictableShuffle (7 TC): permutation + seed 決定性 + empty/single

全 pure function、 mock 不要。

# 完了条件

- [x] 5 file 27 TC pass
- [x] 全 vitest 102 → 129 件 (+27)
- [x] 既存 102 件 regression なし

# 関連

Issue #327 ... webapp Phase 1 親 Issue

Refs #327
