### PR TITLE
✅ test(niji-webapp): part 74 (utils vote / lookup / nounder 系 4 file edge case 強化) で 1644 → 1667 (Issue #479)

### DIFF
--- a/packages/niji-webapp/src/utils/lookupNNSOrENS.test.ts
+++ b/packages/niji-webapp/src/utils/lookupNNSOrENS.test.ts
@@ -64,4 +64,48 @@ describe('lookupNNSOrENS', () => {
     await lookupNNSOrENS(client, TARGET);
     expect(readContract.mock.calls[0][0].args).toEqual([TARGET]);
   });
+
+  it('does NOT call ENS when NNS resolves to a non-empty string (1 call only)', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce('alice.⌐◨-◨');
+    const client: Client = { readContract };
+    await lookupNNSOrENS(client, TARGET);
+    expect(readContract).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to ENS when NNS returns undefined (typeof !== "string")', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce(undefined).mockResolvedValueOnce('bob.eth');
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBe('bob.eth');
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls through to ENS when NNS returns 0 (typeof !== "string")', async () => {
+    const readContract = vi.fn().mockResolvedValueOnce(0).mockResolvedValueOnce('zero.eth');
+    const client: Client = { readContract };
+    await expect(lookupNNSOrENS(client, TARGET)).resolves.toBe('zero.eth');
+    expect(readContract).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes target as args also to ENS fallback call (preserves target)', async () => {
+    const readContract = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('NNS'))
+      .mockResolvedValueOnce('e.eth');
+    const client: Client = { readContract };
+    await lookupNNSOrENS(client, TARGET);
+    expect(readContract.mock.calls[1][0].args).toEqual([TARGET]);
+  });
+
+  it('NNS and ENS use the same functionName "resolve" with different addresses', async () => {
+    const readContract = vi
+      .fn()
+      .mockResolvedValueOnce('') // NNS empty -> ENS
+      .mockResolvedValueOnce('y.eth');
+    const client: Client = { readContract };
+    await lookupNNSOrENS(client, TARGET);
+    expect(readContract.mock.calls[0][0].functionName).toBe('resolve');
+    expect(readContract.mock.calls[1][0].functionName).toBe('resolve');
+    expect(readContract.mock.calls[0][0].address).toBe(NNS_ADDR);
+    expect(readContract.mock.calls[1][0].address).toBe(ENS_ADDR);
+  });
 });

--- a/packages/niji-webapp/src/utils/nounActivity/getProposalVoteIcon.test.ts
+++ b/packages/niji-webapp/src/utils/nounActivity/getProposalVoteIcon.test.ts
@@ -42,4 +42,39 @@ describe('getProposalVoteIcon', () => {
     expect(yes).not.toBe(no);
     expect(abs).not.toBe(no);
   });
+
+  it('returns AbsentVote icon for undefined support + DEFEATED', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.DEFEATED), undefined)).toBeTruthy();
+  });
+
+  it('returns AbsentVote icon for undefined support + SUCCEEDED', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.SUCCEEDED), undefined)).toBeTruthy();
+  });
+
+  it('returns AbsentVote icon for undefined support + VETOED', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.VETOED), undefined)).toBeTruthy();
+  });
+
+  it('returns AbsentVote icon for undefined support + CANCELLED', () => {
+    expect(getProposalVoteIcon(makeProposal(ProposalState.CANCELLED), undefined)).toBeTruthy();
+  });
+
+  it('PendingVote icon for PENDING differs from AbsentVote for terminal state', () => {
+    const pending = getProposalVoteIcon(makeProposal(ProposalState.PENDING), undefined);
+    const terminal = getProposalVoteIcon(makeProposal(ProposalState.EXECUTED), undefined);
+    expect(pending).not.toBe(terminal);
+  });
+
+  it('PendingVote vs FOR vote on ACTIVE state are different icons', () => {
+    const pending = getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), undefined);
+    const yes = getProposalVoteIcon(makeProposal(ProposalState.ACTIVE), Vote.FOR);
+    expect(pending).not.toBe(yes);
+  });
+
+  it('returns NoVote (switch default) for AGAINST regardless of proposal status', () => {
+    // status は switch 経路に到達しないので、 PENDING / EXECUTED どちらでも NoVote 同じ
+    const a = getProposalVoteIcon(makeProposal(ProposalState.PENDING), Vote.AGAINST);
+    const b = getProposalVoteIcon(makeProposal(ProposalState.EXECUTED), Vote.AGAINST);
+    expect(a).toBe(b);
+  });
 });

--- a/packages/niji-webapp/src/utils/nounderNiji.test.ts
+++ b/packages/niji-webapp/src/utils/nounderNiji.test.ts
@@ -36,4 +36,37 @@ describe('isNounderNiji', () => {
     expect(isNounderNiji(500n)).toBe(true);
     expect(isNounderNiji(1000n)).toBe(true);
   });
+
+  it('returns false for nounId 9 (just below first non-zero multiple)', () => {
+    expect(isNounderNiji(9n)).toBe(false);
+  });
+
+  it('returns false for nounId 11 (just above 10)', () => {
+    expect(isNounderNiji(11n)).toBe(false);
+  });
+
+  it('returns true for nounId 1819 boundary check (1819 % 10 = 9, false)', () => {
+    expect(isNounderNiji(1819n)).toBe(false);
+  });
+
+  it('returns false for nounId 1821 (just above 1820)', () => {
+    expect(isNounderNiji(1821n)).toBe(false);
+  });
+
+  it('returns true for negative bigint nounderNiji (-10n, multiple of 10, <= 1820)', () => {
+    // -10n % 10n = 0n かつ -10n <= 1820n で true
+    expect(isNounderNiji(-10n)).toBe(true);
+  });
+
+  it('returns false for negative non-multiple bigint (-1n)', () => {
+    // -1n % 10n = -1n !== 0n
+    expect(isNounderNiji(-1n)).toBe(false);
+  });
+
+  it('returns true for all multiples of 10 from 0 to 1820 (sampling)', () => {
+    // 完全網羅は重いため 0/100/500/1000/1500/1820 だけ抜粋
+    [0n, 100n, 500n, 1000n, 1500n, 1820n].forEach(id => {
+      expect(isNounderNiji(id)).toBe(true);
+    });
+  });
 });

--- a/packages/niji-webapp/src/utils/vote.test.ts
+++ b/packages/niji-webapp/src/utils/vote.test.ts
@@ -39,4 +39,30 @@ describe('Vote enum', () => {
   it('typeof Vote.FOR is number', () => {
     expect(typeof Vote.FOR).toBe('number');
   });
+
+  it('Object.entries length is 6 (3 named + 3 reverse)', () => {
+    expect(Object.entries(Vote).length).toBe(6);
+  });
+
+  it('Object.values contains both numeric and string representations', () => {
+    const values = Object.values(Vote);
+    expect(values).toContain(0);
+    expect(values).toContain(1);
+    expect(values).toContain(2);
+    expect(values).toContain('SUPPORT');
+    expect(values).toContain('FOR');
+    expect(values).toContain('ABSTAIN');
+  });
+
+  it('each enum value is integer (Math.floor(v) === v)', () => {
+    expect(Math.floor(Vote.SUPPORT)).toBe(Vote.SUPPORT);
+    expect(Math.floor(Vote.FOR)).toBe(Vote.FOR);
+    expect(Math.floor(Vote.ABSTAIN)).toBe(Vote.ABSTAIN);
+  });
+
+  it('reverse lookup at index 0 returns SUPPORT (not undefined)', () => {
+    // 0 は falsy だが reverse lookup は存在 -> 'SUPPORT'
+    expect(Vote[0]).toBe('SUPPORT');
+    expect(Vote[0]).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 74` として既存 test 4 file (`utils/lookupNNSOrENS` / `utils/nounActivity/getProposalVoteIcon` / `utils/vote` / `utils/nounderNiji`) に edge case / boundary TC を 23 件追加、 1644 → 1667 (+23、 1 skip 維持)。

通常 test 可能領域は前 PR (part 73) でほぼ完走済 (残未テストは code-gen 巨大 generated file + pages 系のみ)、 本 PR では既存 test の coverage 強化に切替。

## 詳細

### utils/lookupNNSOrENS.test.ts (+5 TC)

既存 7 → 12 TC へ拡張、 `typeof === 'string'` guard と address per-call の routing を網羅。

検証観点。

- NNS が non-empty 文字列を返した時 ENS を呼ばない (1 回呼出)
- NNS が `undefined` (typeof !== "string") で ENS fallback
- NNS が `0` (typeof !== "string") で ENS fallback
- ENS fallback でも target address が同一 args として渡る
- NNS と ENS は同じ `functionName: 'resolve'` を共有、 address だけ異なる

### utils/nounActivity/getProposalVoteIcon.test.ts (+7 TC)

既存 7 → 14 TC へ拡張、 ProposalState 全 terminal 状態の AbsentVote 経路と icon 差別を網羅。

検証観点。

- undefined support + 4 terminal state (DEFEATED / SUCCEEDED / VETOED / CANCELLED) で AbsentVote
- Pending icon と terminal AbsentVote は異なる icon (icon 切替境界)
- ACTIVE 上の PendingVote と FOR vote は異なる icon
- switch 経路 (AGAINST = default) は status に依存しない idempotency

### utils/vote.test.ts (+4 TC)

既存 7 → 11 TC へ拡張、 TypeScript enum の reverse lookup / Object 系操作の整合性を網羅。

検証観点。

- `Object.entries(Vote).length === 6` (3 named + 3 reverse)
- `Object.values(Vote)` に numeric (0,1,2) と string ('SUPPORT', 'FOR', 'ABSTAIN') の両方が含まれる
- 各 enum 値が整数 (`Math.floor(v) === v`)
- `Vote[0]` (falsy index) でも reverse lookup で `'SUPPORT'` truthy が返る

### utils/nounderNiji.test.ts (+7 TC)

既存 8 → 15 TC へ拡張、 modulo / 上限境界 / 負の bigint 経路を網羅。

検証観点。

- 9 (just below 10) / 11 (just above 10) 非倍数
- 1819 (just below 1820, 非倍数) / 1821 (just above 1820, 倍数だが超過)
- `-10n` 負の倍数で `-10n <= 1820n` を満たすため true (source の boolean 仕様)
- `-1n` 非倍数で false (`-1n % 10n = -1n`)
- 6 サンプリング (0n, 100n, 500n, 1000n, 1500n, 1820n) すべて true

## 解決方法

各 file は既存 import 経路を再利用、 既存 describe ブロックに新 `it` を追加。 `lookupNNSOrENS` は `vi.fn()` mock chain を踏襲、 `getProposalVoteIcon` は asset svg import を truthy 確認のみで使う既存パターンに従う。 lint fix 1 件 (prettier line 圧縮) は手動で解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1644 → 1667、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1667 tests + 1 todo (1668)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier fix 1 件適用済)

Closes #479
