### PR TITLE
✅ test(niji-webapp): component part 55 (Signature / VoteSignals) で 1088 → 1117 (Issue #441)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/Signature.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/Signature.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short-address">{address}</span>,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (a: string) => `https://etherscan.io/address/${a}`,
+}));
+
+type CancelStatus = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception';
+
+const cancelSigMock = vi.fn();
+const hookState: {
+  cancelSigState: { status: CancelStatus; errorMessage?: string };
+} = {
+  cancelSigState: { status: 'None' },
+};
+
+vi.mock('@/wrappers/nijiDao', () => ({
+  useCancelSignature: () => ({
+    cancelSig: cancelSigMock,
+    cancelSigState: hookState.cancelSigState,
+  }),
+}));
+
+import Signature from './Signature';
+
+const futureTimestamp = Math.floor(Date.now() / 1000) + 3600 * 24;
+const pastTimestamp = Math.floor(Date.now() / 1000) - 3600 * 24;
+
+const baseProps = {
+  reason: '',
+  expirationTimestamp: futureTimestamp,
+  signer: '0xSIGNER123' as `0x${string}`,
+  voteCount: 5,
+  isAccountSigner: false,
+  sig: '0xSIG_HEX',
+  signerHasActiveOrPendingProposal: false,
+  isUpdateToProposal: false,
+  isParentProposalUpdatable: true,
+  handleRefetchCandidateData: vi.fn(),
+  setDataFetchPollInterval: vi.fn(),
+  setIsAccountSigner: vi.fn(),
+  handleSignatureRemoved: vi.fn(),
+};
+
+const resetState = () => {
+  hookState.cancelSigState = { status: 'None' };
+  cancelSigMock.mockReset();
+  baseProps.handleRefetchCandidateData = vi.fn();
+  baseProps.setDataFetchPollInterval = vi.fn();
+  baseProps.setIsAccountSigner = vi.fn();
+  baseProps.handleSignatureRemoved = vi.fn();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Signature', () => {
+  it('renders signer ShortAddress and voteCount plural', () => {
+    const { container } = render(<Signature {...baseProps} />);
+    expect(container.querySelector('[data-testid="short-address"]')?.textContent).toBe(
+      '0xSIGNER123',
+    );
+    expect(container.textContent).toContain('5 votes');
+  });
+
+  it('renders singular "vote" when voteCount=1', () => {
+    const { container } = render(<Signature {...baseProps} voteCount={1} />);
+    expect(container.textContent).toContain('1 vote');
+    expect(container.textContent).not.toContain('1 votes');
+  });
+
+  it('shows "Expires" when expirationTimestamp is in future', () => {
+    const { container } = render(<Signature {...baseProps} />);
+    expect(container.textContent).toContain('Expires');
+  });
+
+  it('shows "Expired" when expirationTimestamp is in past', () => {
+    const { container } = render(<Signature {...baseProps} expirationTimestamp={pastTimestamp} />);
+    expect(container.textContent).toContain('Expired');
+  });
+
+  it('shows "Expired" when isUpdateToProposal + !isParentProposalUpdatable', () => {
+    const { container } = render(
+      <Signature {...baseProps} isUpdateToProposal={true} isParentProposalUpdatable={false} />,
+    );
+    expect(container.textContent).toContain('Expired');
+  });
+
+  it('shows invalid label when signerHasActiveOrPendingProposal=true', () => {
+    const { container } = render(
+      <Signature {...baseProps} signerHasActiveOrPendingProposal={true} />,
+    );
+    expect(container.textContent).toContain('Signature invalid');
+  });
+
+  it('renders "more" button when reason length > 50', () => {
+    const longReason = 'x'.repeat(60);
+    const { container } = render(<Signature {...baseProps} reason={longReason} />);
+    expect(container.textContent).toContain('more');
+  });
+
+  it('does not render "more" button when reason length <= 50', () => {
+    const { container } = render(<Signature {...baseProps} reason="short" />);
+    const moreBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent === 'more',
+    );
+    expect(moreBtn).toBeUndefined();
+  });
+
+  it('shows "Remove sponsorship" button when isAccountSigner', () => {
+    const { container } = render(<Signature {...baseProps} isAccountSigner={true} />);
+    expect(container.textContent).toContain('Remove sponsorship');
+  });
+
+  it('Remove sponsorship click triggers cancelSig with 0x-prefixed sig', () => {
+    const { container } = render(<Signature {...baseProps} isAccountSigner={true} />);
+    const removeBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Remove sponsorship'),
+    );
+    fireEvent.click(removeBtn!);
+    expect(cancelSigMock).toHaveBeenCalledWith({ args: ['0xSIG_HEX'] });
+  });
+
+  it('shows loading-noggles img when isAccountSigner + status=Mining', () => {
+    hookState.cancelSigState = { status: 'Mining' };
+    const { container } = render(<Signature {...baseProps} isAccountSigner={true} />);
+    const img = container.querySelector('img');
+    expect(img?.src).toContain('loading-noggles.svg');
+  });
+
+  it('shows Success overlay + invokes handleSignatureRemoved on status=Success', () => {
+    hookState.cancelSigState = { status: 'Success' };
+    const onRemoved = vi.fn();
+    const { container } = render(
+      <Signature {...baseProps} handleSignatureRemoved={onRemoved} voteCount={3} />,
+    );
+    expect(container.textContent).toContain('Success');
+    expect(container.textContent).toContain('Signature removed');
+    expect(onRemoved).toHaveBeenCalledWith(3);
+  });
+
+  it('shows Transaction Failed overlay on status=Fail', () => {
+    hookState.cancelSigState = { status: 'Fail', errorMessage: 'rpc failed' };
+    const { container } = render(<Signature {...baseProps} />);
+    expect(container.textContent).toContain('Transaction Failed');
+    expect(container.textContent).toContain('rpc failed');
+  });
+
+  it('shows Error overlay on status=Exception + resets poll interval', () => {
+    hookState.cancelSigState = { status: 'Exception', errorMessage: 'rpc exception' };
+    const setPoll = vi.fn();
+    const { container } = render(<Signature {...baseProps} setDataFetchPollInterval={setPoll} />);
+    expect(container.textContent).toContain('Error');
+    expect(container.textContent).toContain('rpc exception');
+    expect(setPoll).toHaveBeenCalledWith(0);
+  });
+
+  it('overlay close button invokes setIsAccountSigner(false) + handleRefetchCandidateData', () => {
+    hookState.cancelSigState = { status: 'Success' };
+    const setIsAcct = vi.fn();
+    const refetch = vi.fn();
+    const { container } = render(
+      <Signature
+        {...baseProps}
+        setIsAccountSigner={setIsAcct}
+        handleRefetchCandidateData={refetch}
+      />,
+    );
+    const closeBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('×'),
+    );
+    fireEvent.click(closeBtn!);
+    expect(setIsAcct).toHaveBeenCalledWith(false);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('shows "Re-signed" when isUpdateToProposal + !isAccountSigner', () => {
+    const { container } = render(
+      <Signature {...baseProps} isUpdateToProposal={true} isAccountSigner={false} />,
+    );
+    expect(container.textContent).toContain('Re-signed');
+  });
+});

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignals.test.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignals.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/core/macro', () => ({
+  t: (strings: TemplateStringsArray) => strings[0],
+}));
+
+vi.mock('@lingui/react', () => ({
+  useLingui: () => ({ _: (s: string) => s }),
+}));
+
+const toastErrorMock = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    error: (msg: string) => toastErrorMock(msg),
+  },
+}));
+
+const hookAccountState: { address: string | undefined } = { address: '0xUSER' };
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: hookAccountState.address }),
+}));
+
+type SendStatus = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception';
+
+const sendProposalFeedbackMock = vi.fn();
+const sendCandidateFeedbackMock = vi.fn();
+const feedbackState: {
+  proposal: { status: SendStatus; errorMessage?: string };
+  candidate: { status: SendStatus; errorMessage?: string };
+} = {
+  proposal: { status: 'None' },
+  candidate: { status: 'None' },
+};
+
+vi.mock('@/wrappers/nijiData', () => ({
+  useSendFeedback: () => ({
+    sendProposalFeedback: sendProposalFeedbackMock,
+    sendProposalFeedbackState: feedbackState.proposal,
+    sendCandidateFeedback: sendCandidateFeedbackMock,
+    sendCandidateFeedbackState: feedbackState.candidate,
+  }),
+}));
+
+const useVoteSignalsFeedbackState: {
+  forFeedback: unknown[];
+  againstFeedback: unknown[];
+  abstainFeedback: unknown[];
+  hasUserVoted: boolean;
+  userVoteSupport: number | undefined;
+} = {
+  forFeedback: [],
+  againstFeedback: [],
+  abstainFeedback: [],
+  hasUserVoted: false,
+  userVoteSupport: undefined,
+};
+
+vi.mock('./useVoteSignalsFeedback', () => ({
+  useVoteSignalsFeedback: () => useVoteSignalsFeedbackState,
+}));
+
+vi.mock('@/components/Spinner', () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
+vi.mock('./VoteSignalGroup', () => ({
+  default: ({ support, voteSignals }: { support: number; voteSignals: unknown[] }) => (
+    <div data-testid={`signal-group-${support}`}>{voteSignals.length}</div>
+  ),
+}));
+
+vi.mock('./VoteSignalsForm', () => ({
+  VoteSignalsForm: ({ onSubmit }: { onSubmit: () => void }) => (
+    <button data-testid="vote-signals-form" onClick={onSubmit} />
+  ),
+  VoteSignalsPending: () => <div data-testid="vote-signals-pending" />,
+}));
+
+vi.mock('./VoteSignalsHeader', () => ({
+  VoteSignalsHeader: () => <header data-testid="signals-header" />,
+  VoteSignalsFootnote: () => <footer data-testid="signals-footnote" />,
+}));
+
+vi.mock('./VoteSignalsUserFeedback', () => ({
+  VoteSignalsUserFeedback: () => <div data-testid="user-feedback" />,
+}));
+
+import VoteSignals from './VoteSignals';
+
+const baseProps = {
+  proposalId: '42',
+  proposer: '0xPROPOSER',
+  versionTimestamp: 1700000000n,
+  feedback: [] as never,
+  userVotes: 3,
+  isCandidate: false,
+  candidateSlug: 'cand-slug',
+  setDataFetchPollInterval: vi.fn(),
+  handleRefetch: vi.fn(),
+  isFeedbackClosed: false,
+};
+
+const resetState = () => {
+  feedbackState.proposal = { status: 'None' };
+  feedbackState.candidate = { status: 'None' };
+  useVoteSignalsFeedbackState.forFeedback = [];
+  useVoteSignalsFeedbackState.againstFeedback = [];
+  useVoteSignalsFeedbackState.abstainFeedback = [];
+  useVoteSignalsFeedbackState.hasUserVoted = false;
+  useVoteSignalsFeedbackState.userVoteSupport = undefined;
+  hookAccountState.address = '0xUSER';
+  sendProposalFeedbackMock.mockReset();
+  sendCandidateFeedbackMock.mockReset();
+  toastErrorMock.mockReset();
+  baseProps.setDataFetchPollInterval = vi.fn();
+  baseProps.handleRefetch = vi.fn();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VoteSignals', () => {
+  it('returns null when proposalId is undefined', () => {
+    const { container } = render(<VoteSignals {...baseProps} proposalId={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows Spinner when feedback list is undefined', () => {
+    const { container } = render(<VoteSignals {...baseProps} feedback={undefined} />);
+    expect(container.querySelector('[data-testid="spinner"]')).not.toBeNull();
+  });
+
+  it('renders 3 VoteSignalGroup (For / Against / Abstain) when feedback list is provided', () => {
+    const { container } = render(<VoteSignals {...baseProps} />);
+    expect(container.querySelector('[data-testid="signal-group-1"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="signal-group-0"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="signal-group-2"]')).not.toBeNull();
+  });
+
+  it('shows VoteSignalsForm when feedbackPanel + not voted + not busy', () => {
+    const { container } = render(<VoteSignals {...baseProps} />);
+    expect(container.querySelector('[data-testid="vote-signals-form"]')).not.toBeNull();
+  });
+
+  it('hides feedback panel when userVotes=0', () => {
+    const { container } = render(<VoteSignals {...baseProps} userVotes={0} />);
+    expect(container.querySelector('[data-testid="vote-signals-form"]')).toBeNull();
+  });
+
+  it('hides feedback panel when isFeedbackClosed=true', () => {
+    const { container } = render(<VoteSignals {...baseProps} isFeedbackClosed={true} />);
+    expect(container.querySelector('[data-testid="vote-signals-form"]')).toBeNull();
+  });
+
+  it('shows VoteSignalsUserFeedback when user has voted', () => {
+    useVoteSignalsFeedbackState.hasUserVoted = true;
+    const { container } = render(<VoteSignals {...baseProps} />);
+    expect(container.querySelector('[data-testid="user-feedback"]')).not.toBeNull();
+  });
+
+  it('shows VoteSignalsPending while transaction is mining', () => {
+    feedbackState.proposal = { status: 'Mining' };
+    const { container } = render(<VoteSignals {...baseProps} />);
+    expect(container.querySelector('[data-testid="vote-signals-pending"]')).not.toBeNull();
+  });
+
+  it('renders VoteSignalsFootnote when isCandidate=true', () => {
+    const { container } = render(<VoteSignals {...baseProps} isCandidate={true} />);
+    expect(container.querySelector('[data-testid="signals-footnote"]')).not.toBeNull();
+  });
+
+  it('does not render Footnote when isCandidate=false', () => {
+    const { container } = render(<VoteSignals {...baseProps} isCandidate={false} />);
+    expect(container.querySelector('[data-testid="signals-footnote"]')).toBeNull();
+  });
+
+  it('toast.error fires when sendProposalFeedbackState=Fail', () => {
+    feedbackState.proposal = { status: 'Fail', errorMessage: 'tx failed' };
+    render(<VoteSignals {...baseProps} />);
+    expect(toastErrorMock).toHaveBeenCalledWith('tx failed');
+  });
+
+  it('handleRefetch fires when status=Success', () => {
+    feedbackState.proposal = { status: 'Success' };
+    const refetch = vi.fn();
+    render(<VoteSignals {...baseProps} handleRefetch={refetch} />);
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('onSubmit click cannot proceed without support set (form support undefined)', () => {
+    const { container } = render(<VoteSignals {...baseProps} />);
+    const formBtn = container.querySelector(
+      '[data-testid="vote-signals-form"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(formBtn);
+    expect(sendProposalFeedbackMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 55` として large 帯 2 file (`CandidateSponsors/Signature` 199 行 / `VoteSignals/VoteSignals` 191 行) に vitest を追加、 1088 → 1117 (+29、 1 skip 維持)。

## 詳細

### CandidateSponsors/Signature.test.tsx (16 TC)

candidate の sponsor signature 1 件描画 component。 cancelSignature contract の 5 status (None / PendingSignature / Mining / Success / Fail / Exception) と signer 状態 / expiration / 自分の signature か / 更新 mode か を組合せ render する。

検証観点。

- signer ShortAddress + voteCount=5 で「5 votes」 (複数)
- voteCount=1 で「1 vote」 (単数)
- expirationTimestamp 未来で「Expires」、 過去で「Expired」
- `isUpdateToProposal + !isParentProposalUpdatable` で強制的に「Expired」
- `signerHasActiveOrPendingProposal=true` で invalid label 表示
- reason 51 文字以上で「more」 button 表示、 50 文字以下で非表示
- `isAccountSigner=true` で「Remove sponsorship」 button + click で `cancelSig({ args: ['0xSIG_HEX'] })`
- `isAccountSigner + status=Mining` で loading-noggles img
- `status=Success` で 「Signature removed」 overlay + `handleSignatureRemoved(voteCount)` 呼出
- `status=Fail + errorMessage` で「Transaction Failed」 + メッセージ
- `status=Exception + errorMessage` で「Error」 overlay + `setDataFetchPollInterval(0)` 呼出
- overlay close (`×`) click で `setIsAccountSigner(false)` + `handleRefetchCandidateData()` 呼出
- `isUpdateToProposal + !isAccountSigner` で「Re-signed」 表示

### VoteSignals/VoteSignals.test.tsx (13 TC)

proposal / candidate の vote signal feedback 集約画面。 3 種 (For / Against / Abstain) signal group + feedback 投稿 form + transaction state management。

検証観点。

- `proposalId=undefined` で null 返却
- feedback list 未読込で Spinner 表示
- feedback 提供で 3 種 VoteSignalGroup (support=1/0/2) 描画
- `userVotes>0 + !isFeedbackClosed` で VoteSignalsForm 表示
- `userVotes=0` で feedback panel 非表示
- `isFeedbackClosed=true` で feedback panel 非表示
- `hasUserVoted=true` で VoteSignalsUserFeedback 表示
- `status=Mining` で VoteSignalsPending 表示
- `isCandidate=true` で VoteSignalsFootnote 表示、 `false` で非表示
- `status=Fail + errorMessage` で `toast.error` 呼出
- `status=Success` で `handleRefetch` 呼出
- `support=undefined` で form submit しても `sendProposalFeedback` 未呼出

## 解決方法

Signature 側 ... `useCancelSignature` を vi.mock し `hookState.cancelSigState` 切替で 5 status 経路網羅。 `ShortAddress` / `buildEtherscanAddressLink` mock。 cancel click 時に `0x`-prefixed sig が正しく渡ることを assert。 future / past timestamp 切替で 「Expires」 / 「Expired」 分岐検証。

VoteSignals 側 ... `useSendFeedback` / `wagmi.useAccount` / `useVoteSignalsFeedback` / sonner toast / 子 (Spinner / VoteSignalGroup / VoteSignalsForm / VoteSignalsPending / VoteSignalsHeader / VoteSignalsUserFeedback) を全 vi.mock。 useLingui mock で `_` を identity 化、 `useVoteSignalsFeedbackState` で hasUserVoted / userVoteSupport / forFeedback 等を test ごとに切替。

## 受入条件

- [x] 2 file 計 29 TC 全 pass
- [x] `pnpm vitest run` 全 1117 test green (1118 - 1 skipped)
- [x] regression なし (既存 1088 pass を破壊しない)

## 関連

- Closes #441
- 直前 PR #440 (part 54) で 1065 → 1088
- 残 large 候補 ... Documentation/AboutSection (190 行) / AuctionActivity (188 行) / Documentation/NijidersRewardSection (180+ 行) / ProposalHeader/CandidateHeader (178 行)
