### PR TITLE
fix(niji-contracts): forge test 残 10 件全解消、 Issue #326 完全 close (forge 100% pass)

### DIFF
--- a/packages/niji-contracts/test/foundry/NijiDAOData.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOData.t.sol
@@ -888,9 +888,10 @@ contract NijiDAOData_CreateCandidateToUpdateProposalTest is NijiDAODataBaseTest 
         (signer, signerPK) = makeAddrAndKey('signerWithVote1');
         bidAndSettleAuction(auction, signer);
 
-        // ERC721Votes (OZ v5) self-delegate
+        // Niji ... ERC721Votes (OZ v5) self-delegate、 priorVotes snapshot のため delegate 後 +1 block。
         vm.prank(signer);
         NijiToken(payable(address(nounsDao.nouns()))).delegate(signer);
+        vm.roll(block.number + 1);
 
         proposalId = proposeBySigs(
             notNouner,
@@ -970,6 +971,12 @@ contract NijiDAOData_CreateCandidateToUpdateProposalTest is NijiDAODataBaseTest 
     function test_givenProposalNotBySigs_reverts() public {
         address nouner = makeAddr('nouner');
         bidAndSettleAuction(auction, nouner);
+
+        // Niji ... ERC721Votes (OZ v5) は token 受領後 self-delegate しないと votes が active にならない。
+        vm.prank(nouner);
+        NijiToken(payable(address(nounsDao.nouns()))).delegate(nouner);
+        vm.roll(block.number + 1);
+
         proposalId = propose(nouner, makeAddr('target'), 0.142 ether, '', '', 'description');
 
         vm.expectRevert(NijiDAOData.UpdateProposalCandidatesOnlyWorkWithProposalsBySigs.selector);

--- a/packages/niji-contracts/test/foundry/NijiDAOLogic/ProposeBySigs.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiDAOLogic/ProposeBySigs.t.sol
@@ -323,9 +323,10 @@ contract ProposeBySigsTest is NijiDAOLogicBaseTest {
     }
 
     function test_givenProposerAndSignerWithVotesButBelowThreshold_reverts() public {
-        // Minting to push proposer and signer below threshold
+        // Niji ... Nounders auto-distribution 廃止のため、 旧 Nouns で 16 件 mint で nounders 自動 +2 = 21 件想定だったが
+        // Niji では明示的に 17 件 mint して totalSupply=20 へ到達 (3 setUp + 17 = 20、 threshold 1000bps で 2 票、 proposer+signer 2 <= 2 で revert)。
         vm.startPrank(minter);
-        for (uint256 i = 0; i < 16; ++i) {
+        for (uint256 i = 0; i < 17; ++i) {
             nounsToken.mint();
         }
         vm.roll(block.number + 1);
@@ -361,9 +362,9 @@ contract ProposeBySigsTest is NijiDAOLogicBaseTest {
     }
 
     function test_givenProposerAndSignerWithEnoughVotesCombined_worksAndEmitsEvents() public {
-        // Minting to push proposer below threshold, while combined with signer they have enough
+        // Niji ... Nounders 廃止のため 6 件 mint → 7 件 mint で totalSupply=10、 threshold 1 (proposer 1 + signer 1 = 2 > 1)。
         vm.startPrank(minter);
-        for (uint256 i = 0; i < 6; ++i) {
+        for (uint256 i = 0; i < 7; ++i) {
             nounsToken.mint();
         }
         vm.roll(block.number + 1);
@@ -387,9 +388,10 @@ contract ProposeBySigsTest is NijiDAOLogicBaseTest {
     }
 
     function test_givenProposerIsAlsoSigner_reverts() public {
-        // Minting to push proposer below threshold, while if counted twice will have enough
+        // Niji ... Nounders auto-distribution 廃止のため、 旧 Nouns で 6 件 mint で nounders 自動 +1 = 10 件想定だったが
+        // Niji では明示的に 7 件 mint して totalSupply=10 へ到達 (3 setUp + 7 = 10、 threshold 1000bps で 1 票)。
         vm.startPrank(minter);
-        for (uint256 i = 0; i < 6; ++i) {
+        for (uint256 i = 0; i < 7; ++i) {
             nounsToken.mint();
         }
         vm.roll(block.number + 1);
@@ -469,9 +471,9 @@ contract ProposeBySigsTest is NijiDAOLogicBaseTest {
     }
 
     function test_givenProposerWithNoVotesAndTwoSignersWithEnoughVotes_worksAndEmitsEvents() public {
-        // Minting to push a single signer below threshold
+        // Niji ... Nounders 廃止のため 6 件 mint → 7 件 mint で totalSupply=10、 threshold 1。
         vm.startPrank(minter);
-        for (uint256 i = 0; i < 6; ++i) {
+        for (uint256 i = 0; i < 7; ++i) {
             nounsToken.mint();
         }
         vm.roll(block.number + 1);

--- a/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
+++ b/packages/niji-contracts/test/foundry/rewards/ProposalRewards.t.sol
@@ -48,10 +48,13 @@ abstract contract BaseProposalRewardsTest is NijiDAOLogicBaseTest {
         // Niji 仕様で founder distribution は廃止、 該当 transferFrom は不要 (削除)。
 
         // ERC721Votes (OZ v5) self-delegate (bidder1 / bidder2 が token 受領済)
+        // Niji ... ERC721Votes は token 受領時 delegatee=address(0) で受け取り、 後から delegate で votes 移動。
+        // propose 時の getPriorVotes(at block-1) で 0 になるのを防ぐため delegate 後 mineBlocks(1) 必須。
         vm.prank(bidder1);
         NijiToken(payable(address(nounsToken))).delegate(bidder1);
         vm.prank(bidder2);
         NijiToken(payable(address(nounsToken))).delegate(bidder2);
+        mineBlocks(1);
 
         rewards = RewardsDeployer.deployRewards(dao, admin, minter, address(erc20Mock), address(0));
 
@@ -526,16 +529,16 @@ contract ProposalRewardsEligibilityTest is BaseProposalRewardsTest {
 
         lastNounId = settleAuction();
 
-        // verify assumptions
-        assertEq(nounsToken.totalSupply(), 12);
-        assertEq(nounsToken.getCurrentVotes(bidder1), 8);
+        // Niji ... Nounders auto-distribution 廃止のため totalSupply 12 → 11、 bidder1 votes 8 → 9 (snapshot timing で settleAuction 前)。
+        assertEq(nounsToken.totalSupply(), 11);
+        assertEq(nounsToken.getCurrentVotes(bidder1), 9);
 
         votingClientIds = [0];
     }
 
     function test_ineligibleIfBelowQuorum() public {
-        // set quorum to >= 75% so that quorum requires 9 votes
-        proposalParams.proposalEligibilityQuorumBps = 7500;
+        // Niji ... quorum を totalSupply (11) のほぼ全数に設定して proposal を ineligible に。
+        proposalParams.proposalEligibilityQuorumBps = 10000;
         vm.prank(address(dao.timelock()));
         rewards.setProposalRewardParams(proposalParams);
 
@@ -547,7 +550,8 @@ contract ProposalRewardsEligibilityTest is BaseProposalRewardsTest {
     }
 
     function test_eligibleIfAboveQuorum() public {
-        proposalParams.proposalEligibilityQuorumBps = 7000; // (12 * 7000 / 10000) = 8
+        // Niji ... 7000 BPS で (11 * 7000 / 10000) = 7 quorum、 bidder1 vote=9 で eligible。
+        proposalParams.proposalEligibilityQuorumBps = 7000;
         vm.prank(address(dao.timelock()));
         rewards.setProposalRewardParams(proposalParams);
 
@@ -558,7 +562,8 @@ contract ProposalRewardsEligibilityTest is BaseProposalRewardsTest {
     }
 
     function test_canceledProposalsAreIneligible() public {
-        proposalParams.proposalEligibilityQuorumBps = 7000; // (12 * 7000 / 10000) = 8
+        // Niji ... 7000 BPS で eligible だが cancel で ineligible に降格する流れを確認。
+        proposalParams.proposalEligibilityQuorumBps = 7000;
         vm.prank(address(dao.timelock()));
         rewards.setProposalRewardParams(proposalParams);
 
@@ -783,14 +788,14 @@ contract VotesRewardsTest is BaseProposalRewardsTest {
     }
 
     function test_revertsIfNotAllVotesAreAccounted() public {
-        vote(bidder1, proposalId, 1, 'i support', clientId1);
+        // Niji ... noundersDAO 廃止のため、 旧 Nouns で noundersDAO が clientId=0 で vote していた経路を
+        // bidder1 が vote without clientId (clientId=0) で代替する。
+        vote(bidder1, proposalId, 1, 'i support'); // clientId=0
         vote(bidder2, proposalId, 1, 'i support', clientId2);
-        // vote with no clientId means clientId == 0
-        vote(makeAddr('noundersDAO'), proposalId, 0, 'against');
 
         mineBlocks(VOTING_PERIOD);
 
-        votingClientIds = [clientId1, clientId2];
+        votingClientIds = [clientId2];
         vm.expectRevert('not all votes accounted');
         rewards.updateRewardsForProposalWritingAndVoting({
             lastProposalId: proposalId,
@@ -798,13 +803,6 @@ contract VotesRewardsTest is BaseProposalRewardsTest {
         });
 
         votingClientIds = [0, clientId2];
-        vm.expectRevert('not all votes accounted');
-        rewards.updateRewardsForProposalWritingAndVoting({
-            lastProposalId: proposalId,
-            votingClientIds: votingClientIds
-        });
-
-        votingClientIds = [0, clientId1, clientId2];
         rewards.updateRewardsForProposalWritingAndVoting({
             lastProposalId: proposalId,
             votingClientIds: votingClientIds
@@ -827,11 +825,12 @@ contract VotesRewardsTest is BaseProposalRewardsTest {
     }
 
     function test_getVotingClientIds3() public {
+        // Niji ... noundersDAO 廃止のため、 旧 Nouns で noundersDAO が clientId=0 で vote していた経路を
+        // bidder2 vote without clientId (clientId=0) で代替し、 clientId 集合 [0, 1] を期待。
         vote(bidder1, proposalId, 1, 'i support', clientId1);
-        vote(bidder2, proposalId, 1, 'i support', clientId2);
-        vote(makeAddr('noundersDAO'), proposalId, 0, 'against');
+        vote(bidder2, proposalId, 1, 'i support'); // clientId=0
         mineBlocks(VOTING_PERIOD);
-        expectedClientIds = [0, 1, 2];
+        expectedClientIds = [0, 1];
         assertEq(rewards.getVotingClientIds(proposalId), expectedClientIds);
     }
 


### PR DESCRIPTION
## 概要

forge test 残 fail 10 件全解消、 Issue #326 完全 close。 **forge test 全 756 件 pass、 fail 0 件達成 (Niji contract 100% pass)**。 Phase 2 全 fail 解消完了 (118 → 0)。

## 課題

PR #400 / #403 で AuctionV3 24 件解消後の残 10 件は ProposeBySigs 4 件 + ProposalRewards 5 件 + NijiDAOData 1 件で、 旧 Nouns の Nounders auto-distribution と ERC721Votes (OZ v5) の delegate timing が混在していた。

## 詳細

| 領域 | 件数 | 主因 |
|---|---|---|
| ProposeBySigs (proposeBySigs flow) | 4 | Nounders auto +1/+2 廃止 → 明示 mint 数調整 (3→7, 16→17) |
| ProposalRewards setUp (BaseProposalRewardsTest) | 2 | delegate 後 mineBlocks(1) 必須 (priorVotes snapshot) |
| ProposalRewardsEligibilityTest | 1 | totalSupply 12→11, bidder1 votes 8→9 期待値修正 |
| VotesRewardsTest noundersDAO 経路 | 2 | makeAddr('noundersDAO') vote を bidder vote without clientId に置換 |
| NijiDAOData createCandidate | 1 | setUp + test_givenProposalNotBySigs で self-delegate + roll(+1) |

## 解決方法

```mermaid
flowchart LR
    A[旧 Nouns Nounders 自動 +1/+2] --> B[mint 数を明示 +1 で代替]
    C[OZ v5 ERC721Votes delegate timing] --> D[delegate 後 mineBlocks(1) で priorVotes snapshot 確保]
    E[noundersDAO 廃止] --> F[bidder vote without clientId で clientId=0 経路代替]
```

## 仕組み

`ERC721Votes` (OZ v5) は token 受領時 delegatee=address(0) で受け取り、 後から `delegate(self)` で過去累計 votes を当該 delegatee に移動。 `getPriorVotes(block-1)` が 0 にならないよう delegate 後 `mineBlocks(1)` (= `roll +1`) で snapshot 確保。 `noundersDAO` は Niji 仕様で廃止のため、 clientId=0 経路は通常 voter (bidder1/bidder2) の vote without clientId で代替。

## テスト

- [x] `forge test` 全 756 件 pass、 fail 0 件
- [x] 全 Phase 2 fail 解消 (118 → 0)
- [x] regression なし

## 受入条件

- [x] forge test fail 0
- [x] Issue #326 完全 close
- [x] Phase 2 親 Issue #293 の test fail も完全解消

## 関連 / Close

- Issue #293 (Phase 2 親)
- Issue #310 (AuctionV3 settlement、 PR #400 / #403 で close 済)
- Issue #326 (本 PR で close)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx