### PR TITLE
test(niji-webapp): component part 17 (HorizontalStackedNijis/TightStackedCircleNijis) で 431 → 439 (+8)

### DIFF
--- a/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/Niji', () => ({
+  NijiCircular: ({ nounId }: { nounId: bigint }) => (
+    <span data-testid="niji-circular">{nounId.toString()}</span>
+  ),
+}));
+
+import HorizontalStackedNijis from './index';
+
+describe('HorizontalStackedNijis', () => {
+  it('renders nothing for empty array', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={[]} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(0);
+  });
+
+  it('renders all nounIds up to 6', () => {
+    const ids = ['1', '2', '3'];
+    const { container } = render(<HorizontalStackedNijis nounIds={ids} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(3);
+  });
+
+  it('caps at 6 elements (slice(0,6))', () => {
+    const ids = ['1', '2', '3', '4', '5', '6', '7', '8'];
+    const { container } = render(<HorizontalStackedNijis nounIds={ids} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(6);
+  });
+
+  it('wraps in a div with classes.wrapper', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={['1']} />);
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/TightStackedCircleNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNijis/index.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../TightStackedCircleNiji', () => ({
+  default: ({ nounId }: { nounId: number }) => <circle data-niji={nounId} />,
+}));
+
+import TightStackedCircleNijis from './index';
+
+describe('TightStackedCircleNijis', () => {
+  it('renders svg of 55x55', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[1, 2, 3]} />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('width')).toBe('55');
+    expect(svg?.getAttribute('height')).toBe('55');
+  });
+
+  it('caps at 3 elements (MAX_NOUNS_PER_STACK)', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[1, 2, 3, 4, 5]} />);
+    expect(container.querySelectorAll('circle').length).toBe(3);
+  });
+
+  it('renders fewer than max when nounIds has < 3', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[10, 20]} />);
+    expect(container.querySelectorAll('circle').length).toBe(2);
+  });
+
+  it('renders zero circles for empty list', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[]} />);
+    expect(container.querySelectorAll('circle').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 17 として stack 表示 component 2 file に vitest を追加、 test 件数を 431 → 439 (+8)。

## 課題

`HorizontalStackedNijis` (max 6) と `TightStackedCircleNijis` (max 3) は配列を slice で制限する pure logic だが、 上限が壊れると一覧 UI が破綻する。 子 component (NijiCircular / TightStackedCircleNiji) を mock すれば slice 効果を独立検証可能。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `HorizontalStackedNijis` | 4 | empty / 3 件 / 8 件 cap=6 / wrapper div |
| `TightStackedCircleNijis` | 4 | svg 55x55 / 5 件 cap=3 / 2 件 (< max) / empty |

## 解決方法

```mermaid
flowchart LR
    A[配列 nounIds] --> B[slice(0, MAX)]
    B --> C[子 component を vi.mock で stub]
    C --> D[querySelectorAll で出現数を検証]
```

vi.mock で子 component を最小 stub に置換、 出現数で slice 効果を確認。

## 仕組み

`HorizontalStackedNijis` は `nounIds.slice(0, 6)` で配列を最大 6 に絞り、 各要素を `<NijiCircular nounId={BigInt(id)} border />` で wrap。 `TightStackedCircleNijis` は `nounIds.slice(0, 3).reverse()` で最大 3 件 + 描画順反転 (上に来る要素を後で描画して z-order を上げる)、 SVG 55x55 内に子 circle を積み重ね。

## テスト

- [x] `pnpm vitest run` で 439 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 8 TC 全 pass
- [x] `pnpm vitest run` 全 441 test green
- [x] regression なし

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx