### PR TITLE
test(niji-webapp): component part 38 (TransferFundsDetails / TxDiffs / SolidColorModal) で 773 → 790 (+17)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsDetailsStep/index.test.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/BrandDropdown', () => ({
+  default: ({
+    onChange,
+    value,
+    label,
+    children,
+  }: {
+    onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+    value: string;
+    label?: string;
+    children?: React.ReactNode;
+  }) => (
+    <label>
+      {label}
+      <select onChange={onChange} value={value} data-testid="currency">
+        {children}
+      </select>
+    </label>
+  ),
+}));
+
+vi.mock('@/components/BrandNumericEntry', () => ({
+  default: ({
+    onValueChange,
+    value,
+    placeholder,
+    label,
+    isInvalid,
+  }: {
+    onValueChange?: (vals: { value: string; formattedValue: string }) => void;
+    value?: string | number;
+    placeholder?: string;
+    label?: string;
+    isInvalid?: boolean;
+  }) => (
+    <label>
+      {label}
+      <input
+        data-testid="amount"
+        value={value ?? ''}
+        placeholder={placeholder}
+        data-invalid={isInvalid ? 'true' : 'false'}
+        onChange={e => onValueChange?.({ value: e.target.value, formattedValue: e.target.value })}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@/components/BrandTextEntry', () => ({
+  default: ({
+    onChange,
+    value,
+    label,
+    placeholder,
+    isInvalid,
+  }: {
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    value?: string;
+    label?: string;
+    placeholder?: string;
+    isInvalid?: boolean;
+  }) => (
+    <label>
+      {label}
+      <input
+        data-testid="recipient"
+        value={value ?? ''}
+        placeholder={placeholder}
+        data-invalid={isInvalid ? 'true' : 'false'}
+        onChange={onChange}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+    isNextBtnDisabled,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+    isNextBtnDisabled?: boolean;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} disabled={isNextBtnDisabled} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+import TransferFundsDetailsStep from './index';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+  state: {} as never,
+};
+
+describe('TransferFundsDetailsStep', () => {
+  it('renders title + 3 form fields + 2 buttons', () => {
+    const { container } = render(<TransferFundsDetailsStep {...defaults} />);
+    expect(container.querySelector('h1')?.textContent).toContain('Add Transfer Funds Action');
+    expect(container.querySelector('[data-testid="currency"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="amount"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="recipient"]')).not.toBeNull();
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
+
+  it('default currency is USDC', () => {
+    const { container } = render(<TransferFundsDetailsStep {...defaults} />);
+    expect(container.querySelector('[data-testid="currency"]')?.value).toBe('USDC');
+  });
+
+  it('Next is disabled until valid amount + valid address', () => {
+    const { container } = render(<TransferFundsDetailsStep {...defaults} />);
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('Next becomes enabled after entering valid amount + valid address', () => {
+    const { container } = render(<TransferFundsDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="amount"]')!, {
+      target: { value: '100' },
+    });
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: ADDR },
+    });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(false);
+  });
+
+  it('marks recipient invalid when non-empty but not address', () => {
+    const { container } = render(<TransferFundsDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: '0xINVALID' },
+    });
+    expect(container.querySelector('[data-testid="recipient"]')?.getAttribute('data-invalid')).toBe(
+      'true',
+    );
+  });
+
+  it('fires onPrev on Back button click', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <TransferFundsDetailsStep {...defaults} onPrevBtnClick={onPrev} />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists state via setState + fires onNext on Review and Add click', () => {
+    const onNext = vi.fn();
+    const setState = vi.fn();
+    const { container } = render(
+      <TransferFundsDetailsStep {...defaults} onNextBtnClick={onNext} setState={setState} />,
+    );
+    fireEvent.change(container.querySelector('[data-testid="amount"]')!, {
+      target: { value: '100' },
+    });
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: ADDR },
+    });
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransactionsDiffs.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransactionsDiffs.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-diff-viewer-continued', () => ({
+  default: ({ oldValue, newValue }: { oldValue: string; newValue: string }) => (
+    <div data-testid="diff">
+      <span data-testid="old">{oldValue}</span>
+      <span data-testid="new">{newValue}</span>
+    </div>
+  ),
+}));
+
+vi.mock('./ProposalTransaction', () => ({
+  default: ({ transaction }: { transaction: { target: string } }) => (
+    <span data-testid="tx">{transaction.target}</span>
+  ),
+}));
+
+import ProposalTransactionsDiffs from './ProposalTransactionsDiffs';
+
+const makeTx = (target: string, funcSig = 'transfer', value = 0n, callData = '0x') => ({
+  target,
+  functionSig: funcSig,
+  value,
+  callData,
+});
+
+describe('ProposalTransactionsDiffs', () => {
+  it('renders empty when both arrays empty', () => {
+    const { container } = render(
+      <ProposalTransactionsDiffs
+        oldTransactions={[]}
+        newTransactions={[]}
+        activeVersionNumber={1}
+      />,
+    );
+    expect(container.querySelectorAll('[data-testid="diff"]').length).toBe(0);
+  });
+
+  it('renders diff entry for each tx in longer array', () => {
+    const txs = [makeTx('0xA') as never, makeTx('0xB') as never];
+    const { container } = render(
+      <ProposalTransactionsDiffs
+        oldTransactions={[txs[0]]}
+        newTransactions={txs}
+        activeVersionNumber={2}
+      />,
+    );
+    // 2 entries (longerArray=newTransactions)
+    expect(
+      container.querySelectorAll('[data-testid="diff"]').length +
+        container.querySelectorAll('[data-testid="tx"]').length,
+    ).toBeGreaterThanOrEqual(2);
+  });
+
+  it('handles old longer than new', () => {
+    const old = [makeTx('0xA') as never, makeTx('0xB') as never, makeTx('0xC') as never];
+    const { container } = render(
+      <ProposalTransactionsDiffs
+        oldTransactions={old}
+        newTransactions={[makeTx('0xA') as never]}
+        activeVersionNumber={1}
+      />,
+    );
+    expect(
+      container.querySelectorAll('[data-testid="diff"]').length +
+        container.querySelectorAll('[data-testid="tx"]').length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
+  it('handles equal length arrays', () => {
+    const old = [makeTx('0xA') as never];
+    const ne = [makeTx('0xB') as never];
+    const { container } = render(
+      <ProposalTransactionsDiffs
+        oldTransactions={old}
+        newTransactions={ne}
+        activeVersionNumber={1}
+      />,
+    );
+    expect(
+      container.querySelectorAll('[data-testid="diff"]').length +
+        container.querySelectorAll('[data-testid="tx"]').length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/NijisTransition', () => ({
+  default: ({
+    show,
+    children,
+    className,
+  }: {
+    show: boolean;
+    children?: React.ReactNode;
+    className?: string;
+  }) =>
+    show ? (
+      <div className={className} data-testid="transition">
+        {children}
+      </div>
+    ) : null,
+}));
+
+vi.mock('@/utils/cssTransitionUtils', () => ({
+  basicFadeInOut: {},
+  desktopModalSlideInFromTopAndGrow: {},
+  mobileModalSlideInFromBottm: {},
+}));
+
+vi.mock('@/utils/isMobile', () => ({
+  isMobileScreen: () => false,
+}));
+
+import SolidColorBackgroundModal, { Backdrop } from './index';
+
+beforeEach(() => {
+  document.body.innerHTML =
+    '<div id="root"></div><div id="backdrop-root"></div><div id="overlay-root"></div>';
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('Backdrop', () => {
+  it('does not render when show=false', () => {
+    const { container } = render(<Backdrop show={false} onDismiss={() => {}} />);
+    expect(container.querySelector('[data-testid="transition"]')).toBeNull();
+  });
+
+  it('renders when show=true', () => {
+    const { container } = render(<Backdrop show={true} onDismiss={() => {}} />);
+    expect(container.querySelector('[data-testid="transition"]')).not.toBeNull();
+  });
+});
+
+describe('SolidColorBackgroundModal', () => {
+  it('portals into backdrop-root + overlay-root', () => {
+    render(<SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<p>x</p>} />);
+    expect(document.getElementById('backdrop-root')?.children.length).toBe(1);
+    expect((document.getElementById('overlay-root')?.children.length ?? 0) > 0).toBe(true);
+  });
+
+  it('does not show content when show=false', () => {
+    render(<SolidColorBackgroundModal show={false} onDismiss={() => {}} content={<p>x</p>} />);
+    // NijisTransition mock で show=false は null を返すので overlay-root.children は空
+    expect(document.getElementById('overlay-root')?.querySelector('p')).toBeNull();
+  });
+
+  it('renders content when show=true', () => {
+    render(
+      <SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<p>my content</p>} />,
+    );
+    expect(document.getElementById('overlay-root')?.querySelector('p')?.textContent).toBe(
+      'my content',
+    );
+  });
+
+  it('fires onDismiss on close button click', () => {
+    const onDismiss = vi.fn();
+    render(<SolidColorBackgroundModal show={true} onDismiss={onDismiss} content={null} />);
+    const btn = document.getElementById('overlay-root')?.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 38 として 3 file 17 TC、 test 件数を 773 → 790 (+17)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `TransferFundsDetailsStep` | 7 | title + 3 form + 2 btn / default USDC / next disable/enable / recipient invalid / Back click / state persist + onNext |
| `ProposalTransactionsDiffs` | 4 | empty / 異長 old/new / 同長 |
| `SolidColorBackgroundModal` | 6 | Backdrop show 2 + portal show=true/false + onDismiss button |

## 解決方法

react-diff-viewer-continued / NijisTransition / Brand 入力 4 系 / cssTransitionUtils / isMobile を vi.mock で stub、 portal は backdrop-root/overlay-root 注入 pattern を継続再利用。

## テスト

- [x] `pnpm vitest run` で 790 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 3 file 計 17 TC 全 pass
- [x] regression なし

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx