### PR TITLE
✅ test(niji-webapp): part 69 (pastAuctionsAtom + execute + LanguageProvider + Section) で 1516 → 1545 (Issue #469)

### DIFF
--- a/packages/niji-webapp/src/i18n/LanguageProvider.test.tsx
+++ b/packages/niji-webapp/src/i18n/LanguageProvider.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+import { fireEvent, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useActiveLocaleMock = vi.fn();
+vi.mock('../hooks/useActivateLocale', () => ({
+  useActiveLocale: () => useActiveLocaleMock(),
+}));
+
+const dynamicActivateMock = vi.fn();
+vi.mock('./NijiI18nProvider', () => ({
+  dynamicActivate: (...args: unknown[]) => dynamicActivateMock(...args),
+  NijiI18nProvider: ({
+    locale,
+    forceRenderAfterLocaleChange,
+    onActivate,
+    children,
+  }: {
+    locale: string;
+    forceRenderAfterLocaleChange?: boolean;
+    onActivate?: (locale: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <div
+      data-testid="niji-i18n-provider"
+      data-locale={locale}
+      data-force-render={String(forceRenderAfterLocaleChange)}
+    >
+      <button data-testid="trigger-activate" onClick={() => onActivate?.(locale)} />
+      {children}
+    </div>
+  ),
+}));
+
+import { LanguageProvider } from './LanguageProvider';
+
+beforeEach(() => {
+  useActiveLocaleMock.mockReset();
+  dynamicActivateMock.mockReset();
+  useActiveLocaleMock.mockReturnValue('ja-JP');
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('LanguageProvider', () => {
+  it('renders children inside NijiI18nProvider', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <span data-testid="child">child text</span>
+      </LanguageProvider>,
+    );
+    expect(container.querySelector('[data-testid="niji-i18n-provider"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe('child text');
+  });
+
+  it('passes useActiveLocale value to NijiI18nProvider', () => {
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { container } = render(
+      <LanguageProvider>
+        <span>x</span>
+      </LanguageProvider>,
+    );
+    const provider = container.querySelector('[data-testid="niji-i18n-provider"]');
+    expect(provider?.getAttribute('data-locale')).toBe('en-US');
+  });
+
+  it('sets forceRenderAfterLocaleChange=true', () => {
+    const { container } = render(
+      <LanguageProvider>
+        <span>x</span>
+      </LanguageProvider>,
+    );
+    const provider = container.querySelector('[data-testid="niji-i18n-provider"]');
+    expect(provider?.getAttribute('data-force-render')).toBe('true');
+  });
+
+  it('onActivate callback calls dynamicActivate', () => {
+    useActiveLocaleMock.mockReturnValue('zh-CN');
+    const { container } = render(
+      <LanguageProvider>
+        <span>x</span>
+      </LanguageProvider>,
+    );
+    const trigger = container.querySelector(
+      '[data-testid="trigger-activate"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(trigger);
+    expect(dynamicActivateMock).toHaveBeenCalledWith('zh-CN');
+  });
+
+  it('renders without crashing when useActiveLocale returns pseudo locale', () => {
+    useActiveLocaleMock.mockReturnValue('pseudo');
+    const { container } = render(
+      <LanguageProvider>
+        <span>x</span>
+      </LanguageProvider>,
+    );
+    expect(container.querySelector('[data-testid="niji-i18n-provider"]')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/layout/Section/index.test.tsx
+++ b/packages/niji-webapp/src/layout/Section/index.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import Section from './index';
+
+describe('Section', () => {
+  it('renders children', () => {
+    const { container } = render(
+      <Section fullWidth={false}>
+        <span data-testid="child">child text</span>
+      </Section>,
+    );
+    expect(container.querySelector('[data-testid="child"]')?.textContent).toBe('child text');
+  });
+
+  it('applies custom className to outer wrapper', () => {
+    const { container } = render(
+      <Section fullWidth={false} className="custom-section-class">
+        <span>x</span>
+      </Section>,
+    );
+    const outer = container.firstChild as HTMLDivElement;
+    expect(outer.className).toContain('custom-section-class');
+  });
+
+  it('applies custom style to outer wrapper', () => {
+    const { container } = render(
+      <Section fullWidth={false} style={{ backgroundColor: 'red' }}>
+        <span>x</span>
+      </Section>,
+    );
+    const outer = container.firstChild as HTMLDivElement;
+    expect(outer.style.backgroundColor).toBe('red');
+  });
+
+  it('Container is fluid (fullWidth=true)', () => {
+    const { container } = render(
+      <Section fullWidth={true}>
+        <span>x</span>
+      </Section>,
+    );
+    const fluid = container.querySelector('.container-fluid');
+    expect(fluid).not.toBeNull();
+  });
+
+  it('Container is fluid="lg" (fullWidth=false)', () => {
+    const { container } = render(
+      <Section fullWidth={false}>
+        <span>x</span>
+      </Section>,
+    );
+    const fluidLg = container.querySelector('.container-lg');
+    expect(fluidLg).not.toBeNull();
+  });
+
+  it('renders Row with align-items-center class', () => {
+    const { container } = render(
+      <Section fullWidth={false}>
+        <span>x</span>
+      </Section>,
+    );
+    const row = container.querySelector('.row');
+    expect(row?.className).toContain('align-items-center');
+  });
+
+  it('renders multiple children inside Row', () => {
+    const { container } = render(
+      <Section fullWidth={false}>
+        <span data-testid="a">a</span>
+        <span data-testid="b">b</span>
+      </Section>,
+    );
+    expect(container.querySelector('[data-testid="a"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="b"]')).not.toBeNull();
+  });
+
+  it('merges className when both default and custom are present', () => {
+    const { container } = render(
+      <Section fullWidth={false} className="cls-1 cls-2">
+        <span>x</span>
+      </Section>,
+    );
+    const outer = container.firstChild as HTMLDivElement;
+    expect(outer.className).toContain('cls-1');
+    expect(outer.className).toContain('cls-2');
+  });
+
+  it('does not crash when style is undefined', () => {
+    const { container } = render(
+      <Section fullWidth={false}>
+        <span>x</span>
+      </Section>,
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/state/atoms/pastAuctionsAtom.test.ts
+++ b/packages/niji-webapp/src/state/atoms/pastAuctionsAtom.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+
+import { pastAuctionsAtom, subgraphAuctionsToReduxSafe } from './pastAuctionsAtom';
+
+const makeAuction = (overrides: Record<string, unknown> = {}) => ({
+  amount: '1000',
+  bidder: { id: '0xBIDDER' },
+  startTime: '100',
+  endTime: '200',
+  id: '5',
+  bids: [],
+  ...overrides,
+});
+
+const makeBid = (overrides: Record<string, unknown> = {}) => ({
+  amount: '500',
+  bidder: { id: '0xSENDER' },
+  txHash: '0xTX',
+  txIndex: 0,
+  blockTimestamp: '1700000000',
+  ...overrides,
+});
+
+describe('pastAuctionsAtom', () => {
+  it('initial value is empty array', () => {
+    expect(pastAuctionsAtom.init).toEqual([]);
+  });
+});
+
+describe('subgraphAuctionsToReduxSafe', () => {
+  it('returns empty array when data.auctions undefined', () => {
+    const out = subgraphAuctionsToReduxSafe({ auctions: undefined } as never);
+    expect(out).toEqual([]);
+  });
+
+  it('converts auction fields BigInt-strings + settled=false', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [makeAuction({ amount: '5000', startTime: '700', endTime: '800', id: '10' })],
+    } as never);
+    expect(out).toHaveLength(1);
+    expect(out[0].activeAuction?.amount).toBe('5000');
+    expect(out[0].activeAuction?.startTime).toBe('700');
+    expect(out[0].activeAuction?.endTime).toBe('800');
+    expect(out[0].activeAuction?.nounId).toBe('10');
+    expect(out[0].activeAuction?.settled).toBe(false);
+  });
+
+  it('preserves amount=undefined when null', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [makeAuction({ amount: null })],
+    } as never);
+    expect(out[0].activeAuction?.amount).toBeUndefined();
+  });
+
+  it('preserves bidder=undefined when null', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [makeAuction({ bidder: null })],
+    } as never);
+    expect(out[0].activeAuction?.bidder).toBeUndefined();
+  });
+
+  it('maps bidder.id to bidder Address', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [makeAuction({ bidder: { id: '0xALICE' } })],
+    } as never);
+    expect(out[0].activeAuction?.bidder).toBe('0xALICE');
+  });
+
+  it('converts bids array (sender / value / timestamp)', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [
+        makeAuction({
+          bids: [
+            makeBid({
+              amount: '1500',
+              bidder: { id: '0xBOB' },
+              txHash: '0xTX1',
+              blockTimestamp: '1700000001',
+            }),
+          ],
+        }),
+      ],
+    } as never);
+    expect(out[0].bids).toHaveLength(1);
+    expect(out[0].bids[0].value).toBe('1500');
+    expect(out[0].bids[0].sender).toBe('0xBOB');
+    expect(out[0].bids[0].transactionHash).toBe('0xTX1');
+    expect(out[0].bids[0].timestamp).toBe('1700000001');
+  });
+
+  it('processes multiple auctions independently', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [makeAuction({ id: '1' }), makeAuction({ id: '2' }), makeAuction({ id: '3' })],
+    } as never);
+    expect(out).toHaveLength(3);
+    expect(out.map(a => a.activeAuction?.nounId)).toEqual(['1', '2', '3']);
+  });
+
+  it('returns auction with empty bids when bids=[]', () => {
+    const out = subgraphAuctionsToReduxSafe({
+      auctions: [makeAuction({ bids: [] })],
+    } as never);
+    expect(out[0].bids).toEqual([]);
+  });
+});

--- a/packages/niji-webapp/src/subgraphs/execute.test.ts
+++ b/packages/niji-webapp/src/subgraphs/execute.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const configState: { subgraphApiUri: string } = { subgraphApiUri: 'https://subgraph.example' };
+vi.mock('@/config', () => ({
+  default: {
+    get app() {
+      return { subgraphApiUri: configState.subgraphApiUri };
+    },
+  },
+}));
+
+import { execute } from './execute';
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  configState.subgraphApiUri = 'https://subgraph.example';
+  mockFetch.mockReset();
+  global.fetch = mockFetch as never;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('execute', () => {
+  it('returns undefined when subgraphApiUri is empty (fetch not called)', async () => {
+    configState.subgraphApiUri = '';
+    const result = await execute('query x { y }' as never);
+    expect(result).toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('calls fetch with POST to subgraphApiUri', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: { foo: 1 } }) });
+    await execute('query x { y }' as never);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://subgraph.example',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('passes Content-Type + Accept headers', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: {} }) });
+    await execute('query' as never);
+    const call = mockFetch.mock.calls[0][1];
+    expect(call.headers['Content-Type']).toBe('application/json');
+    expect(call.headers.Accept).toBe('application/graphql-response+json');
+  });
+
+  it('sends body with query + variables JSON-stringified', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: {} }) });
+    await execute('query GetX { x }' as never, { id: '1' } as never);
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.query).toBe('query GetX { x }');
+    expect(body.variables).toEqual({ id: '1' });
+  });
+
+  it('returns data field from successful JSON response', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({ data: { proposals: [1, 2] } }) });
+    const result = await execute('query' as never);
+    expect(result).toEqual({ proposals: [1, 2] });
+  });
+
+  it('throws when response.ok is false', async () => {
+    mockFetch.mockResolvedValue({ ok: false, json: async () => ({}) });
+    await expect(execute('query' as never)).rejects.toThrow('Network response was not ok');
+  });
+});


### PR DESCRIPTION
## 概要

`webapp part 69` として残小規模 4 file (`state/atoms/pastAuctionsAtom` 48 行 / `subgraphs/execute` 32 行 / `i18n/LanguageProvider` 23 行 / `layout/Section/index` 22 行) に vitest を追加、 1516 → 1545 (+29、 1 skip 維持)。

## 詳細

### state/atoms/pastAuctionsAtom.test.ts (9 TC)

過去 auction list の Jotai atom + subgraph 型から AuctionState[] への純粋変換関数。

検証観点。

- pastAuctionsAtom 初期値 (空配列)
- subgraphAuctionsToReduxSafe ... auctions undefined で空、 BigInt → string 変換、 amount/bidder undefined 維持、 bidder.id Address mapping、 bids 変換 (sender/value/timestamp string)、 複数 auction、 空 bids 配列、 settled 常に false reset

### subgraphs/execute.test.ts (6 TC)

GraphQL subgraph fetch 関数。 subgraph endpoint 空時の早期 return 経路含む。

検証観点。

- subgraphApiUri 空で undefined return + fetch 未呼出
- fetch URL + POST method
- Content-Type + Accept headers
- body の query+variables JSON
- ok=true で data 返却
- ok=false で throw

### i18n/LanguageProvider.test.tsx (5 TC)

`useActiveLocale` 経由で取得した locale を `NijiI18nProvider` に流す薄 wrapper。

検証観点。

- children を NijiI18nProvider 内に render
- useActiveLocale の値を locale prop に流す
- forceRenderAfterLocaleChange=true 固定
- onActivate callback で dynamicActivate 呼出
- pseudo locale でも crash なし

### layout/Section/index.test.tsx (9 TC)

react-bootstrap Container + Row wrapper component。

検証観点。

- children render
- custom className 適用 + 複数 class merge
- custom style 適用 + style 未指定で crash なし
- fullWidth=true で Container fluid (.container-fluid)
- fullWidth=false で Container fluid="lg" (.container-lg)
- Row.align-items-center class
- 複数 children を Row 内に独立 render

## 解決方法

pastAuctionsAtom 側 ... 直接 import で純粋関数検証、 atom 初期値 .init で検査。

subgraphs/execute 側 ... `@/config` を mock + `global.fetch` を vi.fn で stub し各経路検証。 fetch mock を `global.fetch = mockFetch` 経由で注入。

i18n/LanguageProvider 側 ... `useActiveLocale` + `NijiI18nProvider` + `dynamicActivate` を vi.mock し、 NijiI18nProvider に渡る props を data attr 経由で検証。 onActivate 呼出は子 mock 内に「trigger-activate」 button を仕込んで明示的に発火。

layout/Section 側 ... 子 component (Container / Row) を react-bootstrap actual で使用、 `.container-fluid` / `.container-lg` / `.row.align-items-center` の class 経由で検証。

## 受入条件

- [x] 4 file 計 29 TC 全 pass
- [x] `pnpm vitest run` 全 1545 test green (1546 - 1 skipped)
- [x] regression なし (既存 1516 pass を破壊しない)

## 関連

- Closes #469
- 直前 PR #468 (part 68) で 1484 → 1516
- 残未テスト候補 ... 巨大 generated files (subgraphs/graphql.ts 6012 行 / gql.ts 338 行) は code-gen 対象、 fragment-masking.ts (84 行) も同様、 通常 test 対象外
