### PR TITLE
test(niji-webapp): component part 21 (VoteSignal/CandidateSponsorImage/ForkStatus) で 489 → 503 (+14)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.test.tsx
@@ -1,0 +1,24 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/Niji', () => ({
+  NijiImage: ({ nounId }: { nounId: bigint }) => (
+    <span data-testid="niji-image">{nounId.toString()}</span>
+  ),
+}));
+
+import CandidateSponsorImage from './CandidateSponsorImage';
+
+describe('CandidateSponsorImage', () => {
+  it('passes nounId to NijiImage', () => {
+    const { container } = render(<CandidateSponsorImage nounId={42n} />);
+    expect(container.querySelector('[data-testid="niji-image"]')?.textContent).toBe('42');
+  });
+
+  it('wraps NijiImage in a div with sponsorAvatar class', () => {
+    const { container } = render(<CandidateSponsorImage nounId={1n} />);
+    const div = container.querySelector('div');
+    expect(div).not.toBeNull();
+    expect(div?.querySelector('[data-testid="niji-image"]')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/ForkStatus/index.test.tsx
+++ b/packages/niji-webapp/src/components/ForkStatus/index.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ForkState } from '@/wrappers/nijiDao';
+
+import ForkStatus from './index';
+
+describe('ForkStatus', () => {
+  it('renders "In Escrow" for ESCROW status', () => {
+    const { container } = render(<ForkStatus status={ForkState.ESCROW} />);
+    expect(container.textContent).toBe('In Escrow');
+  });
+
+  it('renders "Forking" for ACTIVE status', () => {
+    const { container } = render(<ForkStatus status={ForkState.ACTIVE} />);
+    expect(container.textContent).toBe('Forking');
+  });
+
+  it('renders "Executed" for EXECUTED status', () => {
+    const { container } = render(<ForkStatus status={ForkState.EXECUTED} />);
+    expect(container.textContent).toBe('Executed');
+  });
+
+  it('renders "Undetermined" for undefined status (default branch)', () => {
+    const { container } = render(<ForkStatus />);
+    expect(container.textContent).toBe('Undetermined');
+  });
+
+  it('renders "Undetermined" for UNDETERMINED enum value', () => {
+    const { container } = render(<ForkStatus status={ForkState.UNDETERMINED} />);
+    expect(container.textContent).toBe('Undetermined');
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<ForkStatus status={ForkState.ACTIVE} className="extra" />);
+    expect(container.querySelector('div')?.className).toContain('extra');
+  });
+});

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignal.test.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignal.test.tsx
@@ -1,0 +1,70 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useEnsNameMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useEnsName: () => useEnsNameMock(),
+}));
+
+vi.mock('blo', () => ({
+  blo: () => 'data:image/png;base64,FAKE',
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+import VoteSignal from './VoteSignal';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+
+describe('VoteSignal', () => {
+  it('renders ShortAddress for given address', () => {
+    useEnsNameMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <VoteSignal support={1} voteCount={1} reason="ok" address={ADDR} />,
+    );
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe(ADDR);
+  });
+
+  it('renders avatar img when ENS is found', () => {
+    useEnsNameMock.mockReturnValue({ data: 'alice.eth' });
+    const { container } = render(
+      <VoteSignal support={1} voteCount={1} reason="ok" address={ADDR} />,
+    );
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('omits avatar img when ENS is missing', () => {
+    useEnsNameMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <VoteSignal support={1} voteCount={1} reason="ok" address={ADDR} />,
+    );
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('uses singular "vote" for voteCount=1', () => {
+    useEnsNameMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <VoteSignal support={1} voteCount={1} reason="ok" address={ADDR} />,
+    );
+    expect(container.textContent).toContain('1 vote');
+    expect(container.textContent).not.toContain('1 votes');
+  });
+
+  it('uses plural "votes" for voteCount=2', () => {
+    useEnsNameMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <VoteSignal support={1} voteCount={2} reason="ok" address={ADDR} />,
+    );
+    expect(container.textContent).toContain('2 votes');
+  });
+
+  it('renders reason text', () => {
+    useEnsNameMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <VoteSignal support={1} voteCount={1} reason="My reason here" address={ADDR} />,
+    );
+    expect(container.textContent).toContain('My reason here');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 21 として 3 file 14 TC、 test 件数を 489 → 503 (+14)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `VoteSignals/VoteSignal` | 6 | ShortAddress / ENS avatar 表示制御 / 単複切替 / reason |
| `CandidateCard/CandidateSponsorImage` | 2 | nounId 渡し + div wrap |
| `ForkStatus` | 6 | 4 status (ESCROW/ACTIVE/EXECUTED/Undetermined) + default 経路 + custom class |

## 解決方法

useEnsName / blo / 子 NijiImage / 子 ShortAddress を vi.mock で stub、 各 component の switch / 条件描画を独立検証。

## テスト

- [x] `pnpm vitest run` で 503 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 14 TC 全 pass
- [x] regression なし

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx