### PR TITLE
fix(niji-contracts): NoracleTestOneAuctionSettledStateTest 18 件解消 (Issue #310 進行)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiAuctionHouseV3.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiAuctionHouseV3.t.sol
@@ -247,17 +247,18 @@ abstract contract NoracleBaseTest is NijiAuctionHouseV3TestBase {
 }
 
 contract NoracleTestOneAuctionSettledStateTest is NoracleBaseTest {
-    IAH.Settlement nounId1Settlement;
+    IAH.Settlement nounId0Settlement;
 
     function setUp() public override {
         super.setUp();
         bidAndWinCurrentAuction(bidder, 1 ether);
 
-        nounId1Settlement = IAH.Settlement({
+        // Niji ... auction は nounId=0 から開始 (Nouns の 1 開始から差し替え済)。
+        nounId0Settlement = IAH.Settlement({
             blockTimestamp: uint32(block.timestamp),
             amount: 1 ether,
             winner: bidder,
-            nounId: 1,
+            nounId: 0,
             clientId: 0
         });
     }
@@ -276,69 +277,69 @@ contract NoracleTestOneAuctionSettledStateTest is NoracleBaseTest {
     function test_getSettlements_skipFalse_1() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(1, false);
 
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsRange_skipFalse_1() public {
+        // Niji ... range(1, 2) は id=1 (現在 auction、 settlementHistory に未書き込みなので 0 entry)。
         IAH.Settlement[] memory settlements = auction.getSettlements(1, 2, false);
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(
+            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 1, clientId: 0 })
+        );
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsFromIdtoTimestamp_skipFalse_1() public {
+        // Niji ... fromId=1 + endTimestamp=now、 nounId=1 は現在 auction (unsettled)、 maxId と一致 + blockTimestamp<=1 で continue → 空配列。
         IAH.Settlement[] memory settlements = auction.getSettlementsFromIdtoTimestamp(1, block.timestamp, false);
-        expectedSettlements.push(nounId1Settlement);
-        assertEq(settlements, expectedSettlements);
+        assertEq(settlements.length, 0);
     }
 
+    // Niji ... NounderNiji 廃止により nounId=0 は raw NounderNiji ではなく通常 auction の latest。
+    // setUp で nounId=0 が 1 件 settle → getSettlements(N, false) は max 1 件のみ返す。
     function test_getSettlements_skipFalse_returnsRawNounderNiji() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(2, false);
 
-        expectedSettlements.push(nounId1Settlement);
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsRange_skipFalse_returnsRawNounderNiji() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(0, 2, false);
+        expectedSettlements.push(nounId0Settlement);
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 1, clientId: 0 })
         );
-        expectedSettlements.push(nounId1Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsFromIdtoTimestamp_skipFalse_returnsRawNounderNiji() public {
         IAH.Settlement[] memory settlements = auction.getSettlementsFromIdtoTimestamp(0, block.timestamp, false);
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsFormIdToTimestamp_skipFalse_stopsAtEndTimestamp() public {
         IAH.Settlement[] memory settlements = auction.getSettlementsFromIdtoTimestamp(0, block.timestamp - 1, false);
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
-        assertEq(settlements, expectedSettlements);
+        // Niji ... nounId=0 settle 完了済 + 現在 auction は nounId=1 (unsettled、 blockTimestamp=1 sentinel)。
+        // endTimestamp=block.timestamp-1 → settle (id=0) は break 条件 settlementState.blockTimestamp(=now) > endTimestamp(=now-1) で break。
+        // 結果空配列。
+        assertEq(settlements.length, 0);
     }
 
     function test_getSettlementsFormIdToTimestamp_skipFalse_startIdInTheFuture_reverts() public {
+        // Niji ... setUp 後の現在 auction nounId は 1。 startId=2 は startId>maxId で revert。
         vm.expectRevert('startId too large');
-        auction.getSettlementsFromIdtoTimestamp(3, block.timestamp, false);
+        auction.getSettlementsFromIdtoTimestamp(2, block.timestamp, false);
     }
 
     function test_getSettlementsRange_skipFalse_returnsEmptyData() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(0, 3, false);
+        expectedSettlements.push(nounId0Settlement);
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 1, clientId: 0 })
         );
-        expectedSettlements.push(nounId1Settlement);
         expectedSettlements.push(
             IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 2, clientId: 0 })
         );
@@ -348,35 +349,32 @@ contract NoracleTestOneAuctionSettledStateTest is NoracleBaseTest {
     function test_getSettlements_skipFalse_returnsLessResultsIfReachedNounZero() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(3, false);
 
-        expectedSettlements.push(nounId1Settlement);
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlements_skipTrue_skipsNounderNiji() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(2, true);
 
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsRange_skipTrue_skipsNounderNiji() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(0, 2, true);
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsFromIdToTimestamp_skipTrue_skipsNonderNiji() public {
         IAH.Settlement[] memory settlements = auction.getSettlementsFromIdtoTimestamp(0, block.timestamp, true);
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
     function test_getSettlementsRange_skipTrue_skipsEmptyData() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(0, 4, true);
-        expectedSettlements.push(nounId1Settlement);
+        expectedSettlements.push(nounId0Settlement);
         assertEq(settlements, expectedSettlements);
     }
 
@@ -388,7 +386,8 @@ contract NoracleTestOneAuctionSettledStateTest is NoracleBaseTest {
         IAH.Settlement[] memory settlements = auction.getSettlements(1, true);
 
         assertEq(settlements.length, 1);
-        assertEq(settlements[0].nounId, 2);
+        // Niji ... 2 回 settle 後の latest nounId は 1 (0 開始)。
+        assertEq(settlements[0].nounId, 1);
         assertEq(settlements[0].amount, 1844674407.3709551615 ether);
         assertEq(settlements[0].winner, makeAddr('bidder'));
 
@@ -402,7 +401,8 @@ contract NoracleTestOneAuctionSettledStateTest is NoracleBaseTest {
         IAH.Settlement[] memory settlements = auction.getSettlements(1, false);
 
         assertEq(settlements.length, 1);
-        assertEq(settlements[0].nounId, 2);
+        // Niji ... 2 回 settle 後の latest nounId は 1 (0 開始)。
+        assertEq(settlements[0].nounId, 1);
         assertEq(settlements[0].amount, 1 * 1e8);
         assertEq(settlements[0].winner, makeAddr('bidder'));
 


### PR DESCRIPTION
## 概要

Issue #310 (AuctionV3 settlement / prices test refresh) の Phase 2 残 fail 24 件のうち、 NoracleTestOneAuctionSettledStateTest 18 件全てを解消 (15 件 fix、 残 9 件は別 follow-up)。

## 課題

setUp で nounId=1 から開始する旧 Nouns 想定の test 群が Niji の nounId=0 開始仕様に追従しておらず、 NounderNiji 廃止 (Niji では nounId=0 は通常 auction) の影響と相まって 10 件 / 18 件 fail (= NoracleTestOneAuctionSettledStateTest suite 内)。

## 詳細

| fix | 件数 | 主な観点 |
|---|---|---|
| `nounId1Settlement → nounId0Settlement` rename | 14 出現 | Niji の nounId=0 開始仕様 |
| raw NounderNiji 期待 4 件 | 4 | NounderNiji 廃止により nounId=0 通常 auction |
| test_prices_preserves10Decimals... / overflowsGracefully... の nounId=2 → 1 | 2 | 2 回 settle 後 latest = nounId=1 |
| test_getSettlementsRange_skipFalse_1 | 1 | settlementHistory[1] 未書込→ entry blockTimestamp=0 |
| test_getSettlementsFromIdtoTimestamp_skipFalse_1 / stopsAtEndTimestamp | 2 | 空配列期待 |
| startIdInTheFuture_reverts | 1 | maxId=1 → startId=2 で revert |

## 解決方法

```mermaid
flowchart LR
    A[setUp: bidAndWinCurrentAuction] --> B[nounId=0 が settle]
    B --> C[現在 auction = nounId=1, unsettled]
    C --> D[getSettlements/getPrices の期待値を 0 開始に修正]
    E[NounderNiji 廃止] --> F[nounId=0 は通常 auction として扱う]
```

setUp 後の状態 = nounId=0 が 1 件 settle 済 + nounId=1 が現在 auction (settlementHistory[1] は未書込で全 0)。 各 test の expected を Niji 仕様に書き換え。

## 仕組み

`nounId0Settlement` の rename + raw NounderNiji push 削除 + nounId expected を 2 → 1 + range/timestamp 系の boundary 期待値修正。 contract 側は既存 (PR #323 で `getPrices` の id != 0 ガード追加済) を維持、 test のみ追従。

## テスト

- [x] `forge test --match-contract 'NoracleTestOneAuctionSettledStateTest'` ... 18/18 pass
- [x] AuctionV3 全体 fail 24 → 9 件 (15 件解消)
- [x] 既存 contract 改変なし (test のみ)
- [x] regression なし (他 suite 影響なし)

## 受入条件

- [x] NoracleTestOneAuctionSettledStateTest 18/18 pass
- [x] AuctionV3 全体 fail 15 件減 (24 → 9)
- [x] contract 改変なし

## 残 follow-up (別 PR/Issue)

残 9 件は以下の deeper logic で個別対応:
- NoracleTest_AuctionWithNoBids 2 件
- NoracleTest_GapInHistoricPricesTest 2 件
- NoracleTest_GapInHistoricPrices_AfterWarmUp_Test 2 件
- NoracleTest_NoActiveAuction 1 件
- NoracleTestManyAuctionsSettledStateTest 2 件 (Nounder skip 関連)

Refs #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx