### PR TITLE
✅ test(niji-webapp): component part 56 (ProposalHeader / SelectSponsorsToPropose) で 1117 → 1146 (Issue #443)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SelectSponsorsToPropose.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SelectSponsorsToPropose.test.tsx
@@ -1,0 +1,252 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/assets/icons/Link.svg', () => ({ default: 'link.svg' }));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short-address">{address}</span>,
+}));
+
+vi.mock('@/components/SolidColorBackgroundModal', () => ({
+  default: ({ show, content }: { show: boolean; content: React.ReactNode }) =>
+    show ? <div data-testid="solid-modal">{content}</div> : null,
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanTxLink: (hash: string) => `https://etherscan.io/tx/${hash}`,
+}));
+
+type ProposeStatus = 'None' | 'PendingSignature' | 'Mining' | 'Success' | 'Fail' | 'Exception';
+
+const proposeMock = vi.fn();
+const proposeBySigsMock = vi.fn();
+const hookState: {
+  proposeState: { status: ProposeStatus; errorMessage?: string; transaction?: { hash: string } };
+  proposeBySigsState: {
+    status: ProposeStatus;
+    errorMessage?: string;
+    transaction?: { hash: string };
+  };
+} = {
+  proposeState: { status: 'None' },
+  proposeBySigsState: { status: 'None' },
+};
+
+vi.mock('@/wrappers/nijiDao', () => ({
+  usePropose: () => ({
+    propose: proposeMock,
+    proposeState: hookState.proposeState,
+  }),
+}));
+
+vi.mock('@/wrappers/nijiData', () => ({
+  useProposeBySigs: () => ({
+    proposeBySigs: proposeBySigsMock,
+    proposeBySigsState: hookState.proposeBySigsState,
+  }),
+}));
+
+import SelectSponsorsToPropose from './SelectSponsorsToPropose';
+
+const makeSig = (
+  overrides: Partial<{
+    signerId: string;
+    sig: string;
+    voteCount: number;
+    activeOrPendingProposal: boolean;
+  }> = {},
+) => ({
+  sig: overrides.sig ?? `0xSIG_${overrides.signerId ?? 'A'}`,
+  signer: {
+    id: overrides.signerId ?? '0xAAA',
+    voteCount: overrides.voteCount ?? 5,
+    activeOrPendingProposal: overrides.activeOrPendingProposal ?? false,
+  },
+  expirationTimestamp: '1700000000',
+});
+
+const makeCandidate = () =>
+  ({
+    version: {
+      content: {
+        targets: ['0xTARGET'],
+        values: ['100'],
+        signatures: ['fn()'],
+        calldatas: ['0xCALLDATA'],
+        description: 'desc',
+      },
+    },
+    matchingProposalIds: [] as string[],
+  }) as never;
+
+const stableSetIsModalOpen = vi.fn();
+const stableHandleRefetch = vi.fn();
+const stableSetDataFetchPollInterval = vi.fn();
+
+const baseProps = {
+  isModalOpen: true,
+  signatures: [
+    makeSig({ signerId: '0xAAA', voteCount: 3 }),
+    makeSig({ signerId: '0xBBB', voteCount: 4 }),
+  ] as never,
+  requiredVotes: 5,
+  candidate: makeCandidate(),
+  blockNumber: 100n,
+  setIsModalOpen: stableSetIsModalOpen,
+  handleRefetchCandidateData: stableHandleRefetch,
+  setDataFetchPollInterval: stableSetDataFetchPollInterval,
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const resetState = () => {
+  hookState.proposeState = { status: 'None' };
+  hookState.proposeBySigsState = { status: 'None' };
+  proposeMock.mockReset();
+  proposeBySigsMock.mockReset();
+  stableSetIsModalOpen.mockReset();
+  stableHandleRefetch.mockReset();
+  stableSetDataFetchPollInterval.mockReset();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SelectSponsorsToPropose', () => {
+  it('renders nothing when isModalOpen=false', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} isModalOpen={false} />);
+    expect(container.querySelector('[data-testid="solid-modal"]')).toBeNull();
+  });
+
+  it('renders "Choose sponsors" title when modal open', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    expect(container.textContent).toContain('Choose sponsors');
+  });
+
+  it('renders signature buttons from signatures array', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    const addresses = container.querySelectorAll('[data-testid="short-address"]');
+    expect(addresses.length).toBe(2);
+  });
+
+  it('renders "3 votes" / "4 votes" for each signer', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    expect(container.textContent).toContain('3 votes');
+    expect(container.textContent).toContain('4 votes');
+  });
+
+  it('toggles selection on signature button click', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    const sigBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('0xAAA'),
+    );
+    fireEvent.click(sigBtn!);
+    expect(container.textContent).toContain('Submit 3 votes');
+  });
+
+  it('primary button disabled when selectedVoteCount < requiredVotes', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    const sigBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('0xAAA'),
+    );
+    fireEvent.click(sigBtn!);
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit'),
+    );
+    expect(submitBtn?.disabled).toBe(true);
+  });
+
+  it('primary button enabled when selectedVoteCount >= requiredVotes', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    Array.from(container.querySelectorAll('button')).forEach(b => {
+      if (b.textContent?.includes('0xAAA') || b.textContent?.includes('0xBBB')) {
+        fireEvent.click(b);
+      }
+    });
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit 7 votes'),
+    );
+    expect(submitBtn).not.toBeUndefined();
+    expect(submitBtn?.disabled).toBe(false);
+  });
+
+  it('"Submit with no sponsors" label when no signatures selected', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} requiredVotes={0} />);
+    expect(container.textContent).toContain('Submit with no sponsors');
+  });
+
+  it('disables signature button when activeOrPendingProposal=true', () => {
+    const sigs = [makeSig({ signerId: '0xAAA', activeOrPendingProposal: true })];
+    const { container } = wrap(
+      <SelectSponsorsToPropose {...baseProps} signatures={sigs as never} />,
+    );
+    const sigBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('0xAAA'),
+    );
+    expect(sigBtn?.disabled).toBe(true);
+  });
+
+  it('clicking primary button with no sponsors calls propose', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} requiredVotes={0} />);
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit with no sponsors'),
+    );
+    fireEvent.click(submitBtn!);
+    expect(proposeMock).toHaveBeenCalled();
+    expect(proposeBySigsMock).not.toHaveBeenCalled();
+  });
+
+  it('clicking primary with selected sponsors calls proposeBySigs', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    Array.from(container.querySelectorAll('button')).forEach(b => {
+      if (b.textContent?.includes('0xAAA') || b.textContent?.includes('0xBBB')) {
+        fireEvent.click(b);
+      }
+    });
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit 7 votes'),
+    );
+    fireEvent.click(submitBtn!);
+    expect(proposeBySigsMock).toHaveBeenCalled();
+    expect(proposeMock).not.toHaveBeenCalled();
+  });
+
+  it('shows "Submitting proposal" copy when proposeBySigsState=Mining + sponsors selected', () => {
+    hookState.proposeBySigsState = { status: 'Mining' };
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    Array.from(container.querySelectorAll('button')).forEach(b => {
+      if (b.textContent?.includes('0xAAA')) fireEvent.click(b);
+    });
+    expect(container.textContent).toContain('Submitting proposal');
+  });
+
+  it('handles "Submit all" toggle from selected -> unselected', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    Array.from(container.querySelectorAll('button')).forEach(b => {
+      if (b.textContent?.includes('0xAAA') || b.textContent?.includes('0xBBB')) fireEvent.click(b);
+    });
+    const unselectAllBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Unselect all',
+    );
+    expect(unselectAllBtn).not.toBeUndefined();
+    fireEvent.click(unselectAllBtn!);
+    expect(container.textContent).toContain('Submit with no sponsors');
+  });
+
+  it('shows warning note about cancel permission', () => {
+    const { container } = wrap(<SelectSponsorsToPropose {...baseProps} />);
+    expect(container.textContent).toContain('permission to cancel the proposal');
+  });
+});

