### PR TITLE
test(niji-webapp): component part 23 (test-utils + HoverCard/Trait/NijiInfoRowHolder) で 522 → 537 (+15)

### DIFF
--- a/packages/niji-webapp/src/components/HoverCard.test.tsx
+++ b/packages/niji-webapp/src/components/HoverCard.test.tsx
@@ -1,0 +1,50 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { WithProviders } from '@/test-utils/providers';
+
+import HoverCard from './HoverCard';
+
+describe('HoverCard', () => {
+  it('renders children inside the trigger span', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={t => <div>{t}</div>} tip="hello" id="x">
+        Trigger
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    expect(container.querySelector('span')?.textContent).toBe('Trigger');
+  });
+
+  it('passes children as ReactNode (nested)', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={() => <></>} tip="x" id="x">
+        <strong>bold</strong>
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    expect(container.querySelector('strong')?.textContent).toBe('bold');
+  });
+
+  it('renders without crashing when hoverCardContent returns null', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={() => null} tip="" id="x">
+        Hi
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    expect(container.querySelector('span')?.textContent).toBe('Hi');
+  });
+
+  it('does NOT render TooltipContent until trigger is hovered (portal default closed)', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={t => <span>tip-{t}</span>} tip="abc" id="x">
+        Trigger
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    // Radix Portal はトリガー前は Portal 本体を生成しない経路、
+    // span 経由でも tip-abc 文字は確認されない (closed state)
+    expect(container.textContent).toBe('Trigger');
+  });
+});

--- a/packages/niji-webapp/src/components/NijiInfoRowHolder.test.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoRowHolder.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => (
+    <span data-testid="short">{address.slice(0, 6)}</span>
+  ),
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiAuctionHouseAddress: { 1: '0xAUCTIONHOUSE' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+vi.mock('@/wrappers/subgraph', () => ({
+  auctionQuery: 'AUCTION_QUERY_PLACEHOLDER',
+}));
+
+const executeMock = vi.fn();
+vi.mock('@/subgraphs/execute', () => ({
+  execute: () => executeMock(),
+}));
+
+import { WithProviders } from '@/test-utils/providers';
+
+import NijiInfoRowHolder from './NijiInfoRowHolder';
+
+describe('NijiInfoRowHolder', () => {
+  it('renders Loading text while query is pending', () => {
+    executeMock.mockReturnValue(new Promise(() => {}));
+    const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
+    expect(container.textContent).toBe('Loading...');
+  });
+
+  it('renders nothing when winner is missing', async () => {
+    executeMock.mockResolvedValue({ auction: null });
+    const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
+    await waitFor(() => expect(container.textContent).toBe(''));
+  });
+
+  it('renders winner ShortAddress + etherscan link when winner is not auction house', async () => {
+    executeMock.mockResolvedValue({ auction: { bidder: { id: '0xBIDDER' } } });
+    const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xBIDD');
+    });
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(
+      'https://etherscan.io/address/0xBIDDER',
+    );
+    expect(container.querySelector('a')?.getAttribute('target')).toBe('_blank');
+    expect(container.querySelector('a')?.getAttribute('rel')).toBe('noreferrer');
+  });
+
+  it('renders "Niji Auction House" when winner equals auction house address', async () => {
+    executeMock.mockResolvedValue({ auction: { bidder: { id: '0xAUCTIONHOUSE' } } });
+    const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
+    await waitFor(() => {
+      expect(container.textContent).toContain('Niji Auction House');
+    });
+    expect(container.querySelector('[data-testid="short"]')).toBeNull();
+  });
+
+  it('merges custom className', async () => {
+    executeMock.mockResolvedValue({ auction: { bidder: { id: '0xBIDDER' } } });
+    const { container } = render(<NijiInfoRowHolder nounId={1n} className="extra" />, {
+      wrapper: WithProviders,
+    });
+    await waitFor(() => {
+      expect(container.querySelector('span')?.className).toContain('extra');
+    });
+  });
+
+  it('renders external link icon (svg)', async () => {
+    executeMock.mockResolvedValue({ auction: { bidder: { id: '0xBIDDER' } } });
+    const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
+    await waitFor(() => {
+      expect(container.querySelector('svg')).not.toBeNull();
+    });
+  });
+});

--- a/packages/niji-webapp/src/components/Trait.test.tsx
+++ b/packages/niji-webapp/src/components/Trait.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@niji/sdk', () => ({
+  buildSVG: () => '<svg></svg>',
+}));
+
+vi.mock('@/lib/nijiAssets', () => ({
+  NijiImageData: {
+    images: {
+      hat: [{ data: '0xABCDEF', filename: 'hat-1' }],
+      special: [],
+    },
+    palette: ['#000000', '#ffffff'],
+  },
+}));
+
+import { WithProviders } from '@/test-utils/providers';
+
+import { Trait } from './Trait';
+
+const FALLBACK_TRANSPARENT = 'data:image/gif;base64,';
+
+describe('Trait', () => {
+  it('renders an <img> element', () => {
+    const { container } = render(<Trait type="hat" seed={0} />, { wrapper: WithProviders });
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('uses transparent fallback when seed is undefined (query disabled)', () => {
+    const { container } = render(<Trait type="hat" />, { wrapper: WithProviders });
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toContain(FALLBACK_TRANSPARENT);
+  });
+
+  it('produces an svg-data URL after query resolves', async () => {
+    const { container } = render(<Trait type="hat" seed={0} />, { wrapper: WithProviders });
+    await waitFor(() => {
+      const src = container.querySelector('img')?.getAttribute('src') ?? '';
+      expect(src.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    });
+  });
+
+  it('falls back when image data is empty (no seed match)', async () => {
+    const { container } = render(<Trait type="special" seed={0} />, { wrapper: WithProviders });
+    // image not found -> buildSVG([], palette) は mock 上 '<svg></svg>' を返すので非 fallback パス
+    await waitFor(() => {
+      const src = container.querySelector('img')?.getAttribute('src') ?? '';
+      expect(src.startsWith('data:image/svg+xml;base64,')).toBe(true);
+    });
+  });
+
+  it('forwards arbitrary img attributes (className)', () => {
+    const { container } = render(<Trait type="hat" className="custom-trait" />, {
+      wrapper: WithProviders,
+    });
+    expect(container.querySelector('img')?.className).toBe('custom-trait');
+  });
+});

--- a/packages/niji-webapp/src/test-utils/providers.tsx
+++ b/packages/niji-webapp/src/test-utils/providers.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+/**
+ * vitest 用の共通 Provider wrapper。
+ *
+ * TanStack QueryClient + Radix TooltipProvider を一括で提供する。
+ * 各 test で `render(ui, { wrapper: WithProviders })` のように使う。
+ */
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+export function WithProviders({ children }: { children: React.ReactNode }) {
+  const client = makeQueryClient();
+  return (
+    <QueryClientProvider client={client}>
+      <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## 概要

webapp component part 23 として共通 Provider wrapper を新設し、 これに依存する 3 component に vitest を追加、 test 件数を 522 → 537 (+15)。

## 課題

部分 1-22 では QueryClient / TooltipProvider 必要 component は Provider 構築なしに render できず skip。 共通 test-utils を作って 1 ファイルで再利用すれば 10+ 件の Provider 依存 component が cover 可能化する。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `src/test-utils/providers.tsx` | (new) | makeQueryClient + WithProviders export |
| `HoverCard` | 4 | trigger span / nested child / null content / portal default closed |
| `Trait` | 5 | img / seed なし fallback / svg base64 / image なし / className |
| `NijiInfoRowHolder` | 6 | loading / winner なし / 通常 winner / Auction House 切替 / className / external icon |

## 解決方法

```mermaid
flowchart LR
    A[WithProviders] --> B[QueryClient retry:false gcTime:0]
    A --> C[TooltipProvider delayDuration:0]
    D[各 test] --> E[render(ui, { wrapper: WithProviders })]
    E --> F[wagmi/SDK 依存は vi.mock で stub]
```

QueryClient は test 用に retry:false + gcTime:0、 TooltipProvider は delayDuration:0 で確実 hover 応答。 `render(ui, { wrapper: WithProviders })` に wagmi/SDK は vi.mock を別途並用。

## 仕組み

`Trait` は useQuery で trait svg を build (seed 未指定で enabled:false → 初期 fallback)、 `NijiInfoRowHolder` は execute(auctionQuery) で auction.bidder.id を取得、 同 chain auction house と一致なら "Niji Auction House"、 不一致なら ShortAddress + etherscan link。 `HoverCard` は Radix Tooltip wrap、 trigger span に children を埋め込み hover で content portal を開く。

## テスト

- [x] `pnpm vitest run` で 537 pass + 1 todo (regression なし)
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 15 TC 全 pass
- [x] regression なし

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx