### PR TITLE
✅ test(niji-webapp): component part 59 (ui/select / ui/tooltip) で 1195 → 1216 (Issue #449)

### DIFF
--- a/packages/niji-webapp/src/components/ui/select.test.tsx
+++ b/packages/niji-webapp/src/components/ui/select.test.tsx
@@ -1,0 +1,234 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from './select';
+
+beforeAll(() => {
+  if (!global.ResizeObserver) {
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {};
+  }
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {};
+  }
+});
+
+describe('Select', () => {
+  it('renders SelectTrigger with placeholder text via SelectValue', () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue placeholder="Pick one" />
+        </SelectTrigger>
+      </Select>,
+    );
+    const trigger = container.querySelector('[data-testid="trigger"]');
+    expect(trigger?.textContent).toContain('Pick one');
+  });
+
+  it('SelectTrigger renders ChevronDown icon (svg) inside', () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger data-testid="trigger">
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+      </Select>,
+    );
+    const trigger = container.querySelector('[data-testid="trigger"]');
+    expect(trigger?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('SelectTrigger merges custom className over defaults', () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger data-testid="trigger" className="custom-trigger-class">
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+      </Select>,
+    );
+    const trigger = container.querySelector('[data-testid="trigger"]');
+    expect(trigger?.className).toContain('custom-trigger-class');
+    expect(trigger?.className).toContain('flex');
+  });
+
+  it('SelectContent items are not rendered when select is closed', () => {
+    render(
+      <Select>
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">Apple</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    expect(document.body.textContent).not.toContain('Apple');
+  });
+
+  it('SelectContent renders SelectItem when select is open', () => {
+    render(
+      <Select open={true} value="a" onValueChange={() => {}}>
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">Apple</SelectItem>
+          <SelectItem value="b">Banana</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    expect(document.body.textContent).toContain('Apple');
+    expect(document.body.textContent).toContain('Banana');
+  });
+
+  it('SelectLabel applies default semibold class', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel data-testid="label">Fruits</SelectLabel>
+            <SelectItem value="a">Apple</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+    const label = document.querySelector('[data-testid="label"]');
+    expect(label?.className).toContain('font-semibold');
+  });
+
+  it('SelectLabel merges custom className', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel data-testid="label" className="custom-label-class">
+              Fruits
+            </SelectLabel>
+            <SelectItem value="a">Apple</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>,
+    );
+    const label = document.querySelector('[data-testid="label"]');
+    expect(label?.className).toContain('custom-label-class');
+  });
+
+  it('SelectSeparator applies default h-px class', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">Apple</SelectItem>
+          <SelectSeparator data-testid="sep" />
+          <SelectItem value="b">Banana</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const sep = document.querySelector('[data-testid="sep"]');
+    expect(sep?.className).toContain('h-px');
+  });
+
+  it('SelectScrollUpButton renders ChevronUp icon', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">A</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const scrollUp = document.querySelector('[class*="cursor-default"]');
+    expect(scrollUp?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('SelectScrollDownButton renders inside SelectContent', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">A</SelectItem>
+          <SelectScrollDownButton data-testid="scroll-down" />
+        </SelectContent>
+      </Select>,
+    );
+    const buttons = document.querySelectorAll('[class*="cursor-default"]');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('SelectScrollUpButton renders inside SelectContent (radix default scroll buttons)', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">A</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const buttons = document.querySelectorAll('[class*="cursor-default"]');
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('SelectTrigger has disabled class when disabled prop is true', () => {
+    const { container } = render(
+      <Select>
+        <SelectTrigger data-testid="trigger" disabled>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+      </Select>,
+    );
+    const trigger = container.querySelector('[data-testid="trigger"]');
+    expect(trigger?.className).toContain('disabled:opacity-50');
+  });
+
+  it('SelectItem renders selected ItemIndicator (Check icon) for current value', () => {
+    render(
+      <Select open={true} value="a">
+        <SelectTrigger>
+          <SelectValue placeholder="x" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem data-testid="item-a" value="a">
+            Apple
+          </SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+    const item = document.querySelector('[data-testid="item-a"]');
+    expect(item?.querySelector('svg')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/ui/tooltip.test.tsx
+++ b/packages/niji-webapp/src/components/ui/tooltip.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
+
+beforeAll(() => {
+  if (!global.ResizeObserver) {
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+  }
+});
+
+describe('Tooltip', () => {
+  it('does not render TooltipContent text when tooltip is closed', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger>hover me</TooltipTrigger>
+          <TooltipContent>
+            <span data-testid="tooltip-body">help text</span>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    expect(document.querySelector('[data-testid="tooltip-body"]')).toBeNull();
+  });
+
+  it('renders TooltipContent via open prop', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip open={true}>
+          <TooltipTrigger>hover me</TooltipTrigger>
+          <TooltipContent>
+            <span data-testid="tooltip-body">help text</span>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    expect(document.querySelector('[data-testid="tooltip-body"]')?.textContent).toBe('help text');
+  });
+
+  it('TooltipContent merges custom className', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip open={true}>
+          <TooltipTrigger>x</TooltipTrigger>
+          <TooltipContent data-testid="content" className="custom-tooltip-class">
+            tip
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    const content = document.querySelector('[data-testid="content"]');
+    expect(content?.className).toContain('custom-tooltip-class');
+    expect(content?.className).toContain('text-xs');
+  });
+
+  it('TooltipContent contains arrow element by default', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip open={true}>
+          <TooltipTrigger>x</TooltipTrigger>
+          <TooltipContent data-testid="content">tip</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    const content = document.querySelector('[data-testid="content"]');
+    expect(content?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('TooltipTrigger renders children text', () => {
+    const { container } = render(
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger data-testid="trigger">hover me</TooltipTrigger>
+          <TooltipContent>tip</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    const trigger = container.querySelector('[data-testid="trigger"]');
+    expect(trigger?.textContent).toBe('hover me');
+  });
+
+  it('handles two tooltips independently (one open, one closed)', () => {
+    render(
+      <TooltipProvider>
+        <Tooltip open={true}>
+          <TooltipTrigger>t1</TooltipTrigger>
+          <TooltipContent>
+            <span data-testid="tip-a">tip a</span>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip open={false}>
+          <TooltipTrigger>t2</TooltipTrigger>
+          <TooltipContent>
+            <span data-testid="tip-b">tip b</span>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>,
+    );
+    expect(document.querySelector('[data-testid="tip-a"]')?.textContent).toBe('tip a');
+    expect(document.querySelector('[data-testid="tip-b"]')).toBeNull();
+  });
+
+  it('TooltipContent default sideOffset is 4 (passes prop without crash)', () => {
+    expect(() =>
+      render(
+        <TooltipProvider>
+          <Tooltip open={true}>
+            <TooltipTrigger>x</TooltipTrigger>
+            <TooltipContent>tip</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('TooltipContent accepts custom sideOffset prop', () => {
+    expect(() =>
+      render(
+        <TooltipProvider>
+          <Tooltip open={true}>
+            <TooltipTrigger>x</TooltipTrigger>
+            <TooltipContent sideOffset={10}>tip</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>,
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp component part 59` として残未テスト shadcn ui 系 2 file (`ui/select` 176 行 / `ui/tooltip` 39 行) に vitest を追加、 1195 → 1216 (+21、 1 skip 維持)。 これで `src/components/` 配下の未テスト component は ui/sonner (27 行 = single line toast wrapper) のみ残す状態に。

## 詳細

### ui/select.test.tsx (13 TC)

shadcn の radix-ui/react-select wrapper。 9 export (Select / SelectGroup / SelectValue / SelectTrigger / SelectContent / SelectLabel / SelectItem / SelectSeparator / SelectScrollUpButton / SelectScrollDownButton) を test。

検証観点。

- SelectTrigger に SelectValue placeholder「Pick one」 表示
- SelectTrigger 内に ChevronDown icon (`asChild` 経由)
- SelectTrigger custom className merge (`flex` + custom-trigger-class)
- closed 状態で SelectItem 非 render
- open=true で SelectItem 描画 (portal 経由 document.body)
- SelectLabel default `font-semibold` class + custom merge
- SelectSeparator default `h-px` class
- SelectScrollUpButton / SelectScrollDownButton が SelectContent 内で render
- SelectTrigger disabled prop で disabled class 反映
- SelectItem 選択値で Check ItemIndicator (svg) 描画

### ui/tooltip.test.tsx (8 TC)

shadcn の radix-ui/react-tooltip wrapper。 4 export (TooltipProvider / Tooltip / TooltipTrigger / TooltipContent) を test。

検証観点。

- 閉時に TooltipContent 子非 render
- open=true で TooltipContent 子 render (portal 経由)
- TooltipContent custom className merge (`text-xs` + custom)
- TooltipContent 内 Arrow svg 描画
- TooltipTrigger children text 描画
- 多重 Tooltip 構成で独立 open / close
- default sideOffset=4 で crash なし
- custom sideOffset prop で crash なし

## 解決方法

両 file とも radix-ui の薄 wrapper のため、 radix mock を入れずに実 component を使用。 jsdom 環境では radix が必要な `ResizeObserver` / `Element.prototype.scrollIntoView` / `hasPointerCapture` / `releasePointerCapture` が未定義のため、 test ファイル冒頭の `beforeAll` で polyfill 定義。 portal 経由 content は `document.querySelector` 経由 (container ではない) で取得。 SelectScrollUpButton / SelectScrollDownButton は radix context 必須のため SelectContent 内で render する経路に変更。

## 受入条件

- [x] 2 file 計 21 TC 全 pass
- [x] `pnpm vitest run` 全 1216 test green (1217 - 1 skipped)
- [x] regression なし (既存 1195 pass を破壊しない)

## 関連

- Closes #449
- 直前 PR #448 (part 58) で 1170 → 1195
- 残未テスト component ... `ui/sonner` (27 行、 sonner toast の薄 export wrapper) のみで `src/components/` 配下完走間近
- 学び ... radix-ui の test では `ResizeObserver` + `scrollIntoView` + `pointerCapture` polyfill が必須 (jsdom 環境では未定義)、 将来 vitest.setup.ts に集約予定
