### PR TITLE
test(niji-webapp): component part 16 (CreateCandidateButton/VoteSignalsHeader/OriginalSignature/Modal) で 405 → 431 (+26)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/OriginalSignature.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/OriginalSignature.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span>{address.slice(0, 6)}</span>,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+import OriginalSignature from './OriginalSignature';
+
+const SIGNER = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+
+describe('OriginalSignature', () => {
+  it('shows "Awaiting signature" when isParentProposalUpdatable=true', () => {
+    const { container } = render(
+      <OriginalSignature voteCount={1} signer={SIGNER} isParentProposalUpdatable={true} />,
+    );
+    expect(container.textContent).toContain('Awaiting signature');
+  });
+
+  it('shows "Did not re-sign" when isParentProposalUpdatable=false', () => {
+    const { container } = render(
+      <OriginalSignature voteCount={1} signer={SIGNER} isParentProposalUpdatable={false} />,
+    );
+    expect(container.textContent).toContain('Did not re-sign');
+  });
+
+  it('singular vote (voteCount=1)', () => {
+    const { container } = render(
+      <OriginalSignature voteCount={1} signer={SIGNER} isParentProposalUpdatable={true} />,
+    );
+    expect(container.textContent).toContain('1 vote');
+    expect(container.textContent).not.toContain('1 votes');
+  });
+
+  it('plural votes (voteCount=2)', () => {
+    const { container } = render(
+      <OriginalSignature voteCount={2} signer={SIGNER} isParentProposalUpdatable={true} />,
+    );
+    expect(container.textContent).toContain('2 votes');
+  });
+
+  it('plural votes (voteCount=0)', () => {
+    const { container } = render(
+      <OriginalSignature voteCount={0} signer={SIGNER} isParentProposalUpdatable={true} />,
+    );
+    expect(container.textContent).toContain('0 votes');
+  });
+
+  it('uses etherscan address link for signer', () => {
+    const { container } = render(
+      <OriginalSignature voteCount={1} signer={SIGNER} isParentProposalUpdatable={true} />,
+    );
+    const a = container.querySelector('a');
+    expect(a?.getAttribute('href')).toBe(`https://etherscan.io/address/${SIGNER}`);
+    expect(a?.getAttribute('target')).toBe('_blank');
+    expect(a?.getAttribute('rel')).toBe('noreferrer');
+  });
+});

--- a/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import CreateCandidateButton from './index';
+
+describe('CreateCandidateButton', () => {
+  it('renders "Create proposal candidate" by default', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain('Create proposal candidate');
+  });
+
+  it('renders warning text when hasActiveOrPendingProposal=true', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain('You already have an active or pending proposal');
+  });
+
+  it('renders react-bootstrap Spinner when isLoading=true', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    // react-bootstrap Spinner は spinner-border class を付与
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+    // 通常テキストは isLoading 中は出ない
+    expect(container.textContent).not.toContain('Create proposal candidate');
+  });
+
+  it('disables button when isFormInvalid=true', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={true}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('disables button when hasActiveOrPendingProposal=true', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('fires handleCreateProposal on click when enabled', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/Modal/index.test.tsx
+++ b/packages/niji-webapp/src/components/Modal/index.test.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Modal, { Backdrop } from './index';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="backdrop-root"></div><div id="overlay-root"></div>';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Backdrop', () => {
+  it('renders a div', () => {
+    const { container } = render(<Backdrop onDismiss={() => {}} />);
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+
+  it('fires onDismiss on click', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(<Backdrop onDismiss={onDismiss} />);
+    const div = container.querySelector('div');
+    if (div) fireEvent.click(div);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Modal', () => {
+  it('portals title + content + close img into overlay-root', () => {
+    render(<Modal title="My Title" content={<p>Body</p>} onDismiss={() => {}} />);
+    const overlay = document.getElementById('overlay-root');
+    expect(overlay?.querySelector('h3')?.textContent).toBe('My Title');
+    expect(overlay?.querySelector('p')?.textContent).toBe('Body');
+    expect(overlay?.querySelector('img')).not.toBeNull();
+  });
+
+  it('portals backdrop into backdrop-root', () => {
+    render(<Modal title="x" content={null} onDismiss={() => {}} />);
+    expect(document.getElementById('backdrop-root')?.children.length).toBe(1);
+  });
+
+  it('close button fires onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(<Modal title="x" content={null} onDismiss={onDismiss} />);
+    const btn = document.getElementById('overlay-root')?.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('backdrop click also fires onDismiss', () => {
+    const onDismiss = vi.fn();
+    render(<Modal title="x" content={null} onDismiss={onDismiss} />);
+    const backdrop = document.getElementById('backdrop-root')?.querySelector('div');
+    if (backdrop) fireEvent.click(backdrop);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles undefined title (h3 still renders)', () => {
+    render(<Modal content={null} onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.querySelector('h3')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.test.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { VoteSignalsFootnote, VoteSignalsHeader } from './VoteSignalsHeader';
+
+describe('VoteSignalsHeader', () => {
+  it('renders "Pre-voting feedback" by default', () => {
+    const { container } = render(<VoteSignalsHeader />);
+    expect(container.textContent).toContain('Pre-voting feedback');
+  });
+
+  it('renders "Pre-proposal feedback" when isCandidate=true', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={true} />);
+    expect(container.textContent).toContain('Pre-proposal feedback');
+  });
+
+  it('hides description paragraph when isCandidate=true', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={true} />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('shows description paragraph when isCandidate=false', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={false} />);
+    expect(container.querySelector('p')).not.toBeNull();
+    expect(container.querySelector('p')?.textContent).toContain('Nijis voters');
+  });
+
+  it('uses text-xl class when isCandidate=true (h2)', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={true} />);
+    expect(container.querySelector('h2')?.className).toContain('text-xl');
+  });
+
+  it('does not have text-xl when isCandidate=false', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={false} />);
+    expect(container.querySelector('h2')?.className).not.toContain('text-xl');
+  });
+});
+
+describe('VoteSignalsFootnote', () => {
+  it('renders explanatory paragraph', () => {
+    const { container } = render(<VoteSignalsFootnote />);
+    expect(container.querySelector('p')?.textContent).toContain('Nijis voters');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 16 として 4 file 計 26 TC を追加、 test 件数を 405 → 431 (+26)。

## 課題

提案作成 button / vote feedback / candidate signature / portal Modal は UI critical だが未テスト。 vi.mock pattern + ReactDOM.createPortal 用の document.body 注入 pattern を導入。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `CreateCandidateButton` | 6 | default text / warning text / Spinner / 2 種 disabled / handle click |
| `VoteSignalsHeader` | 7 | default / isCandidate true/false + text-xl 切替 + p 表示 + Footnote |
| `CandidateSponsors/OriginalSignature` | 6 | Awaiting/Did not + 0/1/2 vote 単複 + etherscan a tag |
| `Modal` | 7 | Backdrop click + Modal portal (title/content/img) + onDismiss 2 経路 + undefined title |

## 解決方法

```mermaid
flowchart LR
    A[Lingui Trans] --> B[vi.mock 素通し]
    C[ReactDOM.createPortal] --> D[beforeEach で document.body 注入]
    D --> E[getElementById で照合]
    F[ShortAddress sub-component] --> G[vi.mock で stub 描画]
```

Portal 系は beforeEach で `<div id="backdrop-root">` / `<div id="overlay-root">` を document.body に注入 → afterEach で cleanup。 ReactDOM.createPortal の target を確実に確保。

## 仕組み

`CreateCandidateButton` は hasActiveOrPendingProposal で variant 切替 (primary/danger) + disabled 制御、 isLoading で Spinner (`.spinner-border` class) 描画。 `VoteSignalsHeader` は isCandidate で見出し 2 種切替 + 説明文 (footnote) の gating。 `OriginalSignature` は voteCount !== 1 で s suffix、 isParentProposalUpdatable で「Awaiting signature」/「Did not re-sign」 切替。 `Modal` は backdrop / overlay の 2 portal を ReactDOM.createPortal で切離し、 close button + backdrop click 両方で onDismiss 発火。

## テスト

- [x] `pnpm vitest run` で 431 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 4 file 計 26 TC 全 pass
- [x] `pnpm vitest run` 全 433 test green
- [x] regression なし

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx