### PR TITLE
test(niji-webapp): component part 32 (ProposalStatus/Holder/Winner) で 671 → 695 (+24)

### DIFF
--- a/packages/niji-webapp/src/components/Holder/index.test.tsx
+++ b/packages/niji-webapp/src/components/Holder/index.test.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+const useSubgraphQueryMock = vi.fn();
+vi.mock('@/hooks/useSubgraphQuery', () => ({
+  useSubgraphQuery: () => useSubgraphQueryMock(),
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+vi.mock('@/wrappers/subgraph', () => ({
+  nounDocument: 'NOUN_DOCUMENT',
+}));
+
+import { WithProviders } from '@/test-utils/providers';
+
+import Holder from './index';
+
+describe('Holder', () => {
+  it('renders nothing while loading', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({ loading: true, error: undefined, data: undefined });
+    const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders error message when query fails', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: new Error('rpc down'),
+      data: undefined,
+    });
+    const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    expect(container.textContent).toContain('Failed to fetch Niji info');
+  });
+
+  it('renders ShortAddress when data has owner', async () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { noun: { owner: { id: '0xOWNER' } } },
+    });
+    const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xOWNER');
+    });
+  });
+
+  it('renders Nounders branch when isNounders=true', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { noun: { owner: { id: '0xOWNER' } } },
+    });
+    const { container } = render(<Holder nounId={1n} isNounders={true} />, {
+      wrapper: WithProviders,
+    });
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalStatus/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalStatus/index.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { ProposalState } from '@/wrappers/nijiDao';
+
+import ProposalStatus from './index';
+
+describe('ProposalStatus', () => {
+  const cases: Array<[ProposalState | undefined, string]> = [
+    [ProposalState.PENDING, 'Pending'],
+    [ProposalState.ACTIVE, 'Active'],
+    [ProposalState.SUCCEEDED, 'Succeeded'],
+    [ProposalState.EXECUTED, 'Executed'],
+    [ProposalState.DEFEATED, 'Defeated'],
+    [ProposalState.QUEUED, 'Queued'],
+    [ProposalState.CANCELLED, 'Canceled'],
+    [ProposalState.VETOED, 'Vetoed'],
+    [ProposalState.EXPIRED, 'Expired'],
+    [ProposalState.OBJECTION_PERIOD, 'Objection period'],
+    [ProposalState.UPDATABLE, 'Updatable'],
+    [undefined, 'Undetermined'],
+  ];
+
+  it.each(cases)('renders status text for %s', (status, expected) => {
+    const { container } = render(<ProposalStatus status={status} />);
+    expect(container.textContent).toContain(expected);
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <ProposalStatus status={ProposalState.ACTIVE} className="my-status" />,
+    );
+    expect(container.querySelector('div')?.className).toContain('my-status');
+  });
+
+  it('applies primary class for PENDING/ACTIVE', () => {
+    const { container: pending } = render(<ProposalStatus status={ProposalState.PENDING} />);
+    const { container: active } = render(<ProposalStatus status={ProposalState.ACTIVE} />);
+    expect(pending.querySelector('div')?.className).toMatch(/primary/i);
+    expect(active.querySelector('div')?.className).toMatch(/primary/i);
+  });
+
+  it('applies success class for SUCCEEDED/EXECUTED', () => {
+    const { container: s } = render(<ProposalStatus status={ProposalState.SUCCEEDED} />);
+    const { container: e } = render(<ProposalStatus status={ProposalState.EXECUTED} />);
+    expect(s.querySelector('div')?.className).toMatch(/success/i);
+    expect(e.querySelector('div')?.className).toMatch(/success/i);
+  });
+
+  it('applies danger class for DEFEATED/VETOED', () => {
+    const { container: d } = render(<ProposalStatus status={ProposalState.DEFEATED} />);
+    const { container: v } = render(<ProposalStatus status={ProposalState.VETOED} />);
+    expect(d.querySelector('div')?.className).toMatch(/danger/i);
+    expect(v.querySelector('div')?.className).toMatch(/danger/i);
+  });
+});

--- a/packages/niji-webapp/src/components/Winner/index.test.tsx
+++ b/packages/niji-webapp/src/components/Winner/index.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAccountMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useAccount: () => useAccountMock(),
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+import { WithProviders } from '@/test-utils/providers';
+
+import Winner from './index';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+
+describe('Winner', () => {
+  it('renders ShortAddress when winner is not connected user', () => {
+    useAccountMock.mockReturnValue({ address: '0xOTHER' });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { container } = render(<Winner winner={ADDR} />, { wrapper: WithProviders });
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe(ADDR);
+  });
+
+  it('renders "you" branch when winner === connected user', () => {
+    useAccountMock.mockReturnValue({ address: ADDR });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { container } = render(<Winner winner={ADDR} />, { wrapper: WithProviders });
+    expect(container.textContent?.toLowerCase()).toContain('you');
+  });
+
+  it('renders Nounders branch when isNounders=true', () => {
+    useAccountMock.mockReturnValue({ address: '0xOTHER' });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { container } = render(<Winner winner={ADDR} isNounders={true} />, {
+      wrapper: WithProviders,
+    });
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+
+  it('handles ja-JP locale layout column variant', () => {
+    useAccountMock.mockReturnValue({ address: ADDR });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('ja-JP');
+    const { container } = render(<Winner winner={ADDR} />, { wrapper: WithProviders });
+    expect(container.textContent?.toLowerCase()).toContain('you');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 32 として 3 file 24 TC、 test 件数を 671 → 695 (+24)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `ProposalStatus` | 16 | 12 status text it.each + className + primary/success/danger class 3 経路 |
| `Holder` | 4 | loading / error / ShortAddress / isNounders、 useSubgraphQuery 経路 |
| `Winner` | 4 | 他人/you/Nounders branch + ja-JP locale layout |

## 解決方法

useSubgraphQuery / useAccount / useAtomValue / useActiveLocale を vi.fn 差替えで分岐を網羅、 WithProviders で QueryClient 提供。

## テスト

- [x] `pnpm vitest run` で 695 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 24 TC 全 pass
- [x] regression なし

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx