### PR TITLE
test(niji-webapp): component part 27 (GovernanceSection/CurrentDelegatePannel/DelegateHoverCard) で 585 → 598 (+13)

### DIFF
--- a/packages/niji-webapp/src/components/CurrentDelegatePannel/index.test.tsx
+++ b/packages/niji-webapp/src/components/CurrentDelegatePannel/index.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAccountMock = vi.fn();
+const useReadNijiTokenDelegatesMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useAccount: () => useAccountMock(),
+}));
+vi.mock('@niji/sdk/react', () => ({
+  useReadNijiTokenDelegates: () => useReadNijiTokenDelegatesMock(),
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/components/NavBarButton', () => {
+  const NavBarButtonStyle = {
+    DELEGATE_BACK: 'back',
+    DELEGATE_PRIMARY: 'primary',
+  };
+  const NavBarButton = ({
+    buttonText,
+    onClick,
+  }: {
+    buttonText: React.ReactNode;
+    buttonStyle: string;
+    onClick: React.MouseEventHandler<HTMLButtonElement>;
+  }) => <button onClick={onClick}>{buttonText}</button>;
+  return { default: NavBarButton, NavBarButtonStyle };
+});
+
+import CurrentDelegatePannel from './index';
+
+describe('CurrentDelegatePannel', () => {
+  it('uses delegate from sdk when available', () => {
+    useAccountMock.mockReturnValue({ address: '0xACCOUNT' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: '0xDELEGATE' });
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+    );
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xDELEGATE');
+  });
+
+  it('falls back to connected account when no delegate', () => {
+    useAccountMock.mockReturnValue({ address: '0xACCOUNT' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+    );
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xACCOUNT');
+  });
+
+  it('falls back to "0x" placeholder when no account + no delegate', () => {
+    useAccountMock.mockReturnValue({ address: undefined });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+    );
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0x');
+  });
+
+  it('fires onSecondaryBtnClick on Close button click', () => {
+    useAccountMock.mockReturnValue({ address: '0xACCOUNT' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const onSec = vi.fn();
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={onSec} />,
+    );
+    const buttons = container.querySelectorAll('button');
+    fireEvent.click(buttons[0]);
+    expect(onSec).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onPrimaryBtnClick on Update Delegate button click', () => {
+    useAccountMock.mockReturnValue({ address: '0xACCOUNT' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const onPri = vi.fn();
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={onPri} onSecondaryBtnClick={() => {}} />,
+    );
+    const buttons = container.querySelectorAll('button');
+    fireEvent.click(buttons[1]);
+    expect(onPri).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders Delegation title', () => {
+    useAccountMock.mockReturnValue({ address: '0xACCOUNT' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+    );
+    expect(container.querySelector('h1')?.textContent).toBe('Delegation');
+  });
+});

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useDelegateNounsAtBlockQueryMock = vi.fn();
+vi.mock('@/wrappers/nijiToken', () => ({
+  useDelegateNounsAtBlockQuery: () => useDelegateNounsAtBlockQueryMock(),
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/components/HorizontalStackedNijis', () => ({
+  default: ({ nounIds }: { nounIds: string[] }) => (
+    <div data-testid="stacked">stack-{nounIds.length}</div>
+  ),
+}));
+
+import DelegateHoverCard from './index';
+
+describe('DelegateHoverCard', () => {
+  it('renders Spinner while loading', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xABC" proposalCreationBlock={1n} />,
+    );
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('renders error fallback when error is set', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xABC', nijiRepresented: [{ id: '1' }] }] },
+      loading: false,
+      error: new Error('boom'),
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xABC" proposalCreationBlock={1n} />,
+    );
+    expect(container.textContent).toBe('Error fetching Vote info');
+  });
+
+  it('renders Spinner when delegates is empty', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: { delegates: [] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xABC" proposalCreationBlock={1n} />,
+    );
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('renders ShortAddress + stacked nijis when data is present', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: {
+        delegates: [{ id: '0xABCDEF', nijiRepresented: [{ id: '1' }, { id: '2' }, { id: '3' }] }],
+      },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xABCDEF" proposalCreationBlock={1n} />,
+    );
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xABCDEF');
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-3');
+  });
+});

--- a/packages/niji-webapp/src/components/Documentation/GovernanceSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/GovernanceSection.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { Accordion } from 'react-bootstrap';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { GovernanceSection } from './GovernanceSection';
+
+const wrap = (ui: React.ReactElement) =>
+  render(
+    <Accordion alwaysOpen defaultActiveKey="4">
+      {ui}
+    </Accordion>,
+  );
+
+describe('GovernanceSection', () => {
+  it('renders accordion header with "Governance ‘Slow Start’"', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect(container.textContent).toContain('Slow Start');
+  });
+
+  it('renders body content mentioning treasury attack risk', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect(container.textContent).toContain('51% attacks');
+    expect(container.textContent).toContain('treasury');
+  });
+
+  it('renders body content mentioning Nijiders', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect(container.textContent).toContain('Nijiders');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 27 として 3 file 13 TC、 test 件数を 585 → 598 (+13)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `Documentation/GovernanceSection` | 3 | Slow Start header / 51% 文言 / Nijiders 文言 |
| `CurrentDelegatePannel` | 6 | delegate 優先 / account fallback / 0x placeholder / 2 button click / Delegation title |
| `DelegateHoverCard` | 4 | Spinner loading / error fallback / 空 delegates / 正常 ShortAddress+stacked |

## 解決方法

useAccount / useReadNijiTokenDelegates / useDelegateNounsAtBlockQuery を vi.fn 差替えで分岐を網羅、 子 component (ShortAddress / HorizontalStackedNijis / NavBarButton) は data-testid stub で props 確認。

## テスト

- [x] `pnpm vitest run` で 598 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 13 TC 全 pass
- [x] regression なし

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx