### PR TITLE
test(niji-webapp): component part 40 (StreamPaymentsPaymentDetails / ProposalTransactions) で 801 → 815 (+14)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/BrandDropdown', () => ({
+  default: ({
+    onChange,
+    value,
+    label,
+    children,
+  }: {
+    onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+    value: string;
+    label?: string;
+    children?: React.ReactNode;
+  }) => (
+    <label>
+      {label}
+      <select onChange={onChange} value={value} data-testid="currency">
+        {children}
+      </select>
+    </label>
+  ),
+}));
+
+vi.mock('@/components/BrandNumericEntry', () => ({
+  default: ({
+    onValueChange,
+    value,
+    placeholder,
+    label,
+  }: {
+    onValueChange?: (vals: { value: string; formattedValue: string }) => void;
+    value?: string | number;
+    placeholder?: string;
+    label?: string;
+  }) => (
+    <label>
+      {label}
+      <input
+        data-testid="amount"
+        value={value ?? ''}
+        placeholder={placeholder}
+        onChange={e => onValueChange?.({ value: e.target.value, formattedValue: e.target.value })}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@/components/BrandTextEntry', () => ({
+  default: ({
+    onChange,
+    value,
+    label,
+    placeholder,
+    isInvalid,
+  }: {
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    value?: string;
+    label?: string;
+    placeholder?: string;
+    isInvalid?: boolean;
+  }) => (
+    <label>
+      {label}
+      <input
+        data-testid="recipient"
+        value={value ?? ''}
+        placeholder={placeholder}
+        data-invalid={isInvalid ? 'true' : 'false'}
+        onChange={onChange}
+      />
+    </label>
+  ),
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+    isNextBtnDisabled,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+    isNextBtnDisabled?: boolean;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} disabled={isNextBtnDisabled} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/ModalSubtitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+import StreamPaymentsPaymentDetailsStep from './index';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+  state: {} as never,
+};
+
+describe('StreamPaymentsPaymentDetailsStep', () => {
+  it('renders title + 3 form fields + 2 buttons', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelector('h1')).not.toBeNull();
+    expect(container.querySelector('[data-testid="currency"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="amount"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="recipient"]')).not.toBeNull();
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
+
+  it('default currency is USDC', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelector('[data-testid="currency"]')?.value).toBe('USDC');
+  });
+
+  it('Next is disabled until valid amount + valid address', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('Next enabled after valid input', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="amount"]')!, {
+      target: { value: '100' },
+    });
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: ADDR },
+    });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(false);
+  });
+
+  it('fires Back', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <StreamPaymentsPaymentDetailsStep {...defaults} onPrevBtnClick={onPrev} />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists state via setState + fires onNext', () => {
+    const onNext = vi.fn();
+    const setState = vi.fn();
+    const { container } = render(
+      <StreamPaymentsPaymentDetailsStep
+        {...defaults}
+        onNextBtnClick={onNext}
+        setState={setState}
+      />,
+    );
+    fireEvent.change(container.querySelector('[data-testid="amount"]')!, {
+      target: { value: '100' },
+    });
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: ADDR },
+    });
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks recipient invalid for non-address input', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: '0xINVALID' },
+    });
+    expect(container.querySelector('[data-testid="recipient"]')?.getAttribute('data-invalid')).toBe(
+      'true',
+    );
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalTransactions/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalTransactions/index.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+import ProposalTransactions from './index';
+
+const makeTx = (signature: string, calldata: string, decoded?: string) => ({
+  address: '0xADDR',
+  signature,
+  calldata,
+  decodedCalldata: decoded,
+  value: 0n,
+  usdcValue: 0,
+});
+
+describe('ProposalTransactions', () => {
+  it('renders empty root div (no transaction entries) for empty array', () => {
+    const { container } = render(
+      <ProposalTransactions proposalTransactions={[]} onRemoveProposalTransaction={() => {}} />,
+    );
+    expect(container.firstChild).not.toBeNull();
+    expect(container.querySelectorAll('button').length).toBe(0);
+  });
+
+  it('renders 1 transaction entry per tx', () => {
+    const txs = [makeTx('transfer()', '0x'), makeTx('mint()', '0xabc')];
+    const { container } = render(
+      <ProposalTransactions proposalTransactions={txs} onRemoveProposalTransaction={() => {}} />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
+
+  it('shows signature in label', () => {
+    const txs = [makeTx('transfer()', '0x')];
+    const { container } = render(
+      <ProposalTransactions proposalTransactions={txs} onRemoveProposalTransaction={() => {}} />,
+    );
+    expect(container.textContent).toContain('transfer()');
+    expect(container.textContent).toContain('Transaction #1');
+  });
+
+  it('falls back to "transfer()" when signature empty', () => {
+    const txs = [makeTx('', '0x')];
+    const { container } = render(
+      <ProposalTransactions proposalTransactions={txs} onRemoveProposalTransaction={() => {}} />,
+    );
+    expect(container.textContent).toContain('transfer()');
+  });
+
+  it('fires onRemoveProposalTransaction with index on button click', () => {
+    const onRemove = vi.fn();
+    const txs = [makeTx('foo()', '0x'), makeTx('bar()', '0x'), makeTx('baz()', '0x')];
+    const { container } = render(
+      <ProposalTransactions proposalTransactions={txs} onRemoveProposalTransaction={onRemove} />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[1]);
+    expect(onRemove).toHaveBeenCalledWith(1);
+  });
+
+  it('renders x-icon remove img for each tx', () => {
+    const txs = [makeTx('foo()', '0x')];
+    const { container } = render(
+      <ProposalTransactions proposalTransactions={txs} onRemoveProposalTransaction={() => {}} />,
+    );
+    expect(container.querySelector('img[alt="Remove Transaction"]')).not.toBeNull();
+  });
+
+  it('applies custom className to root', () => {
+    const { container } = render(
+      <ProposalTransactions
+        proposalTransactions={[]}
+        onRemoveProposalTransaction={() => {}}
+        className="my-tx-list"
+      />,
+    );
+    expect(container.firstChild?.className).toContain('my-tx-list');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 40 として 2 file 14 TC、 test 件数を 801 → 815 (+14)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `StreamPaymentsPaymentDetailsStep` | 7 | title + 3 form + 2 btn / default USDC / next disable/enable / Back / state persist + onNext / recipient invalid |
| `ProposalTransactions/index` | 7 | 空 array / 各 tx entry / signature 表示 + 空 fallback / onRemove + index / x-icon / className |

## 解決方法

Brand 入力 4 系 / Modal* / etherscan を vi.mock で stub、 OverlayTrigger root div 描画は維持。

## テスト

- [x] `pnpm vitest run` で 815 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 14 TC 全 pass
- [x] regression なし

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx