### PR TITLE
test(niji-webapp): hooks part 19 (useForkTreasuryBalance/useBlockTimestamp) で 458 → 470 (+12)

### DIFF
--- a/packages/niji-webapp/src/hooks/useBlockTimestamp.test.tsx
+++ b/packages/niji-webapp/src/hooks/useBlockTimestamp.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const getBlockMock = vi.fn();
+const usePublicClientMock = vi.fn(() => ({ getBlock: getBlockMock }));
+
+vi.mock('wagmi', () => ({
+  usePublicClient: () => usePublicClientMock(),
+}));
+
+import { useBlockTimestamp } from './useBlockTimestamp';
+
+describe('useBlockTimestamp', () => {
+  it('returns undefined initially before fetch resolves', () => {
+    getBlockMock.mockReturnValue(new Promise(() => {}));
+    const { result } = renderHook(() => useBlockTimestamp(100n));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns timestamp after getBlock resolves', async () => {
+    getBlockMock.mockResolvedValue({ timestamp: 1700000000n });
+    const { result } = renderHook(() => useBlockTimestamp(100n));
+    await waitFor(() => expect(result.current).toBe(1700000000));
+  });
+
+  it('returns undefined when blockNumber is not provided', () => {
+    getBlockMock.mockReset();
+    const { result } = renderHook(() => useBlockTimestamp(undefined));
+    expect(result.current).toBeUndefined();
+    expect(getBlockMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined on getBlock error (console.error sink)', async () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    getBlockMock.mockRejectedValue(new Error('rpc down'));
+    const { result } = renderHook(() => useBlockTimestamp(100n));
+    await waitFor(() => expect(errSpy).toHaveBeenCalled());
+    expect(result.current).toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  it('handles timestamp=0 by returning undefined (falsy guard)', async () => {
+    getBlockMock.mockResolvedValue({ timestamp: 0n });
+    const { result } = renderHook(() => useBlockTimestamp(100n));
+    // 短時間で resolve しないことを確認 (0 || undefined)
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/niji-webapp/src/hooks/useForkTreasuryBalance.test.tsx
+++ b/packages/niji-webapp/src/hooks/useForkTreasuryBalance.test.tsx
@@ -1,0 +1,75 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useBalanceMock = vi.fn();
+const useReadStEthBalanceOfMock = vi.fn();
+
+vi.mock('wagmi', () => ({
+  useBalance: (args: unknown) => useBalanceMock(args),
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  useReadStEthBalanceOf: (args: unknown) => useReadStEthBalanceOfMock(args),
+}));
+
+import useForkTreasuryBalance from './useForkTreasuryBalance';
+
+const TREASURY = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+
+describe('useForkTreasuryBalance', () => {
+  it('returns ETH + stETH sum when both are present', () => {
+    useBalanceMock.mockReturnValue({ data: { value: 1_000n } });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: 500n });
+    const { result } = renderHook(() => useForkTreasuryBalance(TREASURY));
+    expect(result.current).toBe(1_500n);
+  });
+
+  it('returns 0n when both are undefined', () => {
+    useBalanceMock.mockReturnValue({ data: undefined });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useForkTreasuryBalance(TREASURY));
+    expect(result.current).toBe(0n);
+  });
+
+  it('falls back to 0n for missing ETH only', () => {
+    useBalanceMock.mockReturnValue({ data: undefined });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: 300n });
+    const { result } = renderHook(() => useForkTreasuryBalance(TREASURY));
+    expect(result.current).toBe(300n);
+  });
+
+  it('falls back to 0n for missing stETH only', () => {
+    useBalanceMock.mockReturnValue({ data: { value: 700n } });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useForkTreasuryBalance(TREASURY));
+    expect(result.current).toBe(700n);
+  });
+
+  it('handles undefined treasuryContractAddress', () => {
+    useBalanceMock.mockReturnValue({ data: undefined });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useForkTreasuryBalance(undefined));
+    expect(result.current).toBe(0n);
+  });
+
+  it('passes args correctly when address is provided', () => {
+    useBalanceMock.mockReturnValue({ data: { value: 0n } });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: 0n });
+    renderHook(() => useForkTreasuryBalance(TREASURY));
+    expect(useBalanceMock).toHaveBeenCalledWith({ address: TREASURY });
+    expect(useReadStEthBalanceOfMock).toHaveBeenCalledWith({
+      args: [TREASURY],
+      query: { enabled: true },
+    });
+  });
+
+  it('disables stETH query when no address', () => {
+    useBalanceMock.mockReturnValue({ data: undefined });
+    useReadStEthBalanceOfMock.mockReturnValue({ data: undefined });
+    renderHook(() => useForkTreasuryBalance(undefined));
+    expect(useReadStEthBalanceOfMock).toHaveBeenCalledWith({
+      args: undefined,
+      query: { enabled: false },
+    });
+  });
+});


### PR DESCRIPTION
## 概要

webapp hooks part 19 として wagmi 依存 2 hook (`useForkTreasuryBalance` / `useBlockTimestamp`) に vitest を追加、 test 件数を 458 → 470 (+12)。

## 課題

wagmi hook 依存の hook test は wallet provider 必須で従来 skip だったが、 wagmi 個別 hook を vi.fn で差替えれば independent test 可能 (part 18 の NetworkAlert で確立した pattern を hooks 全般に展開)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `useForkTreasuryBalance` | 7 | ETH+stETH 合算 / 両 0n / ETH/stETH 欠如 / undefined treasury / args 検証 / enabled 切替 |
| `useBlockTimestamp` | 5 | 初期 undefined / fetch 完了 / blockNumber 未指定 / error sink / timestamp=0 falsy guard |

## 解決方法

```mermaid
flowchart LR
    A[useBalance / useReadStEthBalanceOf] --> B[vi.fn で値切替]
    C[usePublicClient.getBlock] --> D[Promise 返却 mock]
    D --> E[renderHook + waitFor で非同期検証]
```

## 仕組み

`useForkTreasuryBalance` は ETH/stETH それぞれ undefined → 0n の nullish coalescing、 query.enabled は address の有無で gating。 `useBlockTimestamp` は useEffect で getBlock を呼び、 timestamp=0 は `|| undefined` で undefined に降格 (block 0 はチェーン起点で実 use case では出ない想定)。

## テスト

- [x] `pnpm vitest run` で 470 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 12 TC 全 pass
- [x] `pnpm vitest run` 全 472 test green
- [x] regression なし

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx