### PR TITLE
test(niji-webapp): component part 36 (ByLineHoverCard / CandidateSponsors / ProposalTransactions) で 740 → 756 (+16)

### DIFF
--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useSubgraphQueryMock = vi.fn();
+vi.mock('@/hooks/useSubgraphQuery', () => ({
+  useSubgraphQuery: () => useSubgraphQueryMock(),
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/components/HorizontalStackedNijis', () => ({
+  default: ({ nounIds }: { nounIds: string[] }) => (
+    <span data-testid="stacked">stack-{nounIds.length}</span>
+  ),
+}));
+
+vi.mock('@/wrappers/subgraph', () => ({
+  currentlyDelegatedNounsDocument: 'DOC',
+}));
+
+import ByLineHoverCard from './index';
+
+describe('ByLineHoverCard', () => {
+  it('renders spinner when loading', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('renders spinner when delegates is empty', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('renders error message when error is set', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      loading: false,
+      error: new Error('rpc'),
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.textContent).toBe('Error fetching Vote info');
+  });
+
+  it('renders stacked nijis + total when data is present', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: {
+        delegates: [
+          {
+            id: '0xA',
+            nijiRepresented: [{ id: '3' }, { id: '1' }, { id: '2' }],
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-3');
+  });
+});

--- a/packages/niji-webapp/src/components/CandidateCard/CandidateSponsors.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/CandidateSponsors.test.tsx
@@ -1,0 +1,83 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const useDelegateNounsAtBlockQueryMock = vi.fn();
+vi.mock('@/wrappers/nijiToken', () => ({
+  useDelegateNounsAtBlockQuery: () => useDelegateNounsAtBlockQueryMock(),
+}));
+
+vi.mock('./CandidateSponsorImage', () => ({
+  default: ({ nounId }: { nounId: bigint }) => (
+    <span data-testid="sponsor-img">{nounId.toString()}</span>
+  ),
+}));
+
+import CandidateSponsors from './CandidateSponsors';
+
+const makeSigner = (id: string, active = false) =>
+  ({
+    signer: { id, activeOrPendingProposal: active },
+  }) as never;
+
+describe('CandidateSponsors', () => {
+  it('renders nothing (no sponsors, no placeholders) when nothing required', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({ data: undefined });
+    const { container } = render(<CandidateSponsors signers={[]} nounsRequired={0} />);
+    expect(container.querySelectorAll('[data-testid="sponsor-img"]').length).toBe(0);
+  });
+
+  it('renders placeholder spots when no delegates yet (nounsRequired=3)', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({ data: undefined });
+    const { container } = render(<CandidateSponsors signers={[]} nounsRequired={3} />);
+    // 0 active delegates -> placeholder = 3
+    const placeholders = container.querySelectorAll('div div');
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders sponsor images when delegates have nijiRepresented', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: {
+        delegates: [{ id: '0xA', nijiRepresented: [{ id: '10' }, { id: '11' }] }],
+      },
+    });
+    const { container } = render(
+      <CandidateSponsors signers={[makeSigner('0xA'), makeSigner('0xB')]} nounsRequired={5} />,
+    );
+    expect(container.querySelectorAll('[data-testid="sponsor-img"]').length).toBe(2);
+  });
+
+  it('caps visible sponsors at maxVisibleSpots (5)', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: {
+        delegates: [
+          {
+            id: '0xA',
+            nijiRepresented: [
+              { id: '1' },
+              { id: '2' },
+              { id: '3' },
+              { id: '4' },
+              { id: '5' },
+              { id: '6' },
+              { id: '7' },
+            ],
+          },
+        ],
+      },
+    });
+    const { container } = render(
+      <CandidateSponsors signers={[makeSigner('0xA')]} nounsRequired={10} />,
+    );
+    expect(container.querySelectorAll('[data-testid="sponsor-img"]').length).toBe(5);
+  });
+
+  it('shows 1 placeholder when isThresholdMetByProposer=true and no nounIds', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({ data: undefined });
+    const { container } = render(
+      <CandidateSponsors signers={[]} nounsRequired={0} isThresholdMetByProposer={true} />,
+    );
+    // sponsors=0、 placeholder=1
+    const placeholders = container.querySelectorAll('div > div');
+    expect(placeholders.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransactions.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransactions.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiPayerAddress: { 1: '0xPAYER' },
+  nijiTokenBuyerAddress: { 1: '0xTOKENBUYER' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('.', () => ({
+  linkIfAddress: (content: string) => <span data-testid="link">{content}</span>,
+}));
+
+import ProposalTransactions from './ProposalTransactions';
+
+const simpleTx = {
+  target: '0xTARGET1',
+  functionSig: '',
+  callData: 'raw-data',
+  value: 0n,
+} as never;
+
+const sigTx = {
+  target: '0xTARGET2',
+  functionSig: 'transfer',
+  callData: '0xRECIPIENT,1000',
+  value: 50n,
+} as never;
+
+const tokenBuyerTx = {
+  target: '0xTOKENBUYER',
+  functionSig: 'transfer',
+  callData: '0xRECIPIENT,500',
+  value: 10n,
+} as never;
+
+describe('ProposalTransactions', () => {
+  it('renders ol with li per detail', () => {
+    const { container } = render(<ProposalTransactions details={[simpleTx, sigTx]} />);
+    expect(container.querySelectorAll('ol li').length).toBe(2);
+  });
+
+  it('shows raw callData when functionSig empty', () => {
+    const { container } = render(<ProposalTransactions details={[simpleTx]} />);
+    expect(container.textContent).toContain('raw-data');
+  });
+
+  it('renders callData split when functionSig non-empty', () => {
+    const { container } = render(<ProposalTransactions details={[sigTx]} />);
+    expect(container.textContent).toContain('transfer');
+    const links = container.querySelectorAll('[data-testid="link"]');
+    // target + 2 callData parts = 3
+    expect(links.length).toBe(3);
+  });
+
+  it('skips value when 0n', () => {
+    const { container } = render(<ProposalTransactions details={[simpleTx]} />);
+    expect(container.textContent).not.toContain('0n');
+  });
+
+  it('renders TokenBuyer info banner when target is TokenBuyer + transfer', () => {
+    const { container } = render(<ProposalTransactions details={[tokenBuyerTx]} />);
+    expect(container.textContent).toContain('automatically added to refill the TokenBuyer');
+  });
+
+  it('does NOT show TokenBuyer banner for non-TokenBuyer target', () => {
+    const { container } = render(<ProposalTransactions details={[sigTx]} />);
+    expect(container.textContent).not.toContain('automatically added');
+  });
+
+  it('renders empty ol when details is empty', () => {
+    const { container } = render(<ProposalTransactions details={[]} />);
+    expect(container.querySelectorAll('ol li').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 36 として 3 file 16 TC、 test 件数を 740 → 756 (+16)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `ByLineHoverCard` | 4 | spinner loading / 空 delegates / error / 正常 stacked nijis |
| `CandidateCard/CandidateSponsors` | 5 | 空 / 0 active / sponsor images / cap=5 / isThresholdMetByProposer=true |
| `ProposalContent/ProposalTransactions` | 7 | ol li 数 / raw callData / split / 0n skip / TokenBuyer banner gating + 空 details |

## 解決方法

useSubgraphQuery / useDelegateNounsAtBlockQuery / linkIfAddress / 子 component を vi.mock で stub、 SDK address constants も mock 化。

## テスト

- [x] `pnpm vitest run` で 756 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 16 TC 全 pass
- [x] regression なし

Closes #398

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx