### PR TITLE
test(niji-webapp): component part 30 (SignatureFormFields/DelegationModal) で 634 → 655 (+21)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureFormFields.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/signature/SignatureFormFields.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SignatureFormFields } from './SignatureFormFields';
+
+const defaults = {
+  reasonText: '',
+  setReasonText: () => {},
+  setExpirationDate: () => {},
+  expirationDate: 1700000000,
+  dateErrorMessage: '',
+  isWaiting: false,
+  isLoading: false,
+  proposalIdToUpdate: 0,
+  transactionState: '',
+  onSign: () => {},
+};
+
+describe('SignatureFormFields', () => {
+  it('renders "Sponsor this proposal candidate" header', () => {
+    const { container } = render(<SignatureFormFields {...defaults} />);
+    expect(container.textContent).toContain('Sponsor this proposal candidate');
+  });
+
+  it('renders textarea + date input', () => {
+    const { container } = render(<SignatureFormFields {...defaults} />);
+    expect(container.querySelector('textarea')).not.toBeNull();
+    expect(container.querySelector('input[type="date"]')).not.toBeNull();
+  });
+
+  it('fires setReasonText on textarea change', () => {
+    const setReason = vi.fn();
+    const { container } = render(<SignatureFormFields {...defaults} setReasonText={setReason} />);
+    const ta = container.querySelector('textarea');
+    if (ta) fireEvent.change(ta, { target: { value: 'because' } });
+    expect(setReason).toHaveBeenCalledWith('because');
+  });
+
+  it('disables textarea + input when isWaiting=true', () => {
+    const { container } = render(<SignatureFormFields {...defaults} isWaiting={true} />);
+    expect(container.querySelector('textarea')?.disabled).toBe(true);
+    expect(container.querySelector('input[type="date"]')?.disabled).toBe(true);
+  });
+
+  it('disables when isLoading=true', () => {
+    const { container } = render(<SignatureFormFields {...defaults} isLoading={true} />);
+    expect(container.querySelector('textarea')?.disabled).toBe(true);
+  });
+
+  it('shows date error message when provided', () => {
+    const { container } = render(
+      <SignatureFormFields {...defaults} dateErrorMessage="Invalid date" />,
+    );
+    expect(container.textContent).toContain('Invalid date');
+  });
+
+  it('renders "Sponsor" button by default (proposalIdToUpdate=0)', () => {
+    const { container } = render(<SignatureFormFields {...defaults} />);
+    expect(container.querySelector('button')?.textContent).toBe('Sponsor');
+  });
+
+  it('renders "Re-sign" when proposalIdToUpdate > 0', () => {
+    const { container } = render(<SignatureFormFields {...defaults} proposalIdToUpdate={42} />);
+    expect(container.querySelector('button')?.textContent).toBe('Re-sign');
+  });
+
+  it('disables sign button when transactionState=Mining', () => {
+    const { container } = render(<SignatureFormFields {...defaults} transactionState="Mining" />);
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('disables sign button when expirationDate is undefined', () => {
+    const { container } = render(<SignatureFormFields {...defaults} expirationDate={undefined} />);
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('disables sign button when dateErrorMessage is non-empty', () => {
+    const { container } = render(<SignatureFormFields {...defaults} dateErrorMessage="bad" />);
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('renders loading-noggles img when isWaiting=true (no button)', () => {
+    const { container } = render(<SignatureFormFields {...defaults} isWaiting={true} />);
+    expect(container.querySelector('img[alt="loading"]')).not.toBeNull();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('fires onSign when sign button clicked', () => {
+    const onSign = vi.fn();
+    const { container } = render(<SignatureFormFields {...defaults} onSign={onSign} />);
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(onSign).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/DelegationModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegationModal/index.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../ChangeDelegatePanel', () => ({
+  default: ({ delegateTo }: { delegateTo?: string }) => (
+    <div data-testid="change-panel">change-{delegateTo ?? 'none'}</div>
+  ),
+}));
+
+vi.mock('../CurrentDelegatePannel', () => ({
+  default: ({
+    onPrimaryBtnClick,
+    onSecondaryBtnClick,
+  }: {
+    onPrimaryBtnClick: () => void;
+    onSecondaryBtnClick: () => void;
+  }) => (
+    <div data-testid="current-panel">
+      <button onClick={onPrimaryBtnClick}>primary</button>
+      <button onClick={onSecondaryBtnClick}>secondary</button>
+    </div>
+  ),
+}));
+
+import DelegationModal, { Backdrop } from './index';
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="backdrop-root"></div><div id="overlay-root"></div>';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Backdrop', () => {
+  it('renders div', () => {
+    const { container } = render(<Backdrop onDismiss={() => {}} />);
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+
+  it('fires onDismiss on click', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(<Backdrop onDismiss={onDismiss} />);
+    const div = container.querySelector('div');
+    if (div) fireEvent.click(div);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('DelegationModal', () => {
+  it('portals backdrop into backdrop-root + overlay into overlay-root', () => {
+    render(<DelegationModal onDismiss={() => {}} />);
+    expect(document.getElementById('backdrop-root')?.children.length).toBe(1);
+    expect((document.getElementById('overlay-root')?.children.length ?? 0) > 0).toBe(true);
+    expect(document.getElementById('overlay-root')?.querySelector('button')).not.toBeNull();
+  });
+
+  it('renders CurrentDelegatePannel by default (no delegateTo)', () => {
+    render(<DelegationModal onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelector('[data-testid="current-panel"]'),
+    ).not.toBeNull();
+  });
+
+  it('renders ChangeDelegatePanel when delegateTo provided', () => {
+    render(<DelegationModal onDismiss={() => {}} delegateTo="0xABCD" />);
+    expect(
+      document.getElementById('overlay-root')?.querySelector('[data-testid="change-panel"]'),
+    ).not.toBeNull();
+  });
+
+  it('switches to Change panel when primary clicked', () => {
+    render(<DelegationModal onDismiss={() => {}} />);
+    const buttons = document.getElementById('overlay-root')?.querySelectorAll('button');
+    // 0=close, 1=primary, 2=secondary
+    const primary = Array.from(buttons ?? []).find(b => b.textContent === 'primary');
+    if (primary) fireEvent.click(primary);
+    expect(
+      document.getElementById('overlay-root')?.querySelector('[data-testid="change-panel"]'),
+    ).not.toBeNull();
+  });
+
+  it('fires onDismiss on close button click', () => {
+    const onDismiss = vi.fn();
+    render(<DelegationModal onDismiss={onDismiss} />);
+    const closeBtn = document.getElementById('overlay-root')?.querySelector('button:first-of-type');
+    if (closeBtn) fireEvent.click(closeBtn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onDismiss on backdrop click', () => {
+    const onDismiss = vi.fn();
+    render(<DelegationModal onDismiss={onDismiss} />);
+    const backdrop = document.getElementById('backdrop-root')?.querySelector('div');
+    if (backdrop) fireEvent.click(backdrop);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 30 として 2 file 21 TC、 test 件数を 634 → 655 (+21)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `SignatureFormFields` | 13 | header / textarea + date input / setReasonText spy / disabled gating 2 / date error / Sponsor/Re-sign 切替 + 3 disable 経路 + loading-noggles + onSign |
| `DelegationModal` | 8 | Backdrop 2 + portal 6 (位置 / Current default / delegateTo→Change 切替 / primary click 遷移 / 2 dismiss 経路) |

## 解決方法

ChangeDelegatePanel / CurrentDelegatePannel を vi.mock で stub、 portal は part 16/25 で確立した backdrop-root/overlay-root 注入 pattern を再利用。

## テスト

- [x] `pnpm vitest run` で 655 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 21 TC 全 pass
- [x] regression なし

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx