### PR TITLE
test(niji-webapp): component part 37 (StreamPaymentsDateDetailsStep / ProposalContent helpers) で 756 → 773 (+17)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsDateDetailsStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsDateDetailsStep/index.test.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/BrandDatePicker', () => ({
+  default: ({
+    onChange,
+    label,
+    isInvalid,
+  }: {
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    label?: string;
+    isInvalid?: boolean;
+  }) => (
+    <label>
+      {label}
+      <input
+        type="date"
+        onChange={onChange}
+        data-invalid={isInvalid ? 'true' : 'false'}
+        data-label={label}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+    isNextBtnDisabled,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+    isNextBtnDisabled?: boolean;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} disabled={isNextBtnDisabled} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/ModalSubtitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+vi.mock('@/utils/timeUtils', () => ({
+  currentUnixEpoch: () => 1700000000,
+  toUnixEpoch: (date: string) => (date ? new Date(date).getTime() / 1000 : 0),
+}));
+
+import StreamPaymentDateDetailsStep from './index';
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+  state: {} as never,
+};
+
+describe('StreamPaymentDateDetailsStep', () => {
+  it('renders title + 2 date pickers + next/prev buttons', () => {
+    const { container } = render(<StreamPaymentDateDetailsStep {...defaults} />);
+    expect(container.querySelector('h1')?.textContent).toContain('Add Streaming Payment Action');
+    expect(container.querySelectorAll('input[type="date"]').length).toBe(2);
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
+
+  it('fires onPrevBtnClick on Back button click', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <StreamPaymentDateDetailsStep {...defaults} onPrevBtnClick={onPrev} />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls setState + onNextBtnClick when proceeding', () => {
+    const onNext = vi.fn();
+    const setState = vi.fn();
+    const { container } = render(
+      <StreamPaymentDateDetailsStep {...defaults} onNextBtnClick={onNext} setState={setState} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Next when endTimestamp < startTimestamp (start > 0 + end > 0)', () => {
+    const { container } = render(<StreamPaymentDateDetailsStep {...defaults} />);
+    const inputs = container.querySelectorAll('input[type="date"]');
+    fireEvent.change(inputs[0], { target: { value: '2030-12-31' } });
+    fireEvent.change(inputs[1], { target: { value: '2025-01-01' } });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('Next is enabled when both dates empty (default)', () => {
+    const { container } = render(<StreamPaymentDateDetailsStep {...defaults} />);
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(false);
+  });
+
+  it('marks Start date invalid when in past (currentUnixEpoch > startTimestamp)', () => {
+    const { container } = render(<StreamPaymentDateDetailsStep {...defaults} />);
+    const inputs = container.querySelectorAll('input[type="date"]');
+    fireEvent.change(inputs[0], { target: { value: '2020-01-01' } });
+    expect(inputs[0].getAttribute('data-invalid')).toBe('true');
+  });
+
+  it('renders streams start/end note', () => {
+    const { container } = render(<StreamPaymentDateDetailsStep {...defaults} />);
+    expect(container.textContent).toContain('Streams start and end at 00:00 UTC');
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalContent/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/index.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock('remark-breaks', () => ({ default: () => null }));
+
+vi.mock('./ProposalTransactions', () => ({
+  default: ({ details }: { details: unknown[] }) => (
+    <ol data-testid="proposal-tx">tx-count-{details.length}</ol>
+  ),
+}));
+
+vi.mock('@/components/EnsOrLongAddress', () => ({
+  default: ({ address }: { address: string }) => <span>{address}</span>,
+}));
+
+vi.mock('@/utils/processProposalDescriptionText', () => ({
+  processProposalDescriptionText: (d: string, t: string) => `[${t}]${d}`,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (a: string) => `https://etherscan.io/address/${a}`,
+  buildEtherscanHoldingsLink: (a: string) => `https://etherscan.io/tokenholdings?a=${a}`,
+  buildEtherscanTxLink: (h: string) => `https://etherscan.io/tx/${h}`,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiTokenAddress: { 1: '0xTOKEN' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+import ProposalContent, { linkIfAddress, transactionLink, transactionIconLink } from './index';
+
+const details = [{ target: '0xA' }, { target: '0xB' }] as never;
+
+describe('ProposalContent', () => {
+  it('renders Description heading + markdown when description provided', () => {
+    const { container } = render(
+      <ProposalContent description="# body" title="T1" details={details} />,
+    );
+    expect(container.textContent).toContain('Description');
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe('[T1]# body');
+  });
+
+  it('does NOT render markdown when description is empty', () => {
+    const { container } = render(<ProposalContent description="" title="T" details={details} />);
+    expect(container.querySelector('[data-testid="markdown"]')).toBeNull();
+  });
+
+  it('renders ProposalTransactions when details present', () => {
+    const { container } = render(<ProposalContent description="d" title="t" details={details} />);
+    expect(container.querySelector('[data-testid="proposal-tx"]')?.textContent).toBe('tx-count-2');
+  });
+
+  it('does NOT render Proposed Transactions when details is undefined', () => {
+    const { container } = render(
+      <ProposalContent description="d" title="t" details={undefined as never} />,
+    );
+    expect(container.textContent).not.toContain('Proposed Transactions');
+  });
+
+  it('shows original treasury banner when proposeOnV1=true', () => {
+    const { container } = render(
+      <ProposalContent description="d" title="t" details={details} proposeOnV1={true} />,
+    );
+    expect(container.textContent).toContain('original treasury');
+  });
+
+  it('does NOT show banner when proposeOnV1=false', () => {
+    const { container } = render(<ProposalContent description="d" title="t" details={details} />);
+    expect(container.textContent).not.toContain('original treasury');
+  });
+});
+
+describe('linkIfAddress helper', () => {
+  it('returns <a> when content is a valid address', () => {
+    const result = linkIfAddress('0x5FbDB2315678afecb367f032d93F642f64180aa3');
+    const { container } = render(<>{result}</>);
+    expect(container.querySelector('a')?.getAttribute('href')).toContain('etherscan.io/address');
+  });
+
+  it('returns <span> when content is not an address', () => {
+    const result = linkIfAddress('hello');
+    const { container } = render(<>{result}</>);
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.querySelector('span')?.textContent).toBe('hello');
+  });
+});
+
+describe('transactionLink helper', () => {
+  it('returns <a> with 7-char prefix text', () => {
+    const result = transactionLink('0xdeadbeef1234');
+    const { container } = render(<>{result}</>);
+    expect(container.querySelector('a')?.textContent).toBe('0xdeadb');
+    expect(container.querySelector('a')?.getAttribute('href')).toContain('etherscan.io/tx');
+  });
+});
+
+describe('transactionIconLink helper', () => {
+  it('returns <a> with link img', () => {
+    const result = transactionIconLink('0xhash');
+    const { container } = render(<>{result}</>);
+    expect(container.querySelector('a img')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 37 として ProposalActionsModal multi-step の DateDetails step + ProposalContent top-level + 3 helper、 計 17 TC、 test 件数を 756 → 773 (+17)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `StreamPaymentsDateDetailsStep` | 7 | title + 2 date picker + button / 2 click / disable gating (end<start) / 過去日付 invalid / Streams note |
| `ProposalContent/index` | 10 | 6 ProposalContent (Description+markdown / Transactions / V1 banner gating) + 4 helper (linkIfAddress 2 / transactionLink / transactionIconLink) |

## 解決方法

BrandDatePicker / ModalBottomButtonRow / Modal* / ProposalTransactions / EnsOrLongAddress を vi.mock で stub、 etherscan / SDK address は mock 化。 helper も export 経由で個別検証。

## テスト

- [x] `pnpm vitest run` で 773 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 17 TC 全 pass
- [x] regression なし

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx