### PR TITLE
fix(niji-contracts): AuctionV3 残 9 件全解消、 Issue #310 完全 close

### DIFF
--- a/packages/niji-contracts/contracts/NijiAuctionHouseV3.sol
+++ b/packages/niji-contracts/contracts/NijiAuctionHouseV3.sol
@@ -456,14 +456,9 @@ contract NijiAuctionHouseV3 is
         uint256 actualCount = 0;
 
         SettlementState memory settlementState;
-        // Niji ... nounId=0 開始のため id=0 を loop に含める (旧 Nouns nounId=1 開始想定の `id > 0` を修正)
-        // Nounder skip 条件は Niji で founder distribution 廃止のため id != 0 ガードを追加 (id=0 は通常 auction)
+        // Niji ... nounId=0 開始のため id=0 を loop に含める (旧 Nouns nounId=1 開始想定の `id > 0` を修正)。
+        // 旧 Nouns の Nounder skip (id % 10 == 0 で skip) は Niji で founder distribution 廃止のため不要、 完全削除済。
         for (uint256 id = latestNounId; actualCount < auctionCount; --id) {
-            if (id != 0 && id <= 1820 && id % 10 == 0) {
-                if (id == 0) break;
-                continue; // Skip Nounder reward nouns (Niji ... id=0 は対象外)
-            }
-
             settlementState = settlementHistory[id];
             require(settlementState.blockTimestamp > 1, 'Missing data');
             if (settlementState.winner == address(0)) {

--- a/packages/niji-contracts/test/foundry/NijiAuctionHouseV3.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiAuctionHouseV3.t.sol
@@ -421,23 +421,22 @@ contract NoracleTestManyAuctionsSettledStateTest is NoracleBaseTest {
     }
 
     function test_getSettlements_skipsNounderNiji() public {
+        // Niji ... NounderNiji 廃止 + nounId=0 開始のため、 20 回 settle で nounId=0〜19 が全て通常 auction。
+        // skipFalse でも全 20 件 reverse 順で返る (上は最新)。
         IAH.Settlement[] memory settlements = auction.getSettlements(20, true);
-        assertEq(settlements[0].nounId, 22);
-        assertEq(settlements[1].nounId, 21);
-        assertEq(settlements[2].nounId, 19);
-        assertEq(settlements[10].nounId, 11);
-        assertEq(settlements[11].nounId, 9);
-        assertEq(settlements[19].nounId, 1);
+        assertEq(settlements[0].nounId, 19);
+        assertEq(settlements[1].nounId, 18);
+        assertEq(settlements[10].nounId, 9);
+        assertEq(settlements[19].nounId, 0);
 
         assertEq(settlements[0].amount, 20 ether);
         assertEq(settlements[1].amount, 19 ether);
-        assertEq(settlements[2].amount, 18 ether);
         assertEq(settlements[10].amount, 10 ether);
-        assertEq(settlements[11].amount, 9 ether);
         assertEq(settlements[19].amount, 1 ether);
     }
 
     function test_getPrices_skipsNounderNiji() public {
+        // Niji ... NounderNiji 廃止のため 20 回 settle で 20 件全て価格取得。
         uint256[] memory prices = auction.getPrices(20);
         // prettier-ignore
         expectedPrices = [20e18, 19e18, 18e18, 17e18, 16e18, 15e18, 14e18, 13e18, 12e18, 11e18,
@@ -473,16 +472,18 @@ contract NoracleTest_GapInHistoricPricesTest is NoracleBaseTest {
     function setUp() public override {
         super.setUp();
 
-        bidAndWinCurrentAuction(bidder, 1 ether); // settle noun 1
+        // Niji ... auction は nounId=0 から開始 (旧 Nouns 1 開始から差替済)。
+        // settle nounId=0 → token mint で gap (2,3,4) 作成 → settle nounId=1 → settle nounId=5。
+        bidAndWinCurrentAuction(bidder, 1 ether); // settle nounId=0
 
         vm.startPrank(address(auction));
         for (uint256 i = 0; i < 3; ++i) {
-            auction.nouns().mint(); // mint nouns 3,4,5
+            auction.nouns().mint(); // mint nouns 2,3,4
         }
         vm.stopPrank();
 
-        bidAndWinCurrentAuction(bidder, 2 ether); // settle noun 2
-        bidAndWinCurrentAuction(bidder, 6 ether); // settle noun 6
+        bidAndWinCurrentAuction(bidder, 2 ether); // settle nounId=1
+        bidAndWinCurrentAuction(bidder, 6 ether); // settle nounId=5
     }
 
     function test_prices_revertsIfEmptyAuctionData() public {
@@ -499,14 +500,14 @@ contract NoracleTest_GapInHistoricPricesTest is NoracleBaseTest {
 
         uint256 ts = block.timestamp;
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 6, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 5, clientId: 0 })
         );
         expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 2 ether,
                 winner: bidder,
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -515,7 +516,7 @@ contract NoracleTest_GapInHistoricPricesTest is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 48 hours),
                 amount: 1 ether,
                 winner: bidder,
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );
@@ -533,10 +534,7 @@ contract NoracleTest_GapInHistoricPricesTest is NoracleBaseTest {
 
         uint256 ts = block.timestamp;
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 6, clientId: 0 })
-        );
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 5, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 5, clientId: 0 })
         );
         expectedSettlements.push(
             IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 4, clientId: 0 })
@@ -545,11 +543,14 @@ contract NoracleTest_GapInHistoricPricesTest is NoracleBaseTest {
             IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 3, clientId: 0 })
         );
         expectedSettlements.push(
+            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 2, clientId: 0 })
+        );
+        expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 2 ether,
                 winner: bidder,
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -558,16 +559,13 @@ contract NoracleTest_GapInHistoricPricesTest is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 48 hours),
                 amount: 1 ether,
                 winner: bidder,
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
         assertEq(settlements, expectedSettlements);
 
-        IAH.Settlement[] memory settlements2 = auction.getSettlements(0, 7, false);
+        IAH.Settlement[] memory settlements2 = auction.getSettlements(0, 6, false);
         assertEq(settlements2, reverse(expectedSettlements));
 
         IAH.Settlement[] memory settlements3 = auction.getSettlementsFromIdtoTimestamp(0, block.timestamp, false);
@@ -579,18 +577,19 @@ contract NoracleTest_GapInHistoricPrices_AfterWarmUp_Test is NoracleBaseTest {
     function setUp() public override {
         super.setUp();
 
-        auction.warmUpSettlementState(0, 7);
+        auction.warmUpSettlementState(0, 6);
 
-        bidAndWinCurrentAuction(bidder, 1 ether); // settle noun 1
+        // Niji ... auction は nounId=0 から開始 (旧 Nouns 1 開始から差替済)。
+        bidAndWinCurrentAuction(bidder, 1 ether); // settle nounId=0
 
         vm.startPrank(address(auction));
         for (uint256 i = 0; i < 3; ++i) {
-            auction.nouns().mint(); // mint nouns 3,4,5
+            auction.nouns().mint(); // mint nouns 2,3,4
         }
         vm.stopPrank();
 
-        bidAndWinCurrentAuction(bidder, 2 ether); // settle noun 2
-        bidAndWinCurrentAuction(bidder, 6 ether); // settle noun 6
+        bidAndWinCurrentAuction(bidder, 2 ether); // settle nounId=1
+        bidAndWinCurrentAuction(bidder, 6 ether); // settle nounId=5
     }
 
     function test_prices_revertsIfEmptyAuctionData() public {
@@ -607,14 +606,14 @@ contract NoracleTest_GapInHistoricPrices_AfterWarmUp_Test is NoracleBaseTest {
 
         uint256 ts = block.timestamp;
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 6, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 5, clientId: 0 })
         );
         expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 2 ether,
                 winner: bidder,
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -623,7 +622,7 @@ contract NoracleTest_GapInHistoricPrices_AfterWarmUp_Test is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 48 hours),
                 amount: 1 ether,
                 winner: bidder,
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );
@@ -641,10 +640,7 @@ contract NoracleTest_GapInHistoricPrices_AfterWarmUp_Test is NoracleBaseTest {
 
         uint256 ts = block.timestamp;
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 6, clientId: 0 })
-        );
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 1, amount: 0, winner: address(0), nounId: 5, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 6 ether, winner: bidder, nounId: 5, clientId: 0 })
         );
         expectedSettlements.push(
             IAH.Settlement({ blockTimestamp: 1, amount: 0, winner: address(0), nounId: 4, clientId: 0 })
@@ -653,11 +649,14 @@ contract NoracleTest_GapInHistoricPrices_AfterWarmUp_Test is NoracleBaseTest {
             IAH.Settlement({ blockTimestamp: 1, amount: 0, winner: address(0), nounId: 3, clientId: 0 })
         );
         expectedSettlements.push(
+            IAH.Settlement({ blockTimestamp: 1, amount: 0, winner: address(0), nounId: 2, clientId: 0 })
+        );
+        expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 2 ether,
                 winner: bidder,
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -666,18 +665,13 @@ contract NoracleTest_GapInHistoricPrices_AfterWarmUp_Test is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 48 hours),
                 amount: 1 ether,
                 winner: bidder,
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );
-
-        // timestamp remains 0 here because it's a Nounder reward ID that does not get warmed up.
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
         assertEq(settlements, expectedSettlements);
 
-        IAH.Settlement[] memory settlements2 = auction.getSettlements(0, 7, false);
+        IAH.Settlement[] memory settlements2 = auction.getSettlements(0, 6, false);
         assertEq(settlements2, reverse(expectedSettlements));
 
         IAH.Settlement[] memory settlements3 = auction.getSettlementsFromIdtoTimestamp(0, block.timestamp, false);
@@ -689,9 +683,10 @@ contract NoracleTest_AuctionWithNoBids is NoracleBaseTest {
     function setUp() public override {
         super.setUp();
 
-        bidAndWinCurrentAuction(bidder, 1 ether); // settle noun 1
-        endAuctionAndSettle(); // no winner for noun 2
-        bidAndWinCurrentAuction(bidder, 3 ether); // settle noun 3
+        // Niji ... auction は nounId=0 から開始 (旧 Nouns 1 開始から差替済)。
+        bidAndWinCurrentAuction(bidder, 1 ether); // settle nounId=0
+        endAuctionAndSettle(); // no winner for nounId=1
+        bidAndWinCurrentAuction(bidder, 3 ether); // settle nounId=2
     }
 
     function test_getPrices_skipsAuctionsWithNotBids() public {
@@ -705,14 +700,14 @@ contract NoracleTest_AuctionWithNoBids is NoracleBaseTest {
 
         uint256 ts = block.timestamp;
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 3 ether, winner: bidder, nounId: 3, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 3 ether, winner: bidder, nounId: 2, clientId: 0 })
         );
         expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 0,
                 winner: address(0),
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -721,16 +716,13 @@ contract NoracleTest_AuctionWithNoBids is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 48 hours),
                 amount: 1 ether,
                 winner: bidder,
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );
-        expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: 0, amount: 0, winner: address(0), nounId: 0, clientId: 0 })
-        );
         assertEq(settlements, expectedSettlements);
 
-        IAH.Settlement[] memory settlements2 = auction.getSettlements(0, 4, false);
+        IAH.Settlement[] memory settlements2 = auction.getSettlements(0, 3, false);
         assertEq(settlements2, reverse(expectedSettlements));
 
         IAH.Settlement[] memory settlements3 = auction.getSettlementsFromIdtoTimestamp(0, block.timestamp, false);
@@ -742,14 +734,14 @@ contract NoracleTest_AuctionWithNoBids is NoracleBaseTest {
 
         uint256 ts = block.timestamp;
         expectedSettlements.push(
-            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 3 ether, winner: bidder, nounId: 3, clientId: 0 })
+            IAH.Settlement({ blockTimestamp: uint32(ts), amount: 3 ether, winner: bidder, nounId: 2, clientId: 0 })
         );
         expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 0,
                 winner: address(0),
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -758,7 +750,7 @@ contract NoracleTest_AuctionWithNoBids is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 48 hours),
                 amount: 1 ether,
                 winner: bidder,
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );
@@ -793,13 +785,15 @@ contract NoracleTest_NoActiveAuction is NoracleBaseTest {
     function test_getSettlements_includesLastNoun() public {
         IAH.Settlement[] memory settlements = auction.getSettlements(20, true);
 
+        // Niji ... auction は nounId=0 から開始 (旧 Nouns 1 開始から差替済)。
+        // setUp で 2 回 settle: bidder=1 ether@nounId=0 → bidder 2=2 ether@nounId=1。
         uint256 ts = block.timestamp;
         expectedSettlements.push(
             IAH.Settlement({
                 blockTimestamp: uint32(ts),
                 amount: 2 ether,
                 winner: makeAddr('bidder 2'),
-                nounId: 2,
+                nounId: 1,
                 clientId: 0
             })
         );
@@ -808,7 +802,7 @@ contract NoracleTest_NoActiveAuction is NoracleBaseTest {
                 blockTimestamp: uint32(ts - 24 hours),
                 amount: 1 ether,
                 winner: makeAddr('bidder'),
-                nounId: 1,
+                nounId: 0,
                 clientId: 0
             })
         );


### PR DESCRIPTION
## 概要

Issue #310 (AuctionV3 settlement / prices test refresh) を完全 close。 production の getPrices で残存していた Nounder skip ロジックを完全削除し (Niji で founder distribution 廃止仕様)、 残 9 件全 fail を解消。 AuctionV3 全 52 件 pass、 forge test 全体 fail 19 → 10 (-9)。

## 課題

PR #400 で OneAuctionSettledStateTest 18 件解消後の残 9 件は production / test 両側で旧 Nouns 仕様 (nounId=1 開始 + Nounder skip 10% rule) に依存。 Niji 仕様 (nounId=0 開始 + founder distribution 廃止) に完全追従していなかった。

## 詳細

| 領域 | 件数 | 解消方法 |
|---|---|---|
| production `getPrices` Nounder skip 削除 | 1 logic 修正 | `id % 10 == 0` skip 完全削除 |
| `NoracleTest_NoActiveAuction.test_getSettlements_includesLastNoun` | 1 | nounId 1,2 → 0,1 |
| `NoracleTest_AuctionWithNoBids` (3) | 3 | setUp comment + 期待 nounId 1,2,3 → 0,1,2 |
| `NoracleTest_GapInHistoricPricesTest` (3) | 3 | mint nounIds 3,4,5 → 2,3,4 / settle 1,2,6 → 0,1,5 |
| `NoracleTest_GapInHistoricPrices_AfterWarmUp_Test` (3) | 3 | 同上 + warmUp range 0,7 → 0,6 |
| `NoracleTestManyAuctionsSettledStateTest.test_get*_skipsNounderNiji` (2) | 2 | 20 件全件取得 (Nounder skip なし) |

## 解決方法

```mermaid
flowchart LR
    A[旧 Nouns 仕様] --> B[nounId=1 開始 + Nounder skip 10% rule]
    A --> C[founder distribution あり]
    D[Niji 仕様] --> E[nounId=0 開始]
    D --> F[founder distribution 廃止]
    B -.->|production fix| F
    C -.->|test 期待値 0-based 化| E
```

production の getPrices Nounder skip は PR #323 で「`id != 0 && id <= 1820 && id % 10 == 0`」 という mid-state ガードに変更されていたが、 ManyAuctions test (20 件 settle で nounId=0〜19) の id=10 が Niji では通常 auction なのに skip されていたため `Not enough history` revert。 完全削除して通常 auction として扱う。

## 仕組み

`getPrices` ループ内の Nounder skip 分岐 (3 行) を完全削除、 残るのは settle history depth と winner=address(0) skip のみ。 test 側は setUp で settle される nounId 順序を Niji の 0-based に書き換え、 期待値の `nounId` field と長さを修正。

## テスト

- [x] `forge test --match-path NijiAuctionHouseV3.t.sol` 全 52 件 pass (24→0 fail、 100% 解消)
- [x] forge test 全体 fail 19 → 10 (-9)
- [x] regression なし (他 suite 影響なし)

## 受入条件

- [x] AuctionV3 全 52 件 pass
- [x] Issue #310 完全 close
- [x] Nounder skip 廃止仕様を production に反映

## 関連

- Issue #293 (Phase 2 親)
- Issue #310 (本 PR で close)
- Issue #326 (残 10 件 follow-up scope に縮小: ProposalCreatedWithRequirements 4 / VotesBelowProposalThreshold 6)

Closes #310
Refs #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx