### PR TITLE
test(niji-webapp): component part 34 (Documentation/index + SponsorsHeader) で 709 → 721 (+12)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsHeader.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsHeader.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { SponsorsHeader } from './SponsorsHeader';
+
+const baseCandidate = {
+  voteCount: 5,
+  proposerVotes: 3,
+} as never;
+
+describe('SponsorsHeader (new candidate flow)', () => {
+  it('renders threshold-met message when isThresholdMet=true (non-update)', () => {
+    const { container } = render(
+      <SponsorsHeader candidate={baseCandidate} isThresholdMet={true} />,
+    );
+    expect(container.textContent).toContain('met the required threshold');
+  });
+
+  it('shows proposer vote count when > 0 (non-update)', () => {
+    const { container } = render(
+      <SponsorsHeader candidate={baseCandidate} isThresholdMet={false} />,
+    );
+    expect(container.textContent).toContain('Proposer has 3 vote');
+  });
+
+  it('uses singular "vote" when proposerVotes=1', () => {
+    const candidate = { ...baseCandidate, proposerVotes: 1 } as never;
+    const { container } = render(<SponsorsHeader candidate={candidate} isThresholdMet={false} />);
+    expect(container.textContent).toContain('Proposer has 1 vote');
+    expect(container.textContent).not.toContain('1 votes');
+  });
+
+  it('omits proposer line when proposerVotes=0', () => {
+    const candidate = { ...baseCandidate, proposerVotes: 0 } as never;
+    const { container } = render(<SponsorsHeader candidate={candidate} isThresholdMet={false} />);
+    expect(container.textContent).not.toContain('Proposer has');
+  });
+});
+
+describe('SponsorsHeader (update flow)', () => {
+  it('renders "X of Y original signed votes" when isUpdateToProposal=true', () => {
+    const proposal = { signers: [{ id: '0xA' }, { id: '0xB' }] } as never;
+    const { container } = render(
+      <SponsorsHeader
+        candidate={baseCandidate}
+        isUpdateToProposal={true}
+        isThresholdMet={false}
+        originalProposal={proposal}
+      />,
+    );
+    expect(container.textContent).toContain('5 of 2 original signed votes');
+  });
+
+  it('renders ... fallback when originalProposal undefined', () => {
+    const { container } = render(
+      <SponsorsHeader candidate={baseCandidate} isUpdateToProposal={true} isThresholdMet={false} />,
+    );
+    expect(container.textContent).toContain('5 of ... original signed votes');
+  });
+
+  it('renders ... fallback for negative voteCount', () => {
+    const candidate = { ...baseCandidate, voteCount: -1 } as never;
+    const { container } = render(
+      <SponsorsHeader candidate={candidate} isUpdateToProposal={true} isThresholdMet={false} />,
+    );
+    expect(container.textContent).toContain('... of');
+  });
+
+  it('hides proposer vote line in update flow', () => {
+    const { container } = render(
+      <SponsorsHeader candidate={baseCandidate} isUpdateToProposal={true} isThresholdMet={false} />,
+    );
+    expect(container.textContent).not.toContain('Proposer has');
+  });
+});

--- a/packages/niji-webapp/src/components/Documentation/index.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/index.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Link', () => ({
+  default: ({ text, url }: { text: React.ReactNode; url: string }) => <a href={url}>{text}</a>,
+}));
+
+vi.mock('@/layout/Section', () => ({
+  default: ({
+    children,
+    className,
+    style,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    style?: React.CSSProperties;
+  }) => (
+    <section className={className} style={style}>
+      {children}
+    </section>
+  ),
+}));
+
+vi.mock('./AboutSection', () => ({
+  AboutHeader: () => <div data-testid="about-header" />,
+  AboutSection: () => <div data-testid="about-section" />,
+}));
+
+vi.mock('./ArtAndTraitsSection', () => ({
+  ArtAndTraitsSection: () => <div data-testid="art-section" />,
+}));
+
+vi.mock('./GovernanceSection', () => ({
+  GovernanceSection: () => <div data-testid="gov-section" />,
+}));
+
+vi.mock('./NijidersRewardSection', () => ({
+  NijidersRewardSection: () => <div data-testid="nijiders-section" />,
+}));
+
+import Documentation from './index';
+
+describe('Documentation', () => {
+  it('renders 5 sub-sections (AboutHeader + 4 Accordion items)', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelector('[data-testid="about-header"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="about-section"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="gov-section"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="art-section"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="nijiders-section"]')).not.toBeNull();
+  });
+
+  it('applies background color when provided', () => {
+    const { container } = render(<Documentation backgroundColor="#000" />);
+    expect(container.querySelector('section')?.getAttribute('style')).toContain(
+      'background: rgb(0, 0, 0)',
+    );
+  });
+
+  it('forwards backgroundColor as inline style', () => {
+    const { container } = render(<Documentation backgroundColor="#abc" />);
+    expect(container.querySelector('section')?.getAttribute('style')).toBeTruthy();
+  });
+
+  it('renders documentation section class', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelector('section')?.className).toMatch(/documentation/i);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 34 として 2 file 12 TC、 test 件数を 709 → 721 (+12)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `Documentation/index` | 4 | 5 sub-section 集約描画 + 背景色 forward + style + section class |
| `CandidateSponsors/SponsorsHeader` | 8 | new candidate flow 4 + update flow 4 (X of Y / ... fallback / 提案者投票表示切替) |

## 解決方法

Documentation の 5 sub-section (AboutHeader / AboutSection / GovernanceSection / ArtAndTraitsSection / NijidersRewardSection) を data-testid stub で集約描画確認、 SponsorsHeader は ProposalCandidate + Proposal の 2 path 計 4 状態を網羅 (proposer vote 単複 + threshold-met 文言 + update flow X of Y 表示)。

## テスト

- [x] `pnpm vitest run` で 721 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 12 TC 全 pass
- [x] regression なし

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx