### PR TITLE
test(niji-webapp): component part 43 (Footer / DelegationCandidateInfo) で 846 → 858 (+12)

### DIFF
--- a/packages/niji-webapp/src/components/DelegationCandidateInfo/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegationCandidateInfo/index.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('blo', () => ({
+  blo: () => 'data:image/png;base64,FAKE',
+}));
+
+vi.mock('@/components/BrandSpinner', () => ({
+  default: () => <span data-testid="spinner" />,
+}));
+
+vi.mock('@/components/DelegationCandidateVoteCountInfo', () => ({
+  default: ({
+    text,
+    voteCount,
+    isLoading,
+  }: {
+    text: React.ReactNode;
+    voteCount: number;
+    isLoading: boolean;
+  }) => (
+    <span data-testid="vote-info" data-loading={isLoading ? 'true' : 'false'}>
+      {text}={voteCount}
+    </span>
+  ),
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('../ChangeDelegatePanel', () => ({
+  ChangeDelegateState: {
+    ENTER_DELEGATE_ADDRESS: 0,
+    CHANGING: 1,
+    CHANGE_SUCCESS: 2,
+    CHANGE_FAILURE: 3,
+  },
+}));
+
+const useAccountVotesMock = vi.fn();
+vi.mock('@/wrappers/nijiToken', () => ({
+  useAccountVotes: () => useAccountVotesMock(),
+}));
+
+vi.mock('@/utils/addressAndENSDisplayUtils', () => ({
+  formatShortAddress: (addr: string) => `${addr.slice(0, 6)}...`,
+}));
+
+vi.mock('@/utils/pickByState', () => ({
+  usePickByState: (state: number, _states: number[], values: React.ReactNode[]) =>
+    values[state] ?? values[0],
+}));
+
+import { ChangeDelegateState } from '../ChangeDelegatePanel';
+
+import DelegationCandidateInfo from './index';
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3' as const;
+
+describe('DelegationCandidateInfo', () => {
+  it('shows spinner when votes is null', () => {
+    useAccountVotesMock.mockReturnValue(null);
+    const { container } = render(
+      <DelegationCandidateInfo
+        address={ADDR}
+        changeModalState={ChangeDelegateState.ENTER_DELEGATE_ADDRESS}
+        votesToAdd={0}
+      />,
+    );
+    expect(container.querySelector('[data-testid="spinner"]')).not.toBeNull();
+  });
+
+  it('shows ShortAddress + formatted short address when votes loaded', () => {
+    useAccountVotesMock.mockReturnValue(5);
+    const { container } = render(
+      <DelegationCandidateInfo
+        address={ADDR}
+        changeModalState={ChangeDelegateState.ENTER_DELEGATE_ADDRESS}
+        votesToAdd={0}
+      />,
+    );
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe(ADDR);
+    expect(container.textContent).toContain('0x5FbD...');
+  });
+
+  it('renders avatar img using blo', () => {
+    useAccountVotesMock.mockReturnValue(3);
+    const { container } = render(
+      <DelegationCandidateInfo
+        address={ADDR}
+        changeModalState={ChangeDelegateState.ENTER_DELEGATE_ADDRESS}
+        votesToAdd={0}
+      />,
+    );
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,FAKE');
+  });
+
+  it('shows enter state vote info', () => {
+    useAccountVotesMock.mockReturnValue(7);
+    const { container } = render(
+      <DelegationCandidateInfo
+        address={ADDR}
+        changeModalState={ChangeDelegateState.ENTER_DELEGATE_ADDRESS}
+        votesToAdd={0}
+      />,
+    );
+    expect(container.querySelector('[data-testid="vote-info"]')?.textContent).toContain('7');
+  });
+
+  it('shows "Will have" state with isLoading=true during CHANGING', () => {
+    useAccountVotesMock.mockReturnValue(5);
+    const { container } = render(
+      <DelegationCandidateInfo
+        address={ADDR}
+        changeModalState={ChangeDelegateState.CHANGING}
+        votesToAdd={3}
+      />,
+    );
+    expect(container.querySelector('[data-testid="vote-info"]')?.getAttribute('data-loading')).toBe(
+      'true',
+    );
+    // willHaveVoteCount = 5 + 3 = 8
+    expect(container.querySelector('[data-testid="vote-info"]')?.textContent).toContain('8');
+  });
+
+  it('shows "Now has" state (success) with isLoading=false', () => {
+    useAccountVotesMock.mockReturnValue(8);
+    const { container } = render(
+      <DelegationCandidateInfo
+        address={ADDR}
+        changeModalState={ChangeDelegateState.CHANGE_SUCCESS}
+        votesToAdd={3}
+      />,
+    );
+    expect(container.querySelector('[data-testid="vote-info"]')?.getAttribute('data-loading')).toBe(
+      'false',
+    );
+    expect(container.querySelector('[data-testid="vote-info"]')?.textContent).toContain('8');
+  });
+});

--- a/packages/niji-webapp/src/components/Footer.test.tsx
+++ b/packages/niji-webapp/src/components/Footer.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({ t: (s: TemplateStringsArray) => s[0] }),
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiAuctionHouseAddress: { 1: '0xAH' },
+  nijiDescriptorAddress: { 1: '0xDESC' },
+  nijiGovernorAddress: { 1: '0xGOV' },
+  nijiTokenAddress: { 1: '0xTOKEN' },
+  nijiTreasuryAddress: { 1: '0xTREASURY' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+vi.mock('@/assets/icons/socials/discord.svg?react', () => ({
+  default: () => <span data-testid="discord-icon" />,
+}));
+vi.mock('@/assets/icons/socials/farcaster.svg?react', () => ({
+  default: () => <span data-testid="farcaster-icon" />,
+}));
+vi.mock('@/assets/icons/socials/github.svg?react', () => ({
+  default: () => <span data-testid="github-icon" />,
+}));
+vi.mock('@/assets/icons/socials/x.svg?react', () => ({
+  default: () => <span data-testid="x-icon" />,
+}));
+vi.mock('@/assets/noggles.svg?react', () => ({
+  default: ({ className }: { className?: string }) => (
+    <span className={className} data-testid="noggles-icon" />
+  ),
+}));
+
+import { Footer } from './Footer';
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('Footer', () => {
+  it('renders 3 main categories (Niji DAO / Contracts / 他)', () => {
+    const { container } = wrap(<Footer />);
+    expect(container.querySelectorAll('h3').length).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain('Niji DAO');
+    expect(container.textContent).toContain('Contracts');
+  });
+
+  it('renders 4 social icons', () => {
+    const { container } = wrap(<Footer />);
+    expect(container.querySelector('[data-testid="discord-icon"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="farcaster-icon"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="github-icon"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="x-icon"]')).not.toBeNull();
+  });
+
+  it('renders noggles icon in copyright', () => {
+    const { container } = wrap(<Footer />);
+    expect(container.querySelector('[data-testid="noggles-icon"]')).not.toBeNull();
+  });
+
+  it('shows current year + Niji DAO copyright', () => {
+    const { container } = wrap(<Footer />);
+    const year = new Date().getFullYear();
+    expect(container.textContent).toContain(`${year} Niji DAO`);
+  });
+
+  it('uses etherscan links for contract entries', () => {
+    const { container } = wrap(<Footer />);
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const etherscanLinks = anchors.filter(a => a.getAttribute('href')?.includes('etherscan.io'));
+    expect(etherscanLinks.length).toBeGreaterThan(0);
+  });
+
+  it('internal route links use react-router Link (without target=_blank)', () => {
+    const { container } = wrap(<Footer />);
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const internalLinks = anchors.filter(a => a.getAttribute('href')?.startsWith('/'));
+    expect(internalLinks.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 43 として 2 file 12 TC、 test 件数を 846 → 858 (+12)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `Footer` | 6 | 3+ category h3 / 4 social icon / noggles / 当年+Niji DAO 著作権 / etherscan link / internal link |
| `DelegationCandidateInfo` | 6 | votes null spinner / ShortAddress+short / blo avatar / 3 ChangeDelegateState 状態 |

## 解決方法

useLingui / SDK address / etherscan / blo / 子 component を vi.mock で stub、 usePickByState で 3 状態切替検証。

## テスト

- [x] `pnpm vitest run` で 858 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 12 TC 全 pass
- [x] regression なし

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx