### PR TITLE
test(niji-webapp): component part 41 (Stream/TransferFundsReviewStep) で 815 → 828 (+13)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiGovernorAddress: { 1: '0xGOV' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/ModalLabel', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
+}));
+
+vi.mock('@/components/ModalTextPrimary', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="tooltip-content">{children}</span>
+  ),
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+vi.mock('@/hooks/useStreamPaymentTransactions', () => ({
+  default: () => [{ address: '0xACTION', value: '0', signature: 'createStream' }],
+}));
+
+vi.mock('@/utils/streamingPaymentUtils/streamingPaymentUtils', () => ({
+  usePredictStreamAddress: () => '0xPREDICTED',
+  formatTokenAmount: () => 0n,
+  getTokenAddressForCurrency: () => '0xTOKEN',
+}));
+
+vi.mock('@/utils/timeUtils', () => ({
+  unixToDateString: (ts: number) => `date-${ts}`,
+}));
+
+import StreamPaymentsReviewStep from './index';
+
+const baseState = {
+  amount: '1.5',
+  address: '0xRECIPIENT',
+  TransferFundsCurrency: 'USDC',
+  streamStartTimestamp: 1700000000,
+  streamEndTimestamp: 1800000000,
+};
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+  onDismiss: () => {},
+  state: baseState as never,
+};
+
+describe('StreamPaymentsReviewStep', () => {
+  it('renders Review title + 4 labels (Stream/To/Starting/Ending)', () => {
+    const { container } = render(<StreamPaymentsReviewStep {...defaults} />);
+    expect(container.querySelector('h1')?.textContent).toContain('Review Streaming Payment Action');
+    expect(container.querySelectorAll('h2').length).toBe(4);
+  });
+
+  it('shows amount + currency in stream label', () => {
+    const { container } = render(<StreamPaymentsReviewStep {...defaults} />);
+    expect(container.textContent).toContain('1.5');
+    expect(container.textContent).toContain('USDC');
+  });
+
+  it('shows ShortAddress for recipient', () => {
+    const { container } = render(<StreamPaymentsReviewStep {...defaults} />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xRECIPIENT');
+  });
+
+  it('shows start/end timestamps via unixToDateString', () => {
+    const { container } = render(<StreamPaymentsReviewStep {...defaults} />);
+    expect(container.textContent).toContain('date-1700000000');
+    expect(container.textContent).toContain('date-1800000000');
+  });
+
+  it('Back button fires onPrevBtnClick', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <StreamPaymentsReviewStep {...defaults} onPrevBtnClick={onPrev} />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('Next button fires onNextBtnClick + onDismiss', () => {
+    const onNext = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <StreamPaymentsReviewStep {...defaults} onNextBtnClick={onNext} onDismiss={onDismiss} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders tooltip content with full address', () => {
+    const { container } = render(<StreamPaymentsReviewStep {...defaults} />);
+    expect(container.querySelector('[data-testid="tooltip-content"]')?.textContent).toBe(
+      '0xRECIPIENT',
+    );
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiPayerAbi: [
+    {
+      type: 'function',
+      name: 'sendOrRegisterDebt',
+      inputs: [
+        { name: 'to', type: 'address' },
+        { name: 'amount', type: 'uint256' },
+      ],
+      outputs: [],
+      stateMutability: 'nonpayable',
+    },
+  ],
+  nijiPayerAddress: { 1: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+  stEthAddress: { 1: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+import { SupportedCurrency } from '../TransferFundsDetailsStep';
+
+import TransferFundsReviewStep from './index';
+
+const baseState = {
+  amount: '2.5',
+  address: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+  TransferFundsCurrency: SupportedCurrency.ETH,
+} as never;
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+  onDismiss: () => {},
+  state: baseState,
+};
+
+describe('TransferFundsReviewStep', () => {
+  it('renders Review title + Pay/To labels', () => {
+    const { container } = render(<TransferFundsReviewStep {...defaults} />);
+    expect(container.querySelector('h1')?.textContent).toContain('Review Transfer Funds Action');
+    expect(container.textContent).toContain('Pay');
+    expect(container.textContent).toContain('To');
+  });
+
+  it('shows amount + currency', () => {
+    const { container } = render(<TransferFundsReviewStep {...defaults} />);
+    expect(container.textContent).toContain('2.5');
+    expect(container.textContent).toContain('ETH');
+  });
+
+  it('shows ShortAddress for recipient', () => {
+    const { container } = render(<TransferFundsReviewStep {...defaults} />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe(
+      '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+    );
+  });
+
+  it('Back button fires onPrevBtnClick', () => {
+    const onPrev = vi.fn();
+    const { container } = render(<TransferFundsReviewStep {...defaults} onPrevBtnClick={onPrev} />);
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('Next button fires onNextBtnClick (via handleActionAdd) + onDismiss for ETH', () => {
+    const onNext = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <TransferFundsReviewStep {...defaults} onNextBtnClick={onNext} onDismiss={onDismiss} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it.skip('Next button works for STETH currency (skip: BigInt JSON.stringify production bug)', () => {
+    // Niji ... handleActionAdd の STETH branch で `JSON.stringify(args)` が args 内 BigInt を直列化できず throw。
+    // production の既知 bug、 本 PR scope 外のため skip。 follow-up Issue で対応。
+  });
+
+  it('Next button works for USDC currency', () => {
+    const onNext = vi.fn();
+    const onDismiss = vi.fn();
+    const state = { ...baseState, TransferFundsCurrency: SupportedCurrency.USDC };
+    const { container } = render(
+      <TransferFundsReviewStep
+        {...defaults}
+        state={state}
+        onNextBtnClick={onNext}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 41 として 2 file 13 TC + 1 skip、 test 件数を 815 → 828 (+13)。 ProposalActionsModal review 系を完了。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `StreamPaymentsReviewStep` | 7 | Review title + 4 label / amount/currency / ShortAddress / dates / Back / Next+onDismiss / tooltip address |
| `TransferFundsReviewStep` | 6 + 1 skip | Pay/To / amount / ShortAddress / Back / Next ETH+USDC / [skip: STETH JSON.stringify BigInt bug] |

## 解決方法

useStreamPaymentTransactions / usePredictStreamAddress / formatTokenAmount / nijiPayerAbi (minimal sendOrRegisterDebt) / Modal* 系を vi.mock で stub。 STETH 経路は production の `JSON.stringify(args)` で BigInt 引数を直列化できず throw する既知 bug で skip (follow-up Issue で対応)。

## テスト

- [x] `pnpm vitest run` で 828 pass + 1 skip + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 13 TC pass + 1 skip
- [x] regression なし

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx