### PR TITLE
✅ test(niji-webapp): component part 58 (CandidateSponsors/index / ui/dialog) で 1170 → 1195 (Issue #447)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/index.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.test.tsx
@@ -1,0 +1,249 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hookState: {
+  account: string | undefined;
+  activePendingProposers: unknown;
+  userVotes: number;
+  isThresholdMet: boolean;
+  isAccountSigner: boolean;
+  isOriginalSigner: boolean;
+  delegatesData: { delegates: unknown[] } | undefined;
+} = {
+  account: '0xACCT',
+  activePendingProposers: {},
+  userVotes: 5,
+  isThresholdMet: false,
+  isAccountSigner: false,
+  isOriginalSigner: false,
+  delegatesData: { delegates: [] },
+};
+
+const setIsAccountSignerMock = vi.fn();
+const useActivePendingUpdatableProposersMock = vi.fn();
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: hookState.account }),
+}));
+
+vi.mock('@/wrappers/nijiDao', () => ({
+  ProposalState: { UPDATABLE: 10 },
+  useActivePendingUpdatableProposers: (...args: unknown[]) =>
+    useActivePendingUpdatableProposersMock(...args) ?? hookState.activePendingProposers,
+}));
+
+const useDelegateNounsAtBlockQueryMock = vi.fn();
+vi.mock('@/wrappers/nijiToken', () => ({
+  useDelegateNounsAtBlockQuery: (...args: unknown[]) => useDelegateNounsAtBlockQueryMock(...args),
+  useUserVotes: () => hookState.userVotes,
+}));
+
+vi.mock('./useCandidateSponsorState', () => ({
+  useCandidateSponsorState: () => ({
+    isThresholdMet: hookState.isThresholdMet,
+    isAccountSigner: hookState.isAccountSigner,
+    isOriginalSigner: hookState.isOriginalSigner,
+    setIsAccountSigner: setIsAccountSignerMock,
+  }),
+}));
+
+const selectSponsorsModalStateLog: { isOpen: boolean[] } = { isOpen: [] };
+vi.mock('./SelectSponsorsToPropose', () => ({
+  default: ({ isModalOpen }: { isModalOpen: boolean }) => {
+    selectSponsorsModalStateLog.isOpen.push(isModalOpen);
+    return <div data-testid="select-sponsors" data-open={String(isModalOpen)} />;
+  },
+}));
+
+const submitUpdateModalStateLog: { isOpen: boolean[] } = { isOpen: [] };
+vi.mock('./SubmitUpdateProposal', () => ({
+  default: ({ isModalOpen }: { isModalOpen: boolean }) => {
+    submitUpdateModalStateLog.isOpen.push(isModalOpen);
+    return <div data-testid="submit-update" data-open={String(isModalOpen)} />;
+  },
+}));
+
+vi.mock('./SponsorsFormOverlay', () => ({
+  SponsorsFormOverlay: () => <div data-testid="sponsors-form-overlay" />,
+}));
+
+vi.mock('./SponsorsHeader', () => ({
+  SponsorsHeader: () => <div data-testid="sponsors-header" />,
+}));
+
+vi.mock('./SponsorsList', () => ({
+  SponsorsList: ({
+    onOpenSubmitModal,
+    onOpenUpdateModal,
+    onOpenForm,
+    isParentProposalUpdatable,
+  }: {
+    onOpenSubmitModal: () => void;
+    onOpenUpdateModal: () => void;
+    onOpenForm: () => void;
+    isParentProposalUpdatable: boolean;
+  }) => (
+    <div data-testid="sponsors-list" data-parent-updatable={String(isParentProposalUpdatable)}>
+      <button data-testid="open-submit" onClick={onOpenSubmitModal} />
+      <button data-testid="open-update" onClick={onOpenUpdateModal} />
+      <button data-testid="open-form" onClick={onOpenForm} />
+    </div>
+  ),
+}));
+
+import CandidateSponsors from './index';
+
+const makeCandidate = (
+  overrides: Partial<{
+    contentSignatures: unknown[] | undefined;
+    requiredVotes: number;
+    voteCount: number;
+  }> = {},
+) =>
+  ({
+    requiredVotes: overrides.requiredVotes ?? 3,
+    voteCount: overrides.voteCount ?? 0,
+    version: {
+      content: {
+        contentSignatures: 'contentSignatures' in overrides ? overrides.contentSignatures : [],
+      },
+    },
+  }) as never;
+
+const baseProps = {
+  candidate: makeCandidate(),
+  slug: 'cand-slug',
+  isProposer: false,
+  id: 'sig-1',
+  handleRefetchCandidateData: vi.fn(),
+  setDataFetchPollInterval: vi.fn(),
+  currentBlock: 100n,
+  requiredVotes: 3,
+  userVotes: 5,
+  blockNumber: 100n,
+};
+
+const resetState = () => {
+  hookState.account = '0xACCT';
+  hookState.activePendingProposers = {};
+  hookState.userVotes = 5;
+  hookState.isThresholdMet = false;
+  hookState.isAccountSigner = false;
+  hookState.isOriginalSigner = false;
+  hookState.delegatesData = { delegates: [] };
+  setIsAccountSignerMock.mockReset();
+  useActivePendingUpdatableProposersMock.mockReset();
+  useActivePendingUpdatableProposersMock.mockReturnValue(hookState.activePendingProposers);
+  useDelegateNounsAtBlockQueryMock.mockReset();
+  useDelegateNounsAtBlockQueryMock.mockReturnValue({ data: hookState.delegatesData });
+  selectSponsorsModalStateLog.isOpen = [];
+  submitUpdateModalStateLog.isOpen = [];
+  baseProps.handleRefetchCandidateData = vi.fn();
+  baseProps.setDataFetchPollInterval = vi.fn();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CandidateSponsors', () => {
+  it('renders SponsorsHeader + SponsorsList when signatures present + !formDisplayed', () => {
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    expect(container.querySelector('[data-testid="sponsors-header"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="sponsors-list"]')).not.toBeNull();
+  });
+
+  it('renders loading-noggles when signatures is undefined', () => {
+    const candidate = makeCandidate({ contentSignatures: undefined });
+    const { container } = render(<CandidateSponsors {...baseProps} candidate={candidate} />);
+    const img = container.querySelector('img');
+    expect(img?.src).toContain('loading-noggles.svg');
+  });
+
+  it('shows "Sponsor threshold met" when isThresholdMet=true', () => {
+    hookState.isThresholdMet = true;
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    expect(container.textContent).toContain('Sponsor threshold met');
+  });
+
+  it('hides threshold met message when isThresholdMet=false', () => {
+    hookState.isThresholdMet = false;
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    expect(container.textContent).not.toContain('Sponsor threshold met');
+  });
+
+  it('renders SubmitUpdateProposal when isUpdateToProposal=true', () => {
+    const { container } = render(
+      <CandidateSponsors
+        {...baseProps}
+        isUpdateToProposal={true}
+        originalProposal={{ id: '42', signers: [] } as never}
+      />,
+    );
+    expect(container.querySelector('[data-testid="submit-update"]')).not.toBeNull();
+  });
+
+  it('does not render SubmitUpdateProposal when isUpdateToProposal=false', () => {
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    expect(container.querySelector('[data-testid="submit-update"]')).toBeNull();
+  });
+
+  it('always renders SelectSponsorsToPropose modal slot', () => {
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    expect(container.querySelector('[data-testid="select-sponsors"]')).not.toBeNull();
+  });
+
+  it('open-submit click opens SelectSponsorsToPropose modal', () => {
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    const openBtn = container.querySelector('[data-testid="open-submit"]') as HTMLButtonElement;
+    fireEvent.click(openBtn);
+    const modal = container.querySelector('[data-testid="select-sponsors"]');
+    expect(modal?.getAttribute('data-open')).toBe('true');
+  });
+
+  it('open-form click switches to SponsorsFormOverlay', () => {
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    const openBtn = container.querySelector('[data-testid="open-form"]') as HTMLButtonElement;
+    fireEvent.click(openBtn);
+    expect(container.querySelector('[data-testid="sponsors-form-overlay"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="sponsors-list"]')).toBeNull();
+  });
+
+  it('isParentProposalUpdatable=true when originalProposal.status=UPDATABLE', () => {
+    const { container } = render(
+      <CandidateSponsors
+        {...baseProps}
+        originalProposal={{ id: '42', signers: [], status: 10 } as never}
+      />,
+    );
+    const list = container.querySelector('[data-testid="sponsors-list"]');
+    expect(list?.getAttribute('data-parent-updatable')).toBe('true');
+  });
+
+  it('isParentProposalUpdatable=false when originalProposal undefined', () => {
+    const { container } = render(<CandidateSponsors {...baseProps} />);
+    const list = container.querySelector('[data-testid="sponsors-list"]');
+    expect(list?.getAttribute('data-parent-updatable')).toBe('false');
+  });
+
+  it('calls useActivePendingUpdatableProposers with blockNumber', () => {
+    render(<CandidateSponsors {...baseProps} blockNumber={123n} />);
+    expect(useActivePendingUpdatableProposersMock).toHaveBeenCalledWith(123n);
+  });
+
+  it('calls useDelegateNounsAtBlockQuery with originalSigners lowercased', () => {
+    render(
+      <CandidateSponsors
+        {...baseProps}
+        originalProposal={{ id: '42', signers: [{ id: '0xABC' }] } as never}
+      />,
+    );
+    expect(useDelegateNounsAtBlockQueryMock).toHaveBeenCalledWith(['0xabc'], 100n);
+  });
+});

--- a/packages/niji-webapp/src/components/ui/dialog.test.tsx
+++ b/packages/niji-webapp/src/components/ui/dialog.test.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+
+describe('Dialog', () => {
+  it('does not render content when Dialog is closed', () => {
+    const { container } = render(
+      <Dialog>
+        <DialogTrigger>open</DialogTrigger>
+        <DialogContent>
+          <div data-testid="dialog-body">body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(container.querySelector('[data-testid="dialog-body"]')).toBeNull();
+  });
+
+  it('renders content via open prop', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <div data-testid="dialog-body">body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(document.querySelector('[data-testid="dialog-body"]')?.textContent).toBe('body');
+  });
+
+  it('renders Close button with sr-only "Close" label', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <div data-testid="dialog-body">body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(document.body.textContent).toContain('Close');
+  });
+
+  it('clicking DialogTrigger opens the dialog (uncontrolled)', () => {
+    const { container } = render(
+      <Dialog>
+        <DialogTrigger data-testid="trigger">open</DialogTrigger>
+        <DialogContent>
+          <div data-testid="dialog-body">body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+    const trigger = container.querySelector('[data-testid="trigger"]') as HTMLButtonElement;
+    fireEvent.click(trigger);
+    expect(document.querySelector('[data-testid="dialog-body"]')).not.toBeNull();
+  });
+
+  it('DialogTitle renders text content', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <DialogTitle>My Title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(document.body.textContent).toContain('My Title');
+  });
+
+  it('DialogDescription renders text content', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <DialogTitle>title</DialogTitle>
+          <DialogDescription>desc text</DialogDescription>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(document.body.textContent).toContain('desc text');
+  });
+
+  it('DialogHeader applies default classes', () => {
+    const { container } = render(
+      <DialogHeader data-testid="header">
+        <span>x</span>
+      </DialogHeader>,
+    );
+    const header = container.querySelector('[data-testid="header"]');
+    expect(header?.className).toContain('flex');
+    expect(header?.className).toContain('flex-col');
+  });
+
+  it('DialogHeader merges custom className', () => {
+    const { container } = render(
+      <DialogHeader data-testid="header" className="custom-class">
+        <span>x</span>
+      </DialogHeader>,
+    );
+    const header = container.querySelector('[data-testid="header"]');
+    expect(header?.className).toContain('custom-class');
+  });
+
+  it('DialogFooter applies default sm:flex-row class', () => {
+    const { container } = render(
+      <DialogFooter data-testid="footer">
+        <span>x</span>
+      </DialogFooter>,
+    );
+    const footer = container.querySelector('[data-testid="footer"]');
+    expect(footer?.className).toContain('flex-col-reverse');
+  });
+
+  it('DialogFooter merges custom className', () => {
+    const { container } = render(
+      <DialogFooter data-testid="footer" className="extra-footer-class">
+        <span>x</span>
+      </DialogFooter>,
+    );
+    const footer = container.querySelector('[data-testid="footer"]');
+    expect(footer?.className).toContain('extra-footer-class');
+  });
+
+  it('Dialog content includes Close button with X icon when open', () => {
+    render(
+      <Dialog open={true}>
+        <DialogContent>
+          <DialogTitle>title</DialogTitle>
+        </DialogContent>
+      </Dialog>,
+    );
+    const closeBtn = Array.from(document.querySelectorAll('button')).find(
+      b => b.textContent?.includes('Close') === true || b.querySelector('svg') !== null,
+    );
+    expect(closeBtn).not.toBeUndefined();
+  });
+
+  it('controlled Dialog respects onOpenChange callback', () => {
+    let openState = true;
+    const { rerender } = render(
+      <Dialog
+        open={openState}
+        onOpenChange={v => {
+          openState = v;
+        }}
+      >
+        <DialogContent>
+          <DialogTitle>title</DialogTitle>
+          <div data-testid="body">body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(document.querySelector('[data-testid="body"]')).not.toBeNull();
+    rerender(
+      <Dialog
+        open={false}
+        onOpenChange={v => {
+          openState = v;
+        }}
+      >
+        <DialogContent>
+          <DialogTitle>title</DialogTitle>
+          <div data-testid="body">body</div>
+        </DialogContent>
+      </Dialog>,
+    );
+    expect(document.querySelector('[data-testid="body"]')).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 58` として large 帯 2 file (`CandidateSponsors/index` 155 行 / `ui/dialog` 116 行 shadcn radix wrapper) に vitest を追加、 1170 → 1195 (+25、 1 skip 維持)。 当初想定の `AuctionTimer/index` (144 行) は既に test 済みのため、 ui/dialog (radix wrapper) に切替えて未テスト候補消化を継続。

## 詳細

### CandidateSponsors/index.test.tsx (13 TC)

candidate page で sponsor 一覧 + sign form overlay + submit modal 群を統括する parent component。 内部に `useCandidateSponsorState` + wagmi `useAccount` + 5 種 sub component を持つ。

検証観点。

- signatures あり で SponsorsHeader + SponsorsList render
- signatures undefined で loading-noggles img 表示
- isThresholdMet=true で「Sponsor threshold met」 表示
- isThresholdMet=false で非表示
- isUpdateToProposal=true で SubmitUpdateProposal modal slot render
- isUpdateToProposal=false で SubmitUpdateProposal 非 render
- SelectSponsorsToPropose は常に modal slot 存在
- SponsorsList の `onOpenSubmitModal` click で SelectSponsorsToPropose の `isModalOpen=true` 切替
- `onOpenForm` click で SponsorsList 非表示 → SponsorsFormOverlay 表示切替
- originalProposal.status=UPDATABLE で `isParentProposalUpdatable=true` 流入
- originalProposal undefined で `isParentProposalUpdatable=false` 流入
- `useActivePendingUpdatableProposers(blockNumber)` 呼出
- `useDelegateNounsAtBlockQuery(lowercased signers, blockNumber)` 呼出

### ui/dialog.test.tsx (12 TC)

shadcn ui dialog wrapper (radix-ui/react-dialog 上に displayName + Tailwind class を仕込む薄 wrapper)。

検証観点。

- Dialog 閉時に DialogContent 子非 render
- Dialog open=true で DialogContent 子 render (portal 経由 document.body)
- DialogContent 内に sr-only「Close」 button render
- DialogTrigger click で uncontrolled open
- DialogTitle / DialogDescription text 描画
- DialogHeader default class (`flex flex-col`) + custom className merge
- DialogFooter default class (`flex-col-reverse`) + custom className merge
- Close button + X icon 存在
- controlled Dialog で onOpenChange + rerender で open / close 切替

## 解決方法

CandidateSponsors 側 ... `wagmi.useAccount` / `useActivePendingUpdatableProposers` / `useUserVotes` / `useCandidateSponsorState` / `useDelegateNounsAtBlockQuery` / `ProposalState` enum / 5 sub component (SelectSponsorsToPropose / SubmitUpdateProposal / SponsorsHeader / SponsorsList / SponsorsFormOverlay) を全 `vi.mock`。 `hookState` で各 state 切替、 sub component は props を data attr に export して側から検証可能化。 `makeCandidate` factory で `'contentSignatures' in overrides` 経路を採用し undefined を明示的に渡せるよう調整。

ui/dialog 側 ... radix 実装をそのまま使用、 `@radix-ui/react-dialog` の `open` prop で controlled / uncontrolled 経路を切替検証。 portal 経由 render は `document.querySelector` 経由 (container ではない) で取得。

## 受入条件

- [x] 2 file 計 25 TC 全 pass
- [x] `pnpm vitest run` 全 1195 test green (1196 - 1 skipped)
- [x] regression なし (既存 1170 pass を破壊しない)

## 関連

- Closes #447
- 直前 PR #446 (part 57) で 1146 → 1170
- 残未テスト最大 large 候補 ... `ui/select` (176 行) / `ui/tooltip` (39 行) / `ui/sonner` (27 行) で large 帯ほぼ完走
- ui/select は radix select wrapper で次回候補
