### PR TITLE
test(niji-webapp): component part 29 (NijisTransition motion / VoteCardPager / NavBarButton) で 608 → 634 (+26)

### DIFF
--- a/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import NavBarButton, { NavBarButtonStyle, getNavBarButtonVariant } from './index';
+
+describe('getNavBarButtonVariant', () => {
+  it('returns coolInfo class for COOL_INFO', () => {
+    expect(getNavBarButtonVariant(NavBarButtonStyle.COOL_INFO)).toMatch(/cool/i);
+  });
+
+  it('returns warmInfo class for WARM_INFO', () => {
+    expect(getNavBarButtonVariant(NavBarButtonStyle.WARM_INFO)).toMatch(/warm/i);
+  });
+
+  it('returns delegate class for DELEGATE_PRIMARY', () => {
+    expect(getNavBarButtonVariant(NavBarButtonStyle.DELEGATE_PRIMARY)).toMatch(/delegate/i);
+  });
+
+  it('returns FOR_VOTE_SUBMIT class', () => {
+    expect(getNavBarButtonVariant(NavBarButtonStyle.FOR_VOTE_SUBMIT)).toBeTruthy();
+  });
+
+  it('returns AGAINST_VOTE_SUBMIT class', () => {
+    expect(getNavBarButtonVariant(NavBarButtonStyle.AGAINST_VOTE_SUBMIT)).toBeTruthy();
+  });
+
+  it('returns ABSTAIN_VOTE_SUBMIT class', () => {
+    expect(getNavBarButtonVariant(NavBarButtonStyle.ABSTAIN_VOTE_SUBMIT)).toBeTruthy();
+  });
+});
+
+describe('NavBarButton', () => {
+  it('renders buttonText content', () => {
+    const { container } = render(<NavBarButton buttonText="Click me" />);
+    expect(container.textContent).toContain('Click me');
+  });
+
+  it('renders buttonIcon when provided', () => {
+    const { container } = render(
+      <NavBarButton buttonText="x" buttonIcon={<span data-testid="icon" />} />,
+    );
+    expect(container.querySelector('[data-testid="icon"]')).not.toBeNull();
+  });
+
+  it('fires onClick when enabled', () => {
+    const onClick = vi.fn();
+    const { container } = render(<NavBarButton buttonText="x" onClick={onClick} />);
+    fireEvent.click(container.firstChild as Element);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders ChevronDown when isDropdown=true + isButtonUp=false', () => {
+    const { container } = render(
+      <NavBarButton buttonText="x" isDropdown={true} isButtonUp={false} />,
+    );
+    expect(container.querySelectorAll('svg').length).toBeGreaterThan(0);
+  });
+
+  it('renders ChevronUp when isDropdown=true + isButtonUp=true', () => {
+    const { container } = render(
+      <NavBarButton buttonText="x" isDropdown={true} isButtonUp={true} />,
+    );
+    expect(container.querySelectorAll('svg').length).toBeGreaterThan(0);
+  });
+
+  it('does NOT render chevron when isDropdown=false', () => {
+    const { container } = render(<NavBarButton buttonText="x" isDropdown={false} />);
+    expect(container.querySelectorAll('svg').length).toBe(0);
+  });
+
+  it('applies disabled class when disabled=true', () => {
+    const { container } = render(<NavBarButton buttonText="x" disabled={true} />);
+    const inner = container.querySelector('div div div');
+    expect(inner?.className).toMatch(/disabled/i);
+  });
+});

--- a/packages/niji-webapp/src/components/NijisTransition/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijisTransition/index.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('motion/react', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({
+      children,
+      className,
+      onClick,
+    }: {
+      children: React.ReactNode;
+      className?: string;
+      onClick?: React.MouseEventHandler<HTMLDivElement>;
+    }) => (
+      <div className={className} onClick={onClick} data-testid="motion-div">
+        {children}
+      </div>
+    ),
+  },
+}));
+
+import NijisTransition from './index';
+
+const styles = {
+  enteringStyle: { opacity: 0 },
+  enteredStyle: { opacity: 1 },
+  exitingStyle: { opacity: 0 },
+  exitedStyle: { opacity: 0 },
+};
+
+describe('NijisTransition', () => {
+  it('renders children when show=true', () => {
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        <span>visible</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('span')?.textContent).toBe('visible');
+  });
+
+  it('renders nothing when show=false', () => {
+    const { container } = render(
+      <NijisTransition show={false} transitionStyes={styles}>
+        <span>hidden</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('span')).toBeNull();
+  });
+
+  it('applies className to motion.div', () => {
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles} className="my-class">
+        <span>x</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('[data-testid="motion-div"]')?.className).toBe('my-class');
+  });
+
+  it('fires onClick on motion.div click', () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles} onClick={onClick}>
+        <span>x</span>
+      </NijisTransition>,
+    );
+    const div = container.querySelector('[data-testid="motion-div"]');
+    if (div) fireEvent.click(div);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles default children (empty fragment) without crash', () => {
+    const { container } = render(<NijisTransition show={true} transitionStyes={styles} />);
+    expect(container.querySelector('[data-testid="motion-div"]')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/VoteCardPager/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCardPager/index.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import VoteCardPager from './index';
+
+const defaults = {
+  onRightArrowClick: () => {},
+  onLeftArrowClick: () => {},
+  isRightArrowDisabled: false,
+  isLeftArrowDisabled: false,
+  numPages: 3,
+  currentPage: 0,
+};
+
+describe('VoteCardPager', () => {
+  it('renders numPages dots', () => {
+    const { container } = render(<VoteCardPager {...defaults} numPages={5} currentPage={0} />);
+    const spans = container.querySelectorAll('span');
+    expect(spans.length).toBe(5);
+  });
+
+  it('renders left + right arrow buttons', () => {
+    const { container } = render(<VoteCardPager {...defaults} />);
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
+
+  it('disables both arrows when numPages=1 (isOnePage)', () => {
+    const { container } = render(<VoteCardPager {...defaults} numPages={1} />);
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[0]?.disabled).toBe(true);
+    expect(buttons[1]?.disabled).toBe(true);
+  });
+
+  it('disables left arrow when isLeftArrowDisabled=true', () => {
+    const { container } = render(<VoteCardPager {...defaults} isLeftArrowDisabled />);
+    expect(container.querySelectorAll('button')[0]?.disabled).toBe(true);
+  });
+
+  it('disables right arrow when isRightArrowDisabled=true', () => {
+    const { container } = render(<VoteCardPager {...defaults} isRightArrowDisabled />);
+    expect(container.querySelectorAll('button')[1]?.disabled).toBe(true);
+  });
+
+  it('fires onLeftArrowClick on left button click', () => {
+    const onLeft = vi.fn();
+    const { container } = render(<VoteCardPager {...defaults} onLeftArrowClick={onLeft} />);
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onLeft).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onRightArrowClick on right button click', () => {
+    const onRight = vi.fn();
+    const { container } = render(<VoteCardPager {...defaults} onRightArrowClick={onRight} />);
+    fireEvent.click(container.querySelectorAll('button')[1]);
+    expect(onRight).toHaveBeenCalledTimes(1);
+  });
+
+  it('highlights current page dot (no disabledPageDot class)', () => {
+    const { container } = render(<VoteCardPager {...defaults} currentPage={1} numPages={3} />);
+    const spans = container.querySelectorAll('span');
+    expect(spans[0]?.className).toMatch(/disabledPageDot/);
+    expect(spans[1]?.className).toBe('');
+    expect(spans[2]?.className).toMatch(/disabledPageDot/);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 29 として motion + pager + NavBarButton 3 file 26 TC、 test 件数を 608 → 634 (+26)。

## 課題

motion (Framer Motion) transition / arrow pager / 多 enum NavBarButton は UI critical だが未テスト。 motion mock pattern を確立すれば 8+ 件の transition 系 component に展開可能。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `NijisTransition` | 5 | motion mock + show 切替 / className / onClick / default children |
| `VoteCardPager` | 8 | numPages dots / 2 arrows / isOnePage / left/right disable / 2 click / current 強調 |
| `NavBarButton` | 13 | getNavBarButtonVariant 6 enum + render 7 |

## 解決方法

```mermaid
flowchart LR
    A[motion/react] --> B[vi.mock で AnimatePresence pass-through + motion.div stub]
    C[motion.div] --> D[plain div + onClick + className]
    E[NavBarButtonStyle 15 enum] --> F[getNavBarButtonVariant 6 spot-check]
```

## 仕組み

`NijisTransition` は AnimatePresence + motion.div で transition、 mock で pure div として描画させて props 検証。 `VoteCardPager` は numPages=1 で両 arrow disable、 isLeft/RightArrowDisabled で個別 disable、 currentPage 一致 dot は disabled class なし。 `NavBarButton` は 15 enum 中 6 spot-check + render テストで disabled/icon/dropdown chevron up/down/none gating 検証。

## テスト

- [x] `pnpm vitest run` で 634 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 26 TC 全 pass
- [x] regression なし

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx