### PR TITLE
✅ test(niji-webapp): part 71 (utils 4 file edge case 強化) で 1571 → 1601 (Issue #473)

### DIFF
--- a/packages/niji-webapp/src/utils/cssTransitionUtils.test.ts
+++ b/packages/niji-webapp/src/utils/cssTransitionUtils.test.ts
@@ -40,4 +40,52 @@ describe('desktopModalSlideInFromTopAndGrow', () => {
     expect(desktopModalSlideInFromTopAndGrow.exitingStyle).toBeDefined();
     expect(desktopModalSlideInFromTopAndGrow.exitedStyle).toBeDefined();
   });
+
+  it('exitingStyle uses translateY(-1rem) and scale(0)', () => {
+    expect(desktopModalSlideInFromTopAndGrow.exitingStyle.transform).toBe(
+      'translateY(-1rem) scale(0)',
+    );
+  });
+
+  it('enteringStyle uses opacity 1', () => {
+    expect(desktopModalSlideInFromTopAndGrow.enteringStyle.opacity).toBe(1);
+  });
+});
+
+describe('basicFadeInOut — extra opacity contract', () => {
+  it('opacity sequence: enter/entered=1, exiting=0.5, exited=0 (3-stage fade)', () => {
+    // 中間 exitingStyle で 0.5 を経由する design contract を pin
+    expect(basicFadeInOut.enteringStyle.opacity).toBe(1);
+    expect(basicFadeInOut.enteredStyle.opacity).toBe(1);
+    expect(basicFadeInOut.exitingStyle.opacity).toBe(0.5);
+    expect(basicFadeInOut.exitedStyle.opacity).toBe(0);
+  });
+
+  it('all opacity values are numeric (no string-encoded values)', () => {
+    expect(typeof basicFadeInOut.enteringStyle.opacity).toBe('number');
+    expect(typeof basicFadeInOut.enteredStyle.opacity).toBe('number');
+    expect(typeof basicFadeInOut.exitingStyle.opacity).toBe('number');
+    expect(typeof basicFadeInOut.exitedStyle.opacity).toBe('number');
+  });
+
+  it('does NOT include transform / transition (opacity-only fade contract)', () => {
+    // basicFadeInOut は opacity だけで動く軽量 fade、 transform/transition は含まない
+    expect(basicFadeInOut.enteringStyle.transform).toBeUndefined();
+    expect(basicFadeInOut.enteringStyle.transition).toBeUndefined();
+    expect(basicFadeInOut.exitedStyle.transform).toBeUndefined();
+  });
+});
+
+describe('mobileModalSlideInFromBottm — transition format', () => {
+  it('enteringStyle transition includes both opacity 100ms and transform 100ms', () => {
+    expect(mobileModalSlideInFromBottm.enteringStyle.transition).toContain('opacity 100ms');
+    expect(mobileModalSlideInFromBottm.enteringStyle.transition).toContain('transform 100ms');
+  });
+
+  it('exitedStyle is opacity-only (no transform / transition for cleanup)', () => {
+    const exited = mobileModalSlideInFromBottm.exitedStyle as Record<string, unknown>;
+    expect(exited.opacity).toBe(0);
+    expect(exited.transform).toBeUndefined();
+    expect(exited.transition).toBeUndefined();
+  });
 });

--- a/packages/niji-webapp/src/utils/etherscan.test.ts
+++ b/packages/niji-webapp/src/utils/etherscan.test.ts
@@ -55,4 +55,68 @@ describe('etherscan link builders', () => {
     expect(url).toContain('module=account');
     expect(url).toContain('action=tokenbalance');
   });
+
+  it('buildEtherscanTxLink accepts uppercase hash without transformation', async () => {
+    const { buildEtherscanTxLink } = await importEtherscan();
+    expect(buildEtherscanTxLink('0xABCDEF')).toBe('https://etherscan.io/tx/0xABCDEF');
+  });
+
+  it('buildEtherscanTxLink with empty hash still builds /tx/ root', async () => {
+    const { buildEtherscanTxLink } = await importEtherscan();
+    expect(buildEtherscanTxLink('')).toBe('https://etherscan.io/tx/');
+  });
+
+  it('buildEtherscanTokenLink supports tokenId = 0', async () => {
+    const { buildEtherscanTokenLink } = await importEtherscan();
+    expect(buildEtherscanTokenLink('0xt', 0)).toBe('https://etherscan.io/token/0xt?a=0');
+  });
+
+  it('buildEtherscanTokenLink supports large tokenId (Number.MAX_SAFE_INTEGER)', async () => {
+    const { buildEtherscanTokenLink } = await importEtherscan();
+    const id = Number.MAX_SAFE_INTEGER;
+    expect(buildEtherscanTokenLink('0xt', id)).toBe(`https://etherscan.io/token/0xt?a=${id}`);
+  });
+
+  it('buildEtherscanAddressLink builds /address/ without trailing slash for ENS-shaped input', async () => {
+    const { buildEtherscanAddressLink } = await importEtherscan();
+    expect(buildEtherscanAddressLink('vitalik.eth')).toBe(
+      'https://etherscan.io/address/vitalik.eth',
+    );
+  });
+
+  it('buildEtherscanApiQuery URL-encodes address with special characters', async () => {
+    const { buildEtherscanApiQuery } = await importEtherscan();
+    // URLSearchParams encodes spaces as '+' and special chars like '&'
+    const url = buildEtherscanApiQuery('0xfoo&bar baz');
+    expect(url).toContain('address=0xfoo%26bar+baz');
+  });
+
+  it('buildEtherscanApiQuery preserves order: chainid, module, action, address, apikey', async () => {
+    const { buildEtherscanApiQuery } = await importEtherscan();
+    const url = buildEtherscanApiQuery('0xc');
+    const queryString = url.split('?')[1];
+    const idxChain = queryString.indexOf('chainid=');
+    const idxModule = queryString.indexOf('module=');
+    const idxAction = queryString.indexOf('action=');
+    const idxAddress = queryString.indexOf('address=');
+    const idxApikey = queryString.indexOf('apikey=');
+    expect(idxChain).toBeLessThan(idxModule);
+    expect(idxModule).toBeLessThan(idxAction);
+    expect(idxAction).toBeLessThan(idxAddress);
+    expect(idxAddress).toBeLessThan(idxApikey);
+  });
+});
+
+describe('etherscan link builders — fallback URL when blockExplorers undefined', () => {
+  it('falls back to https://etherscan.io when defaultChain.blockExplorers is undefined', async () => {
+    vi.resetModules();
+    vi.doMock('@/config', () => ({ ETHERSCAN_API_KEY: 'TEST_KEY' }));
+    vi.doMock('@/wagmi', () => ({
+      defaultChain: { id: 1 }, // no blockExplorers
+    }));
+    const { buildEtherscanTxLink } = await import('./etherscan');
+    expect(buildEtherscanTxLink('0xdead')).toBe('https://etherscan.io/tx/0xdead');
+    vi.doUnmock('@/config');
+    vi.doUnmock('@/wagmi');
+  });
 });

--- a/packages/niji-webapp/src/utils/moderation/containsBlockedText.test.ts
+++ b/packages/niji-webapp/src/utils/moderation/containsBlockedText.test.ts
@@ -25,4 +25,46 @@ describe('containsBlockedText', () => {
   it('does case-insensitive match for english profanity', () => {
     expect(containsBlockedText('SHIT happens', 'en')).toBe(true);
   });
+
+  it('returns false for jp (regex JSON 配下 jp は空配列)', () => {
+    expect(containsBlockedText('普通の日本語の文章', 'jp')).toBe(false);
+  });
+
+  it('returns false for empty string with empty regex list (jp)', () => {
+    expect(containsBlockedText('', 'jp')).toBe(false);
+  });
+
+  it('returns false for empty language string (unsupported branch, warns)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(containsBlockedText('clean text', '')).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('returns false when language is whitespace-only (unsupported branch)', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(containsBlockedText('clean text', '  ')).toBe(false);
+    warnSpy.mockRestore();
+  });
+
+  it('does not throw when text contains unicode / emoji', () => {
+    expect(() => containsBlockedText('🍣 寿司 cool 中文', 'en')).not.toThrow();
+    expect(containsBlockedText('🍣 寿司 cool 中文', 'en')).toBe(false);
+  });
+
+  it('returns true when en regex JSON entry matches (hate-speech regex coverage)', () => {
+    // moderationRegexes.json en 配下 regex "hate.{0,3}jew" の match 経路を 1 件確認
+    expect(containsBlockedText('I hate jew', 'en')).toBe(true);
+  });
+
+  it('logs warning text containing the unsupported language code', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    containsBlockedText('any', 'fr');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fr'));
+    warnSpy.mockRestore();
+  });
+
+  it('returns false for clean text with punctuation marks', () => {
+    expect(containsBlockedText('Hello, world! How are you?', 'en')).toBe(false);
+  });
 });

--- a/packages/niji-webapp/src/utils/svg2png.test.ts
+++ b/packages/niji-webapp/src/utils/svg2png.test.ts
@@ -26,4 +26,45 @@ describe('svg2png', () => {
     const result = svg2png(svgString, 32, 32);
     expect(result).toBeInstanceOf(Promise);
   });
+
+  it('uses default newWidth/newHeight = 320 when omitted (320 / 32 = 10、 1 decimal OK)', () => {
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"></svg>';
+    expect(() => svg2png(svgString)).not.toThrow();
+  });
+
+  it('rejects when default 320 used against non-divisible src dim (320 / 7 = 45.714...)', async () => {
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg" width="7" height="7"></svg>';
+    await expect(svg2png(svgString)).rejects.toThrow(/Unable to scale canvas/);
+  });
+
+  it('rejects when only width has bad ratio (height OK)', async () => {
+    // width 7 -> 320 NG, height 32 -> 320 OK
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg" width="7" height="32"></svg>';
+    await expect(svg2png(svgString, 320, 320)).rejects.toThrow(/Unable to scale canvas/);
+  });
+
+  it('rejects when only height has bad ratio (width OK)', async () => {
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="7"></svg>';
+    await expect(svg2png(svgString, 320, 320)).rejects.toThrow(/Unable to scale canvas/);
+  });
+
+  it('rejects when src dim missing (NaN -> ratio NaN -> decimals >1)', async () => {
+    // width 属性なし => Number(null) = 0 => 320/0 = Infinity => "Infinity".split('.') -> ['Infinity'] -> decimals 0
+    // 実装挙動: Infinity.toString() = "Infinity" で split('.') 結果 [1] undefined -> decimals 0 -> guard 通過
+    // この想定通り (実際に同期 throw が起きない) であることを契約として固定
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg"></svg>';
+    expect(() => svg2png(svgString, 320, 320)).not.toThrow();
+  });
+
+  it('does NOT throw for 1-decimal ratio 1.5 (canScale guard passes when decimals <= 1)', () => {
+    // 30 / 20 = 1.5 (1 decimal => OK)
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"></svg>';
+    expect(() => svg2png(svgString, 30, 30)).not.toThrow();
+  });
+
+  it('rejects for 2-decimal ratio (canScale guard blocks when decimals > 1)', async () => {
+    // 25 / 4 = 6.25 (2 decimals => NG)
+    const svgString = '<svg xmlns="http://www.w3.org/2000/svg" width="4" height="4"></svg>';
+    await expect(svg2png(svgString, 25, 25)).rejects.toThrow(/Unable to scale canvas/);
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 71` として既存 test 4 file (`utils/svg2png` / `utils/etherscan` / `utils/cssTransitionUtils` / `utils/moderation/containsBlockedText`) に edge case / boundary TC を 30 件追加、 1571 → 1601 (+30、 1 skip 維持)。

通常 test 可能領域は前 PR (part 70) でほぼ完走済 (残未テストは code-gen 巨大 generated file + pages 系のみ)、 本 PR では既存 test の coverage 強化に切替。

## 詳細

### utils/svg2png.test.ts (+7 TC)

既存 4 → 11 TC へ拡張、 `canScale` guard の境界と default 引数経路を網羅。

検証観点。

- default 引数 (newWidth/newHeight 省略で 320 を採用) の経路
- canScale 境界 (1.5 = 1 decimal OK / 6.25 = 2 decimals NG)
- width / height いずれかのみが bad ratio (片方検知)
- src dim 属性なし (`<svg></svg>` で Number(null) = 0 → Infinity ratio) 時の同期 throw 不発挙動

### utils/etherscan.test.ts (+8 TC)

既存 6 → 14 TC へ拡張、 URL builder 5 種の corner case + module mock 切替で fallback URL も確認。

検証観点。

- buildEtherscanTxLink ... uppercase hash / 空 hash
- buildEtherscanTokenLink ... tokenId 0 / Number.MAX_SAFE_INTEGER
- buildEtherscanAddressLink ... ENS-shape address
- buildEtherscanApiQuery ... `&` / 半角 space を含む address の URL encoding / param 順序固定 (chainid → module → action → address → apikey)
- getExplorerUrl の fallback 経路 (defaultChain.blockExplorers undefined で `https://etherscan.io` を採用)

### utils/cssTransitionUtils.test.ts (+7 TC)

既存 5 → 12 TC へ拡張、 3 export object の transform/transition 仕様を pin。

検証観点。

- desktopModalSlideInFromTopAndGrow ... exitingStyle.transform = `translateY(-1rem) scale(0)` / enteringStyle.opacity = 1
- basicFadeInOut ... 4-stage opacity 数値型 / opacity-only 軽量 fade 契約 (transform / transition なし)
- mobileModalSlideInFromBottm ... transition string が `opacity 100ms` + `transform 100ms` 両方含む / exitedStyle が opacity-only cleanup

### utils/moderation/containsBlockedText.test.ts (+8 TC)

既存 5 → 13 TC へ拡張、 unsupported branch / regex JSON 経路 / unicode 安全性を網羅。

検証観点。

- jp (空 regex array) で false / 空 language で false + warn / 全空白 language で false + warn
- regex JSON の en 配下 hate-speech regex の match 経路 (1 件)
- unicode / 絵文字 / 中文混入で例外なし
- 警告メッセージに unsupported language code を含む
- 句読点付き clean text で false

## 解決方法

各 file は既存 import 経路を再利用、 新 describe ブロック追加または既存 describe ブロックに `it` 追加。 純粋関数 / 副作用は `console.warn` のみのため mock 最小 (既存 file の `vi.mock` パターン踏襲、 fallback URL test のみ `vi.resetModules` + `vi.doMock` で動的差し替え)。

`cssTransitionUtils.test.ts` の `mobileModalSlideInFromBottm.exitedStyle` は narrow object literal 型 (`{ opacity: 0 }`) で `transform` / `transition` property が存在しないため、 `as Record<string, unknown>` cast でアクセスして undefined を assert する経路を採用 (`as TransitionStyles` cast は basicFadeInOut のみで、 他 2 export は未 cast の既存設計)。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1571 → 1601、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1601 tests + 1 todo (1602)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier fix 1 件適用済)
- `pnpm check` (tsc --noEmit) → master と同等の既存 type error のみ、 本 PR 由来は cssTransitionUtils の Record cast で解消済

Closes #473
