### PR TITLE
✅ test(niji-webapp): component part 50 (Proposals / ChangeDelegatePanel) で 970 → 996 (Issue #431)

### DIFF
--- a/packages/niji-webapp/src/components/ChangeDelegatePanel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ChangeDelegatePanel/index.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+type DelegateStatus = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception';
+
+const delegateVotesMock = vi.fn();
+const hookState: {
+  account: string | undefined;
+  ensResolved: string | undefined;
+  ensFetched: boolean;
+  delegateState: {
+    status: DelegateStatus;
+    errorMessage?: { message: string } | string;
+    transaction?: { hash: string };
+  };
+  nounTokenBalance: number;
+  proposalThreshold: number;
+  userDelegatee: string | undefined;
+  accountVotes: number;
+  locale: string;
+} = {
+  account: '0xUSER',
+  ensResolved: undefined,
+  ensFetched: true,
+  delegateState: { status: 'None' },
+  nounTokenBalance: 5,
+  proposalThreshold: 1,
+  userDelegatee: '0xOLD',
+  accountVotes: 5,
+  locale: 'en-US',
+};
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: hookState.account }),
+  useEnsAddress: () => ({ data: hookState.ensResolved, isFetched: hookState.ensFetched }),
+}));
+
+vi.mock('@/components/BrandSpinner', () => ({
+  default: () => <span data-testid="brand-spinner" />,
+}));
+
+vi.mock('@/components/DelegationCandidateInfo', () => ({
+  default: ({ address }: { address: string }) => (
+    <div data-testid="delegation-candidate-info">{address}</div>
+  ),
+}));
+
+vi.mock('@/components/NavBarButton', () => ({
+  default: ({
+    buttonText,
+    onClick,
+    disabled,
+  }: {
+    buttonText: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button data-testid="nav-btn" onClick={onClick} disabled={disabled}>
+      {buttonText}
+    </button>
+  ),
+  NavBarButtonStyle: {
+    DELEGATE_PRIMARY: 'primary',
+    DELEGATE_SECONDARY: 'secondary',
+    DELEGATE_BACK: 'back',
+    DELEGATE_DISABLED: 'disabled',
+  },
+}));
+
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => hookState.locale,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanTxLink: (hash: string) => `https://etherscan.io/tx/${hash}`,
+}));
+
+vi.mock('@/utils/pickByState', async () => {
+  const actual = await vi.importActual<typeof import('@/utils/pickByState')>('@/utils/pickByState');
+  return actual;
+});
+
+vi.mock('@/wrappers/nijiDao', () => ({
+  useProposalThreshold: () => hookState.proposalThreshold,
+}));
+
+vi.mock('@/wrappers/nijiToken', () => ({
+  useNounTokenBalance: () => hookState.nounTokenBalance,
+  useDelegateVotes: () => ({
+    delegateVotes: delegateVotesMock,
+    delegateState: hookState.delegateState,
+  }),
+  useUserDelegatee: () => hookState.userDelegatee,
+  useAccountVotes: () => hookState.accountVotes,
+}));
+
+import ChangeDelegatePanel from './index';
+
+const resetState = () => {
+  hookState.account = '0xUSER';
+  hookState.ensResolved = undefined;
+  hookState.ensFetched = true;
+  hookState.delegateState = { status: 'None' };
+  hookState.nounTokenBalance = 5;
+  hookState.proposalThreshold = 1;
+  hookState.userDelegatee = '0xOLD';
+  hookState.accountVotes = 5;
+  hookState.locale = 'en-US';
+  delegateVotesMock.mockReset();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const validAddress = '0x1234567890123456789012345678901234567890';
+const dismissMock = vi.fn();
+
+describe('ChangeDelegatePanel', () => {
+  it('renders default "Update Delegate" title in ENTER state', () => {
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('Update Delegate');
+  });
+
+  it('renders input field in ENTER state without delegateTo', () => {
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.querySelector('input')).not.toBeNull();
+  });
+
+  it('updates delegate input on change', () => {
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: validAddress } });
+    expect(input.value).toBe(validAddress);
+  });
+
+  it('shows DelegationCandidateInfo when valid address entered', () => {
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: validAddress } });
+    expect(container.querySelector('[data-testid="delegation-candidate-info"]')).not.toBeNull();
+  });
+
+  it('shows "already delegated" when input matches current delegate', () => {
+    hookState.userDelegatee = validAddress;
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: validAddress } });
+    expect(container.textContent).toContain("You've already delegated to this address");
+  });
+
+  it('Delegate button calls delegateVotes with address arg', () => {
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: validAddress } });
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const delegateBtn = buttons.find(b => b.textContent?.includes('Delegate'));
+    fireEvent.click(delegateBtn!);
+    expect(delegateVotesMock).toHaveBeenCalledWith({ args: [validAddress] });
+  });
+
+  it('Delegate button disabled when no input', () => {
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const delegateBtn = buttons.find(b => b.textContent?.includes('Delegate'));
+    expect(delegateBtn?.disabled).toBe(true);
+  });
+
+  it('Delegate button disabled when availableVotes=0', () => {
+    hookState.nounTokenBalance = 0;
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: validAddress } });
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const delegateBtn = buttons.find(b => b.textContent?.includes('Delegate'));
+    expect(delegateBtn?.disabled).toBe(true);
+  });
+
+  it('shows CHANGING title when delegateState is Mining', () => {
+    hookState.delegateState = { status: 'Mining' };
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('Updating...');
+  });
+
+  it('shows CHANGE_SUCCESS title when delegateState is Success', () => {
+    hookState.delegateState = { status: 'Success' };
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('Delegate Updated!');
+  });
+
+  it('shows CHANGE_FAILURE title when delegateState is Fail', () => {
+    hookState.delegateState = { status: 'Fail', errorMessage: 'Tx reverted' };
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('Delegate Update Failed');
+    expect(container.textContent).toContain('Tx reverted');
+  });
+
+  it('Close button calls onDismiss', () => {
+    dismissMock.mockReset();
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const closeBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Close',
+    );
+    fireEvent.click(closeBtn!);
+    expect(dismissMock).toHaveBeenCalled();
+  });
+
+  it('shows threshold warning when accountVotes - availableVotes < threshold + 1', () => {
+    hookState.accountVotes = 5;
+    hookState.nounTokenBalance = 5;
+    hookState.proposalThreshold = 10;
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('less than');
+  });
+
+  it('renders BrandSpinner when delegateTo provided but address not yet resolved', () => {
+    const { container } = render(
+      <ChangeDelegatePanel onDismiss={dismissMock} delegateTo="not-yet-resolved.eth" />,
+    );
+    expect(container.querySelector('[data-testid="brand-spinner"]')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/Proposals/index.test.tsx
+++ b/packages/niji-webapp/src/components/Proposals/index.test.tsx
@@ -1,0 +1,268 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: { number: (n: number) => String(n) },
+}));
+
+const navigateMock = vi.fn();
+const locationMock: { hash: string } = { hash: '' };
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual<typeof import('react-router')>('react-router');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+    useLocation: () => locationMock,
+  };
+});
+
+const wagmiState: {
+  blockNumber: bigint | undefined;
+  account: string | undefined;
+} = {
+  blockNumber: 100n,
+  account: undefined,
+};
+vi.mock('wagmi', () => ({
+  useBlockNumber: () => ({ data: wagmiState.blockNumber }),
+  useAccount: () => ({ address: wagmiState.account }),
+}));
+
+const candidatesAtomState: {
+  current: unknown;
+  setter: (v: unknown) => void;
+} = {
+  current: null,
+  setter: vi.fn(),
+};
+vi.mock('jotai/react', () => ({
+  useAtom: () => [candidatesAtomState.current, candidatesAtomState.setter],
+}));
+
+vi.mock('@/state/atoms/candidatesAtom', () => ({
+  candidatesAtom: {},
+}));
+
+vi.mock('@/components/CandidateCard', () => ({
+  default: ({ candidate }: { candidate: { id: string } }) => (
+    <div data-testid="candidate-card">{candidate.id}</div>
+  ),
+}));
+
+vi.mock('@/components/DelegationModal', () => ({
+  default: ({ onDismiss }: { onDismiss: () => void }) => (
+    <div data-testid="delegation-modal" onClick={onDismiss} />
+  ),
+}));
+
+vi.mock('@/components/ProposalStatus', () => ({
+  default: ({ status }: { status: number }) => <span data-testid="proposal-status">{status}</span>,
+}));
+
+vi.mock('@/config', () => ({
+  default: {
+    featureToggles: { candidates: true },
+    contractParameters: { executor: { GRACE_PERIOD_SECONDS: 60 * 60 * 24 * 14 } },
+  },
+}));
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+vi.mock('@/i18n/locales', () => ({
+  SUPPORTED_LOCALE_TO_DAYSJS_LOCALE: { 'en-US': 'en' },
+  SupportedLocale: {},
+}));
+
+vi.mock('@/layout/Section', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <section>{children}</section>,
+}));
+
+vi.mock('@/utils/constants', () => ({
+  AVERAGE_BLOCK_TIME_IN_SECS: 12,
+}));
+
+const isMobileMock = vi.fn();
+vi.mock('@/utils/isMobile', () => ({
+  isMobileScreen: () => isMobileMock(),
+}));
+
+vi.mock('@/utils/proposals', () => ({
+  isProposalUpdatable: () => true,
+}));
+
+const daoState: {
+  isDaoGteV3: boolean;
+  proposalThreshold: number;
+} = {
+  isDaoGteV3: true,
+  proposalThreshold: 1,
+};
+vi.mock('@/wrappers/nijiDao', () => ({
+  ProposalState: {
+    UNDETERMINED: -1,
+    PENDING: 0,
+    ACTIVE: 1,
+    CANCELLED: 2,
+    DEFEATED: 3,
+    SUCCEEDED: 4,
+    QUEUED: 5,
+    EXPIRED: 6,
+    EXECUTED: 7,
+    VETOED: 8,
+    OBJECTION_PERIOD: 9,
+    UPDATABLE: 10,
+  },
+  useIsDaoGteV3: () => daoState.isDaoGteV3,
+  useProposalThreshold: () => daoState.proposalThreshold,
+}));
+
+const candidateState: { data: unknown[]; refetch: () => Promise<void> } = {
+  data: [],
+  refetch: vi.fn().mockResolvedValue(undefined),
+};
+vi.mock('@/wrappers/nijiData', () => ({
+  useCandidateProposals: () => candidateState,
+}));
+
+const tokenState: { balance: number; userVotes: number } = { balance: 1, userVotes: 5 };
+vi.mock('@/wrappers/nijiToken', () => ({
+  useNounTokenBalance: () => tokenState.balance,
+  useUserVotes: () => tokenState.userVotes,
+}));
+
+import Proposals from './index';
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const resetState = () => {
+  wagmiState.blockNumber = 100n;
+  wagmiState.account = undefined;
+  candidatesAtomState.current = null;
+  candidatesAtomState.setter = vi.fn();
+  daoState.isDaoGteV3 = true;
+  daoState.proposalThreshold = 1;
+  tokenState.balance = 1;
+  tokenState.userVotes = 5;
+  locationMock.hash = '';
+  navigateMock.mockReset();
+  useActiveLocaleMock.mockReturnValue('en-US');
+  isMobileMock.mockReturnValue(false);
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Proposals', () => {
+  it('renders "No proposals found" alert when proposals empty', () => {
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('No proposals found');
+  });
+
+  it('renders proposal list when proposals provided', () => {
+    const proposals = [
+      { id: '1', title: 'First', status: 1, startBlock: 50n, endBlock: 200n, eta: '0' },
+      { id: '2', title: 'Second', status: 7, startBlock: 50n, endBlock: 60n, eta: '0' },
+    ] as never;
+    const { container } = wrap(<Proposals proposals={proposals} nounsRequired={2} />);
+    expect(container.textContent).toContain('First');
+    expect(container.textContent).toContain('Second');
+  });
+
+  it('shows "Connect wallet" copy when no account', () => {
+    wagmiState.account = undefined;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('Connect wallet to make a proposal');
+  });
+
+  it('shows "You have no Votes" when account but 0 votes', () => {
+    wagmiState.account = '0xUSER';
+    tokenState.userVotes = 0;
+    tokenState.balance = 0;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('You have no Votes');
+  });
+
+  it('shows "Making a proposal requires N votes" copy when below threshold', () => {
+    wagmiState.account = '0xUSER';
+    tokenState.userVotes = 2;
+    daoState.proposalThreshold = 10;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('Making a proposal requires');
+  });
+
+  it('shows Submit Proposal button when hasEnoughVotesToPropose', () => {
+    wagmiState.account = '0xUSER';
+    tokenState.userVotes = 100;
+    daoState.proposalThreshold = 1;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('Submit Proposal');
+  });
+
+  it('clicking Delegate button opens DelegationModal', () => {
+    wagmiState.account = '0xUSER';
+    tokenState.userVotes = 100;
+    daoState.proposalThreshold = 1;
+    tokenState.balance = 5;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    const delegateBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Delegate',
+    );
+    expect(delegateBtn).not.toBeUndefined();
+    fireEvent.click(delegateBtn!);
+    expect(container.querySelector('[data-testid="delegation-modal"]')).not.toBeNull();
+  });
+
+  it('tab switch sets activeTab on click', () => {
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    const tabs = container.querySelectorAll(`button`);
+    const candidatesTab = Array.from(tabs).find(b => b.textContent?.trim() === 'Candidates');
+    expect(candidatesTab).not.toBeUndefined();
+    fireEvent.click(candidatesTab!);
+    expect(navigateMock).toHaveBeenCalledWith('/vote#candidates');
+  });
+
+  it('shows "Loading candidates" alert when candidates atom is null', () => {
+    locationMock.hash = '#candidates';
+    candidatesAtomState.current = null;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('Loading candidates');
+  });
+
+  it('shows "No candidates found" when candidates array empty', () => {
+    locationMock.hash = '#candidates';
+    candidatesAtomState.current = [];
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('No candidates found');
+  });
+
+  it('renders CandidateCard when candidates list has entries', () => {
+    locationMock.hash = '#candidates';
+    candidatesAtomState.current = [{ id: 'cand-1', proposalIdToUpdate: '0' }];
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.querySelector('[data-testid="candidate-card"]')).not.toBeNull();
+  });
+
+  it('hides Candidates tab when isDaoGteV3=false', () => {
+    daoState.isDaoGteV3 = false;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    const candidatesTab = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Candidates',
+    );
+    expect(candidatesTab).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 50` として large 帯 2 file (`Proposals` 419 行 / `ChangeDelegatePanel` 315 行) に vitest を追加、 970 → 996 (+26、 1 skip 維持)。 1000 件大台到達まで残 4 件。

## 詳細

### Proposals/index.test.tsx (12 TC)

`/vote` 画面の top-level で proposals 一覧 + candidates 一覧 + delegate/submit ボタン群を統括する component。 wagmi (`useBlockNumber` / `useAccount`) + jotai (`candidatesAtom`) + 多数の wrapper hook + tab 状態を組み合わせる。

検証観点。

- proposals 空時 「No proposals found」 Alert
- proposals 提供時に title 列挙
- 未接続で「Connect wallet to make a proposal」
- 接続 + 0 votes で「You have no Votes」
- 投票数 < threshold で「Making a proposal requires N votes」
- `hasEnoughVotesToPropose` で Submit Proposal active button
- Delegate button click で DelegationModal 表示
- Candidates tab click で `navigate('/vote#candidates')`
- `candidatesAtom=null` で「Loading candidates」 Spinner
- `candidatesAtom=[]` で「No candidates found」
- candidates 配列で CandidateCard 表示
- `isDaoGteV3=false` で Candidates tab 非表示

### ChangeDelegatePanel/index.test.tsx (14 TC)

delegate 操作 modal。 `ChangeDelegateState` 4 値 (ENTER / CHANGING / CHANGE_SUCCESS / CHANGE_FAILURE) + ENS 解決 + input validation + `usePickByState` で primary button / copy を切替。

検証観点。

- default title「Update Delegate」 (ENTER)
- input field 描画
- input change で値 update
- 有効 address で DelegationCandidateInfo 表示
- 既存 delegate と同一で「already delegated」 表示
- Delegate button click で `delegateVotes({ args: [address] })`
- input 未入力で Delegate button disabled
- availableVotes=0 で Delegate button disabled
- `delegateState=Mining` で「Updating...」 title
- `delegateState=Success` で「Delegate Updated!」 title
- `delegateState=Fail + errorMessage` で「Delegate Update Failed」 + メッセージ表示
- Close button click で onDismiss
- `accountVotes - availableVotes < threshold + 1` で threshold warning
- `delegateTo` prop + 未解決で BrandSpinner 表示

## 解決方法

`useAccount` / `useBlockNumber` / `useEnsAddress` / `useNounTokenBalance` / `useUserVotes` / `useProposalThreshold` / `useCandidateProposals` / `useIsDaoGteV3` / `useDelegateVotes` / `useUserDelegatee` / `useAccountVotes` / jotai `useAtom` / `useNavigate` / `useLocation` / `useActiveLocale` / 子 (DelegationModal / CandidateCard / ProposalStatus / DelegationCandidateInfo / NavBarButton / BrandSpinner / Section) を全 `vi.mock` で stub し、 `hookState` 経由で test ごとに切替。

`usePickByState` は実装 (`stateResults[states.indexOf(state)]`) を `importActual` で保持し、 state 経路の indirect だけ実コードで検証。 ProposalState enum は wrapper mock 内に literal で再現。

## 受入条件

- [x] 2 file 計 26 TC 全 pass
- [x] `pnpm vitest run` 全 996 test green (997 - 1 skipped)
- [x] regression なし (既存 970 pass を破壊しない)

## 関連

- Closes #431
- 直前 PR #430 (part 49) で 951 → 970 (AddNijisToForkModal 単独 19 TC)
- 1000 件まで残 4 — 次 part 51 で達成見込み
- 残 large 候補 ... VoteModal (252 行) / Bid (240 行) / StreamWithdrawModal (230 行) / ProposalActionsModal (229 行)
