### PR TITLE
✅ test(niji-webapp): part 67 (state/auctionAtom + lib/traitName) で 1454 → 1484 (Issue #465)

### DIFF
--- a/packages/niji-webapp/src/lib/traitName.test.ts
+++ b/packages/niji-webapp/src/lib/traitName.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/nijiAssets', () => ({
+  NijiImageData: {
+    images: {
+      special: [{ filename: 'special-cool-special', data: '0x01' }],
+      choker: [{ filename: 'choker', data: '0x02' }],
+      headphone: [{ filename: 'headphone-pink-headphone', data: '0x03' }],
+      leftHand: [{ filename: 'leftHand', data: '0x04' }],
+      hat: [{ filename: 'hat-cool', data: '0x05' }],
+      clothing: [{ filename: '', data: '0x06' }],
+      ear: [{ filename: 'ear-x', data: '0x07' }],
+      back: [{ filename: 'back-Y', data: '0x08' }],
+      backDecoration: [{ filename: 'backDecoration-z', data: '0x09' }],
+      background: [{ filename: '', data: '0x0a' }],
+      solidBackground: [{ filename: 'solidBackground', data: '0x0b' }],
+      hair: [{ filename: 'hair-rainbow', data: '0x0c' }],
+    },
+  },
+  humanizeTraitKey: (key: string) => {
+    if (key === 'leftHand') return 'Left Hand';
+    if (key === 'backDecoration') return 'Back Decoration';
+    if (key === 'solidBackground') return 'Solid Background';
+    return key.charAt(0).toUpperCase() + key.slice(1);
+  },
+}));
+
+import { traitName } from './traitName';
+
+describe('traitName', () => {
+  it('falls back to humanizeTraitKey when filename undefined (out-of-range index)', () => {
+    expect(traitName('special', 99)).toBe('Special');
+  });
+
+  it('falls back to humanizeTraitKey for leftHand type when filename undefined', () => {
+    expect(traitName('leftHand', 99)).toBe('Left Hand');
+  });
+
+  it('returns capitalized suffix after first hyphen when filename includes "-"', () => {
+    expect(traitName('special', 0)).toBe('Cool Special');
+  });
+
+  it('returns full capitalized filename when no hyphen', () => {
+    expect(traitName('choker', 0)).toBe('Choker');
+  });
+
+  it('handles multi-hyphen filename by taking part after first hyphen', () => {
+    expect(traitName('headphone', 0)).toBe('Pink Headphone');
+  });
+
+  it('handles single-word filename for leftHand type', () => {
+    expect(traitName('leftHand', 0)).toBe('LeftHand');
+  });
+
+  it('handles uppercase first letter preservation', () => {
+    expect(traitName('hat', 0)).toBe('Cool');
+  });
+
+  it('handles empty filename string returns empty (not humanize fallback)', () => {
+    expect(traitName('clothing', 0)).toBe('');
+  });
+
+  it('handles lowercase suffix after hyphen', () => {
+    expect(traitName('ear', 0)).toBe('X');
+  });
+
+  it('preserves uppercase suffix characters after hyphen', () => {
+    expect(traitName('back', 0)).toBe('Y');
+  });
+
+  it('handles compound key backDecoration with hyphen filename', () => {
+    expect(traitName('backDecoration', 0)).toBe('Z');
+  });
+
+  it('rainbow hair filename returns Rainbow', () => {
+    expect(traitName('hair', 0)).toBe('Rainbow');
+  });
+});

--- a/packages/niji-webapp/src/state/atoms/auctionAtom.test.ts
+++ b/packages/niji-webapp/src/state/atoms/auctionAtom.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyActiveAuction,
+  applyAppendBid,
+  applyAuctionExtended,
+  applyAuctionSettled,
+  applyFullAuction,
+  auctionAtom,
+  reduxSafeAuction,
+  reduxSafeBid,
+  reduxSafeNewAuction,
+} from './auctionAtom';
+
+const makeAuction = (overrides: Record<string, unknown> = {}) =>
+  ({
+    amount: '1000',
+    bidder: '0xBIDDER',
+    startTime: '100',
+    endTime: '200',
+    nounId: '5',
+    settled: false,
+    ...overrides,
+  }) as never;
+
+const makeBid = (overrides: Record<string, unknown> = {}) => ({
+  nounId: '5',
+  sender: '0xSENDER' as `0x${string}`,
+  value: '1000',
+  extended: false,
+  transactionHash: '0xTX',
+  transactionIndex: 0,
+  timestamp: '1700000000',
+  ...overrides,
+});
+
+describe('auctionAtom initial value', () => {
+  it('initial value has undefined activeAuction + empty bids array', () => {
+    expect(auctionAtom.init).toEqual({ activeAuction: undefined, bids: [] });
+  });
+});
+
+describe('reduxSafeNewAuction', () => {
+  it('serializes a new auction with default 0 amount + 0x bidder + settled=false', () => {
+    const out = reduxSafeNewAuction({
+      nounId: 5,
+      startTime: 100,
+      endTime: 200,
+      settled: false,
+    });
+    expect(out.amount).toBe('0');
+    expect(out.bidder).toBe('0x');
+    expect(out.settled).toBe(false);
+    expect(out.nounId).toBe('5');
+    expect(out.startTime).toBe('100');
+    expect(out.endTime).toBe('200');
+  });
+});
+
+describe('reduxSafeAuction', () => {
+  it('preserves amount undefined when undefined', () => {
+    const out = reduxSafeAuction(
+      makeAuction({ amount: undefined, bidder: undefined, settled: true }),
+    );
+    expect(out.amount).toBeUndefined();
+    expect(out.bidder).toBeUndefined();
+    expect(out.settled).toBe(true);
+  });
+
+  it('converts amount + nounId + startTime + endTime to strings', () => {
+    const out = reduxSafeAuction(
+      makeAuction({ amount: 5000n, startTime: 1700n, endTime: 1800n, nounId: 10n }),
+    );
+    expect(out.amount).toBe('5000');
+    expect(out.startTime).toBe('1700');
+    expect(out.endTime).toBe('1800');
+    expect(out.nounId).toBe('10');
+  });
+});
+
+describe('reduxSafeBid', () => {
+  it('serializes value + nounId + timestamp as strings', () => {
+    const out = reduxSafeBid(makeBid({ value: 1500n, nounId: 7n, timestamp: 1700000000n }));
+    expect(out.value).toBe('1500');
+    expect(out.nounId).toBe('7');
+    expect(out.timestamp).toBe('1700000000');
+    expect(out.sender).toBe('0xSENDER');
+    expect(out.extended).toBe(false);
+  });
+});
+
+describe('applyActiveAuction', () => {
+  it('replaces activeAuction with reduxSafeNewAuction + resets bids', () => {
+    const prev = {
+      activeAuction: makeAuction({ nounId: '99' }),
+      bids: [makeBid()],
+    };
+    const out = applyActiveAuction(prev, {
+      nounId: 5,
+      startTime: 100,
+      endTime: 200,
+      settled: false,
+    });
+    expect(out.activeAuction?.nounId).toBe('5');
+    expect(out.bids).toEqual([]);
+  });
+});
+
+describe('applyFullAuction', () => {
+  it('replaces activeAuction with reduxSafeAuction', () => {
+    const prev = { activeAuction: undefined, bids: [] };
+    const out = applyFullAuction(prev, makeAuction({ nounId: '5' }));
+    expect(out.activeAuction?.nounId).toBe('5');
+    expect(out.bids).toEqual([]);
+  });
+});
+
+describe('applyAppendBid', () => {
+  it('returns state unchanged when activeAuction is undefined', () => {
+    const prev = { activeAuction: undefined, bids: [] };
+    const out = applyAppendBid(prev, makeBid() as never);
+    expect(out).toBe(prev);
+  });
+
+  it('returns state unchanged when nounId does not match', () => {
+    const prev = {
+      activeAuction: makeAuction({ nounId: '5' }),
+      bids: [],
+    };
+    const out = applyAppendBid(prev, makeBid({ nounId: '99' }) as never);
+    expect(out).toBe(prev);
+  });
+
+  it('returns state unchanged when transactionHash already exists', () => {
+    const prev = {
+      activeAuction: makeAuction({ nounId: '5' }),
+      bids: [makeBid({ transactionHash: '0xDUP' })],
+    };
+    const out = applyAppendBid(prev, makeBid({ transactionHash: '0xDUP' }) as never);
+    expect(out).toBe(prev);
+  });
+
+  it('prepends new bid + updates activeAuction.amount/bidder to max bid', () => {
+    const prev = {
+      activeAuction: makeAuction({ nounId: '5', amount: '500', bidder: '0xOLD' }),
+      bids: [makeBid({ transactionHash: '0xA', value: '500', sender: '0xOLD' })],
+    };
+    const newBid = makeBid({
+      transactionHash: '0xB',
+      value: '2000',
+      sender: '0xNEW',
+    });
+    const out = applyAppendBid(prev, newBid as never);
+    expect(out.bids).toHaveLength(2);
+    expect(out.bids[0].transactionHash).toBe('0xB');
+    expect(out.activeAuction?.amount).toBe('2000');
+    expect(out.activeAuction?.bidder).toBe('0xNEW');
+  });
+
+  it('preserves activeAuction amount when new bid is lower than existing max', () => {
+    const prev = {
+      activeAuction: makeAuction({ nounId: '5', amount: '5000', bidder: '0xHIGH' }),
+      bids: [makeBid({ transactionHash: '0xH', value: '5000', sender: '0xHIGH' })],
+    };
+    const newBid = makeBid({
+      transactionHash: '0xL',
+      value: '100',
+      sender: '0xLOW',
+    });
+    const out = applyAppendBid(prev, newBid as never);
+    expect(out.activeAuction?.amount).toBe('5000');
+    expect(out.activeAuction?.bidder).toBe('0xHIGH');
+  });
+});
+
+describe('applyAuctionSettled', () => {
+  it('returns state unchanged when activeAuction undefined', () => {
+    const prev = { activeAuction: undefined, bids: [] };
+    const out = applyAuctionSettled(prev, { nounId: 5, winner: '0xW', amount: 100 } as never);
+    expect(out).toBe(prev);
+  });
+
+  it('returns state unchanged when nounId mismatches', () => {
+    const prev = { activeAuction: makeAuction({ nounId: '5' }), bids: [] };
+    const out = applyAuctionSettled(prev, { nounId: 99, winner: '0xW', amount: 100 } as never);
+    expect(out).toBe(prev);
+  });
+
+  it('sets settled=true + winner / amount when nounId matches', () => {
+    const prev = {
+      activeAuction: makeAuction({ nounId: '5', amount: '0', settled: false }),
+      bids: [],
+    };
+    const out = applyAuctionSettled(prev, {
+      nounId: 5,
+      winner: '0xWINNER' as `0x${string}`,
+      amount: 1000n,
+    });
+    expect(out.activeAuction?.settled).toBe(true);
+    expect(out.activeAuction?.bidder).toBe('0xWINNER');
+    expect(out.activeAuction?.amount).toBe('1000');
+  });
+});
+
+describe('applyAuctionExtended', () => {
+  it('returns state unchanged when activeAuction undefined', () => {
+    const prev = { activeAuction: undefined, bids: [] };
+    const out = applyAuctionExtended(prev, { nounId: 5, endTime: 500 } as never);
+    expect(out).toBe(prev);
+  });
+
+  it('returns state unchanged when nounId mismatches', () => {
+    const prev = { activeAuction: makeAuction({ nounId: '5', endTime: '200' }), bids: [] };
+    const out = applyAuctionExtended(prev, { nounId: 99, endTime: 500 } as never);
+    expect(out).toBe(prev);
+  });
+
+  it('updates endTime when nounId matches', () => {
+    const prev = { activeAuction: makeAuction({ nounId: '5', endTime: '200' }), bids: [] };
+    const out = applyAuctionExtended(prev, { nounId: 5, endTime: 500n });
+    expect(out.activeAuction?.endTime).toBe('500');
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 67` として新領域 (state / lib) 2 file (`state/atoms/auctionAtom` 145 行 / `lib/traitName` 17 行) に vitest を追加、 1454 → 1484 (+30、 1 skip 維持)。

**マイルストーン** ... wrappers 完走後の新領域 (state / lib) expansion 開始。 候補だった `lib/nijiAssets.test.ts` は既に test 済みと判明。

## 詳細

### state/atoms/auctionAtom.test.ts (18 TC)

current auction の Jotai atom 状態を扱う pure reducer + serializer 群。

検証観点。

- auctionAtom 初期値 (activeAuction undefined / bids [])
- reduxSafeNewAuction ... default 0 amount + 0x bidder + settled=false で BigInt → string 変換
- reduxSafeAuction ... amount/bidder undefined 維持 + BigInt 変換
- reduxSafeBid ... value/nounId/timestamp の BigInt → string
- applyActiveAuction ... payload を reduxSafeNewAuction で変換 + bids=[]
- applyFullAuction ... payload を reduxSafeAuction で変換
- applyAppendBid ... activeAuction undefined / nounId 不一致 / 同 txHash 重複時に state 不変
- applyAppendBid ... 新規 bid を先頭追加 + maxBid で amount/bidder 更新
- applyAppendBid ... 既存 max より低い bid で amount/bidder 不変
- applyAuctionSettled ... activeAuction undefined / nounId 不一致時 state 不変
- applyAuctionSettled ... nounId 一致時 settled=true + winner/amount 更新
- applyAuctionExtended ... activeAuction undefined / nounId 不一致時 state 不変
- applyAuctionExtended ... nounId 一致時 endTime 更新

### lib/traitName.test.ts (12 TC)

trait filename を 表示用テキストに変換する純粋関数。 hyphen 分割 / capitalize / fallback 経路を網羅。

検証観点。

- out-of-range index で humanizeTraitKey fallback
- leftHand type out-of-range fallback ... "Left Hand"
- filename '-' あり ... hyphen 後を capitalize ("special-cool-special" → "Cool Special")
- filename '-' なし ... 全 capitalize ("choker" → "Choker")
- 多 hyphen ... 最初の '-' 後を capitalize + 残 hyphen space 化 ("headphone-pink-headphone" → "Pink Headphone")
- leftHand type に hyphen なし filename "leftHand" ... 内部の H は word boundary 後でないため "LeftHand"
- hyphen ありで hat ... "hat-cool" → "Cool" (slice(indexOf('-')+1)="cool" → "Cool")
- 空 filename ... 「''」 → 空文字 return (humanize fallback には行かない)
- ear "ear-x" → "X" (slice 後の "x" → "X")
- back "back-Y" → "Y" (uppercase 維持)
- backDecoration "backDecoration-z" → "Z" (slice 後の "z" → "Z")
- hair "hair-rainbow" → "Rainbow"

## 解決方法

auctionAtom 側 ... 全 export を vi.mock なしで直接 import、 純粋 reducer 関数を fixture 入力で検証。 `auctionAtom.init` で初期値検査。

traitName 側 ... `@/lib/nijiAssets` を vi.mock し `NijiImageData.images` を fixture object で stub、 各 trait の filename を test ごとに切替検証。 `humanizeTraitKey` も同 mock 内で再現。 `@/wrappers/nijiToken` の `INounSeed` 型は type-only なので mock 不要。

## 受入条件

- [x] 2 file 計 30 TC 全 pass
- [x] `pnpm vitest run` 全 1484 test green (1485 - 1 skipped)
- [x] regression なし (既存 1454 pass を破壊しない)

## 関連

- Closes #465
- 直前 PR #464 (part 66) で 1410 → 1454 (wrappers 完走)
- 残未テスト 候補 ... `state/atoms/pastAuctionsAtom` (48 行) / `i18n/NijiI18nProvider.tsx` (54 行) / `i18n/activeLocaleAtom.ts` (50 行) / `i18n/locales.ts` (34 行) / `subgraphs/execute.ts` (32 行) / `i18n/LanguageProvider.tsx` (23 行) / `layout/Section/index.tsx` (22 行) 等
- 学び ... 既存 test の検出は file 名 1:1 で判断するため、 同名 .ts と .tsx は別判定 (将来 expansion 候補抽出時に注意)
