### PR TITLE
✅ test(niji-webapp): part 66 (wrappers/nijiDao) 最大級 wrapper で 1410 → 1454 + wrappers 完走 (Issue #463)

### DIFF
--- a/packages/niji-webapp/src/wrappers/nijiDao.test.ts
+++ b/packages/niji-webapp/src/wrappers/nijiDao.test.ts
@@ -1,0 +1,466 @@
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const hookState: {
+  account: string | undefined;
+  dynamicQuorumParams:
+    | {
+        minQuorumVotesBPS: number | bigint;
+        maxQuorumVotesBPS: number | bigint;
+        quorumCoefficient: number | bigint;
+      }
+    | undefined;
+  receipt: { hasVoted?: boolean; support?: number | bigint } | undefined;
+  proposalCount: bigint | undefined;
+  proposalThreshold: bigint | undefined;
+  forkThreshold: bigint | undefined;
+  numTokensInForkEscrow: bigint | undefined;
+  adjustedTotalSupply: bigint | undefined;
+} = {
+  account: '0xUSER',
+  dynamicQuorumParams: undefined,
+  receipt: undefined,
+  proposalCount: undefined,
+  proposalThreshold: undefined,
+  forkThreshold: undefined,
+  numTokensInForkEscrow: undefined,
+  adjustedTotalSupply: undefined,
+};
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: hookState.account }),
+  usePublicClient: () => undefined,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  useReadNijiGovernorGetDynamicQuorumParamsAt: () => ({ data: hookState.dynamicQuorumParams }),
+  useReadNijiGovernorGetReceipt: () => ({ data: hookState.receipt }),
+  useReadNijiGovernorProposalCount: () => ({ data: hookState.proposalCount }),
+  useReadNijiGovernorProposalThreshold: () => ({ data: hookState.proposalThreshold }),
+  useReadNijiGovernorForkThreshold: () => ({ data: hookState.forkThreshold }),
+  useReadNijiGovernorNumTokensInForkEscrow: () => ({ data: hookState.numTokensInForkEscrow }),
+  useReadNijiGovernorAdjustedTotalSupply: () => ({ data: hookState.adjustedTotalSupply }),
+  nijiGovernorAddress: { 1: '0xGOVERNOR' as const },
+  nijiTokenAddress: { 1: '0xTOKEN' as const },
+  nijiDataAddress: { 1: '0xDATA' as const },
+  useWriteNijiGovernorCancelSig: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorCastRefundableVote: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorCastRefundableVoteWithReason: () => ({
+    data: undefined,
+    writeContract: vi.fn(),
+  }),
+  useWriteNijiGovernorPropose: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorProposeOnTimelockV1: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorUpdateProposal: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorUpdateProposalTransactions: () => ({
+    data: undefined,
+    writeContract: vi.fn(),
+  }),
+  useWriteNijiGovernorUpdateProposalDescription: () => ({
+    data: undefined,
+    writeContract: vi.fn(),
+  }),
+  useWriteNijiGovernorQueue: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorCancel: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorExecute: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorEscrowToFork: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorWithdrawFromForkEscrow: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorJoinFork: () => ({ data: undefined, writeContract: vi.fn() }),
+  useWriteNijiGovernorExecuteFork: () => ({ data: undefined, writeContract: vi.fn() }),
+  useReadNijiGovernorVotingDelay: () => ({ data: undefined }),
+  useReadNijiGovernorVotingPeriod: () => ({ data: undefined }),
+  useReadNijiGovernorObjectionPeriodDurationInBlocks: () => ({ data: undefined }),
+  useReadNijiGovernorLastMinuteWindowInBlocks: () => ({ data: undefined }),
+  useReadNijiGovernorTimelock: () => ({ data: undefined }),
+  useReadNijiGovernorActivePendingUpdatableProposers: () => ({ data: [] }),
+}));
+
+vi.mock('@/hooks/useSubgraphQuery', () => ({
+  useSubgraphQuery: () => ({ loading: false, data: undefined, error: null, refetch: () => {} }),
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/config', () => ({
+  default: {
+    app: { subgraphApiUri: 'https://subgraph.example' },
+    contractParameters: { executor: { GRACE_PERIOD_SECONDS: 60 * 60 * 24 * 14 } },
+  },
+  CHAIN_ID: 1,
+}));
+
+vi.mock('./subgraph', () => ({
+  proposalDocument: { kind: 'proposal' },
+  partialProposalsDocument: { kind: 'partialProposals' },
+  activePendingUpdatableProposersDocument: { kind: 'activePending' },
+  updatableProposalsDocument: { kind: 'updatable' },
+  proposalVersionsDocument: { kind: 'versions' },
+  bidsByAuctionDocument: { kind: 'bids' },
+  nounDocument: { kind: 'noun' },
+  nounsIndexDocument: { kind: 'nounsIndex' },
+  latestBidsDocument: { kind: 'latestBids' },
+  nounVotingHistoryDocument: { kind: 'nounVotingHistory' },
+  nounTransferHistoryDocument: { kind: 'nounTransferHistory' },
+  nounDelegationHistoryDocument: { kind: 'nounDelegationHistory' },
+  createTimestampAllProposalsDocument: { kind: 'createTimestamp' },
+  proposalVotesDocument: { kind: 'proposalVotes' },
+  adjustedNounSupplyAtPropSnapshotDocument: { kind: 'adjustedNounSupply' },
+  propUsingDynamicQuorumDocument: { kind: 'propUsingDynamicQuorum' },
+  proposalTitlesDocument: { kind: 'proposalTitles' },
+  forkDetailsDocument: { kind: 'forkDetails' },
+  forksDocument: { kind: 'forks' },
+  isForkActiveDocument: { kind: 'isForkActive' },
+  forkJoinsDocument: { kind: 'forkJoins' },
+  escrowDepositEventsDocument: { kind: 'escrowDeposit' },
+  escrowWithdrawEventsDocument: { kind: 'escrowWithdraw' },
+}));
+
+import {
+  concatSelectorToCalldata,
+  extractTitle,
+  ForkState,
+  formatProposalTransactionDetails,
+  formatProposalTransactionDetailsToUpdate,
+  ProposalState,
+  removeMarkdownStyle,
+  useAdjustedTotalSupply,
+  useDynamicQuorumProps,
+  useForkThreshold,
+  useHasVotedOnProposal,
+  useNumTokensInForkEscrow,
+  useProposalCount,
+  useProposalThreshold,
+  useProposalVote,
+  Vote,
+} from './nijiDao';
+
+beforeEach(() => {
+  hookState.account = '0xUSER';
+  hookState.dynamicQuorumParams = undefined;
+  hookState.receipt = undefined;
+  hookState.proposalCount = undefined;
+  hookState.proposalThreshold = undefined;
+  hookState.forkThreshold = undefined;
+  hookState.numTokensInForkEscrow = undefined;
+  hookState.adjustedTotalSupply = undefined;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Vote / ProposalState / ForkState enums', () => {
+  it('Vote enum has AGAINST=0 / FOR=1 / ABSTAIN=2', () => {
+    expect(Vote.AGAINST).toBe(0);
+    expect(Vote.FOR).toBe(1);
+    expect(Vote.ABSTAIN).toBe(2);
+  });
+
+  it('ProposalState contains UNDETERMINED + 11 states', () => {
+    expect(ProposalState.UNDETERMINED).toBe(-1);
+    expect(ProposalState.PENDING).toBe(0);
+    expect(ProposalState.ACTIVE).toBe(1);
+    expect(ProposalState.CANCELLED).toBe(2);
+    expect(ProposalState.UPDATABLE).toBe(10);
+  });
+
+  it('ForkState has ESCROW=0 / ACTIVE=1 / EXECUTED=2', () => {
+    expect(ForkState.UNDETERMINED).toBe(-1);
+    expect(ForkState.ESCROW).toBe(0);
+    expect(ForkState.ACTIVE).toBe(1);
+    expect(ForkState.EXECUTED).toBe(2);
+  });
+});
+
+describe('extractTitle', () => {
+  it('returns null when body is undefined', () => {
+    expect(extractTitle(undefined)).toBeNull();
+  });
+
+  it('returns null when body is empty string', () => {
+    expect(extractTitle('')).toBeNull();
+  });
+
+  it('extracts hash-style title (# Title)', () => {
+    expect(extractTitle('# My Title\n\nbody text')).toBe('My Title');
+  });
+
+  it('extracts equal-style title (Title\\n===)', () => {
+    expect(extractTitle('My Equal Title\n===\n\nbody')).toBe('My Equal Title');
+  });
+
+  it('prefers hash-style over equal-style when both present', () => {
+    expect(extractTitle('# Hash Title\n\nEqual Title\n===')).toBe('Hash Title');
+  });
+
+  it('returns null when no title pattern found', () => {
+    expect(extractTitle('plain text without title')).toBeNull();
+  });
+});
+
+describe('removeMarkdownStyle', () => {
+  it('returns null when text is null', () => {
+    expect(removeMarkdownStyle(null)).toBeNull();
+  });
+
+  it('removes ** bold markers', () => {
+    expect(removeMarkdownStyle('**bold text**')).toBe('bold text');
+  });
+
+  it('removes __ italic markers', () => {
+    expect(removeMarkdownStyle('__italic text__')).toBe('italic text');
+  });
+
+  it('removes both bold and italic', () => {
+    expect(removeMarkdownStyle('**bold** and __italic__')).toBe('bold and italic');
+  });
+
+  it('leaves plain text unchanged', () => {
+    expect(removeMarkdownStyle('plain text')).toBe('plain text');
+  });
+});
+
+describe('concatSelectorToCalldata', () => {
+  it('returns callData unchanged when signature is empty', () => {
+    expect(concatSelectorToCalldata('', '0xabcdef')).toBe('0xabcdef');
+  });
+
+  it('adds 4-byte selector prefix when signature provided', () => {
+    const result = concatSelectorToCalldata('transfer(address,uint256)', '0xabcd');
+    expect(result.startsWith('0x')).toBe(true);
+    expect(result.length).toBe(2 + 8 + 4); // 0x + 8 (selector hex) + 4 (callData hex)
+  });
+});
+
+describe('formatProposalTransactionDetails', () => {
+  it('returns empty array for empty targets', () => {
+    const out = formatProposalTransactionDetails({
+      targets: [],
+      signatures: [],
+      values: [],
+      calldatas: [],
+    });
+    expect(out).toEqual([]);
+  });
+
+  it('returns target + functionSig + raw 0x callData when callData=0x', () => {
+    const out = formatProposalTransactionDetails({
+      targets: ['0xT1' as `0x${string}`],
+      signatures: ['transfer(address,uint256)'],
+      values: [0n],
+      calldatas: ['0x' as `0x${string}`],
+    });
+    expect(out[0].target).toBe('0xT1');
+    expect(out[0].functionSig).toBe('transfer');
+    expect(out[0].callData).toBe('0x');
+  });
+
+  it('returns unknown fallback when no signature + non-empty callData', () => {
+    const out = formatProposalTransactionDetails({
+      targets: ['0xT1' as `0x${string}`],
+      signatures: [''],
+      values: [1n],
+      calldatas: ['0xdeadbeef' as `0x${string}`],
+    });
+    expect(out[0].target).toBe('0xT1');
+    expect(out[0].callData.startsWith('0x')).toBe(true);
+  });
+
+  it('returns ETH value when no signature + empty callData', () => {
+    const out = formatProposalTransactionDetails({
+      targets: ['0xT1' as `0x${string}`],
+      signatures: [''],
+      values: [10n ** 18n],
+      calldatas: ['0x' as `0x${string}`],
+    });
+    expect(out[0].functionSig).toBe('unknown');
+    expect(out[0].callData).toContain('ETH');
+  });
+
+  it('falls back to concatSelectorToCalldata when decode fails', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const out = formatProposalTransactionDetails({
+      targets: ['0xT1' as `0x${string}`],
+      signatures: ['transfer(address,uint256)'],
+      values: [0n],
+      calldatas: ['0xINVALID_HEX' as `0x${string}`],
+    });
+    expect(out[0].target).toBe('0xT1');
+    expect(out[0].callData.startsWith('0x')).toBe(true);
+    errorSpy.mockRestore();
+  });
+
+  it('processes multiple targets independently', () => {
+    const out = formatProposalTransactionDetails({
+      targets: ['0xA' as `0x${string}`, '0xB' as `0x${string}`],
+      signatures: ['', 'transfer(address,uint256)'],
+      values: [1n, 0n],
+      calldatas: ['0x' as `0x${string}`, '0x' as `0x${string}`],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0].target).toBe('0xA');
+    expect(out[1].target).toBe('0xB');
+  });
+});
+
+describe('formatProposalTransactionDetailsToUpdate', () => {
+  it('maps target / signature / calldata / value 1:1', () => {
+    const out = formatProposalTransactionDetailsToUpdate({
+      targets: ['0xT1' as `0x${string}`, '0xT2' as `0x${string}`],
+      signatures: ['sig1', 'sig2'],
+      values: [1n, 2n],
+      calldatas: ['0xcd1' as `0x${string}`, '0xcd2' as `0x${string}`],
+    });
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({
+      target: '0xT1',
+      functionSig: 'sig1',
+      callData: '0xcd1',
+      value: 1n,
+    });
+    expect(out[1].value).toBe(2n);
+  });
+
+  it('defaults value to 0n when values undefined', () => {
+    const out = formatProposalTransactionDetailsToUpdate({
+      targets: ['0xT1' as `0x${string}`],
+      signatures: ['sig1'],
+      calldatas: ['0xcd1' as `0x${string}`],
+    });
+    expect(out[0].value).toBe(0n);
+  });
+});
+
+describe('useDynamicQuorumProps', () => {
+  it('returns undefined when data is undefined', () => {
+    const { result } = renderHook(() => useDynamicQuorumProps(100n));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns Number-converted params when data provided', () => {
+    hookState.dynamicQuorumParams = {
+      minQuorumVotesBPS: 1000n,
+      maxQuorumVotesBPS: 4000n,
+      quorumCoefficient: 5000n,
+    };
+    const { result } = renderHook(() => useDynamicQuorumProps(100n));
+    expect(result.current).toEqual({
+      minQuorumVotesBPS: 1000,
+      maxQuorumVotesBPS: 4000,
+      quorumCoefficient: 5000,
+    });
+  });
+});
+
+describe('useHasVotedOnProposal', () => {
+  it('returns false when receipt undefined', () => {
+    const { result } = renderHook(() => useHasVotedOnProposal(1n));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when receipt.hasVoted=true', () => {
+    hookState.receipt = { hasVoted: true };
+    const { result } = renderHook(() => useHasVotedOnProposal(1n));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when receipt.hasVoted=false', () => {
+    hookState.receipt = { hasVoted: false };
+    const { result } = renderHook(() => useHasVotedOnProposal(1n));
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useProposalVote', () => {
+  it('returns "" when receipt undefined', () => {
+    const { result } = renderHook(() => useProposalVote(1n));
+    expect(result.current).toBe('');
+  });
+
+  it('returns "Against" when support=0', () => {
+    hookState.receipt = { support: 0 };
+    const { result } = renderHook(() => useProposalVote(1n));
+    expect(result.current).toBe('Against');
+  });
+
+  it('returns "For" when support=1', () => {
+    hookState.receipt = { support: 1 };
+    const { result } = renderHook(() => useProposalVote(1n));
+    expect(result.current).toBe('For');
+  });
+
+  it('returns "Abstain" when support=2', () => {
+    hookState.receipt = { support: 2 };
+    const { result } = renderHook(() => useProposalVote(1n));
+    expect(result.current).toBe('Abstain');
+  });
+
+  it('returns "" when support is unexpected value (e.g. 99)', () => {
+    hookState.receipt = { support: 99 };
+    const { result } = renderHook(() => useProposalVote(1n));
+    expect(result.current).toBe('');
+  });
+});
+
+describe('useProposalCount', () => {
+  it('returns undefined when count null', () => {
+    const { result } = renderHook(() => useProposalCount());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns Number when count provided', () => {
+    hookState.proposalCount = 42n;
+    const { result } = renderHook(() => useProposalCount());
+    expect(result.current).toBe(42);
+  });
+});
+
+describe('useProposalThreshold', () => {
+  it('returns null when data null', () => {
+    const { result } = renderHook(() => useProposalThreshold());
+    expect(result.current).toBeNull();
+  });
+
+  it('returns Number when data provided', () => {
+    hookState.proposalThreshold = 5n;
+    const { result } = renderHook(() => useProposalThreshold());
+    expect(result.current).toBe(5);
+  });
+});
+
+describe('useForkThreshold / useNumTokensInForkEscrow / useAdjustedTotalSupply', () => {
+  it('useForkThreshold returns undefined when data undefined', () => {
+    const { result } = renderHook(() => useForkThreshold());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('useForkThreshold returns Number when data provided', () => {
+    hookState.forkThreshold = 10n;
+    const { result } = renderHook(() => useForkThreshold());
+    expect(result.current).toBe(10);
+  });
+
+  it('useNumTokensInForkEscrow returns undefined when data undefined', () => {
+    const { result } = renderHook(() => useNumTokensInForkEscrow());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('useNumTokensInForkEscrow returns Number when data provided', () => {
+    hookState.numTokensInForkEscrow = 25n;
+    const { result } = renderHook(() => useNumTokensInForkEscrow());
+    expect(result.current).toBe(25);
+  });
+
+  it('useAdjustedTotalSupply returns undefined when data undefined', () => {
+    const { result } = renderHook(() => useAdjustedTotalSupply());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('useAdjustedTotalSupply returns Number when data provided', () => {
+    hookState.adjustedTotalSupply = 100n;
+    const { result } = renderHook(() => useAdjustedTotalSupply());
+    expect(result.current).toBe(100);
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 66` として 最大級 wrapper (`wrappers/nijiDao` 1638 行) に vitest を追加、 1410 → **1454** (+44、 1 skip 維持)。

**マイルストーン達成** ... `src/wrappers/` 配下の未テスト wrapper **ゼロ達成** (nijiAuction.ts は type-only)。 wrappers 領域完走。

## 詳細

### wrappers/nijiDao.test.ts (44 TC)

DAO の governance / fork / proposal 経路を統括する 最大級 wrapper file (38 export hook + 純粋関数 + enum)。 主要部分を 44 TC で網羅。

検証対象。

- **3 enum** (3 TC) ... Vote (AGAINST=0/FOR=1/ABSTAIN=2) / ProposalState (12 値) / ForkState (4 値)
- **5 純粋関数** (24 TC)
  - extractTitle ... hash-style / equal-style / undefined / 空 / 両方混在 / no match (6 TC)
  - removeMarkdownStyle ... null / bold / italic / 両方 / plain (5 TC)
  - concatSelectorToCalldata ... 空 signature passthrough / selector prefix 付与 (2 TC)
  - formatProposalTransactionDetails ... 空 / functionSig 0x callData / unknown fallback / ETH value / decode 失敗 fallback / 複数 targets (6 TC)
  - formatProposalTransactionDetailsToUpdate ... 1:1 mapping / value 未指定 default 0n (2 TC)
- **9 read hook** (17 TC)
  - useDynamicQuorumProps ... undefined / Number 変換 (2 TC)
  - useHasVotedOnProposal ... receipt undefined / hasVoted=true / hasVoted=false (3 TC)
  - useProposalVote ... receipt undefined / Against / For / Abstain / unexpected (5 TC)
  - useProposalCount ... null / Number 変換 (2 TC)
  - useProposalThreshold ... null / Number 変換 (2 TC)
  - useForkThreshold / useNumTokensInForkEscrow / useAdjustedTotalSupply ... undefined / Number 変換 (3 pair = 6 TC)

## 解決方法

`@niji/sdk/react` 25+ hook + address 群を vi.mock、 `wagmi.useAccount` / `usePublicClient` / `@/hooks/useSubgraphQuery` / `@/wagmi` / `@/config` / `./subgraph` も vi.mock。 `viem` (decodeAbiParameters / keccak256 / stringToBytes / formatEther) は actual を使い純粋関数を本物の logic で検証。

`hookState` で各 wagmi hook の戻り値を切替、 read hook の Number/null/undefined fallback 経路を直接 assert。 write hook は production code を import するために必要な mock のみ提供 (test 自体は read 系のみで行うため write hook は no-op)。

## 受入条件

- [x] 1 file 44 TC 全 pass
- [x] `pnpm vitest run` 全 1454 test green (1455 - 1 skipped)
- [x] regression なし (既存 1410 pass を破壊しない)
- [x] **`src/wrappers/` 配下未テスト wrapper ゼロ達成** (nijiDao 完了、 nijiAuction は type-only)

## 関連

- Closes #463
- 直前 PR #462 (part 65) で 1376 → 1410 (nijiData)
- wrappers 領域 完走 ... 次は別領域 (subgraphs / state / layout 等) expansion
- 学び ... 巨大 wrapper の test は純粋関数 + read hook を中心に絞ると write hook は no-op mock のみで済む (将来 大型 file の base case)
