### PR TITLE
test(niji-webapp): component part 31 (SponsorsFormOverlay motion / ProposalEditor) で 655 → 671 (+16)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('motion/react', () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+      <div className={className} data-testid="motion-div">
+        {children}
+      </div>
+    ),
+  },
+}));
+
+vi.mock('./SignatureForm', () => ({
+  default: () => <div data-testid="signature-form" />,
+}));
+
+import { SponsorsFormOverlay } from './SponsorsFormOverlay';
+
+const defaults = {
+  isFormDisplayed: false,
+  candidate: {} as never,
+  id: 'cand-1',
+  transactionState: 'None' as const,
+  setTransactionState: () => {},
+  setIsFormDisplayed: () => {},
+  handleRefetchCandidateData: () => {},
+  setDataFetchPollInterval: () => {},
+  proposalIdToUpdate: 0,
+};
+
+describe('SponsorsFormOverlay', () => {
+  it('does not render motion overlay when isFormDisplayed=false', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} />);
+    expect(container.querySelector('[data-testid="motion-div"]')).toBeNull();
+  });
+
+  it('renders motion overlay when isFormDisplayed=true', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} isFormDisplayed={true} />);
+    expect(container.querySelector('[data-testid="motion-div"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="signature-form"]')).not.toBeNull();
+  });
+
+  it('renders Success banner when transactionState=Success', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} transactionState="Success" />);
+    expect(container.textContent).toContain('Success!');
+  });
+
+  it('does NOT render Success banner for other transactionState', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} />);
+    expect(container.textContent).not.toContain('Success!');
+  });
+
+  it('close button calls setIsFormDisplayed(false) + setDataFetchPollInterval(0)', () => {
+    const setIsForm = vi.fn();
+    const setPoll = vi.fn();
+    const { container } = render(
+      <SponsorsFormOverlay
+        {...defaults}
+        isFormDisplayed={true}
+        setIsFormDisplayed={setIsForm}
+        setDataFetchPollInterval={setPoll}
+      />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(setIsForm).toHaveBeenCalledWith(false);
+    expect(setPoll).toHaveBeenCalledWith(0);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalEditor/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalEditor/index.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock('remark-breaks', () => ({
+  default: () => null,
+}));
+
+import ProposalEditor from './index';
+
+const defaults = {
+  title: '',
+  body: '',
+  onTitleInput: () => {},
+  onBodyInput: () => {},
+};
+
+describe('ProposalEditor', () => {
+  it('renders "Proposal" header label by default', () => {
+    const { container } = render(<ProposalEditor {...defaults} />);
+    expect(container.textContent).toContain('Proposal');
+  });
+
+  it('renders "Candidate" label when isCandidate=true', () => {
+    const { container } = render(<ProposalEditor {...defaults} isCandidate={true} />);
+    expect(container.textContent).toContain('Candidate');
+  });
+
+  it('renders title input + body textarea', () => {
+    const { container } = render(<ProposalEditor {...defaults} />);
+    expect(container.querySelector('input')).not.toBeNull();
+    expect(container.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('uses different placeholder when isCandidate=true', () => {
+    const { container } = render(<ProposalEditor {...defaults} isCandidate={true} />);
+    expect(container.querySelector('input')?.getAttribute('placeholder')).toBe(
+      'Proposal candidate title',
+    );
+  });
+
+  it('uses regular placeholder when isCandidate=false', () => {
+    const { container } = render(<ProposalEditor {...defaults} />);
+    expect(container.querySelector('input')?.getAttribute('placeholder')).toBe('Proposal title');
+  });
+
+  it('fires onTitleInput on title change', () => {
+    const onTitle = vi.fn();
+    const { container } = render(<ProposalEditor {...defaults} onTitleInput={onTitle} />);
+    const input = container.querySelector('input');
+    if (input) fireEvent.change(input, { target: { value: 'New Title' } });
+    expect(onTitle).toHaveBeenCalledWith('New Title');
+  });
+
+  it('fires onBodyInput on body change', () => {
+    const onBody = vi.fn();
+    const { container } = render(<ProposalEditor {...defaults} onBodyInput={onBody} />);
+    const ta = container.querySelector('textarea');
+    if (ta) fireEvent.change(ta, { target: { value: 'Body text' } });
+    expect(onBody).toHaveBeenCalledWith('Body text');
+  });
+
+  it('hides preview when body is empty', () => {
+    const { container } = render(<ProposalEditor {...defaults} />);
+    expect(container.querySelector('[data-testid="markdown"]')).toBeNull();
+  });
+
+  it('shows preview + markdown when body is non-empty', () => {
+    const { container } = render(<ProposalEditor {...defaults} body="# Hello" />);
+    expect(container.textContent).toContain('Preview');
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe('# Hello');
+  });
+
+  it('shows title preview h1 when both title + body present', () => {
+    const { container } = render(<ProposalEditor {...defaults} title="My Title" body="# Hello" />);
+    expect(container.querySelector('h1')?.textContent).toBe('My Title');
+  });
+
+  it('does NOT show title preview h1 when only body present', () => {
+    const { container } = render(<ProposalEditor {...defaults} title="" body="# Hello" />);
+    expect(container.querySelector('h1')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 31 として motion + markdown editor 2 file 16 TC、 test 件数を 655 → 671 (+16)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `SponsorsFormOverlay` | 5 | isFormDisplayed gating / signature form / Success banner / 非 Success / close click |
| `ProposalEditor` | 11 | Proposal/Candidate label 切替 / input+textarea / 2 placeholder / 2 onChange spy / preview gating + title h1 gating 2 |

## 解決方法

motion mock pattern (part 29) + ReactMarkdown / remark-breaks stub を継続適用、 SignatureForm 子は data-testid stub で props 確認。

## テスト

- [x] `pnpm vitest run` で 671 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 16 TC 全 pass
- [x] regression なし

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx