### PR TITLE
test(niji-webapp): component part 26 (CustomConnectkit/TightStackedCircleNiji/NijidersRewardSection) で 573 → 585 (+12)

### DIFF
--- a/packages/niji-webapp/src/components/CustomConnectkitProvider.test.tsx
+++ b/packages/niji-webapp/src/components/CustomConnectkitProvider.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+const optionsCapture: { language?: string } = {};
+vi.mock('connectkit', () => ({
+  ConnectKitProvider: ({
+    children,
+    options,
+  }: {
+    children: React.ReactNode;
+    options: { language?: string };
+  }) => {
+    optionsCapture.language = options.language;
+    return <div data-testid="ckp">{children}</div>;
+  },
+}));
+
+import { CustomConnectkitProvider } from './CustomConnectkitProvider';
+
+describe('CustomConnectkitProvider', () => {
+  it('renders ConnectKitProvider wrapping children', () => {
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { container } = render(
+      <CustomConnectkitProvider>
+        <span>child</span>
+      </CustomConnectkitProvider>,
+    );
+    expect(container.querySelector('[data-testid="ckp"]')).not.toBeNull();
+    expect(container.querySelector('span')?.textContent).toBe('child');
+  });
+
+  it('forwards en-US locale option', () => {
+    useActiveLocaleMock.mockReturnValue('en-US');
+    render(
+      <CustomConnectkitProvider>
+        <span>x</span>
+      </CustomConnectkitProvider>,
+    );
+    expect(optionsCapture.language).toBe('en-US');
+  });
+
+  it('forwards ja-JP locale option', () => {
+    useActiveLocaleMock.mockReturnValue('ja-JP');
+    render(
+      <CustomConnectkitProvider>
+        <span>x</span>
+      </CustomConnectkitProvider>,
+    );
+    expect(optionsCapture.language).toBe('ja-JP');
+  });
+
+  it('replaces pseudo locale with en-US (fallback)', () => {
+    useActiveLocaleMock.mockReturnValue('pseudo');
+    render(
+      <CustomConnectkitProvider>
+        <span>x</span>
+      </CustomConnectkitProvider>,
+    );
+    expect(optionsCapture.language).toBe('en-US');
+  });
+});

--- a/packages/niji-webapp/src/components/Documentation/NijidersRewardSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/NijidersRewardSection.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { Accordion } from 'react-bootstrap';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Link', () => ({
+  default: ({ text, url }: { text: React.ReactNode; url: string }) => <a href={url}>{text}</a>,
+}));
+
+import { NijidersRewardSection } from './NijidersRewardSection';
+
+const wrap = (ui: React.ReactElement) =>
+  render(
+    <Accordion alwaysOpen defaultActiveKey="8">
+      {ui}
+    </Accordion>,
+  );
+
+describe('NijidersRewardSection', () => {
+  it('renders "Nijider\'s Reward" header', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    expect(container.textContent).toContain("Nijider's Reward");
+  });
+
+  it('renders 10 nijider links', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    expect(container.querySelectorAll('a').length).toBe(10);
+  });
+
+  it('includes @cryptoseneca link with twitter url', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    const a = Array.from(container.querySelectorAll('a')).find(el =>
+      el.textContent?.includes('cryptoseneca'),
+    );
+    expect(a?.getAttribute('href')).toBe('https://twitter.com/cryptoseneca');
+  });
+
+  it('includes @devcarrot with carrot_init url (handle/url mismatch is intentional)', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    const a = Array.from(container.querySelectorAll('a')).find(el =>
+      el.textContent?.includes('devcarrot'),
+    );
+    expect(a?.getAttribute('href')).toBe('https://twitter.com/carrot_init');
+  });
+});

--- a/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
@@ -1,0 +1,58 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useNounSeedMock = vi.fn();
+vi.mock('@/wrappers/nijiToken', () => ({
+  useNounSeed: () => useNounSeedMock(),
+}));
+
+vi.mock('@/components/LegacyNoun', () => ({
+  LoadingNoun: () => <span data-testid="loading-noun" />,
+}));
+
+const getNijiMock = vi.fn();
+vi.mock('@/components/Niji', () => ({
+  getNiji: () => getNijiMock(),
+}));
+
+import TightStackedCircleNiji from './index';
+
+const renderSvg = (props: React.ComponentProps<typeof TightStackedCircleNiji>) =>
+  render(
+    <svg>
+      <TightStackedCircleNiji {...props} />
+    </svg>,
+  );
+
+describe('TightStackedCircleNiji', () => {
+  it('renders LoadingNoun while seed is undefined', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    const { container } = renderSvg({ nounId: 1, index: 0, square: 55, shift: 3 });
+    expect(container.querySelector('[data-testid="loading-noun"]')).not.toBeNull();
+  });
+
+  it('renders SVG image when seed is present', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'data:image/svg+xml;base64,FAKE' });
+    const { container } = renderSvg({ nounId: 1, index: 0, square: 55, shift: 3 });
+    expect(container.querySelector('image')?.getAttribute('href')).toBe(
+      'data:image/svg+xml;base64,FAKE',
+    );
+  });
+
+  it('places circle with id matching nounId', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'data:image/svg+xml;base64,X' });
+    const { container } = renderSvg({ nounId: 42, index: 0, square: 55, shift: 3 });
+    expect(container.querySelector('circle')?.getAttribute('id')).toBe('42');
+  });
+
+  it('shifts position by index*shift', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'x' });
+    const { container } = renderSvg({ nounId: 1, index: 2, square: 55, shift: 3 });
+    const circle = container.querySelector('circle');
+    expect(circle?.getAttribute('cx')).toBe('34'); // 28 + 2*3
+    expect(circle?.getAttribute('cy')).toBe('28'); // 55 - 21 - 2*3
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 26 として 3 file 12 TC、 test 件数を 573 → 585 (+12)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `CustomConnectkitProvider` | 4 | children / en-US/ja-JP forward / pseudo→en-US fallback |
| `TightStackedCircleNiji` | 4 | LoadingNoun gating / SVG image / circle id / index*shift position |
| `Documentation/NijidersRewardSection` | 4 | header / 10 link / cryptoseneca URL / devcarrot URL ミスマッチ |

## 解決方法

useActiveLocale / useNounSeed / getNiji を vi.fn 差替えで分岐を網羅、 ConnectKitProvider は data-testid stub で options.language を capture、 Accordion 配下の 10 link は href で個別検証。

## テスト

- [x] `pnpm vitest run` で 585 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 12 TC 全 pass
- [x] regression なし

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx