### PR TITLE
test(niji-webapp): component part 24 (GrayCircle/CurrentBid/NavBarTreasury) で 537 → 553 (+16)

### DIFF
--- a/packages/niji-webapp/src/components/CurrentBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/CurrentBid/index.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { parseEther } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+import CurrentBid, { BID_N_A } from './index';
+
+describe('CurrentBid', () => {
+  it('renders "Current bid" when auctionEnded=false', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />);
+    expect(container.textContent).toContain('Current bid');
+  });
+
+  it('renders "Winning bid" when auctionEnded=true', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={parseEther('1')} auctionEnded={true} />);
+    expect(container.textContent).toContain('Winning bid');
+  });
+
+  it('renders truncated amount when currentBid is bigint', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <CurrentBid currentBid={parseEther('2.5')} auctionEnded={false} />,
+    );
+    expect(container.textContent).toContain('Ξ 2.50');
+  });
+
+  it('renders "-" placeholder when currentBid === BID_N_A', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={BID_N_A} auctionEnded={false} />);
+    expect(container.textContent).toContain('-');
+    expect(container.textContent).not.toContain('Ξ');
+  });
+
+  it('uses cool color text when isCool=true', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />);
+    expect(container.querySelector('h4')?.getAttribute('style')).toContain('brand-cool-light-text');
+    expect(container.querySelector('h2')?.getAttribute('style')).toContain('brand-cool-dark-text');
+  });
+
+  it('uses warm color text when isCool=false', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { container } = render(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />);
+    expect(container.querySelector('h4')?.getAttribute('style')).toContain('brand-warm-light-text');
+    expect(container.querySelector('h2')?.getAttribute('style')).toContain('brand-warm-dark-text');
+  });
+});

--- a/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
@@ -1,0 +1,33 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/grayBackgroundSVG', () => ({
+  getGrayBackgroundSVG: () => 'data:image/svg+xml;base64,FAKE',
+}));
+
+import { GrayCircle } from './index';
+
+describe('GrayCircle', () => {
+  it('renders LegacyNoun img with gray background svg src', () => {
+    const { container } = render(<GrayCircle />);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('src')).toBe('data:image/svg+xml;base64,FAKE');
+  });
+
+  it('uses non-delegate (default) wrapper className', () => {
+    const { container } = render(<GrayCircle />);
+    const wrap = container.querySelector('div');
+    expect(wrap?.className).toBe('');
+  });
+
+  it('uses delegate wrapper className when isDelegateView=true', () => {
+    const { container } = render(<GrayCircle isDelegateView={true} />);
+    const wrap = container.querySelector('div');
+    expect(wrap?.className).not.toBe('');
+  });
+
+  it('passes alt="" (empty alt for decorative image)', () => {
+    const { container } = render(<GrayCircle />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('');
+  });
+});

--- a/packages/niji-webapp/src/components/NavBarTreasury/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBarTreasury/index.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    number: (n: number) => n.toLocaleString('en-US'),
+  },
+}));
+
+import { NavBarButtonStyle } from '@/components/NavBarButton';
+
+import NavBarTreasury from './index';
+
+describe('NavBarTreasury', () => {
+  it('renders Treasury label + Ξ amount', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="123456" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    expect(container.textContent).toContain('Treasury');
+    expect(container.textContent).toContain('Ξ');
+    expect(container.textContent).toContain('123,456');
+  });
+
+  it('uses warmInfo class for WARM_INFO style', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.WARM_INFO} />,
+    );
+    expect(container.querySelector('div')?.className).toMatch(/warm/i);
+  });
+
+  it('uses coolInfo class for COOL_INFO style', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.COOL_INFO} />,
+    );
+    expect(container.querySelector('div')?.className).toMatch(/cool/i);
+  });
+
+  it('uses whiteInfo class for WHITE_INFO style', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    expect(container.querySelector('div')?.className).toMatch(/white/i);
+  });
+
+  it('uses whiteInfo class for default (other) style (e.g. DELEGATE_BACK)', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.DELEGATE_BACK} />,
+    );
+    expect(container.querySelector('div')?.className).toMatch(/white/i);
+  });
+
+  it('applies whiteTreasuryHeader class only when WHITE_INFO', () => {
+    const { container: w } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    const { container: c } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.WARM_INFO} />,
+    );
+    const wHeader = w.querySelectorAll('div')[3]?.className ?? '';
+    const cHeader = c.querySelectorAll('div')[3]?.className ?? '';
+    expect(wHeader).toMatch(/white/i);
+    expect(cHeader).not.toMatch(/whiteTreasuryHeader/);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 24 として 3 file 16 TC、 test 件数を 537 → 553 (+16)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `GrayCircle` | 4 | gray svg src / 非 delegate / delegate wrapper class / alt 空 |
| `CurrentBid` | 6 | current/winning 切替 / TruncatedAmount / BID_N_A "-" / cool/warm 色 |
| `NavBarTreasury` | 6 | Treasury label + Ξ + i18n.number / 3 style + default + whiteTreasuryHeader gating |

## 解決方法

`getGrayBackgroundSVG` / `i18n.number` / `useAtomValue` / `Trans` を file 毎に vi.mock、 `NavBarButtonStyle` enum は実 import で型保証 + 5 経路 (WHITE/WARM/COOL/default + whiteTreasuryHeader gating) を網羅。

## テスト

- [x] `pnpm vitest run` で 553 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 16 TC 全 pass
- [x] regression なし

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx