### PR TITLE
test(niji-webapp): utils part 5 で test 168 → 197 (+29)

### DIFF
--- a/packages/niji-webapp/src/utils/getAddressFromQueryParams.test.ts
+++ b/packages/niji-webapp/src/utils/getAddressFromQueryParams.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAddressFromQueryParams } from './getAddressFromQueryParams';
+
+const VALID_ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+describe('getAddressFromQueryParams', () => {
+  it('returns address when valid hex is the queried param value', () => {
+    expect(getAddressFromQueryParams('to', `?to=${VALID_ADDR}`)).toBe(VALID_ADDR);
+  });
+
+  it('returns undefined when param is missing', () => {
+    expect(getAddressFromQueryParams('to', `?foo=${VALID_ADDR}`)).toBeUndefined();
+  });
+
+  it('returns undefined when invalid hex is provided', () => {
+    expect(getAddressFromQueryParams('to', '?to=0xnotanaddress')).toBeUndefined();
+  });
+
+  it('returns ENS name when value ends with .eth', () => {
+    expect(getAddressFromQueryParams('to', '?to=alice.eth')).toBe('alice.eth');
+  });
+
+  it('decodes NNS (encoded ⌐◨-◨) when value ends with encoded suffix', () => {
+    const encoded = encodeURIComponent('alice.⌐◨-◨');
+    expect(getAddressFromQueryParams('to', `?to=${encoded}`)).toBe('alice.⌐◨-◨');
+  });
+
+  it('returns undefined when param value is missing (trailing equals only)', () => {
+    expect(getAddressFromQueryParams('to', '?to')).toBeUndefined();
+  });
+
+  it('handles trailing & separator (& removed from split tokens)', () => {
+    expect(getAddressFromQueryParams('to', `?to=${VALID_ADDR}&`)).toBe(VALID_ADDR);
+  });
+});

--- a/packages/niji-webapp/src/utils/proposals.test.ts
+++ b/packages/niji-webapp/src/utils/proposals.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import { ProposalState } from '@/wrappers/nijiDao';
+
+import {
+  checkEnoughVotes,
+  checkHasActiveOrPendingProposalOrCandidate,
+  checkIsEligibleToPropose,
+  isProposalUpdatable,
+} from './proposals';
+
+const ADDR_A = '0xAAAaaAaaaaaaaaaaAAAAaaaaaaaaaaAAAAAAAaaa';
+const ADDR_B = '0xbBbBbBbBBBBbbbbbBbbBBBBbbBBBbbBbBBbBbbBb';
+
+describe('isProposalUpdatable', () => {
+  it('returns true for UPDATABLE within window', () => {
+    expect(isProposalUpdatable(ProposalState.UPDATABLE, 100n, 50n)).toBe(true);
+  });
+
+  it('returns true for PENDING within window', () => {
+    expect(isProposalUpdatable(ProposalState.PENDING, 100n, 100n)).toBe(true);
+  });
+
+  it('returns false when current block exceeds update period', () => {
+    expect(isProposalUpdatable(ProposalState.UPDATABLE, 100n, 101n)).toBe(false);
+  });
+
+  it('returns false for non-updatable states (ACTIVE)', () => {
+    expect(isProposalUpdatable(ProposalState.ACTIVE, 100n, 50n)).toBe(false);
+  });
+});
+
+describe('checkEnoughVotes', () => {
+  it('returns true when availableVotes strictly exceeds threshold', () => {
+    expect(checkEnoughVotes(5, 3)).toBe(true);
+  });
+
+  it('returns false when votes equal threshold (strict >)', () => {
+    expect(checkEnoughVotes(3, 3)).toBe(false);
+  });
+
+  it('returns false when availableVotes is undefined', () => {
+    expect(checkEnoughVotes(undefined, 3)).toBe(false);
+  });
+
+  it('returns false when threshold is undefined', () => {
+    expect(checkEnoughVotes(5, undefined)).toBe(false);
+  });
+
+  it('handles threshold=0 (no proposals require votes > 0)', () => {
+    expect(checkEnoughVotes(1, 0)).toBe(true);
+    expect(checkEnoughVotes(0, 0)).toBe(false);
+  });
+});
+
+describe('checkIsEligibleToPropose', () => {
+  const baseProposal = {
+    proposer: ADDR_A,
+    status: ProposalState.ACTIVE,
+  } as never;
+
+  it('returns true when account matches proposer and proposal is ACTIVE', () => {
+    expect(checkIsEligibleToPropose(baseProposal, ADDR_A)).toBe(true);
+  });
+
+  it('handles case-insensitive address match', () => {
+    expect(checkIsEligibleToPropose(baseProposal, ADDR_A.toLowerCase())).toBe(true);
+  });
+
+  it('returns false when proposer differs from account', () => {
+    expect(checkIsEligibleToPropose(baseProposal, ADDR_B)).toBe(false);
+  });
+
+  it('returns false when latestProposal is undefined', () => {
+    expect(checkIsEligibleToPropose(undefined, ADDR_A)).toBe(false);
+  });
+
+  it('returns false when account is null', () => {
+    expect(checkIsEligibleToPropose(baseProposal, null)).toBe(false);
+  });
+
+  it('returns false for non-eligible state (CANCELLED)', () => {
+    const cancelled = { ...baseProposal, status: ProposalState.CANCELLED };
+    expect(checkIsEligibleToPropose(cancelled, ADDR_A)).toBe(false);
+  });
+});
+
+describe('checkHasActiveOrPendingProposalOrCandidate', () => {
+  it('returns true for ACTIVE + matching proposer', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.ACTIVE, ADDR_A, ADDR_A)).toBe(
+      true,
+    );
+  });
+
+  it('returns true for PENDING + matching proposer', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.PENDING, ADDR_A, ADDR_A)).toBe(
+      true,
+    );
+  });
+
+  it('returns true for UPDATABLE + matching proposer', () => {
+    expect(
+      checkHasActiveOrPendingProposalOrCandidate(ProposalState.UPDATABLE, ADDR_A, ADDR_A),
+    ).toBe(true);
+  });
+
+  it('returns false for EXECUTED state', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.EXECUTED, ADDR_A, ADDR_A)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when proposer is undefined', () => {
+    expect(
+      checkHasActiveOrPendingProposalOrCandidate(ProposalState.ACTIVE, undefined, ADDR_A),
+    ).toBe(false);
+  });
+
+  it('returns false when account is null', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.ACTIVE, ADDR_A, null)).toBe(
+      false,
+    );
+  });
+
+  it('returns false when proposer differs from account', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.ACTIVE, ADDR_A, ADDR_B)).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## 概要

