### PR TITLE
✅ test(niji-webapp): part 62 (useChainPastAuctions + ensLookup + tokenBuyer) で 1270 → 1301 — 1300 件大台到達 + hooks 完走 (Issue #455)

### DIFF
--- a/packages/niji-webapp/src/hooks/useChainPastAuctions.test.ts
+++ b/packages/niji-webapp/src/hooks/useChainPastAuctions.test.ts
@@ -1,0 +1,249 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useQueryMock = vi.fn();
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (opts: unknown) => useQueryMock(opts),
+}));
+
+const usePublicClientMock = vi.fn();
+vi.mock('wagmi', () => ({
+  usePublicClient: () => usePublicClientMock(),
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiAuctionHouseAddress: { 1: '0xAUCTIONHOUSE' as const },
+}));
+
+const configState: {
+  CHAIN_ID: number;
+  deployBlock: bigint | undefined;
+} = {
+  CHAIN_ID: 1,
+  deployBlock: 100n,
+};
+vi.mock('@/config', () => ({
+  default: {
+    get app() {
+      return { deployBlock: configState.deployBlock };
+    },
+  },
+  CHAIN_ID: {
+    valueOf: () => configState.CHAIN_ID,
+    toString: () => String(configState.CHAIN_ID),
+  },
+}));
+
+vi.mock('viem', async () => {
+  const actual = await vi.importActual<typeof import('viem')>('viem');
+  return {
+    ...actual,
+    parseAbiItem: (sig: string) => ({ type: 'event', signature: sig }),
+  };
+});
+
+import { useChainPastAuctions } from './useChainPastAuctions';
+
+const lastUseQueryOptions = (): {
+  queryKey: unknown[];
+  queryFn: (ctx: { signal?: AbortSignal }) => Promise<unknown>;
+  enabled: boolean;
+  refetchInterval: number;
+} => {
+  const lastCall = useQueryMock.mock.calls[useQueryMock.mock.calls.length - 1];
+  return lastCall[0];
+};
+
+beforeEach(() => {
+  configState.CHAIN_ID = 1;
+  configState.deployBlock = 100n;
+  useQueryMock.mockReset();
+  usePublicClientMock.mockReset();
+  useQueryMock.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  usePublicClientMock.mockReturnValue({
+    getBlockNumber: vi.fn().mockResolvedValue(200n),
+    getLogs: vi.fn().mockResolvedValue([]),
+    getBlock: vi.fn().mockResolvedValue({ timestamp: 1700000000n }),
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useChainPastAuctions', () => {
+  it('disables query when publicClient is undefined', () => {
+    usePublicClientMock.mockReturnValue(undefined);
+    renderHook(() => useChainPastAuctions(true));
+    expect(lastUseQueryOptions().enabled).toBe(false);
+  });
+
+  it('disables query when explicit enabled=false', () => {
+    renderHook(() => useChainPastAuctions(false));
+    expect(lastUseQueryOptions().enabled).toBe(false);
+  });
+
+  it('enables query when publicClient + auctionHouse + enabled=true', () => {
+    renderHook(() => useChainPastAuctions(true));
+    expect(lastUseQueryOptions().enabled).toBe(true);
+  });
+
+  it('queryKey includes auctionHouse address + deployBlock', () => {
+    renderHook(() => useChainPastAuctions(true));
+    const key = lastUseQueryOptions().queryKey;
+    expect(key[0]).toBe('chain-past-auctions');
+    expect(key[1]).toBe('0xAUCTIONHOUSE');
+    expect(key[2]).toBe('100');
+  });
+
+  it('queryKey uses "0" when deployBlock is undefined', () => {
+    configState.deployBlock = undefined;
+    renderHook(() => useChainPastAuctions(true));
+    const key = lastUseQueryOptions().queryKey;
+    expect(key[2]).toBe('0');
+  });
+
+  it('refetchInterval set to 10_000', () => {
+    renderHook(() => useChainPastAuctions(true));
+    expect(lastUseQueryOptions().refetchInterval).toBe(10_000);
+  });
+
+  it('returns useQuery data / isLoading / error fields directly', () => {
+    const err = new Error('rpc');
+    useQueryMock.mockReturnValue({
+      data: { __typename: 'Query', auctions: [] },
+      isLoading: true,
+      error: err,
+    });
+    const { result } = renderHook(() => useChainPastAuctions(true));
+    expect(result.current.data).toEqual({ __typename: 'Query', auctions: [] });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBe(err);
+  });
+
+  it('queryFn fetches getBlockNumber + 3 getLogs (created/settled/bid)', async () => {
+    const getLogsSpy = vi.fn().mockResolvedValue([]);
+    const getBlockNumberSpy = vi.fn().mockResolvedValue(200n);
+    const getBlockSpy = vi.fn().mockResolvedValue({ timestamp: 1700n });
+    usePublicClientMock.mockReturnValue({
+      getBlockNumber: getBlockNumberSpy,
+      getLogs: getLogsSpy,
+      getBlock: getBlockSpy,
+    });
+    renderHook(() => useChainPastAuctions(true));
+    const result = await lastUseQueryOptions().queryFn({ signal: undefined });
+    expect(getBlockNumberSpy).toHaveBeenCalled();
+    expect(getLogsSpy).toHaveBeenCalledTimes(3);
+    expect((result as { auctions: unknown[] }).auctions).toEqual([]);
+  });
+
+  it('queryFn aggregates AuctionCreated + Settled + Bid into auctions array', async () => {
+    const getLogsSpy = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          args: { nounId: 1n, startTime: 1700n, endTime: 1800n },
+          blockNumber: 100n,
+          transactionHash: '0xc1' as `0x${string}`,
+          transactionIndex: 0,
+        },
+      ])
+      .mockResolvedValueOnce([{ args: { nounId: 1n, winner: '0xWINNER', amount: 5000n } }])
+      .mockResolvedValueOnce([
+        {
+          args: { nounId: 1n, sender: '0xBIDDER', value: 4000n, extended: false },
+          blockNumber: 101n,
+          transactionHash: '0xb1' as `0x${string}`,
+          transactionIndex: 1,
+        },
+      ]);
+    usePublicClientMock.mockReturnValue({
+      getBlockNumber: vi.fn().mockResolvedValue(200n),
+      getLogs: getLogsSpy,
+      getBlock: vi.fn().mockResolvedValue({ timestamp: 1701n }),
+    });
+    renderHook(() => useChainPastAuctions(true));
+    const result = (await lastUseQueryOptions().queryFn({ signal: undefined })) as {
+      auctions: Array<{
+        id: string;
+        amount: string;
+        settled: boolean;
+        bidder: { id: string } | null;
+        noun: { owner: { id: string } };
+        bids: Array<{ amount: string }>;
+      }>;
+    };
+    expect(result.auctions).toHaveLength(1);
+    expect(result.auctions[0].id).toBe('1');
+    expect(result.auctions[0].amount).toBe('5000');
+    expect(result.auctions[0].settled).toBe(true);
+    expect(result.auctions[0].bidder?.id).toBe('0xWINNER');
+    expect(result.auctions[0].noun.owner.id).toBe('0xWINNER');
+    expect(result.auctions[0].bids).toHaveLength(1);
+    expect(result.auctions[0].bids[0].amount).toBe('4000');
+  });
+
+  it('queryFn returns ZERO_ADDRESS owner for unsettled auction', async () => {
+    const getLogsSpy = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          args: { nounId: 2n, startTime: 1700n, endTime: 1800n },
+          blockNumber: 100n,
+          transactionHash: '0xc2' as `0x${string}`,
+          transactionIndex: 0,
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    usePublicClientMock.mockReturnValue({
+      getBlockNumber: vi.fn().mockResolvedValue(200n),
+      getLogs: getLogsSpy,
+      getBlock: vi.fn().mockResolvedValue({ timestamp: 1701n }),
+    });
+    renderHook(() => useChainPastAuctions(true));
+    const result = (await lastUseQueryOptions().queryFn({ signal: undefined })) as {
+      auctions: Array<{ noun: { owner: { id: string } }; settled: boolean; bidder: unknown }>;
+    };
+    expect(result.auctions[0].noun.owner.id).toBe('0x0000000000000000000000000000000000000000');
+    expect(result.auctions[0].settled).toBe(false);
+    expect(result.auctions[0].bidder).toBeNull();
+  });
+
+  it('queryFn sorts auctions by nounId desc', async () => {
+    const getLogsSpy = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          args: { nounId: 1n, startTime: 1700n, endTime: 1800n },
+          blockNumber: 100n,
+          transactionHash: '0xc1' as `0x${string}`,
+          transactionIndex: 0,
+        },
+        {
+          args: { nounId: 5n, startTime: 1700n, endTime: 1800n },
+          blockNumber: 101n,
+          transactionHash: '0xc5' as `0x${string}`,
+          transactionIndex: 0,
+        },
+        {
+          args: { nounId: 3n, startTime: 1700n, endTime: 1800n },
+          blockNumber: 102n,
+          transactionHash: '0xc3' as `0x${string}`,
+          transactionIndex: 0,
+        },
+      ])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    usePublicClientMock.mockReturnValue({
+      getBlockNumber: vi.fn().mockResolvedValue(200n),
+      getLogs: getLogsSpy,
+      getBlock: vi.fn().mockResolvedValue({ timestamp: 1701n }),
+    });
+    renderHook(() => useChainPastAuctions(true));
+    const result = (await lastUseQueryOptions().queryFn({ signal: undefined })) as {
+      auctions: Array<{ id: string }>;
+    };
+    expect(result.auctions.map(a => a.id)).toEqual(['5', '3', '1']);
+  });
+});

--- a/packages/niji-webapp/src/utils/ensLookup.test.ts
+++ b/packages/niji-webapp/src/utils/ensLookup.test.ts
@@ -1,0 +1,112 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const lookupNNSOrENSMock = vi.fn();
+vi.mock('./lookupNNSOrENS', () => ({
+  lookupNNSOrENS: (...args: unknown[]) => lookupNNSOrENSMock(...args),
+}));
+
+const usePublicClientMock = vi.fn();
+vi.mock('wagmi', () => ({
+  usePublicClient: () => usePublicClientMock(),
+}));
+
+vi.mock('@/config', () => ({
+  cache: { ens: 'ens' },
+  cacheKey: (bucket: string, chainId: number, address: string) => `${bucket}-${chainId}-${address}`,
+  CHAIN_ID: 1,
+}));
+
+import { ensCacheKey, useReverseENSLookUp } from './ensLookup';
+
+beforeEach(() => {
+  lookupNNSOrENSMock.mockReset();
+  usePublicClientMock.mockReset();
+  usePublicClientMock.mockReturnValue({ chain: { id: 1 } });
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('ensCacheKey', () => {
+  it('builds key with bucket "ens" + chainId + address', () => {
+    expect(ensCacheKey('0xABC')).toBe('ens-1-0xABC');
+  });
+
+  it('different addresses produce different keys', () => {
+    expect(ensCacheKey('0xABC')).not.toBe(ensCacheKey('0xDEF'));
+  });
+});
+
+describe('useReverseENSLookUp', () => {
+  const validAddress = '0x1234567890123456789012345678901234567890' as `0x${string}`;
+
+  it('returns cached ens name when localStorage has unexpired entry', () => {
+    const futureExpires = Date.now() / 1000 + 1000;
+    localStorage.setItem(
+      ensCacheKey(validAddress),
+      JSON.stringify({ name: 'cached.eth', expires: futureExpires }),
+    );
+    const { result } = renderHook(() => useReverseENSLookUp(validAddress));
+    expect(result.current).toBe('cached.eth');
+    expect(lookupNNSOrENSMock).not.toHaveBeenCalled();
+  });
+
+  it('removes expired cache entry and calls lookupNNSOrENS', async () => {
+    const pastExpires = Date.now() / 1000 - 1000;
+    localStorage.setItem(
+      ensCacheKey(validAddress),
+      JSON.stringify({ name: 'old.eth', expires: pastExpires }),
+    );
+    lookupNNSOrENSMock.mockResolvedValue('fresh.eth');
+    const { result } = renderHook(() => useReverseENSLookUp(validAddress));
+    await waitFor(() => expect(lookupNNSOrENSMock).toHaveBeenCalled());
+    await waitFor(() => expect(result.current).toBe('fresh.eth'));
+  });
+
+  it('skips when address is empty', () => {
+    renderHook(() => useReverseENSLookUp('' as `0x${string}`));
+    expect(lookupNNSOrENSMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when publicClient is undefined', () => {
+    usePublicClientMock.mockReturnValue(undefined);
+    renderHook(() => useReverseENSLookUp(validAddress));
+    expect(lookupNNSOrENSMock).not.toHaveBeenCalled();
+  });
+
+  it('stores resolved ens name in localStorage with 30 min ttl', async () => {
+    lookupNNSOrENSMock.mockResolvedValue('user.eth');
+    const { result } = renderHook(() => useReverseENSLookUp(validAddress));
+    await waitFor(() => expect(result.current).toBe('user.eth'));
+    const stored = localStorage.getItem(ensCacheKey(validAddress));
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored ?? '{}');
+    expect(parsed.name).toBe('user.eth');
+    expect(parsed.expires).toBeGreaterThan(Date.now() / 1000);
+  });
+
+  it('does nothing when lookupNNSOrENS returns falsy (no cache write)', async () => {
+    lookupNNSOrENSMock.mockResolvedValue(null);
+    renderHook(() => useReverseENSLookUp(validAddress));
+    await waitFor(() => expect(lookupNNSOrENSMock).toHaveBeenCalled());
+    expect(localStorage.getItem(ensCacheKey(validAddress))).toBeNull();
+  });
+
+  it('catches lookupNNSOrENS rejection via console.warn (no crash)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    lookupNNSOrENSMock.mockRejectedValue(new Error('rpc fail'));
+    renderHook(() => useReverseENSLookUp(validAddress));
+    await waitFor(() => expect(warnSpy).toHaveBeenCalled());
+    warnSpy.mockRestore();
+  });
+
+  it('returns undefined initially when no cache and lookup is pending', () => {
+    lookupNNSOrENSMock.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useReverseENSLookUp(validAddress));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/niji-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.test.ts
+++ b/packages/niji-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useReadNijiTokenBuyerEthNeededMock = vi.fn();
+vi.mock('@niji/sdk/react', () => ({
+  useReadNijiTokenBuyerEthNeeded: (...args: unknown[]) =>
+    useReadNijiTokenBuyerEthNeededMock(...args),
+}));
+
+import { useEthNeeded } from './tokenBuyer';
+
+const lastCallOpts = (): {
+  args: [bigint, bigint];
+  query: { enabled: boolean };
+} => {
+  const calls = useReadNijiTokenBuyerEthNeededMock.mock.calls;
+  return calls[calls.length - 1][0];
+};
+
+beforeEach(() => {
+  useReadNijiTokenBuyerEthNeededMock.mockReset();
+  useReadNijiTokenBuyerEthNeededMock.mockReturnValue({ data: undefined });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useEthNeeded', () => {
+  it('returns undefined when hook data is undefined', () => {
+    const { result } = renderHook(() => useEthNeeded('0xADDR', 10));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns ethNeeded.toString() when hook returns data', () => {
+    useReadNijiTokenBuyerEthNeededMock.mockReturnValue({ data: 1000n });
+    const { result } = renderHook(() => useEthNeeded('0xADDR', 10));
+    expect(result.current).toBe('1000');
+  });
+
+  it('passes BigInt(additionalTokens) + BUFFER_BPS (5000n) as args', () => {
+    renderHook(() => useEthNeeded('0xADDR', 25));
+    expect(lastCallOpts().args).toEqual([25n, 5000n]);
+  });
+
+  it('enables hook when address is non-empty + skip not set', () => {
+    renderHook(() => useEthNeeded('0xADDR', 10));
+    expect(lastCallOpts().query.enabled).toBe(true);
+  });
+
+  it('disables hook when address is empty string', () => {
+    renderHook(() => useEthNeeded('', 10));
+    expect(lastCallOpts().query.enabled).toBe(false);
+  });
+
+  it('disables hook when skip=true', () => {
+    renderHook(() => useEthNeeded('0xADDR', 10, true));
+    expect(lastCallOpts().query.enabled).toBe(false);
+  });
+
+  it('disables hook when skip=true even with valid address', () => {
+    renderHook(() => useEthNeeded('0xADDR', 10, true));
+    expect(lastCallOpts().query.enabled).toBe(false);
+  });
+
+  it('enables hook when skip=false explicitly + address valid', () => {
+    renderHook(() => useEthNeeded('0xADDR', 10, false));
+    expect(lastCallOpts().query.enabled).toBe(true);
+  });
+
+  it('returns undefined for ethNeeded=0n (falsy)', () => {
+    useReadNijiTokenBuyerEthNeededMock.mockReturnValue({ data: 0n });
+    const { result } = renderHook(() => useEthNeeded('0xADDR', 10));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('handles additionalTokens=0 with BigInt(0)', () => {
+    renderHook(() => useEthNeeded('0xADDR', 0));
+    expect(lastCallOpts().args).toEqual([0n, 5000n]);
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 62` として残最終 hook (`hooks/useChainPastAuctions` 267 行) + utils 領域 2 file (`utils/ensLookup` 62 行 / `utils/tokenBuyerContractUtils/tokenBuyer` 12 行) に vitest を追加、 1270 → **1301** (+31、 1 skip 維持)。

**マイルストーン達成** ... `src/hooks/` 配下未テスト hook **ゼロ達成** + `src/utils/` 領域 expansion 進行 + **1300 件大台到達**。

## 詳細

### hooks/useChainPastAuctions.test.ts (11 TC)

chain event log から過去 auction 履歴を構築する hook。 useQuery + getLogs paginate + AuctionCreated/Settled/Bid 集約。

検証観点。

- publicClient undefined で useQuery.enabled=false
- enabled=false で query 未実行
- 有効状態で useQuery.enabled=true
- queryKey が `['chain-past-auctions', auctionHouse, deployBlock]`
- deployBlock undefined で queryKey に「0」 fallback
- refetchInterval=10_000
- useQuery 戻り値 data/isLoading/error を直接 return
- queryFn が getBlockNumber + 3 getLogs (created/settled/bid) 呼出
- queryFn で AuctionCreated + Settled + Bid を auctions 配列に集約
- 未 settle auction の owner が ZERO_ADDRESS
- queryFn が auctions を nounId desc sort

### utils/ensLookup.test.ts (10 TC)

reverse ENS lookup hook + cache key 生成 helper。 localStorage cache (30 min TTL) + lookupNNSOrENS fallback。

検証観点。

- ensCacheKey 関数 ... bucket + chainId + address で組立
- 異なる address で異なる key
- cached unexpired entry を直接 return
- expired cache 削除 + lookupNNSOrENS 呼出
- 空 address で skip
- publicClient undefined で skip
- 解決した名前を localStorage 保存 (30 min TTL)
- lookupNNSOrENS が falsy 返却で cache 書込なし
- lookupNNSOrENS rejection で console.warn catch
- pending lookup で undefined return

### utils/tokenBuyerContractUtils/tokenBuyer.test.ts (10 TC)

DAO の TokenBuyer contract から eth 必要量を取得する hook。

検証観点。

- data undefined で undefined return
- data 提供で toString return
- args が [BigInt(additionalTokens), 5000n (BUFFER_BPS)]
- address 非空 + skip 未指定で enabled=true
- address 空で enabled=false
- skip=true で enabled=false
- skip=true + 有効 address でも enabled=false
- skip=false 明示 + 有効 address で enabled=true
- data=0n (falsy) で undefined return
- additionalTokens=0 で args[0]=0n

## 解決方法

useChainPastAuctions 側 ... `wagmi` usePublicClient / `@niji/sdk/react` nijiAuctionHouseAddress / `@/config` (CHAIN_ID, deployBlock) / `@tanstack/react-query` useQuery / `viem` parseAbiItem を vi.mock。 useQuery を mock で記録し `lastUseQueryOptions()` helper で最終呼出引数を取得、 `queryFn` を直接 invoke して内部経路 (getBlockNumber + getLogs + getBlock + 集約) を assert。

utils/ensLookup 側 ... `./lookupNNSOrENS` + `wagmi.usePublicClient` + `@/config` cache/cacheKey/CHAIN_ID を vi.mock。 `localStorage.clear()` を beforeEach で初期化、 expired / unexpired 経路を future/past Date 切替で検証。

utils/tokenBuyer 側 ... `@niji/sdk/react` useReadNijiTokenBuyerEthNeeded を vi.mock、 mock 引数を `lastCallOpts()` helper で取得し enabled + args の組合せ網羅。

## 受入条件

- [x] 3 file 計 31 TC 全 pass
- [x] `pnpm vitest run` 全 1301 test green (1302 - 1 skipped) — **1300 件大台到達**
- [x] regression なし (既存 1270 pass を破壊しない)
- [x] **`src/hooks/` 配下未テスト hook ゼロ達成** (useChainPastAuctions 完了)

## 関連

- Closes #455
- 直前 PR #454 (part 61) で 1242 → 1270
- 残未テスト utils ... `types.ts` (43 行 type-only) / `lookupNNSOrENS` (54 行) / `svg2png` (60 行) / `proposals` (52 行) 等、 utils 領域はまだ大量 expansion 余地
- 学び ... useQuery wrapper test は mock した useQuery の最終 call で options を取り出して queryFn を直接 invoke する pattern (将来 react-query 系 hook test の base case)
