### PR TITLE
test(niji-webapp): component part 45 (Auction / VoteSignalsForm) で 875 → 895 (+20)

### DIFF
--- a/packages/niji-webapp/src/components/Auction/index.test.tsx
+++ b/packages/niji-webapp/src/components/Auction/index.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+const navigateMock = vi.fn();
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/components/AuctionActivity', () => ({
+  default: ({
+    onPrevAuctionClick,
+    onNextAuctionClick,
+    isFirstAuction,
+    isLastAuction,
+  }: {
+    onPrevAuctionClick: () => void;
+    onNextAuctionClick: () => void;
+    isFirstAuction: boolean;
+    isLastAuction: boolean;
+  }) => (
+    <div data-testid="auction-activity">
+      <button data-testid="prev" onClick={onPrevAuctionClick} disabled={isFirstAuction} />
+      <button data-testid="next" onClick={onNextAuctionClick} disabled={isLastAuction} />
+    </div>
+  ),
+}));
+
+vi.mock('@/components/LegacyNoun', () => ({
+  LoadingNoun: () => <span data-testid="loading" />,
+}));
+
+vi.mock('@/components/Niji', () => ({
+  NijiWithSeed: ({ nounId }: { nounId: bigint }) => (
+    <span data-testid="niji-with-seed">{nounId.toString()}</span>
+  ),
+}));
+
+vi.mock('@/components/NijiContent', () => ({
+  default: () => <div data-testid="niji-content" />,
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+  useSetAtom: () => () => {},
+}));
+
+vi.mock('@/utils/history', () => ({
+  nounPath: (id: number) => `/niji/${id}`,
+}));
+
+vi.mock('@/utils/nounBgColors', () => ({
+  beige: '#beige',
+  grey: '#grey',
+}));
+
+const isNounderMock = vi.fn();
+vi.mock('@/utils/nounderNiji', () => ({
+  isNounderNiji: (id: bigint) => isNounderMock(id),
+}));
+
+import Auction from './index';
+
+const makeAuction = (nounId: bigint) => ({
+  amount: 1000n,
+  bidder: '0xAA',
+  endTime: 100n,
+  startTime: 0n,
+  nounId,
+  settled: false,
+});
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('Auction', () => {
+  it('renders LoadingNoun when no auction', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    const { container } = wrap(<Auction />);
+    expect(container.querySelector('[data-testid="loading"]')).not.toBeNull();
+  });
+
+  it('renders NijiWithSeed when auction is provided', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(5n)} />);
+    expect(container.querySelector('[data-testid="niji-with-seed"]')?.textContent).toBe('5');
+  });
+
+  it('renders AuctionActivity for non-Nounder auction', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(5n)} />);
+    expect(container.querySelector('[data-testid="auction-activity"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="niji-content"]')).toBeNull();
+  });
+
+  it('renders NijiContent for Nounder auction', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(true);
+    const { container } = wrap(<Auction auction={makeAuction(0n)} />);
+    expect(container.querySelector('[data-testid="niji-content"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="auction-activity"]')).toBeNull();
+  });
+
+  it('isFirstAuction=true for nounId=0', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(0n)} />);
+    expect(container.querySelector('[data-testid="prev"]')?.disabled).toBe(true);
+  });
+
+  it('isLastAuction=true when nounId === lastAuctionNounId', () => {
+    useAtomValueMock.mockReturnValue(5n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(5n)} />);
+    expect(container.querySelector('[data-testid="next"]')?.disabled).toBe(true);
+  });
+
+  it('prev click navigates to nounId-1', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    navigateMock.mockReset();
+    const { container } = wrap(<Auction auction={makeAuction(5n)} />);
+    fireEvent.click(container.querySelector('[data-testid="prev"]')!);
+    expect(navigateMock).toHaveBeenCalledWith('/niji/4');
+  });
+
+  it('next click navigates to nounId+1', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    navigateMock.mockReset();
+    const { container } = wrap(<Auction auction={makeAuction(5n)} />);
+    fireEvent.click(container.querySelector('[data-testid="next"]')!);
+    expect(navigateMock).toHaveBeenCalledWith('/niji/6');
+  });
+
+  it('does not render AuctionActivity when lastNounId is undefined', () => {
+    useAtomValueMock.mockReturnValue(undefined);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(5n)} />);
+    expect(container.querySelector('[data-testid="auction-activity"]')).toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsForm.test.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsForm.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { VoteSignalsForm, VoteSignalsPending } from './VoteSignalsForm';
+
+const defaults = {
+  support: undefined as number | undefined,
+  setSupport: () => {},
+  reasonText: '',
+  setReasonText: () => {},
+  isBusy: false,
+  onSubmit: () => {},
+};
+
+describe('VoteSignalsForm', () => {
+  it('renders 3 support buttons + textarea + submit', () => {
+    const { container } = render(<VoteSignalsForm {...defaults} />);
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(4);
+    expect(container.querySelector('textarea')).not.toBeNull();
+  });
+
+  it('Submit is disabled when no support selected', () => {
+    const { container } = render(<VoteSignalsForm {...defaults} />);
+    const submit = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit'),
+    );
+    expect(submit?.disabled).toBe(true);
+  });
+
+  it('Submit is enabled when support is selected', () => {
+    const { container } = render(<VoteSignalsForm {...defaults} support={1} />);
+    const submit = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit'),
+    );
+    expect(submit?.disabled).toBe(false);
+  });
+
+  it('all support buttons disabled when isBusy=true', () => {
+    const { container } = render(<VoteSignalsForm {...defaults} isBusy={true} support={1} />);
+    const buttons = container.querySelectorAll('button');
+    buttons.forEach(b => expect(b.disabled).toBe(true));
+  });
+
+  it('clicking For sets support=1', () => {
+    const setSupport = vi.fn();
+    const { container } = render(<VoteSignalsForm {...defaults} setSupport={setSupport} />);
+    const forBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('For'),
+    );
+    if (forBtn) fireEvent.click(forBtn);
+    expect(setSupport).toHaveBeenCalledWith(1);
+  });
+
+  it('clicking Against sets support=0', () => {
+    const setSupport = vi.fn();
+    const { container } = render(<VoteSignalsForm {...defaults} setSupport={setSupport} />);
+    const againstBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Against'),
+    );
+    if (againstBtn) fireEvent.click(againstBtn);
+    expect(setSupport).toHaveBeenCalledWith(0);
+  });
+
+  it('clicking Abstain sets support=2', () => {
+    const setSupport = vi.fn();
+    const { container } = render(<VoteSignalsForm {...defaults} setSupport={setSupport} />);
+    const abstainBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Abstain'),
+    );
+    if (abstainBtn) fireEvent.click(abstainBtn);
+    expect(setSupport).toHaveBeenCalledWith(2);
+  });
+
+  it('clicking selected support toggles back to undefined', () => {
+    const setSupport = vi.fn();
+    const { container } = render(
+      <VoteSignalsForm {...defaults} setSupport={setSupport} support={1} />,
+    );
+    const forBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('For'),
+    );
+    if (forBtn) fireEvent.click(forBtn);
+    expect(setSupport).toHaveBeenCalledWith(undefined);
+  });
+
+  it('reason textarea fires setReasonText on input', () => {
+    const setReasonText = vi.fn();
+    const { container } = render(<VoteSignalsForm {...defaults} setReasonText={setReasonText} />);
+    fireEvent.change(container.querySelector('textarea')!, {
+      target: { value: 'because' },
+    });
+    expect(setReasonText).toHaveBeenCalledWith('because');
+  });
+
+  it('Submit click fires onSubmit', () => {
+    const onSubmit = vi.fn();
+    const { container } = render(<VoteSignalsForm {...defaults} onSubmit={onSubmit} support={1} />);
+    const submit = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit'),
+    );
+    if (submit) fireEvent.click(submit);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('VoteSignalsPending', () => {
+  it('renders loading-noggles img + Adding text', () => {
+    const { container } = render(<VoteSignalsPending />);
+    expect(container.querySelector('img[alt="loading"]')).not.toBeNull();
+    expect(container.textContent).toContain('Adding your feedback');
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 45 として 2 file 20 TC、 test 件数を 875 → 895 (+20)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `Auction/index` | 9 | LoadingNoun / NijiWithSeed / AuctionActivity / NijiContent (Nounder 切替) / isFirstAuction / isLastAuction / prev/next navigate / lastNounId undefined fallback |
| `VoteSignals/VoteSignalsForm` | 11 | 3 support btn + textarea + submit / 3 選択 / toggle / busy disable / reason / onSubmit + Pending |

## 解決方法

react-router の useNavigate を vi.fn 経由で検証、 子 component (AuctionActivity / NijiWithSeed / NijiContent / LoadingNoun) を vi.mock で stub。 VoteSignalsForm は support button 3 + textarea + submit を pure render testing。

## テスト

- [x] `pnpm vitest run` で 895 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 20 TC 全 pass
- [x] regression なし

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx