### PR TITLE
test(niji-webapp): utils part 7 (lookupNNSOrENS / etherscan / resolveNijiContractAddress) で 224 → 242 (+18)

### DIFF
--- a/packages/niji-webapp/src/utils/etherscan.test.ts
+++ b/packages/niji-webapp/src/utils/etherscan.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/config', () => ({
+  ETHERSCAN_API_KEY: 'TEST_KEY',
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: {
+    id: 1,
+    blockExplorers: {
+      default: { url: 'https://etherscan.io' },
+    },
+  },
+}));
+
+const importEtherscan = async () => import('./etherscan');
+
+describe('etherscan link builders', () => {
+  it('buildEtherscanTxLink uses /tx/ path', async () => {
+    const { buildEtherscanTxLink } = await importEtherscan();
+    expect(buildEtherscanTxLink('0xdeadbeef')).toBe('https://etherscan.io/tx/0xdeadbeef');
+  });
+
+  it('buildEtherscanAddressLink uses /address/ path', async () => {
+    const { buildEtherscanAddressLink } = await importEtherscan();
+    expect(buildEtherscanAddressLink('0xabc')).toBe('https://etherscan.io/address/0xabc');
+  });
+
+  it('buildEtherscanTokenLink encodes tokenId as query param', async () => {
+    const { buildEtherscanTokenLink } = await importEtherscan();
+    expect(buildEtherscanTokenLink('0xtoken', 42)).toBe('https://etherscan.io/token/0xtoken?a=42');
+  });
+
+  it('buildEtherscanHoldingsLink uses /tokenholdings path', async () => {
+    const { buildEtherscanHoldingsLink } = await importEtherscan();
+    expect(buildEtherscanHoldingsLink('0xowner')).toBe(
+      'https://etherscan.io/tokenholdings?a=0xowner',
+    );
+  });
+
+  it('buildEtherscanApiQuery includes chainid + module + action + apikey', async () => {
+    const { buildEtherscanApiQuery } = await importEtherscan();
+    const url = buildEtherscanApiQuery('0xcontract');
+    expect(url).toContain('https://api.etherscan.io/v2/api?');
+    expect(url).toContain('chainid=1');
+    expect(url).toContain('module=contract');
+    expect(url).toContain('action=getsourcecode');
+    expect(url).toContain('address=0xcontract');
+    expect(url).toContain('apikey=TEST_KEY');
+  });
+
+  it('buildEtherscanApiQuery accepts custom module/action overrides', async () => {
+    const { buildEtherscanApiQuery } = await importEtherscan();
+    const url = buildEtherscanApiQuery('0xc', 'account', 'tokenbalance');
+    expect(url).toContain('module=account');
+    expect(url).toContain('action=tokenbalance');
+  });
+});

--- a/packages/niji-webapp/src/utils/lookupNNSOrENS.test.ts
+++ b/packages/niji-webapp/src/utils/lookupNNSOrENS.test.ts
@@ -1,0 +1,67 @@
+import type { Address } from '@/utils/types';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { lookupNNSOrENS } from './lookupNNSOrENS';
+
+const NNS_ADDR = '0x3e1970dc478991b49c4327973ea8a4862ef5a4de';
+const ENS_ADDR = '0x849f92178950f6254db5d16d1ba265e70521ac1b';
+const TARGET: Address = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+type Client = Parameters<typeof lookupNNSOrENS>[0];
+
+describe('lookupNNSOrENS', () => {
+  it('returns NNS name when NNS resolves', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce('alice.⌐◨-◨');
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBe('alice.⌐◨-◨');
+    expect(readContract).toHaveBeenCalledTimes(1);
+    expect(readContract.mock.calls[0][0].address).toBe(NNS_ADDR);
+  });
+
+  it('falls through to ENS when NNS returns empty string', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce('').mockResolvedValueOnce('alice.eth');
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBe('alice.eth');
+    expect(readContract).toHaveBeenCalledTimes(2);
+    expect(readContract.mock.calls[1][0].address).toBe(ENS_ADDR);
+  });
+
+  it('falls through to ENS when NNS throws', async () => {
+    const readContract = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('NNS down'))
+      .mockResolvedValueOnce('bob.eth');
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBe('bob.eth');
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when both NNS and ENS throw', async () => {
+    const readContract = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('NNS down'))
+      .mockRejectedValueOnce(new Error('ENS down'));
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBeNull();
+  });
+
+  it('returns null when ENS returns empty string', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce('').mockResolvedValueOnce('');
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBeNull();
+  });
+
+  it('returns null when NNS returns non-string and ENS returns non-string', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce(123).mockResolvedValueOnce(null);
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBeNull();
+  });
+
+  it('passes the target address as readContract args', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce('cat.eth');
+    const client: Client = { readContract };
+    await lookupNNSOrENS(client, TARGET);
+    expect(readContract.mock.calls[0][0].args).toEqual([TARGET]);
+  });
+});

--- a/packages/niji-webapp/src/utils/resolveNijiContractAddress.test.ts
+++ b/packages/niji-webapp/src/utils/resolveNijiContractAddress.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const GOV = '0x1111111111111111111111111111111111111111';
+const AH = '0x2222222222222222222222222222222222222222';
+const TRE = '0x3333333333333333333333333333333333333333';
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiGovernorAddress: { 1: GOV },
+  nijiAuctionHouseAddress: { 1: AH },
+  nijiTreasuryAddress: { 1: TRE },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+const importResolver = async () => import('./resolveNijiContractAddress');
+
+describe('resolveNijiContractAddress', () => {
+  it('returns "Niji DAO Proxy" for governor address', async () => {
+    const { resolveNijiContractAddress } = await importResolver();
+    expect(resolveNijiContractAddress(GOV)).toBe('Niji DAO Proxy');
+  });
+
+  it('returns "Niji Auction House Proxy" for auction house', async () => {
+    const { resolveNijiContractAddress } = await importResolver();
+    expect(resolveNijiContractAddress(AH)).toBe('Niji Auction House Proxy');
+  });
+
+  it('returns "Niji DAO Treasury" for treasury address', async () => {
+    const { resolveNijiContractAddress } = await importResolver();
+    expect(resolveNijiContractAddress(TRE)).toBe('Niji DAO Treasury');
+  });
+
+  it('handles case-insensitive matching (upper input)', async () => {
+    const { resolveNijiContractAddress } = await importResolver();
+    expect(resolveNijiContractAddress(GOV.toUpperCase())).toBe('Niji DAO Proxy');
+  });
+
+  it('returns undefined for unknown address', async () => {
+    const { resolveNijiContractAddress } = await importResolver();
+    expect(
+      resolveNijiContractAddress('0x9999999999999999999999999999999999999999'),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要

webapp utils part 7 として config / wagmi / SDK 依存の utils 3 file に薄い vi.mock を介した vitest を追加、 test 件数を 224 → 242 (+18)。

## 課題

config (`@/config`) / wagmi (`@/wagmi`) / SDK (`@niji/sdk/react`) に直接依存する utils は part 1-5 の pure pattern だけでは扱えない。 vi.mock で依存を切り出すと pure 比較に持ち込める。

## 詳細

| file | TC 数 | 主な観点 |
|---|---|---|
| `lookupNNSOrENS.test.ts` | 7 | client.readContract を vi.fn 注入、 NNS hit / NNS empty→ENS / NNS throw→ENS / both throw / both empty / non-string / target args |
| `etherscan.test.ts` | 6 | tx / address / token / holdings 4 link + apiQuery default + module/action override |
| `resolveNijiContractAddress.test.ts` | 5 | governor / auction / treasury 解決 + case-insensitive + unknown |

## 解決方法

```mermaid
flowchart LR
    A[依存切り出し] --> B[vi.mock @/config / @/wagmi / @niji/sdk/react]
    B --> C[pure 比較で URL / 名前解決を検証]
    D[client 注入型 API] --> E[vi.fn() で 1 段の mock 注入]
```

依存最小化により mock を「型 / 値」 のみに保つ pattern。 vitest hoisted mock の挙動を活用して module 単位の依存を vi.mock で差し替え。

## 仕組み

`lookupNNSOrENS` は最初の readContract で NNS resolver にコール、 失敗 / 空 / 非 string の各分岐で ENS にフォールバック。 `etherscan` は URL constructor で base + path を結合、 `URLSearchParams` で chainid / module / action / address / apikey を query 化。 `resolveNijiContractAddress` は SDK の address map から `chainId` 引きで取得した 3 種を `toLowerCase()` 比較で identify。

## テスト

- [x] `pnpm vitest run` で 242 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] `lookupNNSOrENS.test.ts` 7 TC 全 pass
- [x] `etherscan.test.ts` 6 TC 全 pass
- [x] `resolveNijiContractAddress.test.ts` 5 TC 全 pass
- [x] `pnpm vitest run` 全 244 test green
- [x] regression なし

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx