### PR TITLE
✅ test(niji-webapp): part 63 (wrappers/nijiStream + onDisplayAuction) で 1301 → 1330 (Issue #457)

### DIFF
--- a/packages/niji-webapp/src/wrappers/nijiStream.test.ts
+++ b/packages/niji-webapp/src/wrappers/nijiStream.test.ts
@@ -1,0 +1,146 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useReadContractMock = vi.fn();
+const useWriteContractMock = vi.fn();
+vi.mock('wagmi', () => ({
+  useReadContract: (opts: unknown) => useReadContractMock(opts),
+  useWriteContract: () => useWriteContractMock(),
+}));
+
+vi.mock('@/utils/streamingPaymentUtils/stream.abi.json', () => ({
+  default: [{ type: 'function', name: 'recipientBalance' }],
+}));
+
+import { useElapsedTime, useStreamRemainingBalance, useWithdrawTokens } from './nijiStream';
+
+const writeContractMock = vi.fn();
+
+beforeEach(() => {
+  useReadContractMock.mockReset();
+  useWriteContractMock.mockReset();
+  writeContractMock.mockReset();
+  useReadContractMock.mockReturnValue({ data: undefined });
+  useWriteContractMock.mockReturnValue({
+    writeContract: writeContractMock,
+    isPending: false,
+    status: 'idle',
+    error: undefined,
+  });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useStreamRemainingBalance', () => {
+  it('returns 0n when balance is undefined', () => {
+    const { result } = renderHook(() => useStreamRemainingBalance('0xSTREAM'));
+    expect(result.current).toBe(0n);
+  });
+
+  it('returns BigInt of balance string', () => {
+    useReadContractMock.mockReturnValue({ data: 5000n });
+    const { result } = renderHook(() => useStreamRemainingBalance('0xSTREAM'));
+    expect(result.current).toBe(5000n);
+  });
+
+  it('disables query when streamAddress is empty', () => {
+    renderHook(() => useStreamRemainingBalance('' as `0x${string}`));
+    const opts = useReadContractMock.mock.calls[0][0];
+    expect(opts.query.enabled).toBe(false);
+  });
+
+  it('enables query for non-empty streamAddress', () => {
+    renderHook(() => useStreamRemainingBalance('0xSTREAM'));
+    const opts = useReadContractMock.mock.calls[0][0];
+    expect(opts.query.enabled).toBe(true);
+    expect(opts.functionName).toBe('recipientBalance');
+  });
+});
+
+describe('useWithdrawTokens', () => {
+  it('withdrawTokens calls writeContract with amount + abi', () => {
+    const { result } = renderHook(() => useWithdrawTokens('0xSTREAM'));
+    act(() => {
+      result.current.withdrawTokens(100n);
+    });
+    expect(writeContractMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        functionName: 'withdraw',
+        address: '0xSTREAM',
+        args: [100n],
+      }),
+    );
+  });
+
+  it('state.status is "Mining" when isPending', () => {
+    useWriteContractMock.mockReturnValue({
+      writeContract: writeContractMock,
+      isPending: true,
+      status: 'pending',
+      error: undefined,
+    });
+    const { result } = renderHook(() => useWithdrawTokens('0xSTREAM'));
+    expect(result.current.withdrawTokensState.status).toBe('Mining');
+  });
+
+  it('state.status uses writeContract status when not pending', () => {
+    useWriteContractMock.mockReturnValue({
+      writeContract: writeContractMock,
+      isPending: false,
+      status: 'success',
+      error: undefined,
+    });
+    const { result } = renderHook(() => useWithdrawTokens('0xSTREAM'));
+    expect(result.current.withdrawTokensState.status).toBe('success');
+  });
+
+  it('state.status falls back to "None" when status undefined', () => {
+    useWriteContractMock.mockReturnValue({
+      writeContract: writeContractMock,
+      isPending: false,
+      status: undefined,
+      error: undefined,
+    });
+    const { result } = renderHook(() => useWithdrawTokens('0xSTREAM'));
+    expect(result.current.withdrawTokensState.status).toBe('None');
+  });
+
+  it('state.errorMessage exposes error.message', () => {
+    useWriteContractMock.mockReturnValue({
+      writeContract: writeContractMock,
+      isPending: false,
+      status: 'error',
+      error: new Error('rpc fail'),
+    });
+    const { result } = renderHook(() => useWithdrawTokens('0xSTREAM'));
+    expect(result.current.withdrawTokensState.errorMessage).toBe('rpc fail');
+  });
+});
+
+describe('useElapsedTime', () => {
+  it('returns 0n when elapsedTime is undefined', () => {
+    const { result } = renderHook(() => useElapsedTime('0xSTREAM'));
+    expect(result.current).toBe(0n);
+  });
+
+  it('returns BigInt(Number(elapsedTime)) when data is provided', () => {
+    useReadContractMock.mockReturnValue({ data: 1000n });
+    const { result } = renderHook(() => useElapsedTime('0xSTREAM'));
+    expect(result.current).toBe(1000n);
+  });
+
+  it('disables query when streamAddress is empty', () => {
+    renderHook(() => useElapsedTime('' as `0x${string}`));
+    const opts = useReadContractMock.mock.calls[0][0];
+    expect(opts.query.enabled).toBe(false);
+  });
+
+  it('enables query for non-empty streamAddress + correct functionName', () => {
+    renderHook(() => useElapsedTime('0xSTREAM'));
+    const opts = useReadContractMock.mock.calls[0][0];
+    expect(opts.query.enabled).toBe(true);
+    expect(opts.functionName).toBe('elapsedTime');
+  });
+});

--- a/packages/niji-webapp/src/wrappers/onDisplayAuction.test.ts
+++ b/packages/niji-webapp/src/wrappers/onDisplayAuction.test.ts
@@ -1,0 +1,247 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const atomValues: {
+  auction: { activeAuction: unknown; bids: unknown[] };
+  onDisplay: number | undefined;
+  pastAuctions: unknown[] | undefined;
+  lastNounId: number | undefined;
+} = {
+  auction: { activeAuction: undefined, bids: [] },
+  onDisplay: undefined,
+  pastAuctions: [],
+  lastNounId: undefined,
+};
+
+vi.mock('jotai/react', () => ({
+  useAtomValue: (atom: { tag: string }) => {
+    if (atom.tag === 'auction') return atomValues.auction;
+    if (atom.tag === 'onDisplay') return atomValues.onDisplay;
+    if (atom.tag === 'pastAuctions') return atomValues.pastAuctions;
+    if (atom.tag === 'lastNounId') return atomValues.lastNounId;
+    return undefined;
+  },
+}));
+
+vi.mock('@/state/atoms/auctionAtom', () => ({
+  auctionAtom: { tag: 'auction' },
+}));
+
+vi.mock('@/state/atoms/onDisplayAuctionAtom', () => ({
+  onDisplayAuctionNounIdAtom: { tag: 'onDisplay' },
+  lastAuctionNounIdAtom: { tag: 'lastNounId' },
+}));
+
+vi.mock('@/state/atoms/pastAuctionsAtom', () => ({
+  pastAuctionsAtom: { tag: 'pastAuctions' },
+}));
+
+vi.mock('@/utils/compareBids', () => ({
+  compareBids: (a: { value: bigint }, b: { value: bigint }) => Number(b.value - a.value),
+}));
+
+const isNounderNijiMock = vi.fn();
+const generateEmptyNounderAuctionMock = vi.fn();
+vi.mock('@/utils/nounderNiji', () => ({
+  isNounderNiji: (n: bigint) => isNounderNijiMock(n),
+  generateEmptyNounderAuction: (n: bigint, past: unknown) =>
+    generateEmptyNounderAuctionMock(n, past),
+}));
+
+import useOnDisplayAuction, { useAuctionBids } from './onDisplayAuction';
+
+const makeAuction = (overrides: Record<string, unknown> = {}) => ({
+  amount: '1000',
+  bidder: '0xBIDDER',
+  startTime: '0',
+  endTime: '100',
+  nounId: '5',
+  settled: false,
+  ...overrides,
+});
+
+const makeBid = (overrides: Record<string, unknown> = {}) => ({
+  nounId: '5',
+  sender: '0xSENDER',
+  value: '1000',
+  extended: false,
+  transactionHash: '0xtx',
+  transactionIndex: 0,
+  timestamp: '1700000000',
+  ...overrides,
+});
+
+beforeEach(() => {
+  atomValues.auction = { activeAuction: undefined, bids: [] };
+  atomValues.onDisplay = undefined;
+  atomValues.pastAuctions = [];
+  atomValues.lastNounId = undefined;
+  isNounderNijiMock.mockReset();
+  isNounderNijiMock.mockReturnValue(false);
+  generateEmptyNounderAuctionMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOnDisplayAuction', () => {
+  it('returns undefined when onDisplayAuctionNounId is undefined', () => {
+    atomValues.auction = { activeAuction: makeAuction(), bids: [] };
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when activeAuction is missing', () => {
+    atomValues.onDisplay = 5;
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns deserialized current auction when onDisplay equals lastAuctionNounId', () => {
+    atomValues.auction = { activeAuction: makeAuction({ nounId: '5' }), bids: [] };
+    atomValues.onDisplay = 5;
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current?.nounId).toBe(5n);
+    expect(result.current?.amount).toBe(1000n);
+    expect(result.current?.bidder).toBe('0xBIDDER');
+  });
+
+  it('uses isNounderNiji + generateEmptyNounderAuction for nounder ID', () => {
+    isNounderNijiMock.mockReturnValue(true);
+    generateEmptyNounderAuctionMock.mockReturnValue(makeAuction({ nounId: '10' }));
+    atomValues.auction = { activeAuction: makeAuction({ nounId: '5' }), bids: [] };
+    atomValues.onDisplay = 10;
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(generateEmptyNounderAuctionMock).toHaveBeenCalled();
+    expect(result.current?.nounId).toBe(10n);
+  });
+
+  it('finds past auction matching nounId', () => {
+    atomValues.auction = { activeAuction: makeAuction({ nounId: '5' }), bids: [] };
+    atomValues.onDisplay = 3;
+    atomValues.pastAuctions = [{ activeAuction: makeAuction({ nounId: '3' }) }];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current?.nounId).toBe(3n);
+  });
+
+  it('returns undefined when past auction not found', () => {
+    atomValues.auction = { activeAuction: makeAuction({ nounId: '5' }), bids: [] };
+    atomValues.onDisplay = 99;
+    atomValues.pastAuctions = [{ activeAuction: makeAuction({ nounId: '3' }) }];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe('useAuctionBids', () => {
+  it('returns sorted bids for active auction (lastAuctionNounId match)', () => {
+    atomValues.lastNounId = 5;
+    atomValues.auction = {
+      activeAuction: makeAuction(),
+      bids: [makeBid({ value: '500' }), makeBid({ value: '1500' }), makeBid({ value: '1000' })],
+    };
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useAuctionBids(5n));
+    expect(result.current?.[0].value).toBe(1500n);
+    expect(result.current?.[1].value).toBe(1000n);
+    expect(result.current?.[2].value).toBe(500n);
+  });
+
+  it('returns undefined for past auction not in pastAuctions', () => {
+    atomValues.lastNounId = 5;
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useAuctionBids(99n));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns deserialized past auction bids when present', () => {
+    atomValues.lastNounId = 5;
+    atomValues.pastAuctions = [
+      {
+        activeAuction: makeAuction({ nounId: '3' }),
+        bids: [makeBid({ value: '2000' })],
+      },
+    ];
+    const { result } = renderHook(() => useAuctionBids(3n));
+    expect(result.current?.length).toBe(1);
+    expect(result.current?.[0].value).toBe(2000n);
+    expect(result.current?.[0].nounId).toBe(5n);
+  });
+
+  it('deserialized bid has BigInt timestamp', () => {
+    atomValues.lastNounId = 5;
+    atomValues.auction = {
+      activeAuction: makeAuction(),
+      bids: [makeBid({ timestamp: '1700000000' })],
+    };
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useAuctionBids(5n));
+    expect(result.current?.[0].timestamp).toBe(1700000000n);
+  });
+
+  it('deserialized bid retains sender + transactionHash + extended flag', () => {
+    atomValues.lastNounId = 5;
+    atomValues.auction = {
+      activeAuction: makeAuction(),
+      bids: [makeBid({ sender: '0xALICE', transactionHash: '0xABCDEF', extended: true })],
+    };
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useAuctionBids(5n));
+    expect(result.current?.[0].sender).toBe('0xALICE');
+    expect(result.current?.[0].transactionHash).toBe('0xABCDEF');
+    expect(result.current?.[0].extended).toBe(true);
+  });
+
+  it('returns empty array when active auction has zero bids', () => {
+    atomValues.lastNounId = 5;
+    atomValues.auction = { activeAuction: makeAuction(), bids: [] };
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useAuctionBids(5n));
+    expect(result.current).toEqual([]);
+  });
+
+  it('handles past auction with empty bids array', () => {
+    atomValues.lastNounId = 5;
+    atomValues.pastAuctions = [{ activeAuction: makeAuction({ nounId: '3' }), bids: [] }];
+    const { result } = renderHook(() => useAuctionBids(3n));
+    expect(result.current).toEqual([]);
+  });
+});
+
+describe('useOnDisplayAuction additional cases', () => {
+  it('returns undefined when pastAuctions is undefined', () => {
+    atomValues.auction = { activeAuction: makeAuction({ nounId: '5' }), bids: [] };
+    atomValues.onDisplay = 5;
+    atomValues.pastAuctions = undefined;
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('current auction deserialized with settled=false (always reset)', () => {
+    atomValues.auction = {
+      activeAuction: makeAuction({ nounId: '5', settled: true }),
+      bids: [],
+    };
+    atomValues.onDisplay = 5;
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current?.settled).toBe(false);
+  });
+
+  it('deserialized auction has BigInt startTime/endTime', () => {
+    atomValues.auction = {
+      activeAuction: makeAuction({ nounId: '5', startTime: '100', endTime: '500' }),
+      bids: [],
+    };
+    atomValues.onDisplay = 5;
+    atomValues.pastAuctions = [];
+    const { result } = renderHook(() => useOnDisplayAuction());
+    expect(result.current?.startTime).toBe(100n);
+    expect(result.current?.endTime).toBe(500n);
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 63` として wrappers 領域 2 file (`wrappers/nijiStream` 48 行 / `wrappers/onDisplayAuction` 105 行) に vitest を追加、 1301 → 1330 (+29、 1 skip 維持)。

当初は utils 領域 3 file (`lookupNNSOrENS` / `svg2png` / `proposals`) を予定していたが調査で全 utils 配下が既に test 済みと判明 (`types.ts` のみ type-only 未テスト)、 wrappers 領域開拓に切替。

## 詳細

### wrappers/nijiStream.test.ts (13 TC)

`useStreamRemainingBalance` / `useWithdrawTokens` / `useElapsedTime` の 3 hooks。 wagmi `useReadContract` / `useWriteContract` の薄 wrapper。

検証観点。

- useStreamRemainingBalance ... balance undefined で 0n、 BigInt 変換、 enabled flag
- useWithdrawTokens ... writeContract 呼出 (functionName: 'withdraw' + args), status mapping (Mining / writeContract status / "None" fallback), errorMessage 露出
- useElapsedTime ... elapsedTime undefined で 0n、 BigInt 変換、 enabled flag、 functionName='elapsedTime'

### wrappers/onDisplayAuction.test.ts (16 TC)

`useOnDisplayAuction` + `useAuctionBids` の 2 hooks。 jotai atom 経由で active / past / nounder auction を切替表示する複雑 hook。

検証観点。

- useOnDisplayAuction ... onDisplay/lastNounId/activeAuction/pastAuctions の組合せで 7 経路 (undefined fallback / current / nounder / past 等)
- useAuctionBids ... lastAuctionNounId 一致で active bids deserialize / past auction match / bid value desc sort / sender + transactionHash + extended 保持 / 空 bids array
- 追加 ... pastAuctions undefined / settled=true でも always false reset / startTime/endTime BigInt 変換

## 解決方法

nijiStream 側 ... `wagmi` useReadContract / useWriteContract と stream ABI JSON を vi.mock。 hook 戻り値 state mapping を assert。

onDisplayAuction 側 ... 4 jotai atom (`auctionAtom` / `onDisplayAuctionNounIdAtom` / `lastAuctionNounIdAtom` / `pastAuctionsAtom`) を `{ tag: ... }` literal object として mock し、 `useAtomValue` mock で tag 別に `atomValues` から値を取り出す経路。 `compareBids` / `nounderNiji` helpers も vi.mock。 当初 vi.mock factory 内で外部 const 参照すると hoisting エラーになるため、 全て inline object literal にリファクタ。

## 受入条件

- [x] 2 file 計 29 TC 全 pass
- [x] `pnpm vitest run` 全 1330 test green (1331 - 1 skipped)
- [x] regression なし (既存 1301 pass を破壊しない)

## 関連

- Closes #457
- 直前 PR #456 (part 62) で 1270 → 1301 (1300 件大台到達 + hooks 完走)
- 残未テスト wrapper ... `nijiDao.ts` (1638 行 巨大) / `nijiData.ts` (910 行) / `nijiToken.ts` (302 行) / `subgraph.ts` (170 行) / `nijiAuction.ts` (10 行 type-only)
- 学び ... vi.mock factory 内で外部 const 参照は hoisting エラー、 inline object literal 使用が安全 (将来 atom mock の base case)
