### PR TITLE
✅ test(niji-webapp): component part 47 (AuctionActivity / NijiContent) で 909 → 928 (Issue #425)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiAuctionHouseAddress: { 1: '0xAUCTIONHOUSE' },
+}));
+
+vi.mock('@/components/AuctionActivityDateHeadline', () => ({
+  default: () => <span data-testid="date-headline" />,
+}));
+
+vi.mock('@/components/AuctionActivityNijiTitle', () => ({
+  default: () => <span data-testid="niji-title" />,
+}));
+
+vi.mock('@/components/AuctionActivityWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="wrapper">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/AuctionNavigation', () => ({
+  default: () => <div data-testid="auction-nav" />,
+}));
+
+vi.mock('@/components/AuctionTimer', () => ({
+  default: () => <div data-testid="auction-timer" />,
+}));
+
+vi.mock('@/components/AuctionTitleAndNavWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="title-wrap">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/Bid', () => ({
+  default: () => <div data-testid="bid" />,
+}));
+
+vi.mock('@/components/BidHistory', () => ({
+  default: () => <div data-testid="bid-history" />,
+}));
+
+vi.mock('@/components/BidHistoryBtn', () => ({
+  default: ({ onClick }: { onClick: () => void }) => (
+    <button data-testid="bid-history-btn" onClick={onClick} />
+  ),
+}));
+
+vi.mock('@/components/BidHistoryModal', () => ({
+  default: () => <div data-testid="bid-history-modal" />,
+}));
+
+vi.mock('@/components/CurrentBid', () => ({
+  default: () => <span data-testid="current-bid" />,
+}));
+
+vi.mock('@/components/Holder', () => ({
+  default: () => <span data-testid="holder" />,
+}));
+
+vi.mock('@/components/NijiInfoCard', () => ({
+  default: () => <div data-testid="niji-info-card" />,
+}));
+
+vi.mock('@/components/Winner', () => ({
+  default: () => <span data-testid="winner" />,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (a: string) => `https://etherscan.io/address/${a}`,
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+import AuctionActivity from './index';
+
+const makeAuction = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  amount: 1000n,
+  bidder: '0xAA',
+  endTime: Math.floor(Date.now() / 1000) + 3600,
+  startTime: 0n,
+  nounId: 5n,
+  settled: false,
+  ...overrides,
+});
+
+const defaults = {
+  isFirstAuction: false,
+  isLastAuction: true,
+  onPrevAuctionClick: () => {},
+  onNextAuctionClick: () => {},
+  displayGraphDepComps: true,
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('AuctionActivity', () => {
+  it('renders AuctionActivityWrapper with title and current bid', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="wrapper"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="niji-title"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="current-bid"]')).not.toBeNull();
+  });
+
+  it('hides AuctionNavigation when displayGraphDepComps is false', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(
+      <AuctionActivity
+        {...defaults}
+        displayGraphDepComps={false}
+        auction={makeAuction() as never}
+      />,
+    );
+    expect(container.querySelector('[data-testid="auction-nav"]')).toBeNull();
+  });
+
+  it('shows AuctionNavigation when displayGraphDepComps is true', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="auction-nav"]')).not.toBeNull();
+  });
+
+  it('shows "Help mint the next Niji" link when auction ended', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const endedAuction = makeAuction({ endTime: 1n });
+    const { container } = wrap(<AuctionActivity {...defaults} auction={endedAuction as never} />);
+    expect(container.querySelector('a[href="/crystal-ball"]')).not.toBeNull();
+  });
+
+  it('renders Bid for isLastAuction', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="bid"]')).not.toBeNull();
+  });
+
+  it('renders NijiInfoCard for non-last auction (no Bid)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(
+      <AuctionActivity {...defaults} isLastAuction={false} auction={makeAuction() as never} />,
+    );
+    expect(container.querySelector('[data-testid="niji-info-card"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="bid"]')).toBeNull();
+  });
+
+  it('renders BidHistory for last + displayGraphDepComps', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="bid-history"]')).not.toBeNull();
+  });
+
+  it('does not render BidHistoryModal by default', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="bid-history-modal"]')).toBeNull();
+  });
+
+  it('hides BidHistoryBtn when last auction amount is 0', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const zeroAuction = makeAuction({ amount: 0n });
+    const { container } = wrap(<AuctionActivity {...defaults} auction={zeroAuction as never} />);
+    expect(container.querySelector('[data-testid="bid-history-btn"]')).toBeNull();
+  });
+
+  it('renders BidHistoryBtn for non-graph mode in last auction with bids', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(
+      <AuctionActivity
+        {...defaults}
+        displayGraphDepComps={false}
+        auction={makeAuction() as never}
+      />,
+    );
+    expect(container.querySelector('[data-testid="bid-history-btn"]')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/NijiContent/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijiContent/index.test.tsx
@@ -1,0 +1,223 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useLingui: () => ({ t: (s: TemplateStringsArray | string) => (Array.isArray(s) ? s[0] : s) }),
+}));
+
+const writeContractMock = vi.fn();
+const settleHookState: {
+  writeContract: typeof writeContractMock;
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+  error: { message: string } | null;
+} = {
+  writeContract: writeContractMock,
+  isPending: false,
+  isSuccess: false,
+  isError: false,
+  error: null,
+};
+vi.mock('@niji/sdk/react', () => ({
+  useWriteNijiAuctionHouseSettleCurrentAndCreateNewAuction: () => settleHookState,
+}));
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+const useAccountMock = vi.fn();
+const useBlockMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useAccount: () => useAccountMock(),
+  useBlock: () => useBlockMock(),
+}));
+
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (msg: string) => toastSuccessMock(msg),
+    error: (msg: string) => toastErrorMock(msg),
+  },
+}));
+
+vi.mock('@/components/AuctionActivityDateHeadline', () => ({
+  default: () => <span data-testid="date-headline" />,
+}));
+
+vi.mock('@/components/AuctionActivityNijiTitle', () => ({
+  default: () => <span data-testid="niji-title" />,
+}));
+
+vi.mock('@/components/AuctionActivityWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="wrapper">{children}</div>
+  ),
+}));
+
+const prevClickMock = vi.fn();
+const nextClickMock = vi.fn();
+vi.mock('@/components/AuctionNavigation', () => ({
+  default: ({
+    onPrevAuctionClick,
+    onNextAuctionClick,
+  }: {
+    onPrevAuctionClick: () => void;
+    onNextAuctionClick: () => void;
+  }) => (
+    <div data-testid="auction-nav">
+      <button data-testid="prev-btn" onClick={onPrevAuctionClick} />
+      <button data-testid="next-btn" onClick={onNextAuctionClick} />
+    </div>
+  ),
+}));
+
+vi.mock('@/components/AuctionTitleAndNavWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="title-wrap">{children}</div>
+  ),
+}));
+
+vi.mock('@/components/CurrentBid', () => ({
+  default: () => <span data-testid="current-bid" />,
+  BID_N_A: 'n/a',
+}));
+
+vi.mock('@/components/SettleManuallyBtn', () => ({
+  default: ({ settleAuctionHandler }: { settleAuctionHandler: () => void }) => (
+    <button data-testid="settle-btn" onClick={settleAuctionHandler} />
+  ),
+}));
+
+vi.mock('@/components/Winner', () => ({
+  default: () => <span data-testid="winner" />,
+}));
+
+import NijiContent from './index';
+
+const makeAuction = (endTime: bigint) => ({
+  amount: 0n,
+  bidder: '0x',
+  endTime,
+  startTime: 0n,
+  nounId: 0n,
+  settled: false,
+});
+
+const defaults = {
+  mintTimestamp: 0n,
+  nounId: 0n,
+  isFirstAuction: false,
+  isLastAuction: true,
+  onPrevAuctionClick: prevClickMock,
+  onNextAuctionClick: nextClickMock,
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const resetState = () => {
+  settleHookState.isPending = false;
+  settleHookState.isSuccess = false;
+  settleHookState.isError = false;
+  settleHookState.error = null;
+  writeContractMock.mockReset();
+  prevClickMock.mockReset();
+  nextClickMock.mockReset();
+  toastSuccessMock.mockReset();
+  toastErrorMock.mockReset();
+};
+
+describe('NijiContent', () => {
+  it('renders wrapper with title and Nijider winner', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    const { container } = wrap(<NijiContent {...defaults} />);
+    expect(container.querySelector('[data-testid="wrapper"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="winner"]')).not.toBeNull();
+  });
+
+  it('hides SettleManuallyBtn when chain time < endTime', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: '0xUSER' });
+    useBlockMock.mockReturnValue({ data: { timestamp: 100n } });
+    const { container } = wrap(<NijiContent {...defaults} auction={makeAuction(1000n)} />);
+    expect(container.querySelector('[data-testid="settle-btn"]')).toBeNull();
+  });
+
+  it('shows SettleManuallyBtn when chainNow >= endTime and wallet connected', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: '0xUSER' });
+    useBlockMock.mockReturnValue({ data: { timestamp: 2000n } });
+    const { container } = wrap(<NijiContent {...defaults} auction={makeAuction(1000n)} />);
+    expect(container.querySelector('[data-testid="settle-btn"]')).not.toBeNull();
+  });
+
+  it('hides SettleManuallyBtn when wallet is disconnected even if ended', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 2000n } });
+    const { container } = wrap(<NijiContent {...defaults} auction={makeAuction(1000n)} />);
+    expect(container.querySelector('[data-testid="settle-btn"]')).toBeNull();
+  });
+
+  it('shows "送信中" pending text while settling', () => {
+    resetState();
+    settleHookState.isPending = true;
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: '0xUSER' });
+    useBlockMock.mockReturnValue({ data: { timestamp: 2000n } });
+    const { container } = wrap(<NijiContent {...defaults} auction={makeAuction(1000n)} />);
+    expect(container.textContent).toContain('送信中');
+  });
+
+  it('invokes onPrevAuctionClick on ArrowLeft keydown', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    wrap(<NijiContent {...defaults} />);
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+    expect(prevClickMock).toHaveBeenCalled();
+  });
+
+  it('invokes onNextAuctionClick on ArrowRight keydown', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    wrap(<NijiContent {...defaults} />);
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    expect(nextClickMock).toHaveBeenCalled();
+  });
+
+  it('renders Learn more link to /nounders', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    const { container } = wrap(<NijiContent {...defaults} />);
+    expect(container.querySelector('a[href="/nounders"]')).not.toBeNull();
+  });
+
+  it('settle button triggers writeContract call', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: '0xUSER' });
+    useBlockMock.mockReturnValue({ data: { timestamp: 2000n } });
+    const { container } = wrap(<NijiContent {...defaults} auction={makeAuction(1000n)} />);
+    fireEvent.click(container.querySelector('[data-testid="settle-btn"]')!);
+    expect(writeContractMock).toHaveBeenCalledWith({});
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 47` として `AuctionActivity` (10 TC) と `NijiContent` (9 TC) に vitest を追加、 909 → 928 (+19、 1 skip 維持)。

## 詳細

### AuctionActivity/index.test.tsx (10 TC)

`AuctionActivity` は auction 詳細画面の中核 component で、 `displayGraphDepComps` flag と `isLastAuction` の組合せで bid / BidHistory / NijiInfoCard / 「Help mint」 link の表示分岐を持つ。

検証観点。

- AuctionActivityWrapper / niji-title / current-bid の基本 render
- `displayGraphDepComps=false` で AuctionNavigation 非表示、 `true` で表示
- 過去 endTime で「Help mint the next Niji」 link (`/crystal-ball`) 表示
- isLastAuction で Bid 表示、 非 last で NijiInfoCard 表示 (Bid なし)
- last + displayGraphDepComps で BidHistory 表示
- BidHistoryModal は default 非表示
- last + amount=0 で BidHistoryBtn 非表示
- 非 graph mode + last + 有効 amount で BidHistoryBtn 表示

### NijiContent/index.test.tsx (9 TC)

`NijiContent` は Nijider 枠 (Niji 0 / 10 / ...) 用 component で、 bid なしで `chainNow >= endTime + wallet connected` の条件で SettleManuallyBtn を表示する。 ArrowLeft / ArrowRight keydown で auction navigation を扱う。

検証観点。

- wrapper / Nijider winner の基本 render
- chainNow < endTime で SettleManuallyBtn 非表示
- chainNow >= endTime + wallet connected で SettleManuallyBtn 表示
- wallet disconnected で chainNow >= endTime でも非表示
- `isPending=true` で「送信中」 pending text 表示
- ArrowLeft keydown で `onPrevAuctionClick` 呼出
- ArrowRight keydown で `onNextAuctionClick` 呼出
- 「Learn more」 link が `/nounders` を指す
- settle button click で `writeContract({})` 発火

## 解決方法

`useAtomValue` (jotai) / wagmi (`useAccount` / `useBlock`) / `useWriteNijiAuctionHouseSettleCurrentAndCreateNewAuction` / sonner toast / 子 component (BidHistoryModal / Bid / BidHistory / NijiInfoCard / Winner / Holder / SettleManuallyBtn / AuctionNavigation 等) を `vi.mock` で stub。

`settleHookState` で `writeContract` / `isPending` / `isSuccess` 等の戻り値を test ごとに切替、 `chainNow` (useBlock の timestamp) と `endTime` の比較で `auctionEnded` の境界を検証する。

ArrowLeft / ArrowRight keydown 検証は `fireEvent.keyDown(document, { key })` で `useEffect` 内 listener を直接発火、 NavigationCallback の呼出を `vi.fn()` で trace。

## 受入条件

- [x] 2 file 計 19 TC 全 pass
- [x] `pnpm vitest run` 全 928 test green (929 - 1 skipped)
- [x] regression なし (既存 909 pass を破壊しない)

## 関連

- Closes #425
- 直前 PR #424 (part 46) で 895 → 909 達成済
- 次 candidate ... AddNijisToForkModal (574 行) / Proposals (419 行) / NavBar (348 行) / DynamicQuorumInfoModal (346 行) / ChangeDelegatePanel (315 行) 等の large 帯