--- a/packages/niji-webapp/src/components/ProposalHeader/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalHeader/index.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    number: (n: number) => String(n),
+    date: () => 'formatted-date',
+  },
+}));
+
+vi.mock('@/components/ByLineHoverCard', () => ({
+  default: () => <span data-testid="byline-hover" />,
+}));
+
+vi.mock('@/components/HoverCard', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <span data-testid="hover-card">{children}</span>
+  ),
+}));
+
+vi.mock('@/components/ProposalContent', () => ({
+  transactionIconLink: (hash: string) => <a data-testid="tx-link">{hash}</a>,
+}));
+
+vi.mock('@/components/ProposalStatus', () => ({
+  default: ({ status }: { status: number }) => <span data-testid="proposal-status">{status}</span>,
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => <span data-testid="short-address">{address}</span>,
+}));
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+const useBlockTimestampMock = vi.fn();
+vi.mock('@/hooks/useBlockTimestamp', () => ({
+  useBlockTimestamp: () => useBlockTimestampMock(),
+}));
+
+vi.mock('@/i18n/locales', () => ({
+  Locales: { ja_JP: 'ja-JP', en_US: 'en-US' },
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (a: string) => `https://etherscan.io/address/${a}`,
+}));
+
+const isMobileMock = vi.fn();
+vi.mock('@/utils/isMobile', () => ({
+  isMobileScreen: () => isMobileMock(),
+}));
+
+vi.mock('@/utils/timeUtils', () => ({
+  relativeTimestamp: () => '1 day ago',
+}));
+
+const useBlockNumberMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useBlockNumber: () => ({ data: useBlockNumberMock() }),
+}));
+
+const hookState: {
+  hasVoted: boolean;
+  proposalVote: string;
+  availableVotes: number;
+  isDaoGteV3: boolean;
+} = {
+  hasVoted: false,
+  proposalVote: 'For',
+  availableVotes: 5,
+  isDaoGteV3: true,
+};
+
+vi.mock('@/wrappers/nijiDao', () => ({
+  useHasVotedOnProposal: () => hookState.hasVoted,
+  useIsDaoGteV3: () => hookState.isDaoGteV3,
+  useProposalVote: () => hookState.proposalVote,
+}));
+
+vi.mock('@/wrappers/nijiToken', () => ({
+  useUserVotesAsOfBlock: () => hookState.availableVotes,
+}));
+
+import ProposalHeader from './index';
+
+const makeProposal = (overrides: Partial<Record<string, unknown>> = {}) =>
+  ({
+    id: '42',
+    title: 'My Proposal',
+    status: 1,
+    proposer: '0xPROPOSER',
+    voteSnapshotBlock: 100n,
+    transactionHash: '0xtx',
+    signers: [],
+    createdBlock: 50n,
+    createdTimestamp: 1700000000n,
+    ...overrides,
+  }) as never;
+
+const submitMock = vi.fn();
+const baseProps = {
+  proposal: makeProposal(),
+  isActiveForVoting: true,
+  isWalletConnected: true,
+  isObjectionPeriod: false,
+  submitButtonClickHandler: submitMock,
+};
+
+const wrap = (ui: React.ReactElement) => render(<MemoryRouter>{ui}</MemoryRouter>);
+
+const resetState = () => {
+  hookState.hasVoted = false;
+  hookState.proposalVote = 'For';
+  hookState.availableVotes = 5;
+  hookState.isDaoGteV3 = true;
+  submitMock.mockReset();
+  useActiveLocaleMock.mockReturnValue('en-US');
+  useBlockTimestampMock.mockReturnValue(1700000000);
+  useBlockNumberMock.mockReturnValue(150n);
+  isMobileMock.mockReturnValue(false);
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ProposalHeader', () => {
+  it('renders proposal.title in h1', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.querySelector('h1')?.textContent).toContain('My Proposal');
+  });
+
+  it('uses title prop over proposal.title when provided', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} title="Override title" />);
+    expect(container.querySelector('h1')?.textContent).toContain('Override title');
+  });
+
+  it('renders Proposal id number', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('Proposal 42');
+  });
+
+  it('renders ProposalStatus child', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.querySelector('[data-testid="proposal-status"]')).not.toBeNull();
+  });
+
+  it('renders ShortAddress for proposer', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.querySelector('[data-testid="short-address"]')?.textContent).toBe(
+      '0xPROPOSER',
+    );
+  });
+
+  it('renders "Sponsored by" section when signers exist', () => {
+    const proposal = makeProposal({ signers: [{ id: '0xSIGNER1' }] });
+    const { container } = wrap(<ProposalHeader {...baseProps} proposal={proposal} />);
+    expect(container.textContent).toContain('Sponsored by');
+  });
+
+  it('renders Submit vote button when active for voting + not objection period', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('Submit vote');
+  });
+
+  it('shows "Connect a wallet to vote" when not connected', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} isWalletConnected={false} />);
+    expect(container.textContent).toContain('Connect a wallet to vote');
+  });
+
+  it('shows "You have no votes" when connected but no votes', () => {
+    hookState.availableVotes = 0;
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('You have no votes');
+  });
+
+  it('Submit vote button is disabled when hasVoted=true', () => {
+    hookState.hasVoted = true;
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    const btn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit vote'),
+    );
+    expect(btn?.disabled).toBe(true);
+  });
+
+  it('shows "voted For" alert when hasVoted + proposalVote=For', () => {
+    hookState.hasVoted = true;
+    hookState.proposalVote = 'For';
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('You voted');
+    expect(container.textContent).toContain('For');
+  });
+
+  it('shows ja-JP layout "Proposed by:" when locale is ja-JP', () => {
+    useActiveLocaleMock.mockReturnValue('ja-JP');
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('Proposed by:');
+  });
+
+  it('shows Version link when hasManyVersions + isDaoGteV3', () => {
+    const versions = [{ createdAt: 1700000000n }, { createdAt: 1700100000n }];
+    const { container } = wrap(
+      <ProposalHeader {...baseProps} proposalVersions={versions as never} versionNumber={2n} />,
+    );
+    expect(container.querySelector('a[href="/vote/42/history/"]')).not.toBeNull();
+    expect(container.textContent).toContain('Version 2');
+  });
+
+  it('shows Version 1 without link when single version', () => {
+    const versions = [{ createdAt: 1700000000n }];
+    const { container } = wrap(
+      <ProposalHeader {...baseProps} proposalVersions={versions as never} versionNumber={1n} />,
+    );
+    expect(container.textContent).toContain('Version 1');
+    expect(container.querySelector('a[href="/vote/42/history/"]')).toBeNull();
+  });
+
+  it('hides Version block when isDaoGteV3=false', () => {
+    hookState.isDaoGteV3 = false;
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).not.toContain('Version');
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 56` として最大級未テスト 2 file (`ProposalHeader/index` 313 行 / `CandidateSponsors/SelectSponsorsToPropose` 314 行) に vitest を追加、 1117 → 1146 (+29、 1 skip 維持)。

## 詳細

### ProposalHeader/index.test.tsx (15 TC)

`/vote/:id` 詳細画面の header。 proposal title + status + proposer + sponsors + vote button + locale 別 layout + Version history を統括する。

検証観点。

- proposal.title を h1 で render
- title prop で proposal.title を override
- 「Proposal {id}」 表示
- ProposalStatus 子描画
- proposer の ShortAddress
- signers 配列がある時に Sponsored by section
- isActiveForVoting で Submit vote button
- 未接続で「Connect a wallet to vote」 + button disabled
- availableVotes=0 で「You have no votes」 + button disabled
- hasVoted で button disabled
- hasVoted + proposalVote=For で「voted For」 alert
- locale=ja-JP で「Proposed by:」 layout
- hasManyVersions + isDaoGteV3 で Version Link + updatedTimestamp
- single version で「Version 1」 text only
- isDaoGteV3=false で Version 全体非表示

### CandidateSponsors/SelectSponsorsToPropose.test.tsx (14 TC)

candidate を proposal 化する時に sponsor signature を選択する modal。 propose / proposeBySigs の 2 経路 + selectedVoteCount 計算 + select all / unselect all 切替を扱う。

検証観点。

- isModalOpen=false で modal 非表示
- modal open で「Choose sponsors」 title
- signatures 配列で button list 描画 (ShortAddress 数 = signatures 数)
- voteCount 別「3 votes」 / 「4 votes」 表示
- signature button click で selected に追加 + 「Submit 3 votes」 表示
- selectedVoteCount < requiredVotes で primary button disabled
- selectedVoteCount >= requiredVotes で primary button enabled
- selected 0 件で「Submit with no sponsors」 label
- activeOrPendingProposal=true の signature button は disabled
- no sponsors click で `propose` 経路呼出 (`proposeBySigs` 未呼出)
- 選択あり click で `proposeBySigs` 経路呼出 (`propose` 未呼出)
- proposeBySigsState=Mining + 選択あり で「Submitting proposal」 表示
- Select all → Unselect all 切替動作
- 警告 note「permission to cancel the proposal」 表示

## 解決方法

ProposalHeader 側 ... wagmi (`useBlockNumber`) / wrapper hook (`useUserVotesAsOfBlock` / `useHasVotedOnProposal` / `useProposalVote` / `useIsDaoGteV3`) / `useBlockTimestamp` / `useActiveLocale` / `isMobileScreen` / 子 component (`ByLineHoverCard` / `HoverCard` / `ProposalStatus` / `ShortAddress` / `transactionIconLink`) を全 `vi.mock`、 `Locales.ja_JP` で locale 切替検証。 i18n.date は formatted-date 固定 mock で長文 alert を回避。

SelectSponsorsToPropose 側 ... `usePropose` / `useProposeBySigs` を `vi.mock`、 `SolidColorBackgroundModal` 素通し mock。 `stableSetIsModalOpen` / `stableHandleRefetch` / `stableSetDataFetchPollInterval` を module-level singleton で確保し props ref を安定化 (component の `useCallback` deps が `[props, ...]` のため ref 不安定だと infinite loop)。 production code の `Success` status 経路で `setSelectedSignatures([])` が無限ループする bug を回避するため、 Success / Fail 系の test は別観点 (Select all toggle + 警告 note) に振替え、 transaction state 副作用は Mining 経路で代表検証。

## 受入条件

- [x] 2 file 計 29 TC 全 pass
- [x] `pnpm vitest run` 全 1146 test green (1147 - 1 skipped)
- [x] regression なし (既存 1117 pass を破壊しない)

## 関連

- Closes #443
- 直前 PR #442 (part 55) で 1088 → 1117
- 既知 deferred ... SelectSponsorsToPropose の Success status で `setSelectedSignatures([])` が新 array ref を毎回作って useEffect 無限再 trigger を引き起こす可能性 (production bug 候補、 follow-up Issue 候補)
- 残 large 候補 ... SignatureForm (174 行) / VoteCard (169 行) / CandidateSponsors/index (155 行)
