### PR TITLE
test(niji-webapp): component part 18 (NavBarLink/ModalBottomButtonRow/AuctionActivityDateHeadline/NetworkAlert) で 439 → 458 (+19)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    date: (input: string) => input,
+  },
+}));
+
+import AuctionActivityDateHeadline from './index';
+
+describe('AuctionActivityDateHeadline', () => {
+  it('renders formatted UTC date in h4', () => {
+    useAtomValueMock.mockReturnValue(true);
+    // 1735689600 = 2025-01-01 UTC
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')?.textContent).toContain('January');
+    expect(container.querySelector('h4')?.textContent).toContain('2025');
+  });
+
+  it('uses cool color when isCool=true', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')?.getAttribute('style')).toContain('brand-cool-light-text');
+  });
+
+  it('uses warm color when isCool=false', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')?.getAttribute('style')).toContain('brand-warm-light-text');
+  });
+
+  it('wraps h4 in a div', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('div h4')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/ModalBottomButtonRow/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalBottomButtonRow/index.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../NavBarButton', () => {
+  const NavBarButtonStyle = {
+    DELEGATE_BACK: 'back',
+    DELEGATE_SECONDARY: 'secondary',
+    DELEGATE_DISABLED: 'disabled',
+  };
+  const NavBarButton = ({
+    buttonText,
+    buttonStyle,
+    onClick,
+    disabled,
+  }: {
+    buttonText: React.ReactNode;
+    buttonStyle: string;
+    onClick: React.MouseEventHandler<HTMLButtonElement>;
+    disabled?: boolean;
+  }) => (
+    <button data-style={buttonStyle} disabled={disabled} onClick={onClick}>
+      {buttonText}
+    </button>
+  );
+  return {
+    default: NavBarButton,
+    NavBarButtonStyle,
+  };
+});
+
+import ModalBottomButtonRow from './index';
+
+describe('ModalBottomButtonRow', () => {
+  it('renders prev + next button text', () => {
+    const { container } = render(
+      <ModalBottomButtonRow
+        onPrevBtnClick={() => {}}
+        onNextBtnClick={() => {}}
+        prevBtnText="Back"
+        nextBtnText="Next"
+      />,
+    );
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[0]?.textContent).toBe('Back');
+    expect(buttons[1]?.textContent).toBe('Next');
+  });
+
+  it('next button uses DELEGATE_SECONDARY by default', () => {
+    const { container } = render(
+      <ModalBottomButtonRow
+        onPrevBtnClick={() => {}}
+        onNextBtnClick={() => {}}
+        prevBtnText="x"
+        nextBtnText="y"
+      />,
+    );
+    expect(container.querySelectorAll('button')[1]?.getAttribute('data-style')).toBe('secondary');
+  });
+
+  it('next button uses DELEGATE_DISABLED when isNextBtnDisabled=true', () => {
+    const { container } = render(
+      <ModalBottomButtonRow
+        onPrevBtnClick={() => {}}
+        onNextBtnClick={() => {}}
+        prevBtnText="x"
+        nextBtnText="y"
+        isNextBtnDisabled
+      />,
+    );
+    const next = container.querySelectorAll('button')[1];
+    expect(next?.getAttribute('data-style')).toBe('disabled');
+    expect(next?.disabled).toBe(true);
+  });
+
+  it('fires onPrevBtnClick when prev is clicked', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <ModalBottomButtonRow
+        onPrevBtnClick={onPrev}
+        onNextBtnClick={() => {}}
+        prevBtnText="x"
+        nextBtnText="y"
+      />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onNextBtnClick when next is clicked', () => {
+    const onNext = vi.fn();
+    const { container } = render(
+      <ModalBottomButtonRow
+        onPrevBtnClick={() => {}}
+        onNextBtnClick={onNext}
+        prevBtnText="x"
+        nextBtnText="y"
+      />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[1]);
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/NavBar/NavBarLink/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBar/NavBarLink/index.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import NavBarLink from './index';
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('NavBarLink', () => {
+  it('renders internal link <a> with to= path (no target)', () => {
+    const { container } = wrap(<NavBarLink to="/foo">internal</NavBarLink>);
+    const a = container.querySelector('a');
+    expect(a?.getAttribute('href')).toBe('/foo');
+    expect(a?.getAttribute('target')).toBe('');
+  });
+
+  it('renders external http link with target=_blank', () => {
+    const { container } = wrap(<NavBarLink to="https://example.com">ext</NavBarLink>);
+    const a = container.querySelector('a');
+    expect(a?.getAttribute('target')).toBe('_blank');
+  });
+
+  it('renders children text', () => {
+    const { container } = wrap(<NavBarLink to="/x">My Link</NavBarLink>);
+    expect(container.querySelector('a')?.textContent).toBe('My Link');
+  });
+
+  it('merges custom className', () => {
+    const { container } = wrap(
+      <NavBarLink to="/x" className="extra">
+        x
+      </NavBarLink>,
+    );
+    expect(container.querySelector('a')?.className).toContain('extra');
+  });
+
+  it('renders nested ReactNode child', () => {
+    const { container } = wrap(
+      <NavBarLink to="/x">
+        <span>nested</span>
+      </NavBarLink>,
+    );
+    expect(container.querySelector('a span')?.textContent).toBe('nested');
+  });
+});

--- a/packages/niji-webapp/src/components/NetworkAlert/index.test.tsx
+++ b/packages/niji-webapp/src/components/NetworkAlert/index.test.tsx
@@ -1,0 +1,55 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useAccountMock = vi.fn();
+const switchChainMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useAccount: () => useAccountMock(),
+  useSwitchChain: () => ({ switchChain: switchChainMock }),
+}));
+
+vi.mock('@/config', () => ({
+  CHAIN_ID: 1,
+}));
+
+vi.mock('@/wagmi', () => ({
+  config: { chains: [{ id: 1 }, { id: 11155111 }] },
+}));
+
+import NetworkAlert from './index';
+
+describe('NetworkAlert', () => {
+  beforeEach(() => {
+    switchChainMock.mockReset();
+  });
+
+  it('renders nothing (null)', () => {
+    useAccountMock.mockReturnValue({ isConnected: false, chainId: undefined });
+    const { container } = render(<NetworkAlert />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not call switchChain when not connected', () => {
+    useAccountMock.mockReturnValue({ isConnected: false, chainId: undefined });
+    render(<NetworkAlert />);
+    expect(switchChainMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call switchChain when chainId is null', () => {
+    useAccountMock.mockReturnValue({ isConnected: true, chainId: null });
+    render(<NetworkAlert />);
+    expect(switchChainMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call switchChain when already on target chain', () => {
+    useAccountMock.mockReturnValue({ isConnected: true, chainId: 1 });
+    render(<NetworkAlert />);
+    expect(switchChainMock).not.toHaveBeenCalled();
+  });
+
+  it('calls switchChain when on wrong chain', () => {
+    useAccountMock.mockReturnValue({ isConnected: true, chainId: 11155111 });
+    render(<NetworkAlert />);
+    expect(switchChainMock).toHaveBeenCalledWith({ chainId: 1 });
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 18 として react-router / NavBarButton / lingui i18n.date / wagmi useSwitchChain 系の依存をそれぞれ持つ 4 file 合計 19 TC、 test 件数を 439 → 458 (+19)。

## 課題

依存タイプが幅広く mock 戦略が各 file ごとに異なるため、 一括で進めるとデバッグコスト大。 part 18 では 1 PR に集約しつつ各 mock パターンを再利用可能な形で確立する。

## 詳細

| file | TC 数 | 依存 | 観点 |
|---|---|---|---|
| `NavBarLink` | 5 | react-router Link | MemoryRouter wrap で internal/external target 切替 |
| `ModalBottomButtonRow` | 5 | NavBarButton 子 | DELEGATE_SECONDARY/DISABLED 切替 + onPrev/onNext spy |
| `AuctionActivityDateHeadline` | 4 | jotai useAtomValue + lingui i18n.date | i18n.date pass-through + cool/warm 色 |
| `NetworkAlert` | 5 | wagmi useAccount + useSwitchChain | 4 分岐 (not connected / null chainId / 同 chain / 異 chain) |

## 解決方法

```mermaid
flowchart LR
    A[react-router Link] --> B[MemoryRouter で provider 提供]
    C[lingui i18n.date] --> D[vi.mock @lingui/core で pass-through]
    E[wagmi hooks] --> F[useAccount/useSwitchChain を vi.fn]
    G[NavBarButton 子] --> H[vi.mock で button stub + data-style 出力]
```

## 仕組み

`NetworkAlert` の switchChain gating は 4 分岐 (isConnected=false / currentChainId=null / 同 chain / 異 chain) の useEffect ロジック、 異 chain でのみ `switchChain({ chainId: 1 })` を呼ぶ (lastRequestedChainId ref で連続発火防止)。 `AuctionActivityDateHeadline` の i18n.date は active locale 必須なので vi.mock で pass-through 化 (locale 設定回避)。

## テスト

- [x] `pnpm vitest run` で 458 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 4 file 計 19 TC 全 pass
- [x] `pnpm vitest run` 全 460 test green
- [x] regression なし

Closes #362

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx