### PR TITLE
✅ test(niji-webapp): component part 54 (FunctionCallSelectFunctionStep / SponsorsList) で 1065 → 1088 (Issue #439)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('./Signature', () => ({
+  default: ({ signer }: { signer: string }) => <li data-testid="signature">{signer}</li>,
+}));
+
+vi.mock('./OriginalSignature', () => ({
+  default: ({ signer }: { signer: string }) => <li data-testid="original-signature">{signer}</li>,
+}));
+
+import { SponsorsList } from './SponsorsList';
+
+const makeSignature = (
+  overrides: Partial<{
+    signerId: string;
+    voteCount: number;
+    canceled: boolean;
+  }> = {},
+) => ({
+  signer: {
+    id: overrides.signerId ?? '0xSIGNER1',
+    voteCount: overrides.voteCount ?? 5,
+    activeOrPendingProposal: false,
+  },
+  reason: '',
+  expirationTimestamp: '1700000000',
+  sig: '0xSIG',
+  canceled: overrides.canceled ?? false,
+});
+
+const makeCandidate = (
+  overrides: Partial<{
+    contentSignatures: ReturnType<typeof makeSignature>[];
+    requiredVotes: number;
+    voteCount: number;
+    isProposal: boolean;
+  }> = {},
+) =>
+  ({
+    version: {
+      content: {
+        contentSignatures: overrides.contentSignatures ?? [makeSignature()],
+      },
+    },
+    requiredVotes: overrides.requiredVotes ?? 3,
+    voteCount: overrides.voteCount ?? 1,
+    isProposal: overrides.isProposal ?? false,
+  }) as never;
+
+const baseProps = {
+  candidate: makeCandidate(),
+  isParentProposalUpdatable: true,
+  isProposer: false,
+  isAccountSigner: false,
+  isOriginalSigner: false,
+  isThresholdMet: false,
+  account: '0xACCT',
+  activePendingProposers: {} as unknown,
+  connectedAccountNounVotes: 5,
+  setIsAccountSigner: vi.fn(),
+  setDataFetchPollInterval: vi.fn(),
+  handleRefetchCandidateData: vi.fn(),
+  onOpenSubmitModal: vi.fn(),
+  onOpenUpdateModal: vi.fn(),
+  onOpenForm: vi.fn(),
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+beforeEach(() => {
+  Object.assign(baseProps, {
+    setIsAccountSigner: vi.fn(),
+    setDataFetchPollInterval: vi.fn(),
+    handleRefetchCandidateData: vi.fn(),
+    onOpenSubmitModal: vi.fn(),
+    onOpenUpdateModal: vi.fn(),
+    onOpenForm: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SponsorsList', () => {
+  it('renders Signature for each valid contentSignature', () => {
+    const candidate = makeCandidate({
+      contentSignatures: [makeSignature({ signerId: '0xS1' }), makeSignature({ signerId: '0xS2' })],
+    });
+    const { container } = wrap(<SponsorsList {...baseProps} candidate={candidate} />);
+    expect(container.querySelectorAll('[data-testid="signature"]')).toHaveLength(2);
+  });
+
+  it('skips canceled signatures', () => {
+    const candidate = makeCandidate({
+      contentSignatures: [
+        makeSignature({ signerId: '0xS1' }),
+        makeSignature({ signerId: '0xS2', canceled: true }),
+      ],
+    });
+    const { container } = wrap(<SponsorsList {...baseProps} candidate={candidate} />);
+    expect(container.querySelectorAll('[data-testid="signature"]')).toHaveLength(1);
+  });
+
+  it('skips signatures with voteCount=0', () => {
+    const candidate = makeCandidate({
+      contentSignatures: [
+        makeSignature({ signerId: '0xS1', voteCount: 0 }),
+        makeSignature({ signerId: '0xS2' }),
+      ],
+    });
+    const { container } = wrap(<SponsorsList {...baseProps} candidate={candidate} />);
+    expect(container.querySelectorAll('[data-testid="signature"]')).toHaveLength(1);
+  });
+
+  it('skips all signatures when activePendingProposers is null', () => {
+    const { container } = wrap(
+      <SponsorsList {...baseProps} activePendingProposers={null as unknown} />,
+    );
+    expect(container.querySelectorAll('[data-testid="signature"]')).toHaveLength(0);
+  });
+
+  it('renders placeholder li for required - voteCount slots', () => {
+    const candidate = makeCandidate({
+      contentSignatures: [],
+      requiredVotes: 3,
+      voteCount: 0,
+    });
+    const { container } = wrap(<SponsorsList {...baseProps} candidate={candidate} />);
+    const placeholders = Array.from(container.querySelectorAll('li')).filter(li =>
+      li.className.includes('placeholder'),
+    );
+    expect(placeholders).toHaveLength(3);
+  });
+
+  it('renders Submit onchain button when isProposer + isThresholdMet', () => {
+    const { container } = wrap(
+      <SponsorsList {...baseProps} isProposer={true} isThresholdMet={true} />,
+    );
+    expect(container.textContent).toContain('Submit onchain');
+  });
+
+  it('Submit onchain click invokes onOpenSubmitModal when non-update', () => {
+    const { container } = wrap(
+      <SponsorsList {...baseProps} isProposer={true} isThresholdMet={true} />,
+    );
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent === 'Submit onchain',
+    );
+    fireEvent.click(submitBtn!);
+    expect(baseProps.onOpenSubmitModal).toHaveBeenCalled();
+  });
+
+  it('renders Sponsor button when canSignNewCandidate + votes > 0', () => {
+    const { container } = wrap(<SponsorsList {...baseProps} />);
+    expect(container.textContent).toContain('Sponsor');
+  });
+
+  it('Sponsor click invokes onOpenForm', () => {
+    const { container } = wrap(<SponsorsList {...baseProps} />);
+    const sponsorBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent === 'Sponsor',
+    );
+    fireEvent.click(sponsorBtn!);
+    expect(baseProps.onOpenForm).toHaveBeenCalled();
+  });
+
+  it('renders "Sponsoring requires at least one Niji vote" when connectedAccountNounVotes=0', () => {
+    const { container } = wrap(<SponsorsList {...baseProps} connectedAccountNounVotes={0} />);
+    expect(container.textContent).toContain(
+      'Sponsoring a proposal requires at least one Niji vote',
+    );
+  });
+
+  it('renders "is no longer updatable" when isUpdateToProposal + !isParentProposalUpdatable', () => {
+    const { container } = wrap(
+      <SponsorsList
+        {...baseProps}
+        isUpdateToProposal={true}
+        isParentProposalUpdatable={false}
+        originalProposal={{ id: '42', signers: [] } as never}
+      />,
+    );
+    expect(container.textContent).toContain('is no longer updatable');
+  });
+
+  it('renders OriginalSignature for original proposal signers in update mode', () => {
+    const candidate = makeCandidate({
+      contentSignatures: [],
+      requiredVotes: 0,
+      voteCount: 0,
+    });
+    const { container } = wrap(
+      <SponsorsList
+        {...baseProps}
+        candidate={candidate}
+        isUpdateToProposal={true}
+        originalProposal={{ id: '42', signers: [{ id: '0xOG' }] } as never}
+        originalSignersDelegates={[{ id: '0xOG', nijiRepresented: [{}, {}] }]}
+      />,
+    );
+    expect(container.querySelectorAll('[data-testid="original-signature"]')).toHaveLength(1);
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.test.tsx
@@ -1,0 +1,253 @@
+import React from 'react';
+
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ABIUpload', () => ({
+  default: ({
+    abiFileName,
+    isValid,
+    isInvalid,
+    onChange,
+  }: {
+    abiFileName?: string;
+    isValid?: boolean;
+    isInvalid?: boolean;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <div
+      data-testid="abi-upload"
+      data-filename={abiFileName ?? ''}
+      data-valid={String(isValid ?? '')}
+      data-invalid={String(isInvalid ?? '')}
+    >
+      <input data-testid="abi-upload-input" type="file" onChange={onChange} />
+    </div>
+  ),
+}));
+
+vi.mock('@/components/BrandDropdown', () => ({
+  default: ({
+    value,
+    onChange,
+    children,
+    label,
+  }: {
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+    children: React.ReactNode;
+    label: string;
+  }) => (
+    <select data-testid={`dropdown-${label}`} value={value} onChange={onChange}>
+      {children}
+    </select>
+  ),
+}));
+
+vi.mock('@/components/BrandTextEntry', () => ({
+  default: ({
+    label,
+    value,
+    onChange,
+  }: {
+    label: string;
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  }) => (
+    <input data-testid={`input-${label}`} value={value} onChange={onChange} placeholder={label} />
+  ),
+}));
+
+vi.mock('@/components/ModalBottomButtonRow', () => ({
+  default: ({
+    prevBtnText,
+    onPrevBtnClick,
+    nextBtnText,
+    onNextBtnClick,
+    isNextBtnDisabled,
+  }: {
+    prevBtnText: React.ReactNode;
+    onPrevBtnClick: () => void;
+    nextBtnText: React.ReactNode;
+    onNextBtnClick: () => void;
+    isNextBtnDisabled: boolean;
+  }) => (
+    <div>
+      <button data-testid="prev-btn" onClick={onPrevBtnClick}>
+        {prevBtnText}
+      </button>
+      <button data-testid="next-btn" onClick={onNextBtnClick} disabled={isNextBtnDisabled}>
+        {nextBtnText}
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ModalTitle', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <h1 data-testid="modal-title">{children}</h1>
+  ),
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanApiQuery: (a: string) => `https://api.etherscan.io/${a}`,
+}));
+
+import FunctionCallSelectFunctionStep from './index';
+
+const validAddress = '0x1234567890123456789012345678901234567890';
+const sampleAbi = [
+  { type: 'function', name: 'transfer', inputs: [] },
+  { type: 'function', name: 'approve', inputs: [] },
+  { type: 'event', name: 'Transfer' },
+];
+
+const onNextBtnClick = vi.fn();
+const onPrevBtnClick = vi.fn();
+const setState = vi.fn();
+
+const baseProps = {
+  onNextBtnClick,
+  onPrevBtnClick,
+  state: {
+    actionType: 'Function Call',
+    address: '' as `0x${string}`,
+  } as never,
+  setState,
+};
+
+beforeEach(() => {
+  onNextBtnClick.mockReset();
+  onPrevBtnClick.mockReset();
+  setState.mockReset();
+  global.fetch = vi.fn().mockResolvedValue({
+    json: () =>
+      Promise.resolve({
+        result: [{ ABI: JSON.stringify(sampleAbi), Proxy: '0' }],
+      }),
+  }) as never;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('FunctionCallSelectFunctionStep', () => {
+  it('renders initial inputs and labels', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    expect(container.querySelector('[data-testid="modal-title"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="input-Contract Address"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="input-Included ETH (optional)"]')).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="dropdown-Select Contract Function"]'),
+    ).not.toBeNull();
+    expect(container.querySelector('[data-testid="abi-upload"]')).not.toBeNull();
+  });
+
+  it('updates address state on input change', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const addressInput = container.querySelector(
+      '[data-testid="input-Contract Address"]',
+    ) as HTMLInputElement;
+    fireEvent.change(addressInput, { target: { value: '0xABC' } });
+    expect(addressInput.value).toBe('0xABC');
+  });
+
+  it('triggers fetch when valid address entered', async () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const addressInput = container.querySelector(
+      '[data-testid="input-Contract Address"]',
+    ) as HTMLInputElement;
+    fireEvent.change(addressInput, { target: { value: validAddress } });
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(`https://api.etherscan.io/${validAddress}`);
+    });
+  });
+
+  it('does not trigger fetch for invalid address', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const addressInput = container.querySelector(
+      '[data-testid="input-Contract Address"]',
+    ) as HTMLInputElement;
+    fireEvent.change(addressInput, { target: { value: 'not-an-address' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('updates ETH amount on input change', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const ethInput = container.querySelector(
+      '[data-testid="input-Included ETH (optional)"]',
+    ) as HTMLInputElement;
+    fireEvent.change(ethInput, { target: { value: '1.5' } });
+    expect(ethInput.value).toBe('1.5');
+  });
+
+  it('Next button is disabled initially', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const nextBtn = container.querySelector('[data-testid="next-btn"]') as HTMLButtonElement;
+    expect(nextBtn.disabled).toBe(true);
+  });
+
+  it('Next button calls setState + onNextBtnClick when clicked', () => {
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, address: validAddress, abi: sampleAbi } as never}
+      />,
+    );
+    const nextBtn = container.querySelector('[data-testid="next-btn"]') as HTMLButtonElement;
+    expect(nextBtn.disabled).toBe(false);
+    fireEvent.click(nextBtn);
+    expect(setState).toHaveBeenCalled();
+    expect(onNextBtnClick).toHaveBeenCalled();
+  });
+
+  it('Prev button calls onPrevBtnClick when clicked', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const prevBtn = container.querySelector('[data-testid="prev-btn"]') as HTMLButtonElement;
+    fireEvent.click(prevBtn);
+    expect(onPrevBtnClick).toHaveBeenCalled();
+  });
+
+  it('populates ABI when state.abi provided', () => {
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, abi: sampleAbi } as never}
+      />,
+    );
+    const abiUpload = container.querySelector('[data-testid="abi-upload"]');
+    expect(abiUpload?.getAttribute('data-filename')).toBe('etherscan-abi-download.json');
+  });
+
+  it('enables Next button when state has valid address + abi', () => {
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, address: validAddress, abi: sampleAbi } as never}
+      />,
+    );
+    const nextBtn = container.querySelector('[data-testid="next-btn"]') as HTMLButtonElement;
+    expect(nextBtn.disabled).toBe(false);
+  });
+
+  it('lists ABI function names as dropdown options when abi loaded', () => {
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, abi: sampleAbi } as never}
+      />,
+    );
+    const dropdown = container.querySelector(
+      '[data-testid="dropdown-Select Contract Function"]',
+    ) as HTMLSelectElement;
+    const options = Array.from(dropdown.options).map(o => o.value);
+    expect(options).toContain('transfer');
+    expect(options).toContain('approve');
+    expect(options).not.toContain('Transfer');
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 54` として large 帯 2 file (`FunctionCallSelectFunctionStep` 203 行 / `CandidateSponsors/SponsorsList` 200 行) に vitest を追加、 1065 → 1088 (+23、 1 skip 維持)。

## 詳細

### FunctionCallSelectFunctionStep/index.test.tsx (11 TC)

proposal action 作成の Function Call step。 Etherscan API で ABI 自動取得 / ABI upload / function 一覧から選択 / 引数 + ETH amount 入力を扱う。

検証観点。

- 初期 render ... ModalTitle / Contract Address input / ETH input / function dropdown / ABI upload 全描画
- address input change で値更新
- valid address (`isAddress(s)=true`) で `fetch` 呼出 (`buildEtherscanApiQuery` 経由)
- invalid address で `fetch` 未呼出
- ETH amount input で値更新
- Next button 初期 disabled
- Next button click で `setState` + `onNextBtnClick` 呼出 (state.abi + valid address 時)
- Prev button click で `onPrevBtnClick` 呼出
- `state.abi` 注入時に `etherscan-abi-download.json` ファイル名表示
- `state.address` + `state.abi` 揃いで Next button enabled
- ABI dropdown option が function type のみ表示 (event 除外)

### CandidateSponsors/SponsorsList.test.tsx (12 TC)

candidate sponsor 一覧 + action button 経路。 SponsorActionButton 5 経路 (Submit onchain / Re-sign / Sponsor / no longer updatable / requires vote) を boolean prop 組合せで網羅。

検証観点。

- valid contentSignature 配列を Signature component に展開
- `canceled=true` signature skip
- `voteCount=0` signature skip
- `activePendingProposers=null` で全 signature skip
- `requiredVotes - voteCount` 分の placeholder li 表示
- `isProposer + isThresholdMet` で「Submit onchain」 button + click で `onOpenSubmitModal`
- canSignNewCandidate (`!isUpdateToProposal + !isAccountSigner + !isProposal`) で「Sponsor」 button + click で `onOpenForm`
- `connectedAccountNounVotes=0` で「Sponsoring requires at least one Niji vote」 メッセージ
- `isUpdateToProposal + !isParentProposalUpdatable` で「is no longer updatable」 表示
- update mode で `originalProposal.signers` から OriginalSignature 展開

## 解決方法

FunctionCallSelectFunctionStep 側 ... 子 (ABIUpload / BrandDropdown / BrandTextEntry / ModalBottomButtonRow / ModalTitle) を vi.mock、 `buildEtherscanApiQuery` を vi.mock、 `global.fetch` を `vi.fn().mockResolvedValue({ json: ... })` で stub。 valid state を `setState({ ...baseProps.state, address: valid, abi: sampleAbi })` で props 経由注入し Next button enable 検証。

SponsorsList 側 ... `Signature` / `OriginalSignature` を vi.mock で簡素化、 `makeSignature` / `makeCandidate` factory で fixture を build、 5 action button 経路を boolean prop 組合せで網羅。 `originalProposal.signers` が undefined だと crash する production 仕様に注意 (test では `signers: []` を必ず渡す)。

## 受入条件

- [x] 2 file 計 23 TC 全 pass
- [x] `pnpm vitest run` 全 1088 test green (1089 - 1 skipped)
- [x] regression なし (既存 1065 pass を破壊しない)

## 関連

- Closes #439
- 直前 PR #438 (part 53) で 1042 → 1065 (Niji / SubmitUpdateProposal)
- 残 large 候補 ... Signature (199 行) / VoteSignals/VoteSignals (191 行) / Documentation/AboutSection (190 行) / AuctionActivity (188 行) / Documentation/NijidersRewardSection (180+ 行)