webapp utils part 5 として軽量 pure utility 2 file (`getAddressFromQueryParams` / `proposals`) に vitest を追加し、 test 件数を 168 → 197 (+29) に拡張する。

## 課題

untested pure utility に部分 1-4 で確立した「pure function vitest pattern (mock-free / 副作用なし / config 依存なし)」 が未適用。 残作業の漸進消化のため軽量 file から進める。

## 詳細

| file | TC 数 | 内容 |
|---|---|---|
| `src/utils/getAddressFromQueryParams.test.ts` | 7 | valid hex / missing / invalid / ENS .eth / NNS encoded / trailing equals / trailing & |
| `src/utils/proposals.test.ts` | 22 | isProposalUpdatable 4 + checkEnoughVotes 5 + checkIsEligibleToPropose 6 + checkHasActiveOrPendingProposalOrCandidate 7 |

## 解決方法

```mermaid
flowchart LR
    A[ProposalState enum] --> B[mock 不要]
    A --> C[実 import]
    D[URL string literal] --> E[副作用なし]
    D --> F[viem isAddress 経由]
```

ProposalState は実 enum を import (型保証)、 URL 解析は string literal の split logic を再現。 副作用 / 外部 mock 不要。

## 仕組み

`getAddressFromQueryParams` は `useLocation` の `?from=X&to=Y` を `=` で split し indexOf でキー位置を探す簡易 logic。 `proposals.ts` の 4 関数はすべて synchronous な if 判定で副作用なし。 部分 1-4 と同じく `pnpm vitest` 1 発で完結する。

## テスト

- [x] `pnpm vitest run` で 197 pass + 1 todo (regression なし、 168 → 197)
- [x] linter / formatter pass (import 順序は ESLint 自動整形済)

## 受入条件

- [x] `getAddressFromQueryParams.test.ts` 7 TC 全 pass
- [x] `proposals.test.ts` 22 TC 全 pass
- [x] `pnpm vitest run` 全 198 test (197 pass + 1 todo + 1 skipped) green
- [x] regression なし (既存 168 pass を破壊しない)

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx