### PR TITLE
✨ feat(niji-webapp): webapp utils part 3 - 4 utility に vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/utils/colorResponsiveUIUtils.test.ts
+++ b/packages/niji-webapp/src/utils/colorResponsiveUIUtils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldUseStateBg } from './colorResponsiveUIUtils';
+
+describe('shouldUseStateBg', () => {
+  it('returns true for "/"', () => {
+    expect(shouldUseStateBg({ pathname: '/' })).toBe(true);
+  });
+
+  it('returns true for paths containing "/noun"', () => {
+    expect(shouldUseStateBg({ pathname: '/noun/1' })).toBe(true);
+    expect(shouldUseStateBg({ pathname: '/noun' })).toBe(true);
+  });
+
+  it('returns true for paths containing "/auction"', () => {
+    expect(shouldUseStateBg({ pathname: '/auction/5' })).toBe(true);
+  });
+
+  it('returns false for other paths', () => {
+    expect(shouldUseStateBg({ pathname: '/vote' })).toBe(false);
+    expect(shouldUseStateBg({ pathname: '/candidates' })).toBe(false);
+    expect(shouldUseStateBg({ pathname: '/playground' })).toBe(false);
+  });
+
+  it('returns false for empty pathname', () => {
+    expect(shouldUseStateBg({ pathname: '' })).toBe(false);
+  });
+});

--- a/packages/niji-webapp/src/utils/cssTransitionUtils.test.ts
+++ b/packages/niji-webapp/src/utils/cssTransitionUtils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  basicFadeInOut,
+  desktopModalSlideInFromTopAndGrow,
+  mobileModalSlideInFromBottm,
+} from './cssTransitionUtils';
+
+describe('basicFadeInOut', () => {
+  it('has all 4 transition styles (enter/entered/exiting/exited)', () => {
+    expect(basicFadeInOut.enteringStyle).toEqual({ opacity: 1 });
+    expect(basicFadeInOut.enteredStyle).toEqual({ opacity: 1 });
+    expect(basicFadeInOut.exitingStyle).toEqual({ opacity: 0.5 });
+    expect(basicFadeInOut.exitedStyle).toEqual({ opacity: 0 });
+  });
+});
+
+describe('mobileModalSlideInFromBottm', () => {
+  it('has 4 transition styles defined', () => {
+    expect(mobileModalSlideInFromBottm.enteringStyle).toBeDefined();
+    expect(mobileModalSlideInFromBottm.enteredStyle).toBeDefined();
+    expect(mobileModalSlideInFromBottm.exitingStyle).toBeDefined();
+    expect(mobileModalSlideInFromBottm.exitedStyle).toBeDefined();
+  });
+
+  it('enteringStyle includes translateY(0rem) and scale(1)', () => {
+    expect(mobileModalSlideInFromBottm.enteringStyle.transform).toContain('translateY(0rem)');
+    expect(mobileModalSlideInFromBottm.enteringStyle.transform).toContain('scale(1)');
+  });
+
+  it('exitingStyle uses translateY(20rem) and scale(0.9)', () => {
+    expect(mobileModalSlideInFromBottm.exitingStyle.transform).toBe('translateY(20rem) scale(0.9)');
+  });
+});
+
+describe('desktopModalSlideInFromTopAndGrow', () => {
+  it('has 4 transition styles defined', () => {
+    expect(desktopModalSlideInFromTopAndGrow.enteringStyle).toBeDefined();
+    expect(desktopModalSlideInFromTopAndGrow.enteredStyle).toBeDefined();
+    expect(desktopModalSlideInFromTopAndGrow.exitingStyle).toBeDefined();
+    expect(desktopModalSlideInFromTopAndGrow.exitedStyle).toBeDefined();
+  });
+});

--- a/packages/niji-webapp/src/utils/timeUtils.test.ts
+++ b/packages/niji-webapp/src/utils/timeUtils.test.ts
@@ -1,0 +1,49 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { currentUnixEpoch, toUnixEpoch, unixToDateString } from './timeUtils';
+
+beforeAll(() => {
+  dayjs.extend(utc);
+});
+
+describe('currentUnixEpoch', () => {
+  it('returns integer seconds (no decimals)', () => {
+    const epoch = currentUnixEpoch();
+    expect(Number.isInteger(epoch)).toBe(true);
+    expect(epoch).toBeGreaterThan(0);
+  });
+
+  it('returns close to Date.now()/1000', () => {
+    const expected = Math.floor(Date.now() / 1000);
+    const actual = currentUnixEpoch();
+    expect(Math.abs(actual - expected)).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('toUnixEpoch', () => {
+  it('converts ISO date string to unix timestamp (seconds)', () => {
+    // 2026-01-01T00:00:00Z = 1767225600 seconds
+    expect(toUnixEpoch('2026-01-01T00:00:00Z')).toBe(1767225600);
+  });
+
+  it('handles epoch zero', () => {
+    expect(toUnixEpoch('1970-01-01T00:00:00Z')).toBe(0);
+  });
+});
+
+describe('unixToDateString', () => {
+  it('formats unix timestamp to "MMMM DD, YYYY"', () => {
+    // 1735689600 = 2025-01-01 UTC
+    expect(unixToDateString(1735689600)).toBe('January 01, 2025');
+  });
+
+  it('handles undefined (default to 0 = epoch start)', () => {
+    expect(unixToDateString()).toBe('January 01, 1970');
+  });
+});
+
+afterAll(() => {
+  // no-op (dayjs extend は global、 unmount は不要)
+});

--- a/packages/niji-webapp/src/utils/vote.test.ts
+++ b/packages/niji-webapp/src/utils/vote.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { Vote } from './vote';
+
+describe('Vote enum', () => {
+  it('has 3 vote values', () => {
+    expect(Vote.SUPPORT).toBe(0);
+    expect(Vote.FOR).toBe(1);
+    expect(Vote.ABSTAIN).toBe(2);
+  });
+
+  it('reverse lookup returns names', () => {
+    expect(Vote[0]).toBe('SUPPORT');
+    expect(Vote[1]).toBe('FOR');
+    expect(Vote[2]).toBe('ABSTAIN');
+  });
+});


### PR DESCRIPTION
# 概要

webapp utils part 3 ... 4 utility に vitest 18 TC 追加、 全 vitest 129 → 147 件 pass。

# 詳細

- vote.ts (2 TC): Vote enum 値 + reverse lookup
- colorResponsiveUIUtils.shouldUseStateBg (5 TC): "/" / "/noun" / "/auction" pathname 判定
- cssTransitionUtils (5 TC): basicFadeInOut / mobileModalSlideInFromBottm / desktopModalSlideInFromTopAndGrow transition styles
- timeUtils (6 TC): currentUnixEpoch / toUnixEpoch / unixToDateString (dayjs.utc)

全 pure function / constant export、 mock 不要。

# 完了条件

- [x] 4 file 18 TC pass
- [x] 全 vitest 129 → 147 件 (+18)
- [x] 既存 129 件 regression なし

# 関連

Issue #327

Refs #327
