### PR TITLE
✅ test(niji-webapp): part 64 (wrappers/subgraph + nijiToken) で 1330 → 1376 (Issue #459)

### DIFF
--- a/packages/niji-webapp/src/wrappers/nijiToken.test.ts
+++ b/packages/niji-webapp/src/wrappers/nijiToken.test.ts
@@ -1,0 +1,417 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hookState: {
+  account: string | undefined;
+  votes: bigint | undefined;
+  priorVotes: bigint | undefined;
+  delegate: string | undefined;
+  balance: bigint | undefined;
+  isApproved: boolean;
+  seedsTuple: bigint[] | undefined;
+  subgraphData: unknown;
+  subgraphLoading: boolean;
+  subgraphError: unknown;
+  delegateState: {
+    isPending: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    data: string | undefined;
+    error: Error | undefined;
+  };
+  approvalState: {
+    isPending: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    data: string | undefined;
+    error: Error | undefined;
+  };
+} = {
+  account: '0xUSER',
+  votes: 5n,
+  priorVotes: 3n,
+  delegate: '0xDELEGATE',
+  balance: 2n,
+  isApproved: false,
+  seedsTuple: undefined,
+  subgraphData: undefined,
+  subgraphLoading: false,
+  subgraphError: null,
+  delegateState: {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    data: undefined,
+    error: undefined,
+  },
+  approvalState: {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    data: undefined,
+    error: undefined,
+  },
+};
+
+const delegateWriteMock = vi.fn();
+const setApprovalAsyncMock = vi.fn().mockResolvedValue(undefined);
+const useSubgraphQueryMock = vi.fn();
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: hookState.account }),
+}));
+
+vi.mock('viem', () => ({
+  zeroAddress: '0x0000000000000000000000000000000000000000',
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiGovernorAddress: { 1: '0xGOVERNOR' as const },
+  nijiTokenAddress: { 1: '0xTOKEN' as const },
+  useReadNijiTokenBalanceOf: () => ({ data: hookState.balance }),
+  useReadNijiTokenDelegates: (opts?: { query?: { enabled?: boolean } }) => ({
+    data: opts?.query?.enabled === false ? undefined : hookState.delegate,
+  }),
+  useReadNijiTokenGetCurrentVotes: () => ({ data: hookState.votes }),
+  useReadNijiTokenGetPriorVotes: (opts?: { query?: { enabled?: boolean } }) => ({
+    data: opts?.query?.enabled === false ? undefined : hookState.priorVotes,
+  }),
+  useReadNijiTokenIsApprovedForAll: (opts?: { query?: { enabled?: boolean } }) => ({
+    data: opts?.query?.enabled === false ? undefined : hookState.isApproved,
+  }),
+  useReadNijiTokenSeeds: () => ({ data: hookState.seedsTuple }),
+  useWriteNijiTokenDelegate: () => ({
+    writeContract: delegateWriteMock,
+    data: hookState.delegateState.data,
+    isPending: hookState.delegateState.isPending,
+    isSuccess: hookState.delegateState.isSuccess,
+    isError: hookState.delegateState.isError,
+    error: hookState.delegateState.error,
+  }),
+  useWriteNijiTokenSetApprovalForAll: () => ({
+    writeContractAsync: setApprovalAsyncMock,
+    data: hookState.approvalState.data,
+    isPending: hookState.approvalState.isPending,
+    isSuccess: hookState.approvalState.isSuccess,
+    isError: hookState.approvalState.isError,
+    error: hookState.approvalState.error,
+  }),
+}));
+
+vi.mock('@/hooks/useSubgraphQuery', () => ({
+  useSubgraphQuery: (opts: unknown) => useSubgraphQueryMock(opts),
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('../config', () => ({
+  cache: { seed: 'seed' },
+  cacheKey: (bucket: string, chainId: number, addr: string) => `${bucket}-${chainId}-${addr}`,
+  CHAIN_ID: 1,
+}));
+
+vi.mock('./subgraph', () => ({
+  accountEscrowedNounsDocument: { kind: 'accountEscrowedNouns' },
+  delegateNounsAtBlockDocument: { kind: 'delegateNounsAtBlock' },
+  ownedNounsDocument: { kind: 'ownedNouns' },
+  seedsDocument: { kind: 'seeds' },
+}));
+
+import {
+  useAccountVotes,
+  useDelegateNounsAtBlockQuery,
+  useDelegateVotes,
+  useIsApprovedForAll,
+  useNounSeed,
+  useNounTokenBalance,
+  useSetApprovalForAll,
+  useUserDelegatee,
+  useUserEscrowedNounIds,
+  useUserOwnedNounIds,
+  useUserVotes,
+  useUserVotesAsOfBlock,
+} from './nijiToken';
+
+const resetState = () => {
+  hookState.account = '0xUSER';
+  hookState.votes = 5n;
+  hookState.priorVotes = 3n;
+  hookState.delegate = '0xDELEGATE';
+  hookState.balance = 2n;
+  hookState.isApproved = false;
+  hookState.seedsTuple = undefined;
+  hookState.subgraphData = undefined;
+  hookState.subgraphLoading = false;
+  hookState.subgraphError = null;
+  hookState.delegateState = {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    data: undefined,
+    error: undefined,
+  };
+  hookState.approvalState = {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    data: undefined,
+    error: undefined,
+  };
+  delegateWriteMock.mockReset();
+  setApprovalAsyncMock.mockReset();
+  setApprovalAsyncMock.mockResolvedValue(undefined);
+  useSubgraphQueryMock.mockReset();
+  useSubgraphQueryMock.mockReturnValue({
+    loading: hookState.subgraphLoading,
+    data: hookState.subgraphData,
+    error: hookState.subgraphError,
+    refetch: () => {},
+  });
+  localStorage.clear();
+};
+
+beforeEach(() => {
+  resetState();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('useUserVotes / useAccountVotes', () => {
+  it('useUserVotes returns Number(votes)', () => {
+    const { result } = renderHook(() => useUserVotes());
+    expect(result.current).toBe(5);
+  });
+
+  it('useUserVotes returns undefined when votes undefined', () => {
+    hookState.votes = undefined;
+    const { result } = renderHook(() => useUserVotes());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('useAccountVotes(undefined) skips args', () => {
+    hookState.votes = undefined;
+    const { result } = renderHook(() => useAccountVotes(undefined));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('useAccountVotes(address) returns Number(votes)', () => {
+    const { result } = renderHook(() => useAccountVotes('0xACCT'));
+    expect(result.current).toBe(5);
+  });
+});
+
+describe('useUserDelegatee', () => {
+  it('returns delegate when address provided', () => {
+    const { result } = renderHook(() => useUserDelegatee());
+    expect(result.current).toBe('0xDELEGATE');
+  });
+
+  it('returns undefined when address undefined (enabled=false)', () => {
+    hookState.account = undefined;
+    const { result } = renderHook(() => useUserDelegatee());
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe('useUserVotesAsOfBlock', () => {
+  it('returns Number(priorVotes) for valid address + block', () => {
+    const { result } = renderHook(() => useUserVotesAsOfBlock(100));
+    expect(result.current).toBe(3);
+  });
+
+  it('returns undefined when block undefined', () => {
+    const { result } = renderHook(() => useUserVotesAsOfBlock(undefined));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when address undefined', () => {
+    hookState.account = undefined;
+    const { result } = renderHook(() => useUserVotesAsOfBlock(100));
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe('useDelegateVotes', () => {
+  it('default status is None', () => {
+    const { result } = renderHook(() => useDelegateVotes());
+    expect(result.current.delegateState.status).toBe('None');
+  });
+
+  it('status=Mining when isPending', () => {
+    hookState.delegateState.isPending = true;
+    const { result } = renderHook(() => useDelegateVotes());
+    expect(result.current.delegateState.status).toBe('Mining');
+  });
+
+  it('status=Success when isSuccess', () => {
+    hookState.delegateState.isSuccess = true;
+    const { result } = renderHook(() => useDelegateVotes());
+    expect(result.current.delegateState.status).toBe('Success');
+  });
+
+  it('status=Fail when isError', () => {
+    hookState.delegateState.isError = true;
+    hookState.delegateState.error = new Error('rpc fail');
+    const { result } = renderHook(() => useDelegateVotes());
+    expect(result.current.delegateState.status).toBe('Fail');
+    expect(result.current.delegateState.errorMessage?.message).toBe('rpc fail');
+  });
+
+  it('delegateVotes is writeContract function', () => {
+    const { result } = renderHook(() => useDelegateVotes());
+    expect(result.current.delegateVotes).toBe(delegateWriteMock);
+  });
+
+  it('exposes transaction.hash from useWriteNijiTokenDelegate data', () => {
+    hookState.delegateState.data = '0xtxhash';
+    const { result } = renderHook(() => useDelegateVotes());
+    expect(result.current.delegateState.transaction.hash).toBe('0xtxhash');
+  });
+});
+
+describe('useNounTokenBalance', () => {
+  it('returns Number(tokenBalance)', () => {
+    const { result } = renderHook(() => useNounTokenBalance('0xACCT'));
+    expect(result.current).toBe(2);
+  });
+
+  it('returns undefined when balance undefined', () => {
+    hookState.balance = undefined;
+    const { result } = renderHook(() => useNounTokenBalance('0xACCT'));
+    expect(result.current).toBeUndefined();
+  });
+});
+
+describe('useIsApprovedForAll', () => {
+  it('returns true when isApproved=true', () => {
+    hookState.isApproved = true;
+    const { result } = renderHook(() => useIsApprovedForAll());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when isApproved=false', () => {
+    const { result } = renderHook(() => useIsApprovedForAll());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when address undefined (enabled=false → undefined data)', () => {
+    hookState.account = undefined;
+    const { result } = renderHook(() => useIsApprovedForAll());
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useSetApprovalForAll', () => {
+  it('default status is None', () => {
+    const { result } = renderHook(() => useSetApprovalForAll());
+    expect(result.current.setApprovalState.status).toBe('None');
+  });
+
+  it('status=Mining when isPending', () => {
+    hookState.approvalState.isPending = true;
+    const { result } = renderHook(() => useSetApprovalForAll());
+    expect(result.current.setApprovalState.status).toBe('Mining');
+  });
+
+  it('status=Success when isSuccess', () => {
+    hookState.approvalState.isSuccess = true;
+    const { result } = renderHook(() => useSetApprovalForAll());
+    expect(result.current.setApprovalState.status).toBe('Success');
+  });
+
+  it('status=Fail when isError + exposes errorMessage', () => {
+    hookState.approvalState.isError = true;
+    hookState.approvalState.error = new Error('approval fail');
+    const { result } = renderHook(() => useSetApprovalForAll());
+    expect(result.current.setApprovalState.status).toBe('Fail');
+    expect(result.current.setApprovalState.errorMessage).toBe('approval fail');
+  });
+
+  it('setApproval calls writeContractAsync with governor + true args', async () => {
+    const { result } = renderHook(() => useSetApprovalForAll());
+    await result.current.setApproval();
+    expect(setApprovalAsyncMock).toHaveBeenCalledWith({ args: ['0xGOVERNOR', true] });
+  });
+});
+
+describe('useUserOwnedNounIds', () => {
+  it('returns Number-converted noun ids from subgraph data', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      data: { nouns: [{ id: '1' }, { id: '3' }] },
+      error: null,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() => useUserOwnedNounIds(0));
+    expect(result.current.data).toEqual([1, 3]);
+  });
+
+  it('returns empty array when subgraph data undefined', () => {
+    const { result } = renderHook(() => useUserOwnedNounIds(0));
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe('useUserEscrowedNounIds', () => {
+  it('filters escrowed nouns by forkId', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      data: {
+        escrowedNouns: [
+          { noun: { id: '1' }, fork: { id: 'fork-1' } },
+          { noun: { id: '2' }, fork: { id: 'fork-2' } },
+          { noun: { id: '3' }, fork: { id: 'fork-1' } },
+        ],
+      },
+      error: null,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() => useUserEscrowedNounIds(0, 'fork-1'));
+    expect(result.current.data).toEqual([1, 3]);
+  });
+
+  it('returns empty array when subgraph data undefined', () => {
+    const { result } = renderHook(() => useUserEscrowedNounIds(0, 'fork-1'));
+    expect(result.current.data).toEqual([]);
+  });
+});
+
+describe('useDelegateNounsAtBlockQuery', () => {
+  it('calls useSubgraphQuery with delegates + block variables', () => {
+    renderHook(() => useDelegateNounsAtBlockQuery(['0xA', '0xB'], 100n));
+    const lastCall = useSubgraphQueryMock.mock.calls[useSubgraphQueryMock.mock.calls.length - 1][0];
+    expect(lastCall.variables).toEqual({ delegates: ['0xA', '0xB'], block: 100 });
+  });
+
+  it('returns loading + data + error from subgraph response', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      loading: true,
+      data: { delegates: [{ id: 'a' }] },
+      error: null,
+      refetch: () => {},
+    });
+    const { result } = renderHook(() => useDelegateNounsAtBlockQuery(['0xA'], 100n));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data?.delegates).toEqual([{ id: 'a' }]);
+  });
+});
+
+describe('useNounSeed', () => {
+  it('returns contract seed when no cache', () => {
+    hookState.seedsTuple = [1n, 2n, 3n, 4n, 5n, 6n, 7n, 8n, 9n, 10n, 11n, 12n];
+    const { result } = renderHook(() => useNounSeed(0n));
+    expect(result.current?.special).toBe(1);
+    expect(result.current?.hair).toBe(12);
+  });
+
+  it('returns undefined when contract returns nothing + no cache', () => {
+    hookState.seedsTuple = undefined;
+    const { result } = renderHook(() => useNounSeed(0n));
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/niji-webapp/src/wrappers/subgraph.test.ts
+++ b/packages/niji-webapp/src/wrappers/subgraph.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/subgraphs', () => ({
+  graphql: (query: string) => ({ kind: 'Document', query }),
+}));
+
+vi.mock('@/subgraphs/graphql', () => {
+  const docs = [
+    'GetProposalDocument',
+    'GetPartialProposalsDocument',
+    'GetActivePendingUpdatableProposersDocument',
+    'GetUpdatableProposalsDocument',
+    'GetCandidateProposalsDocument',
+    'GetCandidateProposalDocument',
+    'GetCandidateProposalVersionsDocument',
+    'GetProposalVersionsDocument',
+    'GetBidsByAuctionDocument',
+    'GetNounDocument',
+    'GetNounsIndexDocument',
+    'GetLatestBidsDocument',
+    'GetNounVotingHistoryDocument',
+    'GetNounTransferHistoryDocument',
+    'GetNounDelegationHistoryDocument',
+    'GetCreateTimestampAllProposalsDocument',
+    'GetProposalVotesDocument',
+    'GetAdjustedNounSupplyAtPropSnapshotDocument',
+    'GetPropUsingDynamicQuorumDocument',
+    'GetProposalFeedbacksDocument',
+    'GetCandidateFeedbacksDocument',
+    'GetOwnedNounsDocument',
+    'GetAccountEscrowedNounsDocument',
+    'GetEscrowDepositEventsDocument',
+    'GetForkJoinsDocument',
+    'GetEscrowWithdrawEventsDocument',
+    'GetProposalTitlesDocument',
+    'GetForkDetailsDocument',
+    'GetForksDocument',
+    'GetIsForkActiveDocument',
+  ];
+  const exports: Record<string, unknown> = {};
+  for (const name of docs) {
+    exports[name] = { kind: 'Document', name };
+  }
+  return exports;
+});
+
+import * as subgraph from './subgraph';
+
+describe('wrappers/subgraph re-exports', () => {
+  it('re-exports proposalDocument', () => {
+    expect(subgraph.proposalDocument).toBeDefined();
+  });
+
+  it('re-exports partialProposalsDocument', () => {
+    expect(subgraph.partialProposalsDocument).toBeDefined();
+  });
+
+  it('re-exports nounDocument', () => {
+    expect(subgraph.nounDocument).toBeDefined();
+  });
+
+  it('re-exports forkDetailsDocument', () => {
+    expect(subgraph.forkDetailsDocument).toBeDefined();
+  });
+
+  it('re-exports candidate-related documents', () => {
+    expect(subgraph.candidateProposalsDocument).toBeDefined();
+    expect(subgraph.candidateProposalDocument).toBeDefined();
+    expect(subgraph.candidateProposalVersionsDocument).toBeDefined();
+  });
+
+  it('re-exports proposal vote / feedback documents', () => {
+    expect(subgraph.proposalVotesDocument).toBeDefined();
+    expect(subgraph.proposalFeedbacksDocument).toBeDefined();
+    expect(subgraph.candidateFeedbacksDocument).toBeDefined();
+  });
+
+  it('re-exports fork-related documents', () => {
+    expect(subgraph.forksDocument).toBeDefined();
+    expect(subgraph.isForkActiveDocument).toBeDefined();
+    expect(subgraph.forkJoinsDocument).toBeDefined();
+    expect(subgraph.escrowDepositEventsDocument).toBeDefined();
+    expect(subgraph.escrowWithdrawEventsDocument).toBeDefined();
+  });
+});
+
+describe('wrappers/subgraph inline graphql documents', () => {
+  it('defines seedsDocument', () => {
+    expect(subgraph.seedsDocument).toBeDefined();
+  });
+
+  it('defines delegateNounsAtBlockDocument', () => {
+    expect(subgraph.delegateNounsAtBlockDocument).toBeDefined();
+  });
+
+  it('defines currentlyDelegatedNounsDocument', () => {
+    expect(subgraph.currentlyDelegatedNounsDocument).toBeDefined();
+  });
+
+  it('defines auctionQuery', () => {
+    expect(subgraph.auctionQuery).toBeDefined();
+  });
+
+  it('defines latestAuctionsQuery', () => {
+    expect(subgraph.latestAuctionsQuery).toBeDefined();
+  });
+
+  it('inline document objects have query strings (from graphql mock)', () => {
+    const doc = subgraph.seedsDocument as { query: string };
+    expect(typeof doc.query).toBe('string');
+    expect(doc.query).toContain('GetSeeds');
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 64` として wrappers 領域 2 file (`wrappers/subgraph` 170 行 / `wrappers/nijiToken` 302 行) に vitest を追加、 1330 → **1376** (+46、 1 skip 維持)。 目標 1360+ を大幅超過。

## 詳細

### wrappers/subgraph.test.ts (13 TC)

graphql document の re-export hub + 5 inline graphql query 定義 file。 「正しく export されているか」 を中心に検証。

検証観点。

- proposalDocument / partialProposalsDocument / nounDocument / forkDetailsDocument / candidate 3 種 / proposal vote/feedback 3 種 / fork 5 種 の re-export 確認
- inline graphql 5 件 (seedsDocument / delegateNounsAtBlockDocument / currentlyDelegatedNounsDocument / auctionQuery / latestAuctionsQuery) の定義確認
- inline document の query 文字列に GraphQL query 名 (GetSeeds 等) を含むことを確認

### wrappers/nijiToken.test.ts (33 TC)

DAO の token / vote / delegate 経路を統括する 12 hooks。 wagmi useReadContract / useWriteContract の薄 wrapper。

検証 hook 一覧。

- useUserVotes / useAccountVotes ... Number 変換 + undefined fallback
- useUserDelegatee ... address undefined で disabled
- useUserVotesAsOfBlock ... block undefined / address undefined で disabled
- useDelegateVotes ... 4 status (None / Mining / Success / Fail) mapping + transaction.hash
- useNounTokenBalance ... Number 変換
- useIsApprovedForAll ... boolean fallback (undefined → false)
- useSetApprovalForAll ... 4 status mapping + setApproval async 呼出 (governor + true args)
- useUserOwnedNounIds ... subgraph data から id Number 変換
- useUserEscrowedNounIds ... forkId filter
- useDelegateNounsAtBlockQuery ... subgraph 呼出引数検証
- useNounSeed ... contract tuple → INounSeed 変換

## 解決方法

subgraph 側 ... `@/subgraphs` graphql tag を identity 化、 `@/subgraphs/graphql` の generated document を 30 件以上 stub。 `seedsDocument` 等 inline document は `graphql` 関数経由で query string を保持する mock を用い、 string 検査経路で検証。

nijiToken 側 ... `@niji/sdk/react` 8 hook export / `wagmi.useAccount` / `viem.zeroAddress` / `@/hooks/useSubgraphQuery` / `@/wagmi` (defaultChain) / `../config` (cache, cacheKey, CHAIN_ID) を全 vi.mock。 `hookState` で各 wagmi hook の戻り値を切替、 `delegateState` / `approvalState` の sub state で各 status 経路を網羅。 `useReadNijiTokenDelegates` / `useReadNijiTokenGetPriorVotes` / `useReadNijiTokenIsApprovedForAll` は `opts.query.enabled === false` 時に data=undefined を返す stub にすることで production code の disabled 経路を直接検証。

## 受入条件

- [x] 2 file 計 46 TC 全 pass
- [x] `pnpm vitest run` 全 1376 test green (1377 - 1 skipped)
- [x] regression なし (既存 1330 pass を破壊しない)

## 関連

- Closes #459
- 直前 PR #458 (part 63) で 1301 → 1330
- 残未テスト wrapper ... `nijiDao.ts` (1638 行 巨大) / `nijiData.ts` (910 行) のみで wrappers 領域もほぼ完走
- 学び ... `useReadContract` 系 hook の disabled 経路は mock で `query.enabled === false` を観測して data=undefined を返す stub にする pattern (production code の `query: { enabled: ... }` 経路を直接検証可)
