### PR TITLE
test(niji-webapp): component part 46 (NavLocaleSwitcher / CandidateHeader) で 895 → 909 (+14)

### DIFF
--- a/packages/niji-webapp/src/components/NavLocaleSwitcher/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavLocaleSwitcher/index.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAtomMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtom: () => useAtomMock(),
+}));
+
+vi.mock('@/utils/colorResponsiveUIUtils', () => ({
+  usePickByStateColor: () => 'state-primary',
+}));
+
+vi.mock('@/components/NavBarButton', () => {
+  const NavBarButtonStyle = { COOL_INFO: 0, WARM_INFO: 1, WHITE_INFO: 4 };
+  const NavBarButton = ({ buttonText }: { buttonText: React.ReactNode }) => (
+    <span data-testid="nav-button">{buttonText}</span>
+  );
+  return { default: NavBarButton, NavBarButtonStyle };
+});
+
+vi.mock('@/components/LanguageSelectionModal', () => ({
+  default: ({ onDismiss }: { onDismiss: () => void }) => (
+    <div data-testid="lang-modal">
+      <button onClick={onDismiss}>close</button>
+    </div>
+  ),
+}));
+
+import NavLocaleSwitcher from './index';
+
+describe('NavLocaleSwitcher', () => {
+  it('renders Language nav button + dropdown wrapper', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    const navButtons = container.querySelectorAll('[data-testid="nav-button"]');
+    expect(navButtons.length).toBeGreaterThanOrEqual(1);
+    expect(container.querySelector('.dropdown')).not.toBeNull();
+  });
+
+  it('mobile button click opens LanguageSelectionModal', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    // mobile wrapper の onClick で modal display
+    const wrapper = container.querySelector('[data-testid="nav-button"]')?.parentElement;
+    if (wrapper) fireEvent.click(wrapper);
+    expect(container.querySelector('[data-testid="lang-modal"]')).not.toBeNull();
+  });
+
+  it('modal close hides itself', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    const wrapper = container.querySelector('[data-testid="nav-button"]')?.parentElement;
+    if (wrapper) fireEvent.click(wrapper);
+    expect(container.querySelector('[data-testid="lang-modal"]')).not.toBeNull();
+    const closeBtn = container.querySelector('[data-testid="lang-modal"] button');
+    if (closeBtn) fireEvent.click(closeBtn);
+    expect(container.querySelector('[data-testid="lang-modal"]')).toBeNull();
+  });
+
+  it('renders Language label in nav button', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    expect(container.textContent).toContain('Language');
+  });
+
+  it('does not render modal by default (closed)', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    expect(container.querySelector('[data-testid="lang-modal"]')).toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalHeader/CandidateHeader.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalHeader/CandidateHeader.test.tsx
@@ -1,0 +1,164 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useBlockNumberMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useBlockNumber: () => useBlockNumberMock(),
+}));
+
+vi.mock('@/components/ByLineHoverCard', () => ({
+  default: () => <span data-testid="byline" />,
+}));
+
+vi.mock('@/components/HoverCard', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="hover">{children}</span>
+  ),
+}));
+
+vi.mock('@/components/ProposalContent', () => ({
+  transactionIconLink: (hash: string) => <a data-testid="tx-link">{hash}</a>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short">{address}</span>,
+}));
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+vi.mock('@/i18n/locales', () => ({
+  Locales: {
+    en_US: 'en-US',
+    ja_JP: 'ja-JP',
+    zh_CN: 'zh-CN',
+  },
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (a: string) => `https://etherscan.io/address/${a}`,
+}));
+
+const isMobileMock = vi.fn();
+vi.mock('@/utils/isMobile', () => ({
+  isMobileScreen: () => isMobileMock(),
+}));
+
+vi.mock('@/utils/timeUtils', () => ({
+  relativeTimestamp: () => '1 day ago',
+}));
+
+const useUserVotesAsOfBlockMock = vi.fn();
+vi.mock('@/wrappers/nijiToken', () => ({
+  useUserVotesAsOfBlock: () => useUserVotesAsOfBlockMock(),
+}));
+
+import CandidateHeader from './CandidateHeader';
+
+const defaults = {
+  title: 'My Candidate',
+  id: 'cand-1',
+  proposer: '0xABC',
+  versionsCount: 1,
+  createdTransactionHash: '0xdeadbeef',
+  lastUpdatedTimestamp: 1700000000,
+  isActiveForVoting: false,
+  isWalletConnected: false,
+  submitButtonClickHandler: () => {},
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('CandidateHeader', () => {
+  it('renders title', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.textContent).toContain('My Candidate');
+  });
+
+  it('renders ShortAddress for proposer', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xABC');
+  });
+
+  it('renders ByLineHoverCard hover content', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.querySelector('[data-testid="hover"]')).not.toBeNull();
+  });
+
+  it('renders transaction icon link', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.querySelector('[data-testid="tx-link"]')).not.toBeNull();
+  });
+
+  it('renders Version link when versionsCount > 1', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} versionsCount={3} />);
+    expect(container.querySelector('a[href="/candidates/cand-1/history/"]')).not.toBeNull();
+    expect(container.textContent).toContain('Version 3');
+  });
+
+  it('renders plain Version text (no link) when versionsCount=1', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} versionsCount={1} />);
+    expect(container.textContent).toContain('Version 1');
+    expect(container.querySelector('a[href*="/history/"]')).toBeNull();
+  });
+
+  it('renders relative timestamp', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.textContent).toContain('1 day ago');
+  });
+
+  it('shows ja-JP layout when locale is ja-JP', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('ja-JP');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.textContent).toContain('Proposed by');
+  });
+
+  it('renders mobile-specific submit when isMobile + isActiveForVoting', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(true);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} isActiveForVoting={true} />);
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 概要

webapp component part 46 として 2 file 14 TC、 test 件数を 895 → 909 (+14)。

## 詳細

| file | TC 数 | 観点 |
|---|---|---|
| `NavLocaleSwitcher` | 5 | Language nav + dropdown wrapper / mobile click で LanguageSelectionModal / modal 閉じる / label / default closed |
| `ProposalHeader/CandidateHeader` | 9 | title / proposer ShortAddress / ByLineHoverCard / tx link / versionsCount>1 Link, =1 text / 相対時間 / ja-JP locale / mobile + isActiveForVoting |

## 解決方法

useAtom / wagmi.useBlockNumber / 子 component (NavBarButton / LanguageSelectionModal / ByLineHoverCard / HoverCard / ShortAddress / transactionIconLink) を vi.mock で stub、 useActiveLocale / isMobileScreen / useUserVotesAsOfBlock を切替検証。

## テスト

- [x] `pnpm vitest run` で 909 pass + 1 todo
- [x] linter / formatter pass

## 受入条件

- [x] 2 file 計 14 TC 全 pass
- [x] regression なし

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StjzDbMa9GUksZs2bHYwx