### PR TITLE
test(niji-webapp): component part 22 (LegacyNoun/NijiInfoCard/CreateProposalButton) で 503 → 522 (+19)

### DIFF
--- a/packages/niji-webapp/src/components/CreateProposalButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateProposalButton/index.test.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    number: (n: number) => String(n),
+  },
+}));
+
+import CreateProposalButton from './index';
+
+describe('CreateProposalButton', () => {
+  it('renders "Create Proposal" by default (hasEnough + no active)', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain('Create Proposal');
+  });
+
+  it('shows warning text when hasActiveOrPendingProposal=true', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain('You already have an active or pending proposal');
+  });
+
+  it('shows threshold warning when no enough votes + proposalThreshold set', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={false}
+        proposalThreshold={2}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    // threshold + 1 = 3 票必要
+    expect(container.textContent).toContain('3 votes to submit a proposal');
+  });
+
+  it('shows generic warning when no enough votes + no threshold', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain("don't have enough votes");
+  });
+
+  it('renders react-bootstrap Spinner when isLoading=true', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+    expect(container.textContent).not.toContain('Create Proposal');
+  });
+
+  it('button is disabled when no enough votes', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('button is disabled when hasActiveOrPendingProposal=true', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('button is disabled when isFormInvalid=true', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={true}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('fires handleCreateProposal on click when enabled', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
+++ b/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import LegacyNoun, { LoadingNoun } from './index';
+
+describe('LegacyNoun', () => {
+  it('renders img with given src + alt', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="my alt" />);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('/x.png');
+    expect(img?.getAttribute('alt')).toBe('my alt');
+  });
+
+  it('falls back to loading skull when imgPath is empty', () => {
+    const { container } = render(<LegacyNoun imgPath="" alt="x" />);
+    const src = container.querySelector('img')?.getAttribute('src') ?? '';
+    expect(src).toMatch(/loading-skull-noun/i);
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="x" className="extra" />);
+    expect(container.querySelector('img')?.className).toContain('extra');
+  });
+
+  it('merges custom wrapperClassName', () => {
+    const { container } = render(
+      <LegacyNoun imgPath="/x.png" alt="x" wrapperClassName="wrap-class" />,
+    );
+    const wrap = container.querySelector('div');
+    expect(wrap?.className).toContain('wrap-class');
+  });
+});
+
+describe('LoadingNoun', () => {
+  it('renders an img', () => {
+    const { container } = render(<LoadingNoun />);
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('loading noun');
+  });
+});

--- a/packages/niji-webapp/src/components/NijiInfoCard.test.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoCard.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/NijiInfoRowHolder', () => ({
+  default: ({ nounId }: { nounId: bigint }) => (
+    <span data-testid="holder">{nounId.toString()}</span>
+  ),
+}));
+
+const onClickHandlerCapture: { handlers: Array<() => void> } = { handlers: [] };
+vi.mock('@/components/NijiInfoRowButton', () => ({
+  default: ({
+    btnText,
+    onClickHandler,
+  }: {
+    btnText: React.ReactNode;
+    onClickHandler: () => void;
+  }) => {
+    onClickHandlerCapture.handlers.push(onClickHandler);
+    return <button onClick={onClickHandler}>{btnText}</button>;
+  },
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiTokenAddress: { 1: '0xTOKEN' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanTokenLink: (addr: string, id: number) =>
+    `https://etherscan.io/token/${addr}?a=${id}`,
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+import NijiInfoCard from './NijiInfoCard';
+
+describe('NijiInfoCard', () => {
+  beforeEach(() => {
+    onClickHandlerCapture.handlers.length = 0;
+  });
+
+  it('renders holder + 2 buttons (Bid history + Etherscan)', () => {
+    useAtomValueMock.mockReturnValue(undefined);
+    const { container } = render(<NijiInfoCard nounId={1n} bidHistoryOnClickHandler={() => {}} />);
+    expect(container.querySelector('[data-testid="holder"]')?.textContent).toBe('1');
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(2);
+  });
+
+  it('shows "Bids" when nounId === lastAuctionNounId', () => {
+    useAtomValueMock.mockReturnValue('1');
+    const { container } = render(<NijiInfoCard nounId={1n} bidHistoryOnClickHandler={() => {}} />);
+    const firstButton = container.querySelectorAll('button')[0];
+    expect(firstButton?.textContent).toBe('Bids');
+  });
+
+  it('shows "Bid history" when nounId !== lastAuctionNounId', () => {
+    useAtomValueMock.mockReturnValue('99');
+    const { container } = render(<NijiInfoCard nounId={1n} bidHistoryOnClickHandler={() => {}} />);
+    const firstButton = container.querySelectorAll('button')[0];
+    expect(firstButton?.textContent).toBe('Bid history');
+  });
+
+  it('fires bidHistoryOnClickHandler on Bid button click', () => {
+    useAtomValueMock.mockReturnValue(undefined);
+    const handler = vi.fn();
+    const { container } = render(<NijiInfoCard nounId={1n} bidHistoryOnClickHandler={handler} />);
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens etherscan on Etherscan button click', () => {
+    useAtomValueMock.mockReturnValue(undefined);
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const { container } = render(<NijiInfoCard nounId={42n} bidHistoryOnClickHandler={() => {}} />);
+    fireEvent.click(container.querySelectorAll('button')[1]);
+    expect(openSpy).toHaveBeenCalledWith('https://etherscan.io/token/0xTOKEN?a=42');
+    openSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 22 として 3 file 19 TC、 test 件数を 503 → 522 (+19)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `LegacyNoun` | 5 | src/alt forward / fallback loading / className/wrapperClassName + LoadingNoun |
| `NijiInfoCard` | 5 | holder + 2 button + Bids/Bid history 切替 + 2 click |
| `CreateProposalButton` | 9 | 3 button text + Spinner + 3 disable 経路 + click + threshold 表示 |

## 解決方法

子 component (NijiInfoRowHolder / NijiInfoRowButton) を vi.mock で stub 化、 props/onClick 経路を独立検証。 CreateProposalButton は disable 3 経路 (isFormInvalid / hasActiveOrPending / !hasEnoughVote) を全件確認。

## テスト

- [x] `pnpm vitest run` で 522 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 19 TC 全 pass
- [x] regression なし

Closes #370

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx