### PR TITLE
test(niji-webapp): component part 13 (Lingui/wagmi vi.mock 5 file) で 338 → 362 (+24)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import AuctionActivityNijiTitle from './index';
+
+describe('AuctionActivityNijiTitle', () => {
+  it('renders Niji id in h1', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={42n} />);
+    expect(container.querySelector('h1')?.textContent).toContain('42');
+  });
+
+  it('renders Niji prefix text', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1n} />);
+    expect(container.querySelector('h1')?.textContent).toContain('Niji');
+  });
+
+  it('uses cool color when isCool=true', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    expect(container.querySelector('h1')?.getAttribute('style')).toContain('brand-cool-dark-text');
+  });
+
+  it('uses warm color when isCool=false', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1n} isCool={false} />);
+    expect(container.querySelector('h1')?.getAttribute('style')).toContain('brand-warm-dark-text');
+  });
+
+  it('defaults to warm color when isCool undefined', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1n} />);
+    expect(container.querySelector('h1')?.getAttribute('style')).toContain('brand-warm-dark-text');
+  });
+});

--- a/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
+++ b/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/ensLookup', () => ({
+  useReverseENSLookUp: vi.fn(),
+}));
+
+vi.mock('@/utils/moderation/containsBlockedText', () => ({
+  containsBlockedText: vi.fn(() => false),
+}));
+
+import { useReverseENSLookUp } from '@/utils/ensLookup';
+import { containsBlockedText } from '@/utils/moderation/containsBlockedText';
+
+import EnsOrLongAddress from './index';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+
+describe('EnsOrLongAddress', () => {
+  it('renders ENS name when reverse lookup returns a name', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('alice.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe('alice.eth');
+  });
+
+  it('falls back to long address when ENS is undefined', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+  });
+
+  it('falls back to long address when ENS matches blocklist', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('badword.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(true);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+  });
+});

--- a/packages/niji-webapp/src/components/MinBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/MinBid/index.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render } from '@testing-library/react';
+import { parseEther } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/assets/noun-pointer.png', () => ({
+  default: 'noun-pointer.png',
+}));
+
+import MinBid from './index';
+
+describe('MinBid', () => {
+  it('renders bid amount via TruncatedAmount when minBid > 0', () => {
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.textContent).toContain('Ξ 1.00');
+    expect(container.textContent).toContain('You must bid at least');
+  });
+
+  it('omits amount when minBid = 0n (falsy guard)', () => {
+    const { container } = render(<MinBid minBid={0n} onClick={() => {}} />);
+    expect(container.textContent).not.toContain('Ξ');
+    expect(container.textContent).toContain('You must bid at least');
+  });
+
+  it('renders pointer image', () => {
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('fires onClick on wrapper click', () => {
+    const onClick = vi.fn();
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={onClick} />);
+    const wrapper = container.querySelector('div');
+    if (wrapper) fireEvent.click(wrapper);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/ShortAddress.test.tsx
+++ b/packages/niji-webapp/src/components/ShortAddress.test.tsx
@@ -1,0 +1,99 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('wagmi', () => ({
+  useEnsName: vi.fn(),
+  useEnsAvatar: vi.fn(),
+}));
+
+vi.mock('@/utils/resolveNijiContractAddress', () => ({
+  resolveNijiContractAddress: vi.fn(),
+}));
+
+vi.mock('@/utils/moderation/containsBlockedText', () => ({
+  containsBlockedText: vi.fn(() => false),
+}));
+
+vi.mock('blo', () => ({
+  blo: () => 'data:image/png;base64,FAKE',
+}));
+
+import { useEnsAvatar, useEnsName } from 'wagmi';
+
+import { containsBlockedText } from '@/utils/moderation/containsBlockedText';
+import { resolveNijiContractAddress } from '@/utils/resolveNijiContractAddress';
+
+import ShortAddress from './ShortAddress';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+const ensReturn = (data: string | undefined | null) => ({ data }) as never;
+
+describe('ShortAddress', () => {
+  it('renders ENS name when available', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} />);
+    expect(container.textContent).toBe('alice.eth');
+  });
+
+  it('falls back to short address when no ENS / resolved name', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn(null));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    const { container } = render(<ShortAddress address={ADDR} />);
+    // formatShortAddress: 先頭 0x + 2 文字 + ... + 末尾 4 文字
+    expect(container.textContent).toMatch(/^0x[\dA-Fa-f]{2}\.{3}[\dA-Fa-f]{4}$/);
+  });
+
+  it('uses resolved contract name when ENS is null', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn(null));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue('Niji DAO Treasury');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} />);
+    expect(container.textContent).toBe('Niji DAO Treasury');
+  });
+
+  it('falls back to short address when resolved name is blocklisted', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('badword.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(true);
+    const { container } = render(<ShortAddress address={ADDR} />);
+    expect(container.textContent).toMatch(/\.{3}/);
+  });
+
+  it('renders avatar img when avatar=true', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} avatar={true} />);
+    expect(container.querySelector('img')).not.toBeNull();
+    expect(container.querySelector('span')?.textContent).toBe('alice.eth');
+  });
+
+  it('uses provided size for avatar', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} avatar={true} size={48} />);
+    const img = container.querySelector('img');
+    expect(img?.style.width).toBe('48px');
+    expect(img?.style.height).toBe('48px');
+  });
+
+  it('uses ENS avatar src when available', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn('https://example.com/alice.png'));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} avatar={true} />);
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://example.com/alice.png',
+    );
+  });
+});

--- a/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
+++ b/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import StartOrEndTime from './index';
+
+describe('StartOrEndTime', () => {
+  it('renders "starts ..." when current time is before startTime', () => {
+    const futureStart = Math.floor(Date.now() / 1000) + 3600;
+    const futureEnd = futureStart + 3600;
+    const { container } = render(<StartOrEndTime startTime={futureStart} endTime={futureEnd} />);
+    expect(container.textContent).toContain('starts');
+  });
+
+  it('renders "ends ..." when between start and end', () => {
+    const pastStart = Math.floor(Date.now() / 1000) - 3600;
+    const futureEnd = Math.floor(Date.now() / 1000) + 3600;
+    const { container } = render(<StartOrEndTime startTime={pastStart} endTime={futureEnd} />);
+    expect(container.textContent).toContain('ends');
+  });
+
+  it('renders "ended ..." when current time is after endTime', () => {
+    const pastStart = Math.floor(Date.now() / 1000) - 7200;
+    const pastEnd = Math.floor(Date.now() / 1000) - 3600;
+    const { container } = render(<StartOrEndTime startTime={pastStart} endTime={pastEnd} />);
+    expect(container.textContent).toContain('ended');
+  });
+
+  it('handles missing startTime (defaults to 0, treated as past)', () => {
+    const pastEnd = Math.floor(Date.now() / 1000) - 100;
+    const { container } = render(<StartOrEndTime endTime={pastEnd} />);
+    expect(container.textContent).toContain('ended');
+  });
+
+  it('handles missing endTime (defaults to 0)', () => {
+    const { container } = render(
+      <StartOrEndTime startTime={Math.floor(Date.now() / 1000) - 100} />,
+    );
+    // start in past, end = 0 → in past too → ended
+    expect(container.textContent).toContain('ended');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 13 として Lingui macro / wagmi 依存の 中型 component 5 file に vi.mock 経由の vitest を追加、 test 件数を 338 → 362 (+24)。

## 課題

部分 1-12 では Lingui macro / wagmi 依存 component は cover できなかったが、 vitest config を触らず test file 側で `vi.mock('@lingui/react/macro', ...)` で macro を素通しすれば既存 plugin 構成を変えずに covering 可能と判明 (AuctionTimer / BidHistoryBtn 等の既存 pattern を流用)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `StartOrEndTime` | 5 | starts / ends / ended 3 分岐 + 未指定 2 |
| `AuctionActivityNijiTitle` | 5 | Niji id 表示 + isCool true/false/undefined |
| `EnsOrLongAddress` | 3 | ENS 解決 / undefined / blocklist hit |
| `ShortAddress` | 7 | ENS / fallback short / Niji contract / blocklist / avatar / size / ENS avatar src |
| `MinBid` | 4 | TruncatedAmount 表示 / 0n omit / pointer img / onClick spy |

## 解決方法

```mermaid
flowchart LR
    A[vi.mock @lingui/react/macro] --> B[Trans を pass-through で素通し]
    C[vi.mock wagmi] --> D[useEnsName/useEnsAvatar を vi.fn]
    E[vi.mock @/utils/...] --> F[依存 util を最小 stub]
```

`vi.mocked(fn).mockReturnValue(...)` で TypeScript 型を保ちつつ動的切替。 既存 macro plugin 不要 (vite plugin 追加すると既存 vi.mock pattern と衝突するため断念、 part 1-12 と同じ vite/vitest 構成を維持)。

## 仕組み

`StartOrEndTime` は dayjs.unix で startTime/endTime と現在時刻比較 → starts/ends/ended の 3 文字列を Trans で wrap。 `ShortAddress` は ENS → resolveNijiContractAddress → formatShortAddress の 3 段 fallback、 blocklist hit 時は ENS を放棄して short address に降格。 `MinBid` は minBid > 0 だけ TruncatedAmount を inline 描画、 0n は文字列のみ。

## テスト

- [x] `pnpm vitest run` で 362 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 5 file 計 24 TC 全 pass
- [x] `pnpm vitest run` 全 364 test green
- [x] regression なし

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx