### PR TITLE
test(niji-webapp): component part 44 (FunctionCallEnterArgsStep / FunctionCallReviewStep) で 858 → 875 (+17)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallEnterArgsStep/index.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+    isNextBtnDisabled,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+    isNextBtnDisabled?: boolean;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} disabled={isNextBtnDisabled} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+import FunctionCallEnterArgsStep from './index';
+
+const abi = [
+  {
+    type: 'function',
+    name: 'transfer',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ type: 'bool' }],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'noArg',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'view',
+  },
+];
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+};
+
+describe('FunctionCallEnterArgsStep', () => {
+  it('renders title', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'transfer' } as never} />,
+    );
+    expect(container.querySelector('h1')?.textContent).toContain('Add Function Call Arguments');
+  });
+
+  it('renders input per ABI argument (transfer = 2)', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'transfer' } as never} />,
+    );
+    expect(container.querySelectorAll('input').length).toBe(2);
+  });
+
+  it('shows "No arguments required" when no inputs', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'noArg' } as never} />,
+    );
+    expect(container.textContent).toContain('No arguments required');
+    expect(container.querySelectorAll('input').length).toBe(0);
+  });
+
+  it('Next is enabled when no args required', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'noArg' } as never} />,
+    );
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(false);
+  });
+
+  it('Next is disabled until args valid', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'transfer' } as never} />,
+    );
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('Back button fires onPrevBtnClick', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <FunctionCallEnterArgsStep
+        {...defaults}
+        onPrevBtnClick={onPrev}
+        state={{ abi, function: 'noArg' } as never}
+      />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('Next button persists state + fires onNext (noArg path)', () => {
+    const onNext = vi.fn();
+    const setState = vi.fn();
+    const { container } = render(
+      <FunctionCallEnterArgsStep
+        {...defaults}
+        onNextBtnClick={onNext}
+        setState={setState}
+        state={{ abi, function: 'noArg' } as never}
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders input names + types as labels', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'transfer' } as never} />,
+    );
+    expect(container.textContent).toContain('to');
+    expect(container.textContent).toContain('amount');
+    expect(container.textContent).toContain('address');
+    expect(container.textContent).toContain('uint256');
+  });
+
+  it('updates args via input typing (Next becomes enabled with valid args)', () => {
+    const { container } = render(
+      <FunctionCallEnterArgsStep {...defaults} state={{ abi, function: 'transfer' } as never} />,
+    );
+    const inputs = container.querySelectorAll('input');
+    fireEvent.change(inputs[0], {
+      target: { value: '0x5FbDB2315678afecb367f032d93F642f64180aa3' },
+    });
+    fireEvent.change(inputs[1], { target: { value: '1000' } });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(false);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.test.tsx
@@ -1,0 +1,210 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (a: string) => `https://etherscan.io/address/${a}`,
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    onPrevBtnClick,
+    onNextBtnClick,
+    prevBtnText,
+    nextBtnText,
+  }: {
+    onPrevBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    onNextBtnClick: React.MouseEventHandler<HTMLDivElement>;
+    prevBtnText: React.ReactNode;
+    nextBtnText: React.ReactNode;
+  }) => (
+    <>
+      <button onClick={onPrevBtnClick as never}>{prevBtnText}</button>
+      <button onClick={onNextBtnClick as never} data-testid="next-btn">
+        {nextBtnText}
+      </button>
+    </>
+  ),
+}));
+
+import FunctionCallReviewStep from './index';
+
+const abi = [
+  {
+    type: 'function',
+    name: 'transfer',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    name: 'noArg',
+    inputs: [],
+    outputs: [],
+    stateMutability: 'view',
+  },
+];
+
+const ADDR = '0x5FbDB2315678afecb367f032d93F642f64180aa3';
+
+const defaults = {
+  onPrevBtnClick: () => {},
+  onNextBtnClick: () => {},
+  setState: () => {},
+  onDismiss: () => {},
+};
+
+describe('FunctionCallReviewStep', () => {
+  it('renders Review title', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '1000'],
+          } as never
+        }
+      />,
+    );
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
+
+  it('shows ShortAddress for target', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '1000'],
+          } as never
+        }
+      />,
+    );
+    expect(container.querySelectorAll('[data-testid="short"]').length).toBeGreaterThan(0);
+  });
+
+  it('shows Arguments section', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '1000'],
+          } as never
+        }
+      />,
+    );
+    expect(container.textContent).toContain('Arguments');
+  });
+
+  it('shows "None" for Arguments when noArg function', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={{ abi, function: 'noArg', address: ADDR, amount: '0', args: [] } as never}
+      />,
+    );
+    expect(container.textContent).toContain('None');
+  });
+
+  it('renders argument names + values for each input', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '1000'],
+          } as never
+        }
+      />,
+    );
+    expect(container.textContent).toContain('to');
+    expect(container.textContent).toContain('amount');
+    expect(container.textContent).toContain('1000');
+  });
+
+  it('Back button fires onPrevBtnClick', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        onPrevBtnClick={onPrev}
+        state={{ abi, function: 'noArg', address: ADDR, amount: '0', args: [] } as never}
+      />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('Next button fires handleActionAdd + onDismiss', () => {
+    const onNext = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        onNextBtnClick={onNext}
+        onDismiss={onDismiss}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '1000'],
+          } as never
+        }
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('Next button works for noArg path (fallback signature="")', () => {
+    const onNext = vi.fn();
+    const onDismiss = vi.fn();
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        onNextBtnClick={onNext}
+        onDismiss={onDismiss}
+        state={{ abi, function: 'noArg', address: ADDR, amount: '0', args: [] } as never}
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 44 として ProposalActionsModal FunctionCall 2 step、 計 17 TC、 test 件数を 858 → 875 (+17)。 ProposalActionsModal の主要 step 全 cover 完了。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `FunctionCallEnterArgsStep` | 9 | title / 引数 input 数 / No args 文言 / next gating / Back / setState+onNext / name+type label / 有効 args で next enable |
| `FunctionCallReviewStep` | 8 | title / ShortAddress / Arguments section / None for noArg / 引数名+値 / Back / Next+onDismiss / noArg path |

## 解決方法

viem の getAbiItem / encodeFunctionData / parseEther 等は実 module で動作確認、 Modal* / ShortAddress / etherscan 子は vi.mock で stub。

## テスト

- [x] `pnpm vitest run` で 875 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 17 TC 全 pass
- [x] regression なし

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx