### PR TITLE
test(niji-webapp): component part 11 (8 file 小型 presentational) で 304 → 328 (+24)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import AuctionActivityWrapper from './index';
+
+describe('AuctionActivityWrapper', () => {
+  it('renders children inside a div', () => {
+    const { container } = render(<AuctionActivityWrapper>hi</AuctionActivityWrapper>);
+    const div = container.querySelector('div');
+    expect(div?.textContent).toBe('hi');
+  });
+
+  it('applies max-lg:mx-4 class', () => {
+    const { container } = render(<AuctionActivityWrapper>x</AuctionActivityWrapper>);
+    const div = container.querySelector('div');
+    expect(div?.className).toContain('max-lg:mx-4');
+  });
+
+  it('renders nested elements', () => {
+    const { container } = render(
+      <AuctionActivityWrapper>
+        <span>nested</span>
+      </AuctionActivityWrapper>,
+    );
+    expect(container.querySelector('span')?.textContent).toBe('nested');
+  });
+});

--- a/packages/niji-webapp/src/components/BrandSpinner/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandSpinner/index.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import BrandSpinner from './index';
+
+describe('BrandSpinner', () => {
+  it('renders an <svg> element', () => {
+    const { container } = render(<BrandSpinner />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('uses 25x25 viewBox', () => {
+    const { container } = render(<BrandSpinner />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('25');
+    expect(svg?.getAttribute('height')).toBe('25');
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 25 25');
+  });
+
+  it('contains a path + a circle', () => {
+    const { container } = render(<BrandSpinner />);
+    expect(container.querySelector('svg path')).not.toBeNull();
+    expect(container.querySelector('svg circle')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ModalLabel from './index';
+
+describe('ModalLabel', () => {
+  it('renders children inside a div', () => {
+    const { container } = render(<ModalLabel>label-text</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('label-text');
+  });
+
+  it('renders empty when no children', () => {
+    const { container } = render(<ModalLabel />);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+});

--- a/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ModalSubtitle from './index';
+
+describe('ModalSubtitle', () => {
+  it('renders children inside a div', () => {
+    const { container } = render(<ModalSubtitle>subtitle</ModalSubtitle>);
+    expect(container.querySelector('div')?.textContent).toBe('subtitle');
+  });
+
+  it('renders nested ReactNode', () => {
+    const { container } = render(
+      <ModalSubtitle>
+        <span>nested</span>
+      </ModalSubtitle>,
+    );
+    expect(container.querySelector('span')?.textContent).toBe('nested');
+  });
+});

--- a/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ModalTextPrimary from './index';
+
+describe('ModalTextPrimary', () => {
+  it('renders children inside a div', () => {
+    const { container } = render(<ModalTextPrimary>hello</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('hello');
+  });
+
+  it('renders empty when no children', () => {
+    const { container } = render(<ModalTextPrimary />);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+});

--- a/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
@@ -1,0 +1,20 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import ModalTitle from './index';
+
+describe('ModalTitle', () => {
+  it('wraps children in a <h1> inside a div', () => {
+    const { container } = render(<ModalTitle>Hello Modal</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe('Hello Modal');
+  });
+
+  it('renders nested elements inside h1', () => {
+    const { container } = render(
+      <ModalTitle>
+        <span>nested</span>
+      </ModalTitle>,
+    );
+    expect(container.querySelector('h1 span')?.textContent).toBe('nested');
+  });
+});

--- a/packages/niji-webapp/src/components/TruncatedAmount/index.test.tsx
+++ b/packages/niji-webapp/src/components/TruncatedAmount/index.test.tsx
@@ -1,0 +1,32 @@
+import { render } from '@testing-library/react';
+import { parseEther } from 'viem';
+import { describe, expect, it } from 'vitest';
+
+import TruncatedAmount from './index';
+
+describe('TruncatedAmount', () => {
+  it('formats 1 ETH (1e18 wei) to "Ξ 1.00"', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('1')} />);
+    expect(container.textContent).toBe('Ξ 1.00');
+  });
+
+  it('truncates 1.2345 ETH to "Ξ 1.23" (2 decimal places)', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('1.2345')} />);
+    expect(container.textContent).toBe('Ξ 1.23');
+  });
+
+  it('formats 0 ETH to "Ξ 0.00"', () => {
+    const { container } = render(<TruncatedAmount amount={0n} />);
+    expect(container.textContent).toBe('Ξ 0.00');
+  });
+
+  it('formats 0.1 ETH to "Ξ 0.10"', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('0.1')} />);
+    expect(container.textContent).toBe('Ξ 0.10');
+  });
+
+  it('formats 100 ETH to "Ξ 100.00"', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('100')} />);
+    expect(container.textContent).toBe('Ξ 100.00');
+  });
+});

--- a/packages/niji-webapp/src/components/VoteStatusPill/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteStatusPill/index.test.tsx
@@ -1,0 +1,34 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import VoteStatusPill from './index';
+
+describe('VoteStatusPill', () => {
+  it('renders text content inside a div', () => {
+    const { container } = render(<VoteStatusPill status="success" text="PASS" />);
+    expect(container.querySelector('div')?.textContent).toBe('PASS');
+  });
+
+  it('uses success class for status="success"', () => {
+    const { container } = render(<VoteStatusPill status="success" text="ok" />);
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toMatch(/pass/i);
+  });
+
+  it('uses failure class for status="failure"', () => {
+    const { container } = render(<VoteStatusPill status="failure" text="x" />);
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toMatch(/fail/i);
+  });
+
+  it('uses pending class for unknown status (default branch)', () => {
+    const { container } = render(<VoteStatusPill status="unknown-state" text="..." />);
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toMatch(/pending/i);
+  });
+
+  it('renders ReactNode text (nested span)', () => {
+    const { container } = render(<VoteStatusPill status="success" text={<span>nested</span>} />);
+    expect(container.querySelector('span')?.textContent).toBe('nested');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 11 として小型 presentational component 8 file を一括 vitest 化、 test 件数を 304 → 328 (+24)。

## 課題

`src/components/` 配下に 20 行以下の小型 presentational component が多数残存。 個別 file で 1 PR 立てるとレビュー負荷大、 まとめて 1 PR で進めて回数を抑える。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `AuctionActivityWrapper` | 3 | children / class / nested |
| `ModalTextPrimary` | 2 | children / empty |
| `ModalLabel` | 2 | children / empty |
| `ModalSubtitle` | 2 | children / nested |
| `ModalTitle` | 2 | h1 wrap / nested |
| `TruncatedAmount` | 5 | viem formatEther + 2 decimal trunc (1 / 1.2345 / 0 / 0.1 / 100 ETH) |
| `BrandSpinner` | 3 | SVG 25x25 / path + circle |
| `VoteStatusPill` | 5 | success / failure / default / ReactNode |

## 解決方法

```mermaid
flowchart LR
    A[testing-library render] --> B[querySelector で要素取得]
    C[viem formatEther + toFixed(2)] --> D[境界 5 ケース検証]
    E[switch (status)] --> F[3 分岐すべて検証]
```

`@testing-library/react` の render + querySelector で wagmi / Provider 不要の pure render テスト。

## 仕組み

`TruncatedAmount` は viem.formatEther でwei→string 化後、 `parseFloat().toFixed(2)` で 2 桁切り捨て表示 (Ξ プレフィックス付き)。 `VoteStatusPill` は status='success'/'failure'/それ以外 の switch で CSS Modules class を切替、 unknown は default の pending pill。 `Modal*` 群は CSS Modules 経由の単純 div wrap。

## テスト

- [x] `pnpm vitest run` で 328 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 8 file 計 24 TC 全 pass
- [x] `pnpm vitest run` 全 330 test green
- [x] regression なし

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx