### PR TITLE
✅ test(niji-webapp): part 68 (i18n 3 file) で 1484 → 1516 (Issue #467)

### DIFF
--- a/packages/niji-webapp/src/i18n/NijiI18nProvider.test.tsx
+++ b/packages/niji-webapp/src/i18n/NijiI18nProvider.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+
+import { render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const i18nState: {
+  locale: string | undefined;
+  load: ReturnType<typeof vi.fn>;
+  activate: ReturnType<typeof vi.fn>;
+} = {
+  locale: undefined,
+  load: vi.fn(),
+  activate: vi.fn(),
+};
+
+vi.mock('@lingui/core', () => ({
+  i18n: {
+    get locale() {
+      return i18nState.locale;
+    },
+    load: (...args: unknown[]) => i18nState.load(...args),
+    activate: (...args: unknown[]) => i18nState.activate(...args),
+  },
+}));
+
+vi.mock('@lingui/react', () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="i18n-provider">{children}</div>
+  ),
+}));
+
+import { NijiI18nProvider } from './NijiI18nProvider';
+
+beforeEach(() => {
+  i18nState.locale = undefined;
+  i18nState.load = vi.fn();
+  i18nState.activate = vi.fn();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NijiI18nProvider', () => {
+  it('renders children inside I18nProvider', () => {
+    const { container } = render(
+      <NijiI18nProvider locale="ja-JP">
+        <span data-testid="child">child text</span>
+      </NijiI18nProvider>,
+    );
+    expect(container.querySelector('[data-testid="i18n-provider"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe('child text');
+  });
+
+  it('initializes DEFAULT_LOCALE (ja-JP) when i18n.locale is undefined', () => {
+    i18nState.locale = undefined;
+    render(
+      <NijiI18nProvider locale="ja-JP">
+        <span>x</span>
+      </NijiI18nProvider>,
+    );
+    expect(i18nState.load).toHaveBeenCalledWith('ja-JP', {});
+    expect(i18nState.activate).toHaveBeenCalledWith('ja-JP');
+  });
+
+  it('does not eagerly initialize when locale is not DEFAULT_LOCALE', () => {
+    i18nState.locale = undefined;
+    render(
+      <NijiI18nProvider locale="en-US">
+        <span>x</span>
+      </NijiI18nProvider>,
+    );
+    expect(i18nState.load).not.toHaveBeenCalledWith('en-US', {});
+  });
+
+  it('does not eagerly initialize when i18n.locale is already set', () => {
+    i18nState.locale = 'en-US';
+    render(
+      <NijiI18nProvider locale="ja-JP">
+        <span>x</span>
+      </NijiI18nProvider>,
+    );
+    expect(i18nState.load).not.toHaveBeenCalledWith('ja-JP', {});
+  });
+
+  it('calls onActivate after locale activation succeeds', async () => {
+    const onActivate = vi.fn();
+    render(
+      <NijiI18nProvider locale="ja-JP" onActivate={onActivate}>
+        <span>x</span>
+      </NijiI18nProvider>,
+    );
+    await waitFor(() => expect(onActivate).toHaveBeenCalledWith('ja-JP'));
+  });
+
+  it('logs error when dynamicActivate fails (catalog import error)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <NijiI18nProvider locale={'invalid-LOCALE' as never}>
+        <span>x</span>
+      </NijiI18nProvider>,
+    );
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+    errorSpy.mockRestore();
+  });
+
+  it('renders without crashing for all 3 supported locales', () => {
+    const locales: Array<'ja-JP' | 'en-US' | 'zh-CN'> = ['ja-JP', 'en-US', 'zh-CN'];
+    for (const locale of locales) {
+      const { container, unmount } = render(
+        <NijiI18nProvider locale={locale}>
+          <span>x</span>
+        </NijiI18nProvider>,
+      );
+      expect(container.querySelector('[data-testid="i18n-provider"]')).not.toBeNull();
+      unmount();
+    }
+  });
+});

--- a/packages/niji-webapp/src/i18n/activeLocaleAtom.test.ts
+++ b/packages/niji-webapp/src/i18n/activeLocaleAtom.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('jotai/utils', () => ({
+  atomWithStorage: <T>(_key: string, init: T) => ({ tag: 'atomWithStorage', init }),
+  createJSONStorage: () => ({}),
+}));
+
+vi.mock('jotai/vanilla', () => ({
+  atom: (read: unknown, write: unknown) => ({ tag: 'atom', read, write }),
+}));
+
+vi.mock('jotai-effect', () => ({
+  withAtomEffect: (a: unknown) => a,
+}));
+
+vi.mock('./NijiI18nProvider', () => ({
+  dynamicActivate: vi.fn(),
+}));
+
+import { pickSupportedLocale } from './activeLocaleAtom';
+
+describe('pickSupportedLocale', () => {
+  it('returns exact match for ja-JP', () => {
+    expect(pickSupportedLocale(['ja-JP'])).toBe('ja-JP');
+  });
+
+  it('returns exact match for en-US', () => {
+    expect(pickSupportedLocale(['en-US'])).toBe('en-US');
+  });
+
+  it('returns exact match for zh-CN', () => {
+    expect(pickSupportedLocale(['zh-CN'])).toBe('zh-CN');
+  });
+
+  it('returns ja-JP for base "ja" match (e.g. "ja-XX")', () => {
+    expect(pickSupportedLocale(['ja-XX'])).toBe('ja-JP');
+  });
+
+  it('returns en-US for base "en" match (e.g. "en-GB")', () => {
+    expect(pickSupportedLocale(['en-GB'])).toBe('en-US');
+  });
+
+  it('returns zh-CN for base "zh" match (e.g. "zh-TW")', () => {
+    expect(pickSupportedLocale(['zh-TW'])).toBe('zh-CN');
+  });
+
+  it('skips null candidates and uses next', () => {
+    expect(pickSupportedLocale([null, 'en-US'])).toBe('en-US');
+  });
+
+  it('skips undefined candidates and uses next', () => {
+    expect(pickSupportedLocale([undefined, 'zh-CN'])).toBe('zh-CN');
+  });
+
+  it('returns DEFAULT_LOCALE (ja-JP) when no candidates match', () => {
+    expect(pickSupportedLocale(['fr', 'de-DE', 'ko'])).toBe('ja-JP');
+  });
+
+  it('returns DEFAULT_LOCALE (ja-JP) for empty candidates array', () => {
+    expect(pickSupportedLocale([])).toBe('ja-JP');
+  });
+
+  it('prefers first matching candidate over later matches', () => {
+    expect(pickSupportedLocale(['en-US', 'zh-CN'])).toBe('en-US');
+  });
+
+  it('returns DEFAULT_LOCALE when all candidates are null/undefined', () => {
+    expect(pickSupportedLocale([null, undefined, null])).toBe('ja-JP');
+  });
+});

--- a/packages/niji-webapp/src/i18n/locales.test.ts
+++ b/packages/niji-webapp/src/i18n/locales.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_LOCALE,
+  Locales,
+  LOCALE_LABEL,
+  SUPPORTED_LOCALE_TO_DAYSJS_LOCALE,
+  SUPPORTED_LOCALES,
+} from './locales';
+
+describe('SUPPORTED_LOCALES', () => {
+  it('contains exactly 3 locales in fixed order (ja-JP first)', () => {
+    expect(SUPPORTED_LOCALES).toEqual(['ja-JP', 'en-US', 'zh-CN']);
+  });
+});
+
+describe('DEFAULT_LOCALE', () => {
+  it('is ja-JP', () => {
+    expect(DEFAULT_LOCALE).toBe('ja-JP');
+  });
+
+  it('appears at index 0 of SUPPORTED_LOCALES', () => {
+    expect(SUPPORTED_LOCALES[0]).toBe(DEFAULT_LOCALE);
+  });
+});
+
+describe('LOCALE_LABEL', () => {
+  it('maps en-US to "English"', () => {
+    expect(LOCALE_LABEL['en-US']).toBe('English');
+  });
+
+  it('maps zh-CN to 中文', () => {
+    expect(LOCALE_LABEL['zh-CN']).toBe('中文');
+  });
+
+  it('maps ja-JP to 日本語', () => {
+    expect(LOCALE_LABEL['ja-JP']).toBe('日本語');
+  });
+
+  it('includes pseudo locale label', () => {
+    expect(LOCALE_LABEL.pseudo).toBeDefined();
+  });
+});
+
+describe('Locales enum', () => {
+  it('en_US = "en-US"', () => {
+    expect(Locales.en_US).toBe('en-US');
+  });
+
+  it('zh_CN = "zh-CN"', () => {
+    expect(Locales.zh_CN).toBe('zh-CN');
+  });
+
+  it('ja_JP = "ja-JP"', () => {
+    expect(Locales.ja_JP).toBe('ja-JP');
+  });
+});
+
+describe('SUPPORTED_LOCALE_TO_DAYSJS_LOCALE', () => {
+  it('has dayjs locale for all 3 supported locales + pseudo', () => {
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['en-US']).toBeDefined();
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['zh-CN']).toBeDefined();
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['ja-JP']).toBeDefined();
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE.pseudo).toBeDefined();
+  });
+
+  it('pseudo locale falls back to en dayjs locale', () => {
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE.pseudo).toBe(
+      SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['en-US'],
+    );
+  });
+
+  it('all dayjs locale objects have a name property', () => {
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['en-US'].name).toBeDefined();
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['zh-CN'].name).toBeDefined();
+    expect(SUPPORTED_LOCALE_TO_DAYSJS_LOCALE['ja-JP'].name).toBeDefined();
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 68` として i18n 領域 3 file (`i18n/locales` 34 行 / `i18n/activeLocaleAtom` 50 行 / `i18n/NijiI18nProvider` 54 行) に vitest を追加、 1484 → 1516 (+32、 1 skip 維持)。 i18n 領域 expansion 開始。

## 詳細

### i18n/locales.test.ts (13 TC)

3 言語サポート (ja-JP / en-US / zh-CN) + pseudo の constants / enum / dayjs マッピング検証。

検証観点。

- SUPPORTED_LOCALES ... 3 件 ja-JP 先頭順序固定
- DEFAULT_LOCALE ... ja-JP
- LOCALE_LABEL ... 各 locale の表示名 (English / 中文 / 日本語 / pseudo)
- Locales enum ... en_US / zh_CN / ja_JP 値
- SUPPORTED_LOCALE_TO_DAYSJS_LOCALE ... 3 locale + pseudo マッピング、 pseudo → en fallback、 dayjs name property 存在確認

### i18n/activeLocaleAtom.test.ts (12 TC)

`pickSupportedLocale` 純粋関数 (locale 候補から SupportedLocale 解決)。

検証観点。

- 完全一致 (ja-JP / en-US / zh-CN)
- base 言語一致 (ja-XX → ja-JP / en-GB → en-US / zh-TW → zh-CN)
- null / undefined skip
- 全該当なしで DEFAULT_LOCALE
- 空配列で DEFAULT_LOCALE
- 複数候補で先頭優先
- 全 null/undefined で DEFAULT_LOCALE

### i18n/NijiI18nProvider.test.tsx (7 TC)

i18n Provider React component + 初期化経路。

検証観点。

- children を I18nProvider 内に render
- DEFAULT_LOCALE (ja-JP) + i18n.locale undefined で eager `i18n.load + activate` 呼出
- 非 DEFAULT_LOCALE では eager init しない
- i18n.locale が既に set されていれば eager init しない
- locale 指定で dynamicActivate → onActivate コールバック呼出
- 不正 locale で catalog 失敗 → console.error
- 3 supported locale 全てで render crash なし

## 解決方法

i18n/locales 側 ... 直接 import で純粋 constants 検証、 dayjs locale 実 module を使用。

i18n/activeLocaleAtom 側 ... `jotai/utils` + `jotai/vanilla` + `jotai-effect` + `./NijiI18nProvider` を vi.mock し副作用排除、 `pickSupportedLocale` のみ独立検証。 activeLocaleAtom 本体は副作用付き complex atom のため test 範囲は pickSupportedLocale に絞る。

i18n/NijiI18nProvider 側 ... `@lingui/core` `i18n` を getter mock 経由で locale 切替、 `@lingui/react` `I18nProvider` を簡素 mock。 `dynamicActivate` は test 内で実 import 経由で実行され `../locales/${locale}.po` import 失敗時の error 経路を console.error catch で検証。

## 受入条件

- [x] 3 file 計 32 TC 全 pass
- [x] `pnpm vitest run` 全 1516 test green (1517 - 1 skipped)
- [x] regression なし (既存 1484 pass を破壊しない)

## 関連

- Closes #467
- 直前 PR #466 (part 67) で 1454 → 1484
- 残未テスト 候補 ... state/atoms/pastAuctionsAtom (48 行) / subgraphs/execute (32 行) / i18n/LanguageProvider (23 行) / layout/Section (22 行) 等
- 学び ... jotai atom + side-effect 経路は pickSupportedLocale のような純粋 helper を独立 export して test 化する pattern (将来 atom test の base case)
