### PR TITLE
fix(niji-webapp): TransferFundsReviewStep STETH の JSON.stringify BigInt bug 修正

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.test.tsx
@@ -114,9 +114,24 @@ describe('TransferFundsReviewStep', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it.skip('Next button works for STETH currency (skip: BigInt JSON.stringify production bug)', () => {
-    // Niji ... handleActionAdd の STETH branch で `JSON.stringify(args)` が args 内 BigInt を直列化できず throw。
-    // production の既知 bug、 本 PR scope 外のため skip。 follow-up Issue で対応。
+  it('Next button works for STETH currency (BigInt JSON.stringify replacer 経路)', () => {
+    const onNext = vi.fn();
+    const onDismiss = vi.fn();
+    const state = { ...baseState, TransferFundsCurrency: SupportedCurrency.STETH };
+    const { container } = render(
+      <TransferFundsReviewStep
+        {...defaults}
+        state={state}
+        onNextBtnClick={onNext}
+        onDismiss={onDismiss}
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    // BigInt が "2500000000000000000" 等の文字列として直列化されているか
+    const callArg = (onNext as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(callArg.decodedCalldata).toContain('2500000000000000000');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('Next button works for USDC currency', () => {

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/TransferFundsReviewStep/index.tsx
@@ -49,11 +49,13 @@ const handleActionAdd = (
       args,
     });
 
+    // Niji ... args は readonly [Address, BigInt] tuple、 JSON.stringify は BigInt 直列化不能で throw。
+    // BigInt を string に変換する replacer を渡して STETH transfer の決定値を安全に直列化する。
     onActionAdd({
       address: stEthAddress[chainId],
       value: 0n,
       signature: 'transfer(address,uint256)',
-      decodedCalldata: JSON.stringify(args),
+      decodedCalldata: JSON.stringify(args, (_, v) => (typeof v === 'bigint' ? v.toString() : v)),
       calldata,
     });
   } else if (state.TransferFundsCurrency === SupportedCurrency.USDC) {


### PR DESCRIPTION
## 概要

`TransferFundsReviewStep` STETH branch の `JSON.stringify(args)` BigInt 直列化失敗 bug を production fix。 PR #412 で skip 化していた STETH test を解除し、 test 828 → 829。

## 課題

PR #412 で TransferFundsReviewStep を vitest 化した際、 STETH 経路 click で `handleActionAdd` 内 `JSON.stringify([address, BigInt(value)])` が `TypeError: Do not know how to serialize a BigInt` で throw する経路を発見。 production の STETH 提案フロー全断、 当 PR で根本修正。

## 詳細

- `TransferFundsReviewStep/index.tsx` ... `JSON.stringify(args)` → `JSON.stringify(args, (_, v) => typeof v === 'bigint' ? v.toString() : v)` replacer 追加
- `TransferFundsReviewStep/index.test.tsx` ... skip 解除 + STETH branch で `onNext.mock.calls[0][0].decodedCalldata` を BigInt 文字列化形 ("2500000000000000000") で実 verify

## 解決方法

```mermaid
flowchart LR
    A[STETH args = address, BigInt(value)] --> B[JSON.stringify は仕様で BigInt throw]
    B --> C[replacer (_, v) => bigint ? toString() : v]
    C --> D[文字列直列化で安全に]
```

JSON.stringify の 第 2 引数 replacer を活用、 typeof === 'bigint' で文字列化。 ETH/USDC 経路は元から BigInt 不含のため影響なし。

## 仕組み

viem `encodeFunctionData` は BigInt 引数 OK だが、 `JSON.stringify` は仕様 (ECMA-262) で BigInt 直列化不可。 replacer 引数で typeof 判定 + toString() に変換、 calldata 自体は viem hex 文字列のため別経路で保持される。

## テスト

- [x] `TransferFundsReviewStep/index.test.tsx` 7/7 pass (skip 解除 + STETH 経路実検証)
- [x] `pnpm vitest run` 全 829 pass + 1 todo
- [x] regression なし (ETH/USDC 経路は影響なし)

## 受入条件

- [x] STETH transfer click で throw しない
- [x] decodedCalldata に BigInt が文字列化されて保持
- [x] PR #412 で skip 化した test pass

Closes #413
Refs #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx