### PR TITLE
test(niji-webapp): component part 12 (Link / NavBarItem) で 328 → 338 (+10)

### DIFF
--- a/packages/niji-webapp/src/components/Link/index.test.tsx
+++ b/packages/niji-webapp/src/components/Link/index.test.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Link from './index';
+
+describe('Link', () => {
+  it('renders an <a> with the given url', () => {
+    const { container } = render(<Link text="hi" url="https://example.com" leavesPage={false} />);
+    const a = container.querySelector('a');
+    expect(a?.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it('uses target="_blank" when leavesPage=true', () => {
+    const { container } = render(<Link text="x" url="/x" leavesPage={true} />);
+    expect(container.querySelector('a')?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('uses target="_self" when leavesPage=false', () => {
+    const { container } = render(<Link text="x" url="/x" leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('target')).toBe('_self');
+  });
+
+  it('sets rel="noreferrer"', () => {
+    const { container } = render(<Link text="x" url="/x" leavesPage={true} />);
+    expect(container.querySelector('a')?.getAttribute('rel')).toBe('noreferrer');
+  });
+
+  it('renders text content', () => {
+    const { container } = render(<Link text="click me" url="/x" leavesPage={false} />);
+    expect(container.querySelector('a')?.textContent).toBe('click me');
+  });
+
+  it('renders ReactNode text (nested span)', () => {
+    const { container } = render(<Link text={<span>nested</span>} url="/x" leavesPage={false} />);
+    expect(container.querySelector('a span')?.textContent).toBe('nested');
+  });
+});

--- a/packages/niji-webapp/src/components/NavBar/NavBarItem/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBar/NavBarItem/index.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import NavBarItem from './index';
+
+describe('NavBarItem', () => {
+  it('renders children inside a div', () => {
+    const { container } = render(<NavBarItem>Hello</NavBarItem>);
+    expect(container.querySelector('div')?.textContent).toBe('Hello');
+  });
+
+  it('fires onClick when clicked', () => {
+    const onClick = vi.fn();
+    const { container } = render(<NavBarItem onClick={onClick}>x</NavBarItem>);
+    const div = container.querySelector('div');
+    if (div) fireEvent.click(div);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<NavBarItem className="extra-class">x</NavBarItem>);
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toContain('extra-class');
+  });
+
+  it('renders without onClick (optional prop)', () => {
+    const { container } = render(<NavBarItem>x</NavBarItem>);
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 12 として `Link` (6 TC) + `NavBar/NavBarItem` (4 TC) に vitest を追加、 test 件数を 328 → 338 (+10)。

## 課題

部品的に小さい component (10-30 行) のうち、 react-router / wagmi / Lingui macro 不要な pure prop-driven のものから順次 vitest 整備。 Lingui の `<Trans>` macro は vitest setup で transform 未対応のため対象外 (例 AuctionActivityNijiTitle / StartOrEndTime / EnsOrLongAddress)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `Link/index.test.tsx` | 6 | href / target _blank/_self / rel=noreferrer / text + ReactNode |
| `NavBar/NavBarItem/index.test.tsx` | 4 | children / onClick spy / className merge / onClick 任意 |

## 解決方法

```mermaid
flowchart LR
    A[Link plain a 要素] --> B[href/target/rel 検証]
    C[NavBarItem onClick] --> D[fireEvent.click + vi.fn spy]
```

`fireEvent.click` で onClick を検証する pattern を導入。 macro / wagmi / Provider 不要のため Wrapper 設定なし。

## 仕組み

`Link` は target='_blank' (leavesPage=true) / '_self' (false) を切替、 `rel="noreferrer"` 固定で外部 link 安全性を担保。 `NavBarItem` は CSS Modules class + props.onClick 受け取り pattern、 onClick が undefined でも warning なし。

## テスト

- [x] `pnpm vitest run` で 338 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] `Link/index.test.tsx` 6 TC 全 pass
- [x] `NavBar/NavBarItem/index.test.tsx` 4 TC 全 pass
- [x] `pnpm vitest run` 全 340 test green
- [x] regression なし

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx