### PR TITLE
test(niji-webapp): component part 28 (Documentation AboutSection/ArtAndTraitsSection) で 598 → 608 (+10)

### DIFF
--- a/packages/niji-webapp/src/components/Documentation/AboutSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/AboutSection.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { Accordion } from 'react-bootstrap';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Link', () => ({
+  default: ({ text, url }: { text: React.ReactNode; url: string }) => <a href={url}>{text}</a>,
+}));
+
+import { AboutHeader, AboutSection } from './AboutSection';
+
+const links = {
+  cryptopunksLink: <a href="https://cryptopunks.app/">CryptoPunks</a>,
+  playgroundLink: <a href="/playground">Playground</a>,
+  publicDomainLink: <a href="https://creativecommons.org/publicdomain/zero/1.0/">public domain</a>,
+  compoundGovLink: <a href="https://compound.finance/governance">Compound Governance</a>,
+};
+
+describe('AboutHeader', () => {
+  it('renders "WTF?" heading', () => {
+    const { container } = render(
+      <AboutHeader cryptopunksLink={links.cryptopunksLink} playgroundLink={links.playgroundLink} />,
+    );
+    expect(container.querySelector('h1')?.textContent).toBe('WTF?');
+  });
+
+  it('includes CryptoPunks reference in the about text', () => {
+    const { container } = render(
+      <AboutHeader cryptopunksLink={links.cryptopunksLink} playgroundLink={links.playgroundLink} />,
+    );
+    expect(container.textContent).toContain('CryptoPunks');
+  });
+
+  it('includes Playground reference', () => {
+    const { container } = render(
+      <AboutHeader cryptopunksLink={links.cryptopunksLink} playgroundLink={links.playgroundLink} />,
+    );
+    expect(container.textContent).toContain('Playground');
+  });
+
+  it('mentions on-chain avatar communities', () => {
+    const { container } = render(
+      <AboutHeader cryptopunksLink={links.cryptopunksLink} playgroundLink={links.playgroundLink} />,
+    );
+    expect(container.textContent).toContain('on-chain avatar communities');
+  });
+});
+
+const wrapAccordion = (ui: React.ReactElement) =>
+  render(
+    <Accordion alwaysOpen defaultActiveKey="0">
+      {ui}
+    </Accordion>,
+  );
+
+describe('AboutSection', () => {
+  it('renders inside accordion item', () => {
+    const { container } = wrapAccordion(<AboutSection {...links} />);
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+
+  it('references compound governance link', () => {
+    const { container } = wrapAccordion(<AboutSection {...links} />);
+    expect(container.textContent).toContain('Compound Governance');
+  });
+
+  it('references public domain link', () => {
+    const { container } = wrapAccordion(<AboutSection {...links} />);
+    expect(container.textContent).toContain('public domain');
+  });
+});

--- a/packages/niji-webapp/src/components/Documentation/ArtAndTraitsSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/ArtAndTraitsSection.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { Accordion } from 'react-bootstrap';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ArtAndTraitsSection } from './ArtAndTraitsSection';
+
+const wrap = (ui: React.ReactElement) =>
+  render(
+    <Accordion alwaysOpen defaultActiveKey="1">
+      {ui}
+    </Accordion>,
+  );
+
+describe('ArtAndTraitsSection', () => {
+  it('renders accordion header with "Niji Art and Traits"', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    expect(container.textContent?.toLowerCase()).toContain('art');
+    expect(container.textContent?.toLowerCase()).toContain('traits');
+  });
+
+  it('lists 12 trait keys (Special / Choker / Headphone etc.)', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    const items = container.querySelectorAll('li');
+    expect(items.length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('humanizes Niji trait keys (Special / Hat / Hair)', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    const text = container.textContent ?? '';
+    expect(text).toContain('Special');
+    expect(text).toContain('Hat');
+    expect(text).toContain('Hair');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 28 として Documentation 配下の 2 file 10 TC、 test 件数を 598 → 608 (+10)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `Documentation/AboutSection` | 7 | AboutHeader 4 (WTF? / CryptoPunks / Playground / on-chain avatar) + AboutSection 3 (Accordion / Compound Gov / public domain) |
| `Documentation/ArtAndTraitsSection` | 3 | header / 12 trait items / humanizeTraitKey Special/Hat/Hair |

## 解決方法

@/components/Link を data-testid stub、 Accordion で wrap して default open 状態に固定。 `nijiTraitKeys` + `humanizeTraitKey` は part 9 で lib 単体テスト済の関数が UI 表示でも正しく動くことを SSOT として確認。

## テスト

- [x] `pnpm vitest run` で 608 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 10 TC 全 pass
- [x] regression なし

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx