### PR TITLE
✅ test(niji-webapp): component part 49 (AddNijisToForkModal 574 行 単独) で 951 → 970 (Issue #429)

### DIFF
--- a/packages/niji-webapp/src/components/AddNijisToForkModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/AddNijisToForkModal/index.test.tsx
@@ -1,0 +1,297 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/assets/icons/Link.svg', () => ({
+  default: 'link.svg',
+}));
+
+vi.mock('@/components/SolidColorBackgroundModal', () => ({
+  default: ({ show, content }: { show: boolean; content: React.ReactNode }) =>
+    show ? <div data-testid="solid-modal">{content}</div> : null,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanTxLink: (hash: string) => `https://etherscan.io/tx/${hash}`,
+}));
+
+type ApprovalStatus = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception';
+
+const setApprovalMock = vi.fn();
+const escrowToForkMock = vi.fn();
+const joinForkMock = vi.fn();
+
+const hookState: {
+  isApprovedForAll: boolean;
+  setApprovalState: { status: ApprovalStatus; errorMessage?: string };
+  escrowToForkState: {
+    status: ApprovalStatus;
+    errorMessage?: string;
+    transaction?: { hash: string };
+  };
+  joinForkState: { status: ApprovalStatus; errorMessage?: string };
+  proposals: { id: string; title: string }[];
+} = {
+  isApprovedForAll: true,
+  setApprovalState: { status: 'None' },
+  escrowToForkState: { status: 'None' },
+  joinForkState: { status: 'None' },
+  proposals: [
+    { id: '1', title: 'Proposal One' },
+    { id: '2', title: 'Proposal Two' },
+  ],
+};
+
+vi.mock('@/wrappers/nijiDao', () => ({
+  useAllProposals: () => ({ data: hookState.proposals }),
+  useEscrowToFork: () => ({
+    escrowToFork: escrowToForkMock,
+    escrowToForkState: hookState.escrowToForkState,
+  }),
+  useJoinFork: () => ({ joinFork: joinForkMock, joinForkState: hookState.joinForkState }),
+}));
+
+vi.mock('@/wrappers/nijiToken', () => ({
+  useIsApprovedForAll: () => hookState.isApprovedForAll,
+  useSetApprovalForAll: () => ({
+    setApproval: setApprovalMock,
+    setApprovalState: hookState.setApprovalState,
+  }),
+}));
+
+import AddNijisToForkModal from './index';
+
+const noop = () => {};
+
+const baseProps = {
+  setIsModalOpen: noop,
+  isModalOpen: true,
+  isConfirmModalOpen: false,
+  isForkingPeriod: false,
+  title: 'title',
+  description: 'desc',
+  selectLabel: 'select',
+  selectDescription: 'select-desc',
+  account: '0xACCT',
+  ownedNouns: [1, 2, 3],
+  userEscrowedNouns: [] as number[],
+  refetchData: vi.fn(),
+  setDataFetchPollInterval: vi.fn(),
+  setIsConfirmModalOpen: vi.fn(),
+};
+
+const resetState = () => {
+  hookState.isApprovedForAll = true;
+  hookState.setApprovalState = { status: 'None' };
+  hookState.escrowToForkState = { status: 'None' };
+  hookState.joinForkState = { status: 'None' };
+  hookState.proposals = [
+    { id: '1', title: 'Proposal One' },
+    { id: '2', title: 'Proposal Two' },
+  ];
+  setApprovalMock.mockReset();
+  escrowToForkMock.mockReset();
+  joinForkMock.mockReset();
+  baseProps.refetchData = vi.fn();
+  baseProps.setDataFetchPollInterval = vi.fn();
+  baseProps.setIsConfirmModalOpen = vi.fn();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AddNijisToForkModal', () => {
+  it('renders confirm modal content when isConfirmModalOpen is true', () => {
+    const { container } = render(
+      <AddNijisToForkModal {...baseProps} isModalOpen={false} isConfirmModalOpen={true} />,
+    );
+    expect(container.textContent).toContain('Confirm');
+    expect(container.textContent).toContain('Join');
+    expect(container.textContent).toContain('Cancel');
+  });
+
+  it('renders main modal with "Add Nijis to escrow" title when not in forking period', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    expect(container.textContent).toContain('Add Nijis to escrow');
+  });
+
+  it('renders main modal with "Join fork" title during forking period', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} isForkingPeriod={true} />);
+    expect(container.textContent).toContain('Join fork');
+  });
+
+  it('updates reason text on input change', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const reasonInput = container.querySelector(
+      'input[aria-label="Your reason for forking"]',
+    ) as HTMLInputElement;
+    expect(reasonInput).not.toBeNull();
+    fireEvent.change(reasonInput, { target: { value: 'my reason' } });
+    expect(reasonInput.value).toBe('my reason');
+  });
+
+  it('adds proposal to selectedProposals via select change', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const select = container.querySelector(
+      'select[aria-label="Select proposal(s)"]',
+    ) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '1' } });
+    expect(container.textContent).toContain('Proposal One');
+  });
+
+  it('toggles individual Niji selection on button click', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const nijiButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent?.includes('Niji 1'),
+    );
+    expect(nijiButtons.length).toBeGreaterThan(0);
+    fireEvent.click(nijiButtons[0]);
+    expect(container.textContent).toContain('Adding Niji 1');
+  });
+
+  it('renders Select all button when ownedNouns > escrowed', () => {
+    const { container } = render(
+      <AddNijisToForkModal {...baseProps} userEscrowedNouns={[1]} ownedNouns={[1, 2, 3]} />,
+    );
+    expect(container.textContent).toContain('Select all');
+  });
+
+  it('Select all click selects all owned nouns', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const selectAllBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Select all',
+    );
+    expect(selectAllBtn).not.toBeUndefined();
+    fireEvent.click(selectAllBtn!);
+    expect(container.textContent).toContain('Niji 1, Niji 2, Niji 3');
+  });
+
+  it('disables escrowed Niji buttons', () => {
+    const { container } = render(
+      <AddNijisToForkModal {...baseProps} userEscrowedNouns={[2]} ownedNouns={[1, 2, 3]} />,
+    );
+    const nijiButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent?.includes('Niji 2'),
+    );
+    const escrowedBtn = nijiButtons.find(b => b.textContent?.includes('in escrow'));
+    expect(escrowedBtn?.disabled).toBe(true);
+  });
+
+  it('primary button is disabled when no Nijis selected', () => {
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const primaryBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Niji'),
+    );
+    const addBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.startsWith('Add'),
+    );
+    expect(primaryBtn).not.toBeUndefined();
+    expect(addBtn?.disabled).toBe(true);
+  });
+
+  it('triggers escrowToFork directly when isApprovedForAll=true (no fork period)', () => {
+    hookState.isApprovedForAll = true;
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const nijiButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent?.includes('Niji 1'),
+    );
+    fireEvent.click(nijiButtons[0]);
+    const addBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.startsWith('Add'),
+    );
+    fireEvent.click(addBtn!);
+    expect(escrowToForkMock).toHaveBeenCalled();
+    expect(joinForkMock).not.toHaveBeenCalled();
+  });
+
+  it('triggers joinFork directly when isApprovedForAll=true and isForkingPeriod=true', () => {
+    hookState.isApprovedForAll = true;
+    const { container } = render(<AddNijisToForkModal {...baseProps} isForkingPeriod={true} />);
+    const nijiButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent?.includes('Niji 1'),
+    );
+    fireEvent.click(nijiButtons[0]);
+    const addBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.startsWith('Add'),
+    );
+    fireEvent.click(addBtn!);
+    expect(joinForkMock).toHaveBeenCalled();
+    expect(escrowToForkMock).not.toHaveBeenCalled();
+  });
+
+  it('triggers setApproval and 2-step UI when not approved', () => {
+    hookState.isApprovedForAll = false;
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const nijiButtons = Array.from(container.querySelectorAll('button')).filter(b =>
+      b.textContent?.includes('Niji 1'),
+    );
+    fireEvent.click(nijiButtons[0]);
+    const addBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.startsWith('Add'),
+    );
+    fireEvent.click(addBtn!);
+    expect(setApprovalMock).toHaveBeenCalled();
+    expect(container.textContent).toContain('Set approval');
+  });
+
+  it('shows "approve access" note when not approved', () => {
+    hookState.isApprovedForAll = false;
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    expect(container.textContent).toContain("You'll be asked to approve access");
+  });
+
+  it('shows success message + etherscan link on escrowToForkState=Success', () => {
+    hookState.escrowToForkState = {
+      status: 'Success',
+      transaction: { hash: '0xabc' },
+    };
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    expect(container.textContent).toContain('added to escrow');
+    expect(container.querySelector('a[href*="0xabc"]')).not.toBeNull();
+  });
+
+  it('shows error message + Try again button on escrowToForkState=Fail', () => {
+    hookState.escrowToForkState = { status: 'Fail', errorMessage: 'Tx failed' };
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    expect(container.textContent).toContain('Tx failed');
+    expect(container.textContent).toContain('Try again');
+  });
+
+  it('Try again button clears error state', () => {
+    hookState.escrowToForkState = { status: 'Fail', errorMessage: 'Tx failed' };
+    const { container } = render(<AddNijisToForkModal {...baseProps} />);
+    const tryAgain = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Try again',
+    );
+    fireEvent.click(tryAgain!);
+    expect(container.textContent).not.toContain('Tx failed');
+  });
+
+  it('confirm modal Cancel button calls setIsConfirmModalOpen(false)', () => {
+    const { container } = render(
+      <AddNijisToForkModal {...baseProps} isModalOpen={false} isConfirmModalOpen={true} />,
+    );
+    const cancelBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Cancel',
+    );
+    fireEvent.click(cancelBtn!);
+    expect(baseProps.setIsConfirmModalOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('renders nothing when both modals closed', () => {
+    const { container } = render(
+      <AddNijisToForkModal {...baseProps} isModalOpen={false} isConfirmModalOpen={false} />,
+    );
+    expect(container.querySelector('[data-testid="solid-modal"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 49` として最大 file `AddNijisToForkModal` (574 行) 単独 PR で vitest を追加、 951 → 970 (+19、 1 skip 維持)。 残 large 帯候補で最も大きい file を 1 PR で完走。

## 詳細

### AddNijisToForkModal/index.test.tsx (19 TC)

DAO の fork 機能で Niji を escrow / join するための modal。 approval / escrow / joinFork の 3 contract 呼出と、 escrow 期間 / fork 期間の分岐、 2-step 承認 UI、 transaction state 5 種 (PendingSignature / Mining / Success / Fail / Exception) を扱う複雑 component。

検証観点。

- confirm modal を `isConfirmModalOpen=true` で表示 (Join / Cancel)
- 通常 modal を `isModalOpen=true` で表示
- escrow / fork 期間別 title 切替 ("Add Nijis to escrow" / "Join fork")
- reason text input 値 update
- proposal select で `selectedProposals` 追加
- 個別 Niji button click で `selectedNouns` トグル
- Select all button が `ownedNouns > escrowed` 時表示
- Select all click で全選択
- userEscrowedNouns に含まれる Niji は disabled
- 選択数 0 で primary button disabled
- `isApprovedForAll=true` + 非 fork 期間 で `escrowToFork` 即発火
- `isApprovedForAll=true` + fork 期間 で `joinFork` 即発火
- `isApprovedForAll=false` で `setApproval` + 2-step UI 表示
- 「approve access」 note 表示
- escrow Success で etherscan link + 成功メッセージ
- Fail で error message + Try again button
- Try again click で error state clear
- confirm modal Cancel で `setIsConfirmModalOpen(false)`
- 両 modal close で何も render しない

## 解決方法

`useAllProposals` / `useEscrowToFork` / `useJoinFork` / `useSetApprovalForAll` / `useIsApprovedForAll` を `vi.mock` で stub し、 `hookState` 経由で test ごとに state を切替。 `SolidColorBackgroundModal` は `show=true` 時に content を直接 render する mock に置換し portal を回避 (PR #428 で確立した portal mock pattern より単純な経路、 modal wrapper 自体を簡素化)。

`escrowToForkState` の各 status 経路は React.useEffect 内で副作用が発火するため、 `hookState.escrowToForkState = { status: 'Success', transaction: { hash: '0xabc' } }` を pre-set した状態で `render()` を呼ぶと初回 effect で UI が成功表示に切り替わる。

## 受入条件

- [x] 1 file 19 TC 全 pass
- [x] `pnpm vitest run` 全 970 test green (971 - 1 skipped)
- [x] regression なし (既存 951 pass を破壊しない)

## 関連

- Closes #429
- 直前 PR #428 (part 48) で 928 → 951 (large 帯 2 file 23 TC)
- 残 large 候補 ... Proposals (419 行) / ChangeDelegatePanel (315 行) / VoteModal (252 行) / Bid (240 行) / StreamWithdrawModal (230 行)
- 観察 ... product code 上で `userEscrowedNouns` ∈ `ownedNouns` 重複時に React `Encountered two children with the same key` 警告 (`[...ownedNouns, ...userEscrowedNouns]` で同 id を 2 回 push する設計、 fix 候補は別 Issue)
