### PR TITLE
test(niji-webapp): component part 15 (NijiInfoRowButton/DelegationCandidate/VoteProgressBar) で 388 → 405 (+17)

### DIFF
--- a/packages/niji-webapp/src/components/DelegationCandidateVoteCountInfo/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegationCandidateVoteCountInfo/index.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import DelegationCandidateVoteCountInfo from './index';
+
+describe('DelegationCandidateVoteCountInfo', () => {
+  it('uses singular "Vote" for voteCount=1', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="Alice" voteCount={1} isLoading={false} />,
+    );
+    expect(container.textContent).toContain('1 Vote');
+    expect(container.textContent).not.toContain('Votes');
+  });
+
+  it('uses plural "Votes" for voteCount=0', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="Alice" voteCount={0} isLoading={false} />,
+    );
+    expect(container.textContent).toContain('0 Votes');
+  });
+
+  it('uses plural "Votes" for voteCount=2', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="Alice" voteCount={2} isLoading={false} />,
+    );
+    expect(container.textContent).toContain('2 Votes');
+  });
+
+  it('renders spinner svg when isLoading=true', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="Alice" voteCount={1} isLoading={true} />,
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('omits spinner when isLoading=false', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="Alice" voteCount={1} isLoading={false} />,
+    );
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('renders text prop content', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="my-name" voteCount={1} isLoading={false} />,
+    );
+    expect(container.textContent).toContain('my-name');
+  });
+});

--- a/packages/niji-webapp/src/components/NijiInfoRowButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoRowButton/index.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+import NijiInfoRowButton from './index';
+
+describe('NijiInfoRowButton', () => {
+  it('renders button text', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="Vote" onClickHandler={() => {}} />,
+    );
+    expect(container.textContent).toBe('Vote');
+  });
+
+  it('renders the icon image', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/icon.png" btnText="x" onClickHandler={() => {}} />,
+    );
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('/icon.png');
+  });
+
+  it('uses cool class when isCool=true', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="x" onClickHandler={() => {}} />,
+    );
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toMatch(/cool/i);
+  });
+
+  it('uses warm class when isCool=false', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="x" onClickHandler={() => {}} />,
+    );
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toMatch(/warm/i);
+  });
+
+  it('fires onClickHandler when clicked', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const onClick = vi.fn();
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="x" onClickHandler={onClick} />,
+    );
+    const div = container.querySelector('div');
+    if (div) fireEvent.click(div);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/VoteProgressBar/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteProgressBar/index.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { VoteCardVariant } from '@/components/VoteCard';
+
+import VoteProgressBar from './index';
+
+describe('VoteProgressBar', () => {
+  it('renders FOR variant with forProgressBar class', () => {
+    const { container } = render(<VoteProgressBar variant={VoteCardVariant.FOR} percentage={50} />);
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.className).toMatch(/for/i);
+  });
+
+  it('renders AGAINST variant with againstProgressBar class', () => {
+    const { container } = render(
+      <VoteProgressBar variant={VoteCardVariant.AGAINST} percentage={30} />,
+    );
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.className).toMatch(/against/i);
+  });
+
+  it('renders ABSTAIN (default) variant with abstainProgressBar class', () => {
+    const { container } = render(
+      <VoteProgressBar variant={VoteCardVariant.ABSTAIN} percentage={20} />,
+    );
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.className).toMatch(/abstain/i);
+  });
+
+  it('sets width style from percentage', () => {
+    const { container } = render(<VoteProgressBar variant={VoteCardVariant.FOR} percentage={75} />);
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 75%');
+  });
+
+  it('handles 0%', () => {
+    const { container } = render(<VoteProgressBar variant={VoteCardVariant.FOR} percentage={0} />);
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 0%');
+  });
+
+  it('handles 100%', () => {
+    const { container } = render(
+      <VoteProgressBar variant={VoteCardVariant.FOR} percentage={100} />,
+    );
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 100%');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 15 として `NijiInfoRowButton` / `DelegationCandidateVoteCountInfo` / `VoteProgressBar` の 3 component に vitest を追加、 test 件数を 388 → 405 (+17)。

## 課題

isCool 切替 / 単複切替 / variant 分岐などの presentational ロジックは Lingui macro / wagmi 依存なしで pure check 可能だが未テスト。 jotai/react.useAtomValue は vi.mock で差替えして isCool テーマ切替を網羅。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `NijiInfoRowButton` | 5 | text / icon src / cool/warm class / onClick spy |
| `DelegationCandidateVoteCountInfo` | 6 | 1=Vote / 0,2=Votes / spinner ON/OFF / text content |
| `VoteProgressBar` | 6 | FOR/AGAINST/ABSTAIN 3 variant + width style 0/75/100% |

## 解決方法

```mermaid
flowchart LR
    A[isCool 切替] --> B[jotai useAtomValue を vi.fn 差替]
    C[単複切替] --> D[voteCount=0/1/2 で Vote/Votes 分岐確認]
    E[variant 分岐] --> F[3 enum すべて render + class match]
```

`jotai/react` の useAtomValue を `vi.fn()` 経由で値切替できるよう vi.mock factory 内で参照。

## 仕組み

`NijiInfoRowButton` は isCool 値で `nounButtonCool` / `nounButtonWarm` を選択。 `DelegationCandidateVoteCountInfo` は voteCount===1 のみ単数 Vote、 他は Votes (0 含む) + isLoading=true で BrandSpinner 表示。 `VoteProgressBar` は switch で FOR/AGAINST/ABSTAIN の class set を切替、 inner div の width=percentage% を style 属性で動的指定。

## テスト

- [x] `pnpm vitest run` で 405 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 17 TC 全 pass
- [x] `pnpm vitest run` 全 407 test green
- [x] regression なし

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx