### PR TITLE
test(niji-webapp): lib part 9 (utils/traitCategory/nijiAssets) で 251 → 271 (+20)

### DIFF
--- a/packages/niji-webapp/src/lib/nijiAssets.test.ts
+++ b/packages/niji-webapp/src/lib/nijiAssets.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { humanizeTraitKey, nijiTraitKeys } from './nijiAssets';
+
+describe('humanizeTraitKey', () => {
+  it('splits camelCase: leftHand → "Left Hand"', () => {
+    expect(humanizeTraitKey('leftHand')).toBe('Left Hand');
+  });
+
+  it('splits camelCase: backDecoration → "Back Decoration"', () => {
+    expect(humanizeTraitKey('backDecoration')).toBe('Back Decoration');
+  });
+
+  it('splits camelCase: solidBackground → "Solid Background"', () => {
+    expect(humanizeTraitKey('solidBackground')).toBe('Solid Background');
+  });
+
+  it('capitalizes single-word default: hat → "Hat"', () => {
+    expect(humanizeTraitKey('hat')).toBe('Hat');
+  });
+
+  it('capitalizes special → "Special"', () => {
+    expect(humanizeTraitKey('special')).toBe('Special');
+  });
+
+  it('capitalizes hair → "Hair"', () => {
+    expect(humanizeTraitKey('hair')).toBe('Hair');
+  });
+});
+
+describe('nijiTraitKeys', () => {
+  it('has 12 entries in trait id order', () => {
+    expect(nijiTraitKeys.length).toBe(12);
+    expect(nijiTraitKeys[0]).toBe('special');
+    expect(nijiTraitKeys[11]).toBe('hair');
+  });
+
+  it('contains all NijiSeed keys', () => {
+    const required = [
+      'special',
+      'choker',
+      'headphone',
+      'leftHand',
+      'hat',
+      'clothing',
+      'ear',
+      'back',
+      'backDecoration',
+      'background',
+      'solidBackground',
+      'hair',
+    ];
+    expect([...nijiTraitKeys].sort()).toEqual(required.sort());
+  });
+});

--- a/packages/niji-webapp/src/lib/traitCategory.test.ts
+++ b/packages/niji-webapp/src/lib/traitCategory.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { traitCategory } from './traitCategory';
+
+describe('traitCategory', () => {
+  it('contains all expected niji trait keys', () => {
+    const expected = [
+      'special',
+      'choker',
+      'headphone',
+      'leftHand',
+      'hat',
+      'clothing',
+      'ear',
+      'back',
+      'backDecoration',
+      'background',
+      'solidBackground',
+      'hair',
+    ];
+    expect(Object.keys(traitCategory).sort()).toEqual([...expected].sort());
+  });
+
+  it('maps each key to its own name (identity map)', () => {
+    for (const [k, v] of Object.entries(traitCategory)) {
+      expect(v).toBe(k);
+    }
+  });
+
+  it('does not contain stale Nouns-original keys (accessory / body / glasses)', () => {
+    expect(traitCategory).not.toHaveProperty('accessory');
+    expect(traitCategory).not.toHaveProperty('body');
+    expect(traitCategory).not.toHaveProperty('glasses');
+  });
+
+  it('exposes exactly 12 keys', () => {
+    expect(Object.keys(traitCategory).length).toBe(12);
+  });
+});

--- a/packages/niji-webapp/src/lib/utils.test.ts
+++ b/packages/niji-webapp/src/lib/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { cn } from './utils';
+
+describe('cn (clsx + tailwind-merge)', () => {
+  it('joins simple class names', () => {
+    expect(cn('text-red-500', 'font-bold')).toBe('text-red-500 font-bold');
+  });
+
+  it('filters out falsy values (undefined / null / false / "")', () => {
+    expect(cn('foo', undefined, null, false, '', 'bar')).toBe('foo bar');
+  });
+
+  it('resolves tailwind conflicts (later wins)', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4');
+  });
+
+  it('preserves non-conflicting tailwind classes', () => {
+    expect(cn('p-2', 'm-4')).toBe('p-2 m-4');
+  });
+
+  it('flattens nested arrays', () => {
+    expect(cn(['foo', ['bar', 'baz']])).toBe('foo bar baz');
+  });
+
+  it('accepts conditional object syntax', () => {
+    expect(cn({ active: true, disabled: false })).toBe('active');
+  });
+
+  it('returns empty string when no truthy inputs', () => {
+    expect(cn()).toBe('');
+    expect(cn(undefined, null, false)).toBe('');
+  });
+
+  it('handles tailwind color conflict (text-red vs text-blue)', () => {
+    expect(cn('text-red-500', 'text-blue-500')).toBe('text-blue-500');
+  });
+});


### PR DESCRIPTION
## 概要

webapp lib part 9 として `src/lib/` 配下 3 file (`utils` / `traitCategory` / `nijiAssets`) の pure helper に vitest を追加、 test 件数を 251 → 271 (+20)。

## 課題

`src/lib/` は shadcn/ui 経路で多用される pure helper 群だが、 vitest テスト未整備だった。 `cn` (clsx + tailwind-merge wrapper) は UI 各所で利用、 `traitCategory` は 12 trait 識別子の SSOT、 `humanizeTraitKey` は表示用 camelCase 分解。 いずれも mock 不要 pure。

## 詳細

| file | TC 数 | 主な観点 |
|---|---|---|
| `lib/utils.test.ts` | 8 | clsx + twMerge: 結合 / falsy / tailwind conflict / 非衝突 / array flatten / conditional / empty / color conflict |
| `lib/traitCategory.test.ts` | 4 | 12 key 揃え + identity map + Nouns-original 旧 key 不在 (regression defense) + count |
| `lib/nijiAssets.test.ts` | 8 | humanizeTraitKey: leftHand/backDecoration/solidBackground 3 + single-word 3、 nijiTraitKeys: 順序 + count |

## 解決方法

```mermaid
flowchart LR
    A[cn = clsx + tailwind-merge] --> B[衝突解決 + falsy filter を pure 比較]
    C[traitCategory] --> D[identity map + Niji 移行で旧 Nouns key 不在を確認]
    E[humanizeTraitKey] --> F[switch (leftHand/backDecoration/solidBackground) + default 1 文字 capital]
```

特に `traitCategory` で `accessory`/`body`/`glasses` (Nouns-original) が残っていないことを defense-in-depth で検証、 将来の regression を防ぐ。

## 仕組み

`cn` は `tailwind-merge` の `twMerge(clsx(inputs))` で、 後者の class が前者を上書き (例 `p-2 p-4` → `p-4`)。 `traitCategory` は `Record<keyof INounSeed, keyof INounSeed>` で 12 trait の identity map (UI 側で `traitCategory.special` 等で参照)。 `humanizeTraitKey` は switch で 3 種 (`leftHand`/`backDecoration`/`solidBackground`) を表示文字列に変換、 残は default で先頭大文字。

## テスト

- [x] `pnpm vitest run` で 271 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] `lib/utils.test.ts` 8 TC 全 pass
- [x] `lib/traitCategory.test.ts` 4 TC 全 pass
- [x] `lib/nijiAssets.test.ts` 8 TC 全 pass
- [x] `pnpm vitest run` 全 273 test green
- [x] regression なし

Closes #344

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx