### PR TITLE
test(niji-webapp): component part 33 (BidHistoryModalRow/SettleManuallyBtn/NavDropdown) で 695 → 709 (+14)

### DIFF
--- a/packages/niji-webapp/src/components/BidHistoryModalRow/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModalRow/index.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { parseEther } from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/ensLookup', () => ({
+  useReverseENSLookUp: vi.fn(),
+}));
+
+vi.mock('@/utils/moderation/containsBlockedText', () => ({
+  containsBlockedText: vi.fn(() => false),
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanTxLink: (hash: string) => `https://etherscan.io/tx/${hash}`,
+}));
+
+vi.mock('blo', () => ({
+  blo: () => 'data:image/png;base64,FAKE',
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    date: (d: Date) => d.toISOString(),
+  },
+}));
+
+import { useReverseENSLookUp } from '@/utils/ensLookup';
+import { containsBlockedText } from '@/utils/moderation/containsBlockedText';
+
+import BidHistoryModalRow from './index';
+
+import type { Bid } from '@/utils/types';
+
+const bid: Bid = {
+  nounId: 1n,
+  sender: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  value: parseEther('1'),
+  extended: false,
+  transactionHash: '0xdeadbeef',
+  transactionIndex: 0,
+  timestamp: 1735689600n,
+};
+
+describe('BidHistoryModalRow', () => {
+  it('renders truncated amount (Ξ 1.00)', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    expect(container.textContent).toContain('Ξ 1.00');
+  });
+
+  it('renders avatar img (blo) for sender', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    const avatar = container.querySelector(`img[alt="${bid.sender}"]`);
+    expect(avatar).not.toBeNull();
+  });
+
+  it('renders ENS name when ENS is set and not blocklisted', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('alice.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    expect(container.textContent).toContain('alice');
+  });
+
+  it('falls back to short address when ENS is blocklisted', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('badword.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(true);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    expect(container.textContent).not.toContain('badword');
+  });
+
+  it('renders trophy icon when index=0 (winning bid)', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={0} />);
+    const imgs = container.querySelectorAll('img');
+    expect(imgs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('omits trophy icon when index > 0', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={5} />);
+    const imgs = container.querySelectorAll('img');
+    expect(imgs.length).toBe(1);
+  });
+
+  it('renders etherscan tx link', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(
+      'https://etherscan.io/tx/0xdeadbeef',
+    );
+  });
+});

--- a/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/colorResponsiveUIUtils', () => ({
+  usePickByStateColor: () => ({
+    stateSelectedDropdownClass: 'state-dropdown',
+    statePrimaryButtonClass: 'state-primary',
+  }),
+}));
+
+vi.mock('@/components/NavBarButton', () => {
+  const NavBarButtonStyle = { COOL_INFO: 0 };
+  const NavBarButton = ({ buttonText }: { buttonText: React.ReactNode }) => (
+    <span data-testid="nav-button">{buttonText}</span>
+  );
+  return { default: NavBarButton, NavBarButtonStyle };
+});
+
+import NavDropDown from './index';
+
+describe('NavDropDown', () => {
+  it('renders NavBarButton with buttonText inside dropdown toggle', () => {
+    const { container } = render(
+      <NavDropDown buttonText="Menu">
+        <span>item</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe('Menu');
+  });
+
+  it('accepts buttonIcon and forwards to NavBarButton', () => {
+    const { container } = render(
+      <NavDropDown buttonText="Menu" buttonIcon={<span data-testid="icon" />}>
+        <span>x</span>
+      </NavDropDown>,
+    );
+    // mock NavBarButton は icon を直接描画しないので nav-button 自体の確認
+    expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
+  });
+
+  it('renders Dropdown wrapper element', () => {
+    const { container } = render(
+      <NavDropDown buttonText="Menu">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('.dropdown')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/SettleManuallyBtn/index.test.tsx
+++ b/packages/niji-webapp/src/components/SettleManuallyBtn/index.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import dayjs from 'dayjs';
+import duration from 'dayjs/plugin/duration';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+beforeAll(() => {
+  dayjs.extend(duration);
+});
+
+import SettleManuallyBtn from './index';
+
+import type { Auction } from '@/wrappers/nijiAuction';
+
+const auction: Auction = {
+  amount: 1000000000000000000n,
+  bidder: '0xAA',
+  endTime: BigInt(Math.floor(Date.now() / 1000) - 600),
+  startTime: BigInt(Math.floor(Date.now() / 1000) - 3600),
+  nounId: 1n,
+  settled: false,
+};
+
+describe('SettleManuallyBtn', () => {
+  it('renders Settle manually button (timer 0 で即時有効)', () => {
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={() => {}} auction={auction} />,
+    );
+    expect(container.textContent).toContain('Settle manually');
+  });
+
+  it('button is enabled (settleEnabled=true after immediate flip)', () => {
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={() => {}} auction={auction} />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(false);
+  });
+
+  it('fires settleAuctionHandler on button click', () => {
+    const handler = vi.fn();
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={handler} auction={auction} />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps button in <p> element', () => {
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={() => {}} auction={auction} />,
+    );
+    expect(container.querySelector('p button')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 33 として 3 file 14 TC、 test 件数を 695 → 709 (+14)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `BidHistoryModalRow` | 7 | Ξ amount + blo avatar + ENS / blocklist fallback + trophy gating + etherscan link |
| `SettleManuallyBtn` | 4 | Settle manually 即時表示 + 有効 + click + p ラッパー |
| `NavDropdown` | 3 | NavBarButton 渡し + dropdown wrapper + buttonIcon |

## 解決方法

useReverseENSLookUp / containsBlockedText / blo / NavBarButton 子を vi.mock で stub、 dayjs.duration plugin を beforeAll で extend (SettleManuallyBtn 用)。 NavDropdown の Menu は lazy mount のため `.dropdown` wrapper のみ verify。

## テスト

- [x] `pnpm vitest run` で 709 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 14 TC 全 pass
- [x] regression なし

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx