### PR TITLE
test(niji-webapp): component part 35 (CandidateCard / ProposalTransaction / BidHistoryModal) で 721 → 740 (+19)

### DIFF
--- a/packages/niji-webapp/src/components/BidHistoryModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModal/index.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/BidHistoryModalRow', () => ({
+  default: ({ bid }: { bid: { transactionHash: string } }) => (
+    <li data-testid="row">{bid.transactionHash}</li>
+  ),
+}));
+
+vi.mock('@/components/Niji', () => ({
+  NijiRoundedCorners: ({ nounId }: { nounId: bigint }) => (
+    <span data-testid="niji-rounded">{nounId.toString()}</span>
+  ),
+}));
+
+const useAuctionBidsMock = vi.fn();
+vi.mock('@/wrappers/onDisplayAuction', () => ({
+  useAuctionBids: () => useAuctionBidsMock(),
+}));
+
+import BidHistoryModal, { Backdrop } from './index';
+
+import type { Auction } from '@/wrappers/nijiAuction';
+
+const auction: Auction = {
+  amount: 1000n,
+  bidder: '0xAA',
+  endTime: 100n,
+  startTime: 0n,
+  nounId: 42n,
+  settled: false,
+};
+
+beforeEach(() => {
+  document.body.innerHTML = '<div id="backdrop-root"></div><div id="overlay-root"></div>';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Backdrop', () => {
+  it('renders div + fires onDismiss', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(<Backdrop onDismiss={onDismiss} />);
+    fireEvent.click(container.querySelector('div')!);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('BidHistoryModal', () => {
+  it('portals backdrop into backdrop-root', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(document.getElementById('backdrop-root')?.children.length).toBe(1);
+  });
+
+  it('renders NijiRoundedCorners with auction nounId', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelector('[data-testid="niji-rounded"]')
+        ?.textContent,
+    ).toBe('42');
+  });
+
+  it('shows null-state text when no bids', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.textContent).toContain('Bids will appear here');
+  });
+
+  it('renders bid rows when bids present', () => {
+    useAuctionBidsMock.mockReturnValue([{ transactionHash: '0x1' }, { transactionHash: '0x2' }]);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelectorAll('[data-testid="row"]').length,
+    ).toBe(2);
+  });
+
+  it('close button fires onDismiss', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const onDismiss = vi.fn();
+    render(<BidHistoryModal auction={auction} onDismiss={onDismiss} />);
+    const btn = document.getElementById('overlay-root')?.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('backdrop click fires onDismiss', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const onDismiss = vi.fn();
+    render(<BidHistoryModal auction={auction} onDismiss={onDismiss} />);
+    const backdrop = document.getElementById('backdrop-root')?.querySelector('div');
+    if (backdrop) fireEvent.click(backdrop);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/CandidateCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/index.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('./CandidateSponsors', () => ({
+  default: ({ nounsRequired }: { nounsRequired: number }) => (
+    <span data-testid="sponsors">req-{nounsRequired}</span>
+  ),
+}));
+
+vi.mock('@/utils/timeUtils', () => ({
+  relativeTimestamp: () => '1 day ago',
+}));
+
+import CandidateCard from './index';
+
+const baseCandidate = {
+  id: 'cand-1',
+  proposer: '0xPROPOSER',
+  proposerVotes: 5,
+  requiredVotes: 3,
+  voteCount: 2,
+  version: {
+    content: {
+      title: 'My Candidate',
+      contentSignatures: [],
+    },
+  },
+} as never;
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('CandidateCard', () => {
+  it('renders candidate title', () => {
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={3} />);
+    expect(container.textContent).toContain('My Candidate');
+  });
+
+  it('links to /candidates/{id}', () => {
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={3} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/candidates/cand-1');
+  });
+
+  it('renders ShortAddress for proposer', () => {
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={3} />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xPROPOSER');
+  });
+
+  it('renders CandidateSponsors with requiredVotes', () => {
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={3} />);
+    expect(container.querySelector('[data-testid="sponsors"]')?.textContent).toBe('req-3');
+  });
+
+  it('handles empty proposer string', () => {
+    const candidate = { ...baseCandidate, proposer: null } as never;
+    const { container } = wrap(<CandidateCard candidate={candidate} nounsRequired={3} />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('');
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransaction.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransaction.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiPayerAddress: { 1: '0xPAYER' },
+  nijiTokenBuyerAddress: { 1: '0xTOKENBUYER' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('.', () => ({
+  linkIfAddress: (content: string) => <span data-testid="link-if-addr">{content}</span>,
+}));
+
+import ProposalTransaction from './ProposalTransaction';
+
+const simpleTx = {
+  target: '0xTARGET',
+  functionSig: '',
+  callData: 'plain-data',
+  value: 0n,
+} as never;
+
+const sigTx = {
+  target: '0xTARGET',
+  functionSig: 'transfer(address,uint256)',
+  callData: '0xRECIPIENT,1000',
+  value: 100n,
+} as never;
+
+describe('ProposalTransaction', () => {
+  it('renders target via linkIfAddress', () => {
+    const { container } = render(<ProposalTransaction transaction={simpleTx} />);
+    const links = container.querySelectorAll('[data-testid="link-if-addr"]');
+    expect(links[0]?.textContent).toBe('0xTARGET');
+  });
+
+  it('renders functionSig when present', () => {
+    const { container } = render(<ProposalTransaction transaction={sigTx} />);
+    expect(container.textContent).toContain('transfer(address,uint256)');
+  });
+
+  it('renders raw callData when functionSig is empty', () => {
+    const { container } = render(<ProposalTransaction transaction={simpleTx} />);
+    expect(container.textContent).toContain('plain-data');
+  });
+
+  it('renders callData split as multiple linkIfAddress entries', () => {
+    const { container } = render(<ProposalTransaction transaction={sigTx} />);
+    const links = container.querySelectorAll('[data-testid="link-if-addr"]');
+    // target + 2 callData parts = 3
+    expect(links.length).toBe(3);
+  });
+
+  it('renders value when present (non-zero)', () => {
+    const { container } = render(<ProposalTransaction transaction={sigTx} />);
+    expect(container.textContent).toContain('100');
+  });
+
+  it('skips value when 0n (falsy)', () => {
+    const { container } = render(<ProposalTransaction transaction={simpleTx} />);
+    expect(container.textContent).not.toContain('0n');
+  });
+
+  it('uses <li> as root element', () => {
+    const { container } = render(<ProposalTransaction transaction={simpleTx} />);
+    expect(container.querySelector('li')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 35 として 3 file 19 TC、 test 件数を 721 → 740 (+19)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `CandidateCard/index` | 5 | title / link href / proposer ShortAddress / CandidateSponsors required / null proposer |
| `ProposalContent/ProposalTransaction` | 7 | target linkIfAddress / functionSig 描画 / callData split 3 entries / value / 0n skip / li root |
| `BidHistoryModal/index` | 7 | Backdrop click + portal + NijiRoundedCorners + null-state + bid rows + 2 dismiss 経路 |

## 解決方法

MemoryRouter で react-router 提供、 子 component (ShortAddress / CandidateSponsors / linkIfAddress / NijiRoundedCorners / BidHistoryModalRow) を vi.mock で stub、 portal は part 16/25/30 と同じ backdrop-root/overlay-root 注入 pattern を再利用。

## テスト

- [x] `pnpm vitest run` で 740 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 19 TC 全 pass
- [x] regression なし

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx