### PR TITLE
✨ feat(niji-webapp): webapp utils part 4 - 5 utility に vitest 追加 (Issue #327)

### DIFF
--- a/packages/niji-webapp/src/utils/constants.test.ts
+++ b/packages/niji-webapp/src/utils/constants.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { AVERAGE_BLOCK_TIME_IN_SECS } from './constants';
+
+describe('constants', () => {
+  it('exports AVERAGE_BLOCK_TIME_IN_SECS as 12', () => {
+    expect(AVERAGE_BLOCK_TIME_IN_SECS).toBe(12);
+  });
+});

--- a/packages/niji-webapp/src/utils/getNijiVotes.test.ts
+++ b/packages/niji-webapp/src/utils/getNijiVotes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { getNijiVotes } from './getNijiVotes';
+
+describe('getNijiVotes', () => {
+  const votes = [
+    { supportDetailed: 0 as const, nijiRepresented: ['1', '2'] },
+    { supportDetailed: 1 as const, nijiRepresented: ['3', '4', '5'] },
+    { supportDetailed: 2 as const, nijiRepresented: ['6'] },
+    { supportDetailed: 1 as const, nijiRepresented: ['7'] },
+  ];
+
+  it('returns flat list of nijiIds voting against (0)', () => {
+    expect(getNijiVotes(votes, 0)).toEqual(['1', '2']);
+  });
+
+  it('returns flat list of nijiIds voting for (1)', () => {
+    expect(getNijiVotes(votes, 1)).toEqual(['3', '4', '5', '7']);
+  });
+
+  it('returns flat list of nijiIds voting abstain (2)', () => {
+    expect(getNijiVotes(votes, 2)).toEqual(['6']);
+  });
+
+  it('returns empty array when no matching support value', () => {
+    expect(getNijiVotes(votes, 99 as 0)).toEqual([]);
+  });
+
+  it('handles empty votes array', () => {
+    expect(getNijiVotes([], 1)).toEqual([]);
+  });
+});

--- a/packages/niji-webapp/src/utils/history.test.ts
+++ b/packages/niji-webapp/src/utils/history.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { nounPath } from './history';
+
+describe('nounPath', () => {
+  it('returns /niji/{id} format', () => {
+    expect(nounPath(0)).toBe('/niji/0');
+    expect(nounPath(123)).toBe('/niji/123');
+  });
+
+  it('handles negative id (no validation)', () => {
+    expect(nounPath(-1)).toBe('/niji/-1');
+  });
+});

--- a/packages/niji-webapp/src/utils/logParsing.test.ts
+++ b/packages/niji-webapp/src/utils/logParsing.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterToKey, keyToFilter } from './logParsing';
+
+describe('filterToKey', () => {
+  it('converts simple filter to colon-separated key', () => {
+    expect(filterToKey({ address: '0xabc', topics: ['0xdef'] })).toBe('0xabc:0xdef');
+  });
+
+  it('handles empty address', () => {
+    expect(filterToKey({ topics: ['0xdef'] })).toBe(':0xdef');
+  });
+
+  it('handles empty topics', () => {
+    expect(filterToKey({ address: '0xabc' })).toBe('0xabc:');
+  });
+
+  it('handles array of topics joined with -', () => {
+    expect(filterToKey({ address: '0xabc', topics: ['0x1', '0x2'] })).toBe('0xabc:0x1-0x2');
+  });
+
+  it('handles nested array (OR topics) joined with ;', () => {
+    expect(filterToKey({ address: '0xabc', topics: [['0x1', '0x2']] })).toBe('0xabc:0x1;0x2');
+  });
+
+  it('handles null topic as \\0', () => {
+    expect(filterToKey({ address: '0xabc', topics: [null] })).toBe('0xabc:\0');
+  });
+});
+
+describe('keyToFilter', () => {
+  it('parses simple key back to filter', () => {
+    const result = keyToFilter('0xabc:0xdef');
+    expect(result.address).toBe('0xabc');
+    expect(result.topics).toEqual(['0xdef']);
+  });
+
+  it('parses empty address to undefined', () => {
+    const result = keyToFilter(':0xdef');
+    expect(result.address).toBeUndefined();
+  });
+
+  it('parses nested topics (semicolon-separated)', () => {
+    const result = keyToFilter('0xabc:0x1;0x2');
+    expect(result.topics).toEqual([['0x1', '0x2']]);
+  });
+
+  it('round-trip: filterToKey then keyToFilter preserves data', () => {
+    const original = { address: '0xabc', topics: ['0x1', '0x2'] };
+    expect(keyToFilter(filterToKey(original))).toEqual({
+      address: '0xabc',
+      topics: ['0x1', '0x2'],
+    });
+  });
+});

--- a/packages/niji-webapp/src/utils/nounBgColors.test.ts
+++ b/packages/niji-webapp/src/utils/nounBgColors.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { beige, grey } from './nounBgColors';
+
+describe('nounBgColors', () => {
+  it('exports grey hex code', () => {
+    expect(grey).toBe('#d5d7e1');
+  });
+
+  it('exports beige hex code', () => {
+    expect(beige).toBe('#e1d7d5');
+  });
+
+  it('grey and beige are distinct', () => {
+    expect(grey).not.toBe(beige);
+  });
+});


### PR DESCRIPTION
# 概要

webapp utils part 4 ... 5 utility に vitest 21 TC 追加、 全 vitest 147 → 168 件 pass。

# 詳細

- constants.ts (1 TC): AVERAGE_BLOCK_TIME_IN_SECS=12
- nounBgColors (3 TC): grey / beige hex + 異値
- history.nounPath (2 TC): "/niji/{id}"
- getNijiVotes (5 TC): supportDetailed 別 flat
- logParsing (10 TC): filterToKey + keyToFilter round-trip

全 pure function。

# 完了条件

- [x] 5 file 21 TC pass
- [x] 全 vitest 147 → 168 (+21)
- [x] 既存 147 regression なし

Refs #327
