### PR TITLE
✅ test(niji-webapp): component part 57 (SignatureForm / VoteCard) で 1146 → 1170 (Issue #445)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SignatureForm.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiGovernorAddress: { 1: '0xGOVERNOR' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+const signTypedDataMock = vi.fn();
+const hookState: {
+  signature: string | undefined;
+  isSignPending: boolean;
+} = {
+  signature: '0xSIGNED',
+  isSignPending: false,
+};
+
+vi.mock('wagmi', () => ({
+  useSignTypedData: () => ({
+    data: hookState.signature,
+    signTypedData: signTypedDataMock,
+    isPending: hookState.isSignPending,
+  }),
+}));
+
+const addSignatureMock = vi.fn();
+const validateExpirationDateMock = vi.fn();
+const clearTransactionStateMock = vi.fn();
+const setIsGetSignatureWaitingMock = vi.fn();
+const setIsGetSignatureTxSuccessfulMock = vi.fn();
+const setGetSignatureErrorMessageMock = vi.fn();
+const setIsWaitingMock = vi.fn();
+
+const flowState: {
+  dateErrorMessage: string;
+  isWaiting: boolean;
+  isLoading: boolean;
+  isTxSuccessful: boolean;
+  isGetSignatureWaiting: boolean;
+  isGetSignatureTxSuccessful: boolean;
+  errorMessage: string;
+  getSignatureErrorMessage: string;
+  isOverlayVisible: boolean;
+  addSignatureState: { transaction?: { hash: string } };
+} = {
+  dateErrorMessage: '',
+  isWaiting: false,
+  isLoading: false,
+  isTxSuccessful: false,
+  isGetSignatureWaiting: false,
+  isGetSignatureTxSuccessful: false,
+  errorMessage: '',
+  getSignatureErrorMessage: '',
+  isOverlayVisible: false,
+  addSignatureState: {},
+};
+
+vi.mock('./signature/useSignatureFlow', () => ({
+  useSignatureFlow: () => ({
+    ...flowState,
+    addSignature: addSignatureMock,
+    validateExpirationDate: validateExpirationDateMock,
+    clearTransactionState: clearTransactionStateMock,
+    setIsGetSignatureWaiting: setIsGetSignatureWaitingMock,
+    setIsGetSignatureTxSuccessful: setIsGetSignatureTxSuccessfulMock,
+    setGetSignatureErrorMessage: setGetSignatureErrorMessageMock,
+    setIsWaiting: setIsWaitingMock,
+  }),
+}));
+
+vi.mock('./signature/encodeProposalData', () => ({
+  calcProposalEncodeData: vi.fn().mockResolvedValue('0xENCODED'),
+}));
+
+vi.mock('./signature/types', () => ({
+  createProposalTypes: { Proposal: [] },
+  updateProposalTypes: { UpdateProposal: [] },
+}));
+
+vi.mock('./signature/SignatureFormFields', () => ({
+  SignatureFormFields: ({
+    onSign,
+    dateErrorMessage,
+    isWaiting,
+    isLoading,
+    proposalIdToUpdate,
+  }: {
+    onSign: () => Promise<void>;
+    dateErrorMessage: string;
+    isWaiting: boolean;
+    isLoading: boolean;
+    proposalIdToUpdate: number;
+  }) => (
+    <div
+      data-testid="signature-form-fields"
+      data-date-error={dateErrorMessage}
+      data-is-waiting={String(isWaiting)}
+      data-is-loading={String(isLoading)}
+      data-proposal-id={String(proposalIdToUpdate)}
+    >
+      <button data-testid="sign-btn" onClick={onSign} />
+    </div>
+  ),
+}));
+
+vi.mock('./signature/SignatureStatusOverlay', () => ({
+  SignatureStatusOverlay: ({
+    isOverlayVisible,
+    errorMessage,
+    onTryAgain,
+    onClose,
+  }: {
+    isOverlayVisible: boolean;
+    errorMessage: string;
+    onTryAgain: () => void;
+    onClose: () => void;
+  }) => (
+    <div
+      data-testid="signature-status-overlay"
+      data-overlay-visible={String(isOverlayVisible)}
+      data-error-message={errorMessage}
+    >
+      <button data-testid="overlay-try-again" onClick={onTryAgain} />
+      <button data-testid="overlay-close" onClick={onClose} />
+    </div>
+  ),
+}));
+
+import SignatureForm from './SignatureForm';
+
+const makeCandidate = () =>
+  ({
+    proposer: '0x1234567890123456789012345678901234567890',
+    slug: 'cand-slug',
+    version: {
+      content: {
+        targets: ['0x2222222222222222222222222222222222222222'],
+        values: ['100'],
+        signatures: ['fn()'],
+        calldatas: ['0xCALLDATA'],
+        description: 'desc',
+      },
+    },
+  }) as never;
+
+const baseProps = {
+  id: 'sig-1',
+  transactionState: 'idle' as never,
+  setTransactionState: vi.fn(),
+  setIsFormDisplayed: vi.fn(),
+  candidate: makeCandidate(),
+  handleRefetchCandidateData: vi.fn(),
+  setDataFetchPollInterval: vi.fn(),
+  proposalIdToUpdate: 0,
+};
+
+const resetState = () => {
+  hookState.signature = '0xSIGNED';
+  hookState.isSignPending = false;
+  Object.assign(flowState, {
+    dateErrorMessage: '',
+    isWaiting: false,
+    isLoading: false,
+    isTxSuccessful: false,
+    isGetSignatureWaiting: false,
+    isGetSignatureTxSuccessful: false,
+    errorMessage: '',
+    getSignatureErrorMessage: '',
+    isOverlayVisible: false,
+    addSignatureState: {},
+  });
+  signTypedDataMock.mockReset();
+  addSignatureMock.mockReset();
+  validateExpirationDateMock.mockReset();
+  clearTransactionStateMock.mockReset();
+  setIsGetSignatureWaitingMock.mockReset();
+  setIsGetSignatureTxSuccessfulMock.mockReset();
+  setGetSignatureErrorMessageMock.mockReset();
+  setIsWaitingMock.mockReset();
+  baseProps.setIsFormDisplayed = vi.fn();
+  baseProps.setTransactionState = vi.fn();
+  baseProps.handleRefetchCandidateData = vi.fn();
+  baseProps.setDataFetchPollInterval = vi.fn();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SignatureForm', () => {
+  it('renders SignatureFormFields and SignatureStatusOverlay and note', () => {
+    const { container } = render(<SignatureForm {...baseProps} />);
+    expect(container.querySelector('[data-testid="signature-form-fields"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="signature-status-overlay"]')).not.toBeNull();
+    expect(container.textContent).toContain('Once a signed proposal is onchain');
+  });
+
+  it('passes proposalIdToUpdate prop to SignatureFormFields', () => {
+    const { container } = render(<SignatureForm {...baseProps} proposalIdToUpdate={5} />);
+    const fields = container.querySelector('[data-testid="signature-form-fields"]');
+    expect(fields?.getAttribute('data-proposal-id')).toBe('5');
+  });
+
+  it('passes flow.isWaiting + isLoading to SignatureFormFields', () => {
+    flowState.isWaiting = true;
+    flowState.isLoading = true;
+    const { container } = render(<SignatureForm {...baseProps} />);
+    const fields = container.querySelector('[data-testid="signature-form-fields"]');
+    expect(fields?.getAttribute('data-is-waiting')).toBe('true');
+    expect(fields?.getAttribute('data-is-loading')).toBe('true');
+  });
+
+  it('passes flow.errorMessage + isOverlayVisible to SignatureStatusOverlay', () => {
+    flowState.errorMessage = 'sig error';
+    flowState.isOverlayVisible = true;
+    const { container } = render(<SignatureForm {...baseProps} />);
+    const overlay = container.querySelector('[data-testid="signature-status-overlay"]');
+    expect(overlay?.getAttribute('data-overlay-visible')).toBe('true');
+    expect(overlay?.getAttribute('data-error-message')).toBe('sig error');
+  });
+
+  it('clicking sign btn calls signTypedData with createProposalTypes when proposalIdToUpdate=0', async () => {
+    const { container } = render(<SignatureForm {...baseProps} proposalIdToUpdate={0} />);
+    const signBtn = container.querySelector('[data-testid="sign-btn"]') as HTMLButtonElement;
+    fireEvent.click(signBtn);
+    await new Promise(r => setTimeout(r, 0));
+    expect(signTypedDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryType: 'Proposal' }),
+    );
+  });
+
+  it('clicking sign btn calls signTypedData with updateProposalTypes when proposalIdToUpdate>0', async () => {
+    const { container } = render(<SignatureForm {...baseProps} proposalIdToUpdate={5} />);
+    const signBtn = container.querySelector('[data-testid="sign-btn"]') as HTMLButtonElement;
+    fireEvent.click(signBtn);
+    await new Promise(r => setTimeout(r, 0));
+    expect(signTypedDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({ primaryType: 'UpdateProposal' }),
+    );
+  });
+
+  it('overlay close button calls setIsFormDisplayed(false) + clearTransactionState', () => {
+    const setFormDisplayed = vi.fn();
+    const { container } = render(
+      <SignatureForm {...baseProps} setIsFormDisplayed={setFormDisplayed} />,
+    );
+    const closeBtn = container.querySelector('[data-testid="overlay-close"]') as HTMLButtonElement;
+    fireEvent.click(closeBtn);
+    expect(setFormDisplayed).toHaveBeenCalledWith(false);
+    expect(clearTransactionStateMock).toHaveBeenCalled();
+  });
+
+  it('overlay try-again button calls clearTransactionState', () => {
+    const { container } = render(<SignatureForm {...baseProps} />);
+    const tryBtn = container.querySelector(
+      '[data-testid="overlay-try-again"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(tryBtn);
+    expect(clearTransactionStateMock).toHaveBeenCalled();
+  });
+
+  it('passes dateErrorMessage from flow to SignatureFormFields', () => {
+    flowState.dateErrorMessage = 'invalid date';
+    const { container } = render(<SignatureForm {...baseProps} />);
+    const fields = container.querySelector('[data-testid="signature-form-fields"]');
+    expect(fields?.getAttribute('data-date-error')).toBe('invalid date');
+  });
+
+  it('calls validateExpirationDate on render (useEffect)', () => {
+    render(<SignatureForm {...baseProps} />);
+    expect(validateExpirationDateMock).toHaveBeenCalled();
+  });
+});

--- a/packages/niji-webapp/src/components/VoteCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCard/index.test.tsx
@@ -1,0 +1,306 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Plural: ({ value, one, other }: { value: number; one: string; other: string }) => (
+    <>{value === 1 ? one : other}</>
+  ),
+}));
+
+vi.mock('@lingui/core', () => ({
+  i18n: { number: (n: number) => String(n) },
+}));
+
+const usePublicClientMock = vi.fn();
+vi.mock('wagmi', () => ({
+  usePublicClient: () => usePublicClientMock(),
+}));
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+vi.mock('@/utils/ensLookup', () => ({
+  ensCacheKey: (a: string) => `ens-cache-${a}`,
+}));
+
+const lookupNNSOrENSMock = vi.fn();
+vi.mock('@/utils/lookupNNSOrENS', () => ({
+  lookupNNSOrENS: (...args: unknown[]) => lookupNNSOrENSMock(...args),
+}));
+
+vi.mock('@/lib/utils', () => ({
+  cn: (...args: string[]) => args.filter(Boolean).join(' '),
+}));
+
+vi.mock('@/components/VoteProgressBar', () => ({
+  default: ({ percentage, variant }: { percentage: number; variant: number }) => (
+    <div
+      data-testid="vote-progress"
+      data-percentage={String(percentage)}
+      data-variant={String(variant)}
+    />
+  ),
+}));
+
+vi.mock('../DelegateGroupedNijiImageVoteTable', () => ({
+  default: ({
+    filteredDelegateGroupedVoteData,
+    propId,
+  }: {
+    filteredDelegateGroupedVoteData: unknown[];
+    propId: number;
+  }) => (
+    <div
+      data-testid="delegate-grouped"
+      data-count={String(filteredDelegateGroupedVoteData.length)}
+      data-prop-id={String(propId)}
+    />
+  ),
+}));
+
+import VoteCard, { VoteCardVariant } from './index';
+
+const makeProposal = (overrides: Partial<Record<string, unknown>> = {}) =>
+  ({
+    id: '42',
+    forCount: 10,
+    againstCount: 5,
+    abstainCount: 2,
+    createdBlock: 100n,
+    ...overrides,
+  }) as never;
+
+const resetState = () => {
+  usePublicClientMock.mockReturnValue({ chain: { id: 1 } });
+  useActiveLocaleMock.mockReturnValue('en-US');
+  lookupNNSOrENSMock.mockReset();
+  lookupNNSOrENSMock.mockResolvedValue('alice.eth');
+  localStorage.clear();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VoteCard', () => {
+  it('renders FOR variant with forCount', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    expect(container.textContent).toContain('For');
+    expect(container.textContent).toContain('10');
+  });
+
+  it('renders AGAINST variant with againstCount', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={25}
+        variant={VoteCardVariant.AGAINST}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    expect(container.textContent).toContain('Against');
+    expect(container.textContent).toContain('5');
+  });
+
+  it('renders ABSTAIN variant with abstainCount', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={10}
+        variant={VoteCardVariant.ABSTAIN}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    expect(container.textContent).toContain('Abstain');
+    expect(container.textContent).toContain('2');
+  });
+
+  it('shows voter count when delegateGroupedVoteData matches variant', () => {
+    const delegateData = [
+      {
+        delegate: '0xAAA' as `0x${string}`,
+        supportDetailed: 1 as const,
+        nijiRepresented: ['1', '2'],
+      },
+      { delegate: '0xBBB' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['3'] },
+    ];
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    expect(container.textContent).toContain('2');
+    expect(container.textContent).toContain('voters');
+  });
+
+  it('passes filtered count to DelegateGroupedNijiImageVoteTable', () => {
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+      { delegate: '0xBBB' as `0x${string}`, supportDetailed: 0 as const, nijiRepresented: ['2'] },
+    ];
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    const table = container.querySelector('[data-testid="delegate-grouped"]');
+    expect(table?.getAttribute('data-count')).toBe('1');
+    expect(table?.getAttribute('data-prop-id')).toBe('42');
+  });
+
+  it('forwards percentage + variant to VoteProgressBar', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={75}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    const bar = container.querySelector('[data-testid="vote-progress"]');
+    expect(bar?.getAttribute('data-percentage')).toBe('75');
+    expect(bar?.getAttribute('data-variant')).toBe(String(VoteCardVariant.FOR));
+  });
+
+  it('triggers lookupNNSOrENS for new delegate addresses', async () => {
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+    ];
+    render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    await waitFor(() => {
+      expect(lookupNNSOrENSMock).toHaveBeenCalledWith(expect.anything(), '0xAAA');
+    });
+  });
+
+  it('skips lookupNNSOrENS when delegate cached in localStorage', () => {
+    localStorage.setItem(
+      'ens-cache-0xAAA',
+      JSON.stringify({ name: 'cached', expires: 9999999999 }),
+    );
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+    ];
+    render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    expect(lookupNNSOrENSMock).not.toHaveBeenCalled();
+  });
+
+  it('skips ENS lookup when publicClient is undefined', () => {
+    usePublicClientMock.mockReturnValue(undefined);
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+    ];
+    render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    expect(lookupNNSOrENSMock).not.toHaveBeenCalled();
+  });
+
+  it('renders without crashing for non-en-US locale', () => {
+    useActiveLocaleMock.mockReturnValue('ja-JP');
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    expect(container.textContent).toContain('For');
+  });
+
+  it('hides voters count text when filteredDelegateGroupedVoteData is empty', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={[]}
+      />,
+    );
+    expect(container.textContent).not.toContain('voters');
+  });
+
+  it('shows singular "voter" when filteredDelegateGroupedVoteData has exactly 1 entry', () => {
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+    ];
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    expect(container.textContent).toContain('voter');
+    expect(container.textContent).not.toMatch(/2\s*voters/);
+  });
+
+  it('passes proposal.id=undefined fallback to DelegateGroupedNijiImageVoteTable (propId=0)', () => {
+    const proposal = makeProposal({ id: undefined });
+    const { container } = render(
+      <VoteCard
+        proposal={proposal}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    const table = container.querySelector('[data-testid="delegate-grouped"]');
+    expect(table?.getAttribute('data-prop-id')).toBe('0');
+  });
+
+  it('handles undefined delegateGroupedVoteData gracefully (no crash, table count=0)', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.AGAINST}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    const table = container.querySelector('[data-testid="delegate-grouped"]');
+    expect(table?.getAttribute('data-count')).toBe('0');
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 57` として large 帯 2 file (`CandidateSponsors/SignatureForm` 174 行 / `VoteCard/index` 169 行) に vitest を追加、 1146 → 1170 (+24、 1 skip 維持)。

## 詳細

### CandidateSponsors/SignatureForm.test.tsx (10 TC)

candidate に signature を付ける form。 wagmi `useSignTypedData` で EIP-712 typed signature を取得、 `useSignatureFlow` hook で transaction state を管理、 子 (SignatureFormFields / SignatureStatusOverlay) に props 流入。

検証観点。

- 基本 render ... SignatureFormFields + SignatureStatusOverlay + 末尾 note
- `proposalIdToUpdate` を SignatureFormFields に流す
- `flow.isWaiting` + `isLoading` を SignatureFormFields に流す
- `flow.errorMessage` + `isOverlayVisible` を SignatureStatusOverlay に流す
- sign btn click で `signTypedData({ primaryType: 'Proposal' })` (proposalIdToUpdate=0)
- sign btn click で `signTypedData({ primaryType: 'UpdateProposal' })` (proposalIdToUpdate>0)
- overlay close で `setIsFormDisplayed(false)` + `clearTransactionState`
- overlay try-again で `clearTransactionState`
- `dateErrorMessage` を SignatureFormFields に流す
- 初回 render で `validateExpirationDate` (useEffect)

### VoteCard/index.test.tsx (14 TC)

proposal vote card。 FOR / AGAINST / ABSTAIN の 3 variant + voter count + ENS lookup pre-fetch + VoteProgressBar + DelegateGroupedNijiImageVoteTable を統括。

検証観点。

- FOR / AGAINST / ABSTAIN variant 別 label + 該当 count 表示
- delegateGroupedVoteData が variant に合致する場合 voter 件数表示
- DelegateGroupedNijiImageVoteTable に filtered count + propId 流入
- VoteProgressBar に percentage + variant 流入
- 未 cache delegate に `lookupNNSOrENS` 呼出
- localStorage cache 済 delegate は `lookupNNSOrENS` 未呼出
- publicClient undefined で `lookupNNSOrENS` 未呼出
- 非 en-US locale で crash なし
- voter 件数 0 で「voters」 text 非表示
- voter 件数 1 で singular「voter」
- proposal.id=undefined で propId=0 fallback
- delegateGroupedVoteData=undefined で table count=0

## 解決方法

SignatureForm 側 ... wagmi `useSignTypedData` / `useSignatureFlow` hook / 子 (SignatureFormFields / SignatureStatusOverlay) / `calcProposalEncodeData` / `@niji/sdk/react` (nijiGovernorAddress) / `@/wagmi` (defaultChain) / `./signature/types` を全 vi.mock。 `flowState` で flow object の状態を test ごとに切替、 子 component は props 引数を data attr に export し test 側から検証可能化。

VoteCard 側 ... `wagmi.usePublicClient` / `useActiveLocale` / `lookupNNSOrENS` / `cn` / 子 (VoteProgressBar / DelegateGroupedNijiImageVoteTable) を vi.mock。 `localStorage.clear()` を beforeEach で初期化し ENS cache 検証経路を独立化。 `Plural` Lingui macro は value 1 で `one`、 それ以外で `other` を返す簡素 mock。

## 受入条件

- [x] 2 file 計 24 TC 全 pass
- [x] `pnpm vitest run` 全 1170 test green (1171 - 1 skipped)
- [x] regression なし (既存 1146 pass を破壊しない)

## 関連

- Closes #445
- 直前 PR #444 (part 56) で 1117 → 1146
- 残 large 候補 ... CandidateSponsors/index (155 行) / AuctionTimer (144 行) / NavBarButton (140 行) 等
