### PR TITLE
✅ test(niji-webapp): component part 53 (Niji / SubmitUpdateProposal) で 1042 → 1065 (Issue #437)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SubmitUpdateProposal.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SubmitUpdateProposal.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/assets/icons/Link.svg', () => ({
+  default: 'link.svg',
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanTxLink: (hash: string) => `https://etherscan.io/tx/${hash}`,
+}));
+
+type UpdateStatus = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception';
+
+const updateProposalBySigsMock = vi.fn();
+const hookState: {
+  updateProposalBySigsState: {
+    status: UpdateStatus;
+    errorMessage?: string;
+    transaction?: { hash: string };
+  };
+} = {
+  updateProposalBySigsState: { status: 'None' },
+};
+
+vi.mock('@/wrappers/nijiData', () => ({
+  useUpdateProposalBySigs: () => ({
+    updateProposalBySigs: updateProposalBySigsMock,
+    updateProposalBySigsState: hookState.updateProposalBySigsState,
+  }),
+}));
+
+vi.mock('../SolidColorBackgroundModal', () => ({
+  default: ({ show, content }: { show: boolean; content: React.ReactNode }) =>
+    show ? <div data-testid="solid-modal">{content}</div> : null,
+}));
+
+import SubmitUpdateProposal from './SubmitUpdateProposal';
+
+const makeCandidate = () =>
+  ({
+    version: {
+      content: {
+        targets: ['0xTARGET1', '0xTARGET2'],
+        values: ['100', '200'],
+        signatures: ['fn1()', 'fn2()'],
+        calldatas: ['0xCALLDATA1', '0xCALLDATA2'],
+        description: 'test description',
+      },
+    },
+  }) as never;
+
+const makeSignatures = () => [
+  {
+    sig: '0xSIG_B',
+    signer: { id: '0xBBB' },
+    expirationTimestamp: '1700000000',
+  },
+  {
+    sig: '0xSIG_A',
+    signer: { id: '0xAAA' },
+    expirationTimestamp: '1700000000',
+  },
+];
+
+const baseProps = {
+  isModalOpen: true,
+  signatures: makeSignatures() as never,
+  candidate: makeCandidate(),
+  setIsModalOpen: vi.fn(),
+  handleRefetchCandidateData: vi.fn(),
+  setDataFetchPollInterval: vi.fn(),
+  proposalIdToUpdate: '42',
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const resetState = () => {
+  hookState.updateProposalBySigsState = { status: 'None' };
+  updateProposalBySigsMock.mockReset();
+  baseProps.setIsModalOpen = vi.fn();
+  baseProps.handleRefetchCandidateData = vi.fn();
+  baseProps.setDataFetchPollInterval = vi.fn();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SubmitUpdateProposal', () => {
+  it('renders modal content when isModalOpen=true', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    expect(container.textContent).toContain('Update proposal');
+    expect(container.textContent).toContain('Add an optional message');
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.placeholder).toBe('Optional message');
+  });
+
+  it('does not render modal when isModalOpen=false', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} isModalOpen={false} />);
+    expect(container.querySelector('[data-testid="solid-modal"]')).toBeNull();
+  });
+
+  it('updates reason on textarea change', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'my reason' } });
+    expect(textarea.value).toBe('my reason');
+  });
+
+  it('Submit update click invokes updateProposalBySigs with sorted signers', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Submit update',
+    );
+    fireEvent.click(submitBtn!);
+    expect(updateProposalBySigsMock).toHaveBeenCalledTimes(1);
+    const call = updateProposalBySigsMock.mock.calls[0][0];
+    const sortedSigs = call.args[1];
+    expect(sortedSigs[0].signer).toBe('0xAAA');
+    expect(sortedSigs[1].signer).toBe('0xBBB');
+  });
+
+  it('shows "Awaiting confirmation" when status=PendingSignature', () => {
+    hookState.updateProposalBySigsState = { status: 'PendingSignature' };
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    expect(container.textContent).toContain('Awaiting confirmation');
+  });
+
+  it('shows "Submitting proposal" when status=Mining', () => {
+    hookState.updateProposalBySigsState = { status: 'Mining' };
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    expect(container.textContent).toContain('Submitting proposal');
+  });
+
+  it('shows Success message + etherscan link when status=Success', () => {
+    hookState.updateProposalBySigsState = {
+      status: 'Success',
+      transaction: { hash: '0xabc' },
+    };
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    expect(container.textContent).toContain('Success!');
+    expect(container.querySelector('a[href*="0xabc"]')).not.toBeNull();
+  });
+
+  it('shows error message when status=Fail', () => {
+    hookState.updateProposalBySigsState = { status: 'Fail', errorMessage: 'rpc failed' };
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    expect(container.textContent).toContain('rpc failed');
+    expect(container.textContent).toContain('Try again');
+  });
+
+  it('Try again click clears error state', () => {
+    hookState.updateProposalBySigsState = { status: 'Fail', errorMessage: 'rpc failed' };
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    const tryAgain = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Try again',
+    );
+    fireEvent.click(tryAgain!);
+    expect(container.textContent).not.toContain('rpc failed');
+  });
+});

--- a/packages/niji-webapp/src/components/Niji.test.tsx
+++ b/packages/niji-webapp/src/components/Niji.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@niji/sdk', () => ({
+  buildSVG: () => '<svg>stub</svg>',
+}));
+
+const hookState: {
+  fetchedSeed: {
+    background: number;
+    body: number;
+    accessory: number;
+    head: number;
+    glasses: number;
+  };
+  querySvg: string | undefined;
+} = {
+  fetchedSeed: { background: 1, body: 2, accessory: 3, head: 4, glasses: 5 },
+  querySvg: '<svg>render</svg>',
+};
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: ({ enabled }: { enabled?: boolean }) => ({
+    data: enabled === true ? hookState.querySvg : undefined,
+  }),
+}));
+
+const setOnDisplayAuctionNounIdMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useSetAtom: () => setOnDisplayAuctionNounIdMock,
+}));
+
+vi.mock('@/assets/loading-skull-noun.gif', () => ({
+  default: 'loading-skull.gif',
+}));
+
+vi.mock('@/lib/nijiAssets', () => ({
+  getNijiData: () => ({ parts: [], background: 'fff' }),
+  NijiImageData: { palette: [] },
+}));
+
+vi.mock('@/state/atoms/onDisplayAuctionAtom', () => ({
+  onDisplayAuctionNounIdAtom: {},
+}));
+
+vi.mock('@/wrappers/nijiToken', () => ({
+  useNounSeed: () => hookState.fetchedSeed,
+}));
+
+vi.mock('@/components/LegacyNoun/Noun.module.css', () => ({
+  default: {
+    img: 'img-class',
+    imgWrapper: 'img-wrapper',
+    circular: 'circular',
+    circleWithBorder: 'circle-border',
+    circularNounWrapper: 'circle-wrapper',
+    rounded: 'rounded',
+  },
+}));
+
+import DefaultLinkedNiji, {
+  Niji,
+  NijiCircular,
+  NijiImage,
+  NijiRoundedCorners,
+  NijiWithSeed,
+} from './Niji';
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const resetState = () => {
+  hookState.fetchedSeed = { background: 1, body: 2, accessory: 3, head: 4, glasses: 5 };
+  hookState.querySvg = '<svg>render</svg>';
+  setOnDisplayAuctionNounIdMock.mockReset();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Niji', () => {
+  it('default export renders img inside Link', () => {
+    const { container } = wrap(<DefaultLinkedNiji nounId={5n} />);
+    expect(container.querySelector('a[href="/niji/5"]')).not.toBeNull();
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('LinkedNiji omits Link when shouldLinkToProfile=false', () => {
+    const { container } = wrap(<DefaultLinkedNiji nounId={5n} shouldLinkToProfile={false} />);
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('LinkedNiji click triggers setOnDisplayAuctionNounId(Number)', () => {
+    const { container } = wrap(<DefaultLinkedNiji nounId={9n} />);
+    const link = container.querySelector('a') as HTMLAnchorElement;
+    fireEvent.click(link);
+    expect(setOnDisplayAuctionNounIdMock).toHaveBeenCalledWith(9);
+  });
+
+  it('Niji renders data:image/svg+xml src when query returns svg', () => {
+    const { container } = render(<Niji nounId={5n} />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.src.startsWith('data:image/svg+xml;base64,')).toBe(true);
+  });
+
+  it('Niji renders fallback transparent pixel when no svg', () => {
+    hookState.querySvg = undefined;
+    const { container } = render(<Niji nounId={5n} />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.src.startsWith('data:image/gif;base64,')).toBe(true);
+  });
+
+  it('Niji loadingNounFallback=true with no svg renders loading gif', () => {
+    hookState.querySvg = undefined;
+    const { container } = render(<Niji nounId={5n} loadingNounFallback={true} />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.src).toContain('loading-skull.gif');
+  });
+
+  it('Niji uses provided alt prop over auto-generated alt', () => {
+    const { container } = render(<Niji nounId={5n} alt="custom alt" />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.alt).toBe('custom alt');
+  });
+
+  it('Niji auto-generates alt from nounId when no alt provided', () => {
+    const { container } = render(<Niji nounId={5n} />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.alt).toContain('Niji 5');
+  });
+
+  it('NijiImage renders without fallback by default', () => {
+    const { container } = render(<NijiImage nounId={1n} />);
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('NijiCircular border=true applies circleWithBorder class', () => {
+    const { container } = wrap(<NijiCircular nounId={1n} border={true} />);
+    const img = container.querySelector('img');
+    expect(img?.className).toContain('circle-border');
+  });
+
+  it('NijiCircular border=false applies circular class', () => {
+    const { container } = wrap(<NijiCircular nounId={1n} border={false} />);
+    const img = container.querySelector('img');
+    expect(img?.className).toContain('circular');
+  });
+
+  it('NijiRoundedCorners applies rounded class', () => {
+    const { container } = wrap(<NijiRoundedCorners nounId={1n} />);
+    const img = container.querySelector('img');
+    expect(img?.className).toContain('rounded');
+  });
+
+  it('NijiWithSeed calls onLoadSeed when seed is valid', () => {
+    const onLoadSeedMock = vi.fn();
+    wrap(<NijiWithSeed nounId={1n} onLoadSeed={onLoadSeedMock} />);
+    expect(onLoadSeedMock).toHaveBeenCalledWith(hookState.fetchedSeed);
+  });
+
+  it('NijiWithSeed skips onLoadSeed when seed is all zeros (invalid)', () => {
+    hookState.fetchedSeed = { background: 0, body: 0, accessory: 0, head: 0, glasses: 0 };
+    const onLoadSeedMock = vi.fn();
+    wrap(<NijiWithSeed nounId={1n} onLoadSeed={onLoadSeedMock} />);
+    expect(onLoadSeedMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 53` として large 帯 2 file (`Niji.tsx` 216 行 / `CandidateSponsors/SubmitUpdateProposal.tsx` 206 行) に vitest を追加、 1042 → 1065 (+23、 1 skip 維持)。 Niji.tsx は 5 種の export 派生を一括 cover。

## 詳細

### Niji.test.tsx (14 TC)

Niji DAO の中核 component。 SVG 生成 (buildSVG + useQuery)、 wallet 表示用画像、 link 経由 detail page navigation。 6 export ... `Niji` / `NijiImage` / `NijiCircular` / `NijiRoundedCorners` / `NijiWithSeed` / default LinkedNiji。

検証観点。

- default LinkedNiji ... img + Link (`/niji/{nounId}`) 描画
- LinkedNiji ... `shouldLinkToProfile=false` で Link 描画なし
- LinkedNiji ... click で `setOnDisplayAuctionNounId(Number(nounId))`
- Niji ... query svg ありで `data:image/svg+xml;base64,` src
- Niji ... query svg なしで fallback transparent pixel src
- Niji ... `loadingNounFallback=true` + svg なしで loading gif src
- Niji ... `alt` prop 指定で alt 優先
- Niji ... nounId のみで自動 alt 生成 (「Niji {N}」)
- NijiImage ... 基本 render
- NijiCircular ... `border=true` で `circleWithBorder` class
- NijiCircular ... `border=false` で `circular` class
- NijiRoundedCorners ... `rounded` class 適用
- NijiWithSeed ... valid seed で `onLoadSeed` コールバック発火
- NijiWithSeed ... all-zero seed (invalid) で `onLoadSeed` 未発火

### SubmitUpdateProposal.test.tsx (9 TC)

candidate を proposal に update する modal。 sig sort + contract write + Mining/Success/Fail state machine + etherscan link 表示。

検証観点。

- isModalOpen=true で content render
- isModalOpen=false で modal 非表示
- reason textarea 入力で state 更新
- Submit click で `updateProposalBySigs` 呼出、 sig は signer address 昇順 sort 済
- status=PendingSignature で「Awaiting confirmation」
- status=Mining で「Submitting proposal」
- status=Success で「Success!」 + etherscan link (a[href*="0xabc"])
- status=Fail + errorMessage で error + Try again button
- Try again click で error state クリア

## 解決方法

Niji.tsx 側 ... `@niji/sdk` (`buildSVG`) / `@tanstack/react-query` (`useQuery`) / jotai (`useSetAtom`) / `@/wrappers/nijiToken` (`useNounSeed`) / `@/lib/nijiAssets` (`getNijiData` / `NijiImageData`) / Noun.module.css を vi.mock。 `useQuery` mock では `enabled === true` で `querySvg` を返し、 svg 切替で fallback 3 経路 (loading gif / transparent pixel / data:svg+xml) を検証。

SubmitUpdateProposal 側 ... `useUpdateProposalBySigs` を vi.mock。 `SolidColorBackgroundModal` を show=true で content 直接 render する mock。 sig sort 検証は signer address `0xBBB` / `0xAAA` の順で渡し、 呼出時に `0xAAA` / `0xBBB` 順になることを assert。

## 受入条件

- [x] 2 file 計 23 TC 全 pass
- [x] `pnpm vitest run` 全 1065 test green (1066 - 1 skipped)
- [x] regression なし (既存 1042 pass を破壊しない)

## 関連

- Closes #437
- 直前 PR #436 (part 52) で 1020 → 1042 (StreamWithdrawModal / ProposalActionsModal)
- 残 large 候補 ... FunctionCallSelectFunctionStep (203 行) / SponsorsList (200 行) / Signature (199 行) / VoteSignals/VoteSignals (191 行) / Documentation/AboutSection (190 行)
