### PR TITLE
✅ test(niji-webapp): hooks part 61 (useStreamPaymentTransactions + useSubgraphQuery + useActivateLocale) で 1242 → 1270 (Issue #453)

### DIFF
--- a/packages/niji-webapp/src/hooks/useActivateLocale.test.ts
+++ b/packages/niji-webapp/src/hooks/useActivateLocale.test.ts
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useAtomValueMock = vi.fn();
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => useAtomValueMock(),
+}));
+
+vi.mock('@/i18n/activeLocaleAtom', () => ({
+  activeLocaleAtom: {},
+}));
+
+import { useActiveLocale } from './useActivateLocale';
+
+beforeEach(() => {
+  useAtomValueMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useActiveLocale', () => {
+  it('returns en-US locale from jotai atom', () => {
+    useAtomValueMock.mockReturnValue('en-US');
+    const { result } = renderHook(() => useActiveLocale());
+    expect(result.current).toBe('en-US');
+  });
+
+  it('returns ja-JP locale from jotai atom', () => {
+    useAtomValueMock.mockReturnValue('ja-JP');
+    const { result } = renderHook(() => useActiveLocale());
+    expect(result.current).toBe('ja-JP');
+  });
+
+  it('returns whatever atom value is currently set (no transformation)', () => {
+    useAtomValueMock.mockReturnValue('zh-CN');
+    const { result } = renderHook(() => useActiveLocale());
+    expect(result.current).toBe('zh-CN');
+  });
+
+  it('calls useAtomValue exactly once per render', () => {
+    useAtomValueMock.mockReturnValue('en-US');
+    renderHook(() => useActiveLocale());
+    expect(useAtomValueMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-webapp/src/hooks/useStreamPaymentTransactions.test.ts
+++ b/packages/niji-webapp/src/hooks/useStreamPaymentTransactions.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiPayerAbi: [{ type: 'function', name: 'sendOrRegisterDebt', inputs: [] }],
+  nijiPayerAddress: { 1: '0xPAYER' as const },
+  nijiStreamFactoryAbi: [{ type: 'function', name: 'createStream', inputs: [] }],
+  nijiStreamFactoryAddress: { 1: '0xFACTORY' as const },
+  usdcAddress: { 1: '0xUSDC' as const },
+  wethAddress: { 1: '0xWETH' as const },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/components/ProposalActionsModal/steps/TransferFundsDetailsStep', () => ({
+  SupportedCurrency: { USDC: 'USDC', WETH: 'WETH' },
+}));
+
+vi.mock('@/utils/streamingPaymentUtils/streamingPaymentUtils', () => ({
+  formatTokenAmount: (amount: number, currency: string) =>
+    currency === 'USDC' ? BigInt(amount * 1_000_000) : BigInt(amount),
+  getTokenAddressForCurrency: (currency: string) => (currency === 'USDC' ? '0xUSDC' : '0xWETH'),
+}));
+
+vi.mock('@/utils/usdcUtils', () => ({
+  human2ContractUSDCFormat: (a: string) => String(Number(a) * 1_000_000),
+}));
+
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...actual,
+    encodeFunctionData: ({ functionName, args }: { functionName: string; args: unknown[] }) => {
+      return `0xENCODED_${functionName}_${args.length}` as `0x${string}`;
+    },
+    parseEther: (s: string) => BigInt(Math.floor(Number(s) * 1e18)),
+    parseAbi: (signatures: string[]) => signatures.map(s => ({ type: 'function', signature: s })),
+  };
+});
+
+import useStreamPaymentTransactions from './useStreamPaymentTransactions';
+
+const makeState = (
+  overrides: Partial<{
+    TransferFundsCurrency: string;
+    amount: string;
+    address: string;
+    streamStartTimestamp: number;
+    streamEndTimestamp: number;
+  }> = {},
+) =>
+  ({
+    actionType: 'STREAM',
+    address: (overrides.address ?? '0xRECIPIENT') as `0x${string}`,
+    TransferFundsCurrency: overrides.TransferFundsCurrency ?? 'USDC',
+    amount: overrides.amount ?? '100',
+    streamStartTimestamp: overrides.streamStartTimestamp ?? 1700000000,
+    streamEndTimestamp: overrides.streamEndTimestamp ?? 1800000000,
+  }) as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useStreamPaymentTransactions', () => {
+  it('returns empty array when predictedAddress is undefined', () => {
+    const actions = useStreamPaymentTransactions({ state: makeState() });
+    expect(actions).toEqual([]);
+  });
+
+  it('returns 2 actions for USDC currency (createStream + sendOrRegisterDebt)', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'USDC' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions).toHaveLength(2);
+    expect(actions[0].signature).toBe('createStream');
+    expect(actions[1].signature).toBe('sendOrRegisterDebt');
+  });
+
+  it('returns 3 actions for WETH currency (createStream + deposit + transfer)', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions).toHaveLength(3);
+    expect(actions[0].signature).toBe('createStream');
+    expect(actions[1].signature).toBe('deposit()');
+    expect(actions[2].signature).toBe('transfer');
+  });
+
+  it('createStream action address is nijiStreamFactoryAddress', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState(),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[0].address).toBe('0xFACTORY');
+  });
+
+  it('USDC sendOrRegisterDebt action address is nijiPayerAddress', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'USDC' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[1].address).toBe('0xPAYER');
+  });
+
+  it('WETH deposit + transfer actions use wethAddress', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[1].address).toBe('0xWETH');
+    expect(actions[2].address).toBe('0xWETH');
+  });
+
+  it('WETH deposit action value uses parseEther(amount)', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH', amount: '1' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[1].value).toBe(String(BigInt(1e18)));
+  });
+
+  it('USDC usdcValue is human2ContractUSDCFormat numeric value', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'USDC', amount: '50' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[0].usdcValue).toBe(50_000_000);
+  });
+
+  it('WETH currency keeps usdcValue=0 on all actions', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH', amount: '5' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions.every(a => a.usdcValue === 0)).toBe(true);
+  });
+
+  it('createStream decodedCalldata contains predictedAddress + streamStart/End timestamps', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ streamStartTimestamp: 1100, streamEndTimestamp: 2200 }),
+      predictedAddress: '0xPRED',
+    });
+    const parsed = JSON.parse(actions[0].decodedCalldata);
+    expect(parsed).toContain('0xPRED');
+    expect(parsed).toContain(1100);
+    expect(parsed).toContain(2200);
+  });
+
+  it('WETH transfer decodedCalldata contains predictedAddress + amount eth', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH', amount: '2' }),
+      predictedAddress: '0xPRED',
+    });
+    const parsed = JSON.parse(actions[2].decodedCalldata);
+    expect(parsed).toContain('0xPRED');
+    expect(parsed).toContain(String(BigInt(2e18)));
+  });
+
+  it('amount default "0" used when state.amount is missing', () => {
+    const stateWithoutAmount = {
+      actionType: 'STREAM',
+      address: '0xRECIPIENT' as `0x${string}`,
+      TransferFundsCurrency: 'USDC',
+      streamStartTimestamp: 1700000000,
+      streamEndTimestamp: 1800000000,
+    } as never;
+    const actions = useStreamPaymentTransactions({
+      state: stateWithoutAmount,
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[0].usdcValue).toBe(0);
+  });
+});

--- a/packages/niji-webapp/src/hooks/useSubgraphQuery.test.ts
+++ b/packages/niji-webapp/src/hooks/useSubgraphQuery.test.ts
@@ -1,0 +1,169 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useQueryMock = vi.fn();
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: unknown) => useQueryMock(opts),
+}));
+
+const configState: { subgraphApiUri: string } = { subgraphApiUri: 'https://subgraph.example' };
+vi.mock('@/config', () => ({
+  default: {
+    get app() {
+      return { subgraphApiUri: configState.subgraphApiUri };
+    },
+  },
+}));
+
+const executeMock = vi.fn();
+vi.mock('@/subgraphs/execute', () => ({
+  execute: (...args: unknown[]) => executeMock(...args),
+}));
+
+import { useSubgraphQuery } from './useSubgraphQuery';
+
+const fakeDocument = 'query GetThing { thing { id } }' as never;
+const fakeQueryKey = ['test-key'];
+
+const lastUseQueryOptions = (): {
+  queryKey: unknown[];
+  queryFn: () => unknown;
+  enabled: boolean;
+  refetchInterval: number | false;
+} => {
+  const lastCall = useQueryMock.mock.calls[useQueryMock.mock.calls.length - 1];
+  return lastCall[0];
+};
+
+beforeEach(() => {
+  configState.subgraphApiUri = 'https://subgraph.example';
+  useQueryMock.mockReset();
+  executeMock.mockReset();
+  useQueryMock.mockReturnValue({
+    isLoading: false,
+    data: undefined,
+    error: null,
+    refetch: () => {},
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useSubgraphQuery', () => {
+  it('passes queryKey to useQuery', () => {
+    renderHook(() => useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }));
+    expect(lastUseQueryOptions().queryKey).toBe(fakeQueryKey);
+  });
+
+  it('enabled=true + subgraphApiUri set results in useQuery.enabled=true', () => {
+    renderHook(() => useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }));
+    expect(lastUseQueryOptions().enabled).toBe(true);
+  });
+
+  it('subgraphApiUri empty disables query (enabled=false)', () => {
+    configState.subgraphApiUri = '';
+    renderHook(() => useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }));
+    expect(lastUseQueryOptions().enabled).toBe(false);
+  });
+
+  it('explicit enabled=false disables query', () => {
+    renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey, enabled: false }),
+    );
+    expect(lastUseQueryOptions().enabled).toBe(false);
+  });
+
+  it('queryFn invokes execute with document + variables', () => {
+    renderHook(() =>
+      useSubgraphQuery({
+        document: fakeDocument,
+        queryKey: fakeQueryKey,
+        variables: { id: '1' } as never,
+      }),
+    );
+    const opts = lastUseQueryOptions();
+    opts.queryFn();
+    expect(executeMock).toHaveBeenCalledWith(fakeDocument, { id: '1' });
+  });
+
+  it('default refetchInterval is false', () => {
+    renderHook(() => useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }));
+    expect(lastUseQueryOptions().refetchInterval).toBe(false);
+  });
+
+  it('explicit refetchInterval passes through', () => {
+    renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey, refetchInterval: 5000 }),
+    );
+    expect(lastUseQueryOptions().refetchInterval).toBe(5000);
+  });
+
+  it('maps useQuery isLoading to loading field', () => {
+    useQueryMock.mockReturnValue({
+      isLoading: true,
+      data: undefined,
+      error: null,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }),
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('maps useQuery data to data field', () => {
+    useQueryMock.mockReturnValue({
+      isLoading: false,
+      data: { proposals: [{ id: '1' }] },
+      error: null,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }),
+    );
+    expect(result.current.data).toEqual({ proposals: [{ id: '1' }] });
+  });
+
+  it('maps useQuery error to error field (truthy)', () => {
+    const err = new Error('boom');
+    useQueryMock.mockReturnValue({
+      isLoading: false,
+      data: undefined,
+      error: err,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }),
+    );
+    expect(result.current.error).toBe(err);
+  });
+
+  it('error null is normalized to undefined', () => {
+    useQueryMock.mockReturnValue({
+      isLoading: false,
+      data: undefined,
+      error: null,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }),
+    );
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('exposes refetch function from useQuery', () => {
+    const refetchMock = vi.fn();
+    useQueryMock.mockReturnValue({
+      isLoading: false,
+      data: undefined,
+      error: null,
+      refetch: refetchMock,
+    });
+    const { result } = renderHook(() =>
+      useSubgraphQuery({ document: fakeDocument, queryKey: fakeQueryKey }),
+    );
+    expect(result.current.refetch).toBe(refetchMock);
+  });
+});


### PR DESCRIPTION
## 概要

`webapp hooks part 61` として hooks 領域 3 file (`useStreamPaymentTransactions` 125 行 / `useSubgraphQuery` 45 行 / `useActivateLocale` 9 行) に vitest を追加、 1242 → 1270 (+28、 1 skip 維持)。 これで `src/hooks/` 配下の未テスト hook は `useChainPastAuctions.ts` (267 行) のみ残す状態。

## 詳細

### useStreamPaymentTransactions.test.ts (12 TC)

DAO proposal で stream payment 用 contract calls を組み立てる純粋関数 hook。 USDC currency で 2 actions (createStream + sendOrRegisterDebt)、 WETH currency で 3 actions (createStream + deposit + transfer)。

検証観点。

- predictedAddress 未指定で空配列
- USDC 2 actions / WETH 3 actions の構成
- createStream の address が nijiStreamFactoryAddress
- USDC sendOrRegisterDebt の address が nijiPayerAddress
- WETH deposit + transfer の address が wethAddress
- WETH deposit value が parseEther(amount)
- USDC usdcValue が human2ContractUSDCFormat 数値
- WETH 経路で全 actions の usdcValue=0
- decodedCalldata に predictedAddress + streamStart/End timestamp が含まれる
- WETH transfer decodedCalldata に predictedAddress + amount eth
- amount 未指定で default '0'

### useSubgraphQuery.test.ts (12 TC)

react-query `useQuery` + subgraph execute の薄 wrapper hook。

検証観点。

- queryKey が useQuery に流入
- subgraphApiUri 設定済み + enabled=true で useQuery.enabled=true
- subgraphApiUri 空で useQuery.enabled=false
- 明示 enabled=false で useQuery.enabled=false
- queryFn invoke で execute が document + variables 引数で呼出
- default refetchInterval=false
- 明示 refetchInterval 流入
- useQuery isLoading → loading field
- useQuery data → data field
- useQuery error (truthy) → error field
- useQuery error null → undefined 正規化
- useQuery refetch 関数を露出

### useActivateLocale.test.ts (4 TC)

jotai atom passthrough hook。

検証観点。

- en-US / ja-JP / zh-CN 任意 locale を atom から取得
- 1 render あたり useAtomValue 1 回呼出

## 解決方法

useStreamPaymentTransactions 側 ... `@niji/sdk/react` の各 ABI / address / `@/utils/streamingPaymentUtils` / `@/utils/usdcUtils` / `@/wagmi` / `viem` の encodeFunctionData / parseEther / parseAbi を vi.mock。 `formatTokenAmount` mock では USDC currency で `BigInt(amount * 1_000_000)` を返す stub にし USDC / WETH の分岐を可視化。

useSubgraphQuery 側 ... `@tanstack/react-query` useQuery / `@/config` (subgraphApiUri) / `@/subgraphs/execute` を vi.mock し、 `useQueryMock` の最後の呼出引数を `lastUseQueryOptions()` helper で取り出し検証。

useActivateLocale 側 ... `jotai/react` useAtomValue を vi.mock、 戻り値切替で各 locale 検証。

## 受入条件

- [x] 3 file 計 28 TC 全 pass
- [x] `pnpm vitest run` 全 1270 test green (1271 - 1 skipped)
- [x] regression なし (既存 1242 pass を破壊しない)

## 関連

- Closes #453
- 直前 PR #452 (part 60) で 1216 → 1242
- 残未テスト hook ... `useChainPastAuctions.ts` (267 行) のみで hooks 領域完走間近
- 次候補 ... useChainPastAuctions 単独大型 PR、 wrappers / utils 領域 expansion
