### PR TITLE
test(niji-webapp): utils subdirs part 6 (moderation/streaming/nounActivity) で 197 → 224 (+27)

### DIFF
--- a/packages/niji-webapp/src/utils/moderation/containsBlockedText.test.ts
+++ b/packages/niji-webapp/src/utils/moderation/containsBlockedText.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { containsBlockedText } from './containsBlockedText';
+
+describe('containsBlockedText', () => {
+  it('returns false when language is unsupported (warns)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(containsBlockedText('anything goes', 'xx-not-real')).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns false for clean english text', () => {
+    expect(containsBlockedText('hello world how are you today', 'en')).toBe(false);
+  });
+
+  it('returns true for english profanity (bad-words filter)', () => {
+    expect(containsBlockedText('this is shit', 'en')).toBe(true);
+  });
+
+  it('handles empty text without throwing', () => {
+    expect(containsBlockedText('', 'en')).toBe(false);
+  });
+
+  it('does case-insensitive match for english profanity', () => {
+    expect(containsBlockedText('SHIT happens', 'en')).toBe(true);
+  });
+});

--- a/packages/niji-webapp/src/utils/nounActivity/getProposalVoteIcon.test.ts
+++ b/packages/niji-webapp/src/utils/nounActivity/getProposalVoteIcon.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { ProposalState, Vote } from '@/wrappers/nijiDao';
+
+import { getProposalVoteIcon } from './getProposalVoteIcon';
+
+const makeProposal = (status: ProposalState) =>
+  ({
+    status,
+  }) as never;
+
+describe('getProposalVoteIcon', () => {
+  it('returns PendingVote icon when no support + status is PENDING', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.PENDING), undefined)).toBeTruthy();
+  });
+
+  it('returns PendingVote icon when no support + status is ACTIVE', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), undefined)).toBeTruthy();
+  });
+
+  it('returns AbsentVote icon when no support + status is terminal (EXECUTED)', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.EXECUTED), undefined)).toBeTruthy();
+  });
+
+  it('returns YesVote icon for FOR vote', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.FOR)).toBeTruthy();
+  });
+
+  it('returns AbstainVote icon for ABSTAIN vote', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.ABSTAIN)).toBeTruthy();
+  });
+
+  it('returns NoVote icon (default switch) for AGAINST vote', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.AGAINST)).toBeTruthy();
+  });
+
+  it('produces distinct icons for FOR vs ABSTAIN vs AGAINST', () => {
+    const yes = getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.FOR);
+    const abs = getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.ABSTAIN);
+    const no = getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.AGAINST);
+    expect(yes).not.toBe(abs);
+    expect(yes).not.toBe(no);
+    expect(abs).not.toBe(no);
+  });
+});

--- a/packages/niji-webapp/src/utils/streamingPaymentUtils/streamingPaymentUtils.test.ts
+++ b/packages/niji-webapp/src/utils/streamingPaymentUtils/streamingPaymentUtils.test.ts
@@ -1,0 +1,97 @@
+import { parseEther, zeroAddress } from 'viem';
+import { describe, expect, it } from 'vitest';
+
+import { SupportedCurrency } from '@/components/ProposalActionsModal/steps/TransferFundsDetailsStep';
+
+import {
+  formatTokenAmount,
+  getTokenAddressForCurrency,
+  parseStreamCreationCallData,
+} from './streamingPaymentUtils';
+
+describe('formatTokenAmount', () => {
+  it('USDC scales by 1_000_000', () => {
+    expect(formatTokenAmount(1.5, SupportedCurrency.USDC)).toBe(1_500_000n);
+  });
+
+  it('WETH parses as ether (18 decimals)', () => {
+    expect(formatTokenAmount(1, SupportedCurrency.WETH)).toBe(parseEther('1'));
+  });
+
+  it('STETH also parses as ether', () => {
+    expect(formatTokenAmount(0.5, SupportedCurrency.STETH)).toBe(parseEther('0.5'));
+  });
+
+  it('default branch converts to bigint', () => {
+    expect(formatTokenAmount(42)).toBe(42n);
+  });
+
+  it('returns 0n for undefined amount', () => {
+    expect(formatTokenAmount(undefined, SupportedCurrency.USDC)).toBe(0n);
+    expect(formatTokenAmount(undefined, SupportedCurrency.WETH)).toBe(0n);
+    expect(formatTokenAmount(undefined)).toBe(0n);
+  });
+
+  it('returns 0n for amount=0 (falsy guard)', () => {
+    expect(formatTokenAmount(0, SupportedCurrency.USDC)).toBe(0n);
+  });
+});
+
+describe('getTokenAddressForCurrency', () => {
+  it('USDC returns address (default chainId=1)', () => {
+    expect(getTokenAddressForCurrency(SupportedCurrency.USDC)).not.toBe(zeroAddress);
+  });
+
+  it('WETH returns address', () => {
+    expect(getTokenAddressForCurrency(SupportedCurrency.WETH)).not.toBe(zeroAddress);
+  });
+
+  it('STETH returns address', () => {
+    expect(getTokenAddressForCurrency(SupportedCurrency.STETH)).not.toBe(zeroAddress);
+  });
+
+  it('default branch (ETH) returns zeroAddress', () => {
+    expect(getTokenAddressForCurrency(SupportedCurrency.ETH)).toBe(zeroAddress);
+  });
+
+  it('undefined currency returns zeroAddress', () => {
+    expect(getTokenAddressForCurrency(undefined)).toBe(zeroAddress);
+  });
+
+  it('unsupported chainId falls back to zeroAddress', () => {
+    expect(getTokenAddressForCurrency(SupportedCurrency.USDC, 99999)).toBe(zeroAddress);
+  });
+});
+
+describe('parseStreamCreationCallData', () => {
+  it('parses 7-element callData (with streamAddress at index 6)', () => {
+    const callData = '0xRecipient,1000,0xToken,1700000000,1800000000,42,0xStreamAddr';
+    const result = parseStreamCreationCallData(callData);
+    expect(result.recipient).toBe('0xRecipient');
+    expect(result.streamAmount).toBe(1000);
+    expect(result.tokenAddress).toBe('0xToken');
+    expect(result.startTime).toBe(1700000000);
+    expect(result.endTime).toBe(1800000000);
+    expect(result.nonce).toBe('42');
+    expect(result.streamAddress).toBe('0xStreamAddr');
+  });
+
+  it('returns empty defaults for too-short callData', () => {
+    const result = parseStreamCreationCallData('a,b,c');
+    expect(result).toEqual({
+      recipient: '',
+      streamAddress: '',
+      startTime: 0,
+      endTime: 0,
+      streamAmount: 0,
+      tokenAddress: '',
+    });
+  });
+
+  it('handles 6-element input (streamAddress becomes undefined)', () => {
+    const result = parseStreamCreationCallData('a,1,b,2,3,4');
+    expect(result.recipient).toBe('a');
+    expect(result.streamAddress).toBeUndefined();
+    expect(result.nonce).toBe('4');
+  });
+});


### PR DESCRIPTION
## 概要

webapp utils part 6 として subdirs 配下の pure logic 3 file (`moderation/containsBlockedText` / `streamingPaymentUtils/streamingPaymentUtils` / `nounActivity/getProposalVoteIcon`) に vitest を追加、 test 件数を 197 → 224 (+27) に拡張する。

## 課題

subdirs (`utils/{moderation,nounActivity,streamingPaymentUtils,...}/`) 配下に pure logic util が未テストで残存。 part 1-5 の mock-free pattern が subdir まで届いていなかった。

## 詳細

| file | TC 数 | 主な観点 |
|---|---|---|
| `moderation/containsBlockedText.test.ts` | 5 | unsupported lang / clean / profanity / empty / case-insensitive |
| `streamingPaymentUtils/streamingPaymentUtils.test.ts` | 15 | formatTokenAmount (7) + getTokenAddressForCurrency (6) + parseStreamCreationCallData (3) |
| `nounActivity/getProposalVoteIcon.test.ts` | 7 | no-support × pending/active/terminal + FOR/ABSTAIN/AGAINST + 各 icon distinctness |

## 解決方法

```mermaid
flowchart LR
    A[bad-words filter] --> B[console.warn を vi.spyOn で sink]
    A --> C[english profanity サンプルで真偽切替]
    D[currency 変換] --> E[viem parseEther/zeroAddress を実 import]
    D --> F[SupportedCurrency 実 enum]
    G[SVG icon] --> H[資源 path に依存せず truthy + 互いに distinct で検証]
```

icon 検証は import の identity 比較で実装、 SVG 内部表現に依存しない。

## 仕組み

`containsBlockedText` は unsupported lang → `console.warn` + false、 supported lang → bad-words filter → custom regex の 2 段。 `formatTokenAmount` は USDC は `*1_000_000` の bigint、 WETH/STETH は `parseEther`、 default は `BigInt(amount)`、 amount=0 / undefined は 0n。 `getTokenAddressForCurrency` は SDK の address map から chainId 引きで取得、 unsupported chain は zeroAddress。 `parseStreamCreationCallData` は `,` split で 6 要素未満は default object、 6+ で各 index を取り出す (streamAddress は index 6)。

## テスト

- [x] `pnpm vitest run` で 224 pass + 1 todo (regression なし)
- [x] linter / formatter pass (import 順序は ESLint 自動整形済)

## 受入条件

- [x] `containsBlockedText.test.ts` 5 TC 全 pass
- [x] `streamingPaymentUtils.test.ts` 15 TC 全 pass
- [x] `getProposalVoteIcon.test.ts` 7 TC 全 pass
- [x] `pnpm vitest run` 全 226 test (224 pass + 1 todo + 1 skipped) green
- [x] regression なし (既存 197 pass を破壊しない)

Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx