### PR TITLE
test(niji-webapp): component part 25 (ProposalCandidateContent/ThemeProvider/EditProposalButton/LanguageSelectionModal) で 553 → 573 (+20)

### DIFF
--- a/packages/niji-webapp/src/components/EditProposalButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/EditProposalButton/index.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    number: (n: number) => String(n),
+  },
+}));
+
+import EditProposalButton from './index';
+
+const defaults = {
+  isLoading: false,
+  hasActiveOrPendingProposal: false,
+  hasEnoughVote: true,
+  isFormInvalid: false,
+  handleCreateProposal: () => {},
+};
+
+describe('EditProposalButton', () => {
+  it('renders "Update Proposal" by default (proposal)', () => {
+    const { container } = render(<EditProposalButton {...defaults} />);
+    expect(container.textContent).toBe('Update Proposal');
+  });
+
+  it('renders "Update Proposal Candidate" when isCandidate=true', () => {
+    const { container } = render(<EditProposalButton {...defaults} isCandidate={true} />);
+    expect(container.textContent).toBe('Update Proposal Candidate');
+  });
+
+  it('shows warning when hasActiveOrPendingProposal=true', () => {
+    const { container } = render(
+      <EditProposalButton {...defaults} hasActiveOrPendingProposal={true} />,
+    );
+    expect(container.textContent).toContain('You already have an active or pending proposal');
+  });
+
+  it('shows threshold warning when no enough votes + threshold set', () => {
+    const { container } = render(
+      <EditProposalButton {...defaults} hasEnoughVote={false} proposalThreshold={2} />,
+    );
+    expect(container.textContent).toContain('3 votes to submit a proposal');
+  });
+
+  it('shows generic warning when no enough votes + no threshold', () => {
+    const { container } = render(<EditProposalButton {...defaults} hasEnoughVote={false} />);
+    expect(container.textContent).toContain("don't have enough votes");
+  });
+
+  it('renders Spinner when isLoading=true', () => {
+    const { container } = render(<EditProposalButton {...defaults} isLoading={true} />);
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('button disabled when invalid form / no votes / active', () => {
+    const { container: a } = render(<EditProposalButton {...defaults} isFormInvalid={true} />);
+    const { container: b } = render(<EditProposalButton {...defaults} hasEnoughVote={false} />);
+    const { container: c } = render(
+      <EditProposalButton {...defaults} hasActiveOrPendingProposal={true} />,
+    );
+    expect(a.querySelector('button')?.disabled).toBe(true);
+    expect(b.querySelector('button')?.disabled).toBe(true);
+    expect(c.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('fires handleCreateProposal on click when enabled', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <EditProposalButton {...defaults} handleCreateProposal={handle} />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAtomMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtom: () => useAtomMock(),
+}));
+
+import LanguageSelectionModal from './index';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="backdrop-root"></div><div id="overlay-root"></div>';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('LanguageSelectionModal', () => {
+  it('renders Select Language title in modal overlay', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.querySelector('h3')?.textContent).toBe(
+      'Select Language',
+    );
+  });
+
+  it('renders 3 language buttons (ja/en/zh)', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    const buttons = document.getElementById('overlay-root')?.querySelectorAll('.languageButton');
+    // CSS Modules でクラス名が変わるので textContent で確認
+    const overlay = document.getElementById('overlay-root');
+    const text = overlay?.textContent ?? '';
+    expect(text).toContain('日本語');
+    expect(text).toContain('English');
+    expect(text).toContain('中文');
+  });
+
+  it('shows Check icon next to active locale', () => {
+    useAtomMock.mockReturnValue(['ja-JP', vi.fn()]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    const overlay = document.getElementById('overlay-root');
+    expect(overlay?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('calls setActiveLocale + onDismiss on language click', () => {
+    const setLocale = vi.fn();
+    const onDismiss = vi.fn();
+    useAtomMock.mockReturnValue(['ja-JP', setLocale]);
+    render(<LanguageSelectionModal onDismiss={onDismiss} />);
+    const overlay = document.getElementById('overlay-root');
+    // 日本語ボタンを探してクリック
+    const buttons = overlay?.querySelectorAll('div');
+    const jaBtn = Array.from(buttons ?? []).find(d => d.textContent === '日本語');
+    if (jaBtn) fireEvent.click(jaBtn);
+    expect(setLocale).toHaveBeenCalledWith('ja-JP');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalCandidateContent.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalCandidateContent.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./ProposalTransactions', () => ({
+  default: ({ details }: { details: unknown[] }) => (
+    <div data-testid="proposal-tx">tx-count={details.length}</div>
+  ),
+}));
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock('remark-breaks', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/utils/processProposalDescriptionText', () => ({
+  processProposalDescriptionText: (desc: string, title: string) => `[${title}]${desc}`,
+}));
+
+import ProposalCandidateContent from './ProposalCandidateContent';
+
+const baseProposal = {
+  version: {
+    content: {
+      title: 'My Title',
+      description: '# Body',
+      details: [{ target: '0xA' }, { target: '0xB' }],
+    },
+  },
+} as never;
+
+describe('ProposalCandidateContent', () => {
+  it('renders "Description" + "Proposed Transactions" headings when proposal is present', () => {
+    const { container } = render(<ProposalCandidateContent proposal={baseProposal} />);
+    expect(container.textContent).toContain('Description');
+    expect(container.textContent).toContain('Proposed Transactions');
+  });
+
+  it('does NOT render Proposed Transactions when proposal is undefined', () => {
+    const { container } = render(<ProposalCandidateContent />);
+    expect(container.textContent).toContain('Description');
+    expect(container.textContent).not.toContain('Proposed Transactions');
+  });
+
+  it('passes processed description text to ReactMarkdown', () => {
+    const { container } = render(<ProposalCandidateContent proposal={baseProposal} />);
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe(
+      '[My Title]# Body',
+    );
+  });
+
+  it('does NOT render markdown when description is empty', () => {
+    const proposalEmpty = {
+      version: {
+        content: { title: 't', description: '', details: [] },
+      },
+    } as never;
+    const { container } = render(<ProposalCandidateContent proposal={proposalEmpty} />);
+    expect(container.querySelector('[data-testid="markdown"]')).toBeNull();
+  });
+
+  it('passes details count to ProposalTransactions', () => {
+    const { container } = render(<ProposalCandidateContent proposal={baseProposal} />);
+    expect(container.querySelector('[data-testid="proposal-tx"]')?.textContent).toBe('tx-count=2');
+  });
+});

--- a/packages/niji-webapp/src/components/ThemeProvider.test.tsx
+++ b/packages/niji-webapp/src/components/ThemeProvider.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-themes', () => ({
+  ThemeProvider: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & Record<string, unknown>) => (
+    <div data-testid="next-themes-provider" data-attribute={String(props.attribute ?? '')}>
+      {children}
+    </div>
+  ),
+}));
+
+import { ThemeProvider } from './ThemeProvider';
+
+describe('ThemeProvider', () => {
+  it('renders NextThemesProvider with children', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>child</span>
+      </ThemeProvider>,
+    );
+    expect(container.querySelector('[data-testid="next-themes-provider"]')).not.toBeNull();
+    expect(container.querySelector('span')?.textContent).toBe('child');
+  });
+
+  it('forwards arbitrary props to NextThemesProvider', () => {
+    const { container } = render(
+      <ThemeProvider attribute="class">
+        <span>x</span>
+      </ThemeProvider>,
+    );
+    expect(
+      container
+        .querySelector('[data-testid="next-themes-provider"]')
+        ?.getAttribute('data-attribute'),
+    ).toBe('class');
+  });
+
+  it('renders multiple children inside provider', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>a</span>
+        <span>b</span>
+      </ThemeProvider>,
+    );
+    const spans = container.querySelectorAll('span');
+    expect(spans.length).toBe(2);
+    expect(spans[0].textContent).toBe('a');
+    expect(spans[1].textContent).toBe('b');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 25 として 4 file 20 TC、 test 件数を 553 → 573 (+20)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `ProposalCandidateContent` | 5 | Description/Transactions 切替 / 子 ProposalTransactions 数 / ReactMarkdown 処理済テキスト |
| `ThemeProvider` | 3 | children pass-through / attribute forward / multiple |
| `EditProposalButton` | 8 | Update/Candidate label + 3 warning + Spinner + disable 3 + click |
| `LanguageSelectionModal` | 4 | Modal portal pattern + 3 言語 + Check icon + setLocale/onDismiss |

## 解決方法

ReactMarkdown / remark-breaks / ProposalTransactions を vi.mock で stub、 LanguageSelectionModal は part 16 で確立した backdrop-root/overlay-root 注入 pattern を再利用。

## テスト

- [x] `pnpm vitest run` で 573 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 4 file 計 20 TC 全 pass
- [x] regression なし

Closes #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx