### PR TITLE
✅ test(niji-webapp): part 76 (hooks locale / block / key / scroll 4 file edge case 強化) で 1691 → 1712 (Issue #483)

### DIFF
--- a/packages/niji-webapp/src/hooks/useActivateLocale.test.ts
+++ b/packages/niji-webapp/src/hooks/useActivateLocale.test.ts
@@ -44,4 +44,38 @@ describe('useActiveLocale', () => {
     renderHook(() => useActiveLocale());
     expect(useAtomValueMock).toHaveBeenCalledTimes(1);
   });
+
+  it('returns fr-FR locale (no transformation)', () => {
+    useAtomValueMock.mockReturnValue('fr-FR');
+    const { result } = renderHook(() => useActiveLocale());
+    expect(result.current).toBe('fr-FR');
+  });
+
+  it('returns whatever atom returns including unconventional values', () => {
+    useAtomValueMock.mockReturnValue('xx-YY');
+    const { result } = renderHook(() => useActiveLocale());
+    expect(result.current).toBe('xx-YY');
+  });
+
+  it('two separate renderHook calls reflect different mock values independently', () => {
+    useAtomValueMock.mockReturnValueOnce('en-US').mockReturnValueOnce('ja-JP');
+    const { result: r1 } = renderHook(() => useActiveLocale());
+    const { result: r2 } = renderHook(() => useActiveLocale());
+    expect(r1.current).toBe('en-US');
+    expect(r2.current).toBe('ja-JP');
+  });
+
+  it('reflects atom value change between rerenders', () => {
+    useAtomValueMock.mockReturnValueOnce('en-US').mockReturnValueOnce('ja-JP');
+    const { result, rerender } = renderHook(() => useActiveLocale());
+    expect(result.current).toBe('en-US');
+    rerender();
+    expect(result.current).toBe('ja-JP');
+  });
+
+  it('returns undefined when atom returns undefined (no defensive default)', () => {
+    useAtomValueMock.mockReturnValue(undefined);
+    const { result } = renderHook(() => useActiveLocale());
+    expect(result.current).toBeUndefined();
+  });
 });

--- a/packages/niji-webapp/src/hooks/useBlockTimestamp.test.tsx
+++ b/packages/niji-webapp/src/hooks/useBlockTimestamp.test.tsx
@@ -46,4 +46,60 @@ describe('useBlockTimestamp', () => {
     await new Promise(resolve => setTimeout(resolve, 50));
     expect(result.current).toBeUndefined();
   });
+
+  it('returns large timestamp under Number.MAX_SAFE_INTEGER', async () => {
+    const large = 9_007_199_254_740_990n; // < 2^53-1
+    getBlockMock.mockReset();
+    getBlockMock.mockResolvedValue({ timestamp: large });
+    const { result } = renderHook(() => useBlockTimestamp(100n));
+    await waitFor(() => expect(result.current).toBe(Number(large)));
+  });
+
+  it('skips fetch when blockNumber is 0n (falsy)', () => {
+    getBlockMock.mockReset();
+    const { result } = renderHook(() => useBlockTimestamp(0n));
+    expect(result.current).toBeUndefined();
+    expect(getBlockMock).not.toHaveBeenCalled();
+  });
+
+  it('passes BigInt(blockNumber) to getBlock with same value', async () => {
+    getBlockMock.mockReset();
+    getBlockMock.mockResolvedValue({ timestamp: 1n });
+    renderHook(() => useBlockTimestamp(42n));
+    await waitFor(() => expect(getBlockMock).toHaveBeenCalled());
+    expect(getBlockMock).toHaveBeenCalledWith({ blockNumber: 42n });
+  });
+
+  it('skips fetch when blockNumber undefined (no getBlock call)', () => {
+    getBlockMock.mockReset();
+    const { result } = renderHook(() => useBlockTimestamp());
+    expect(result.current).toBeUndefined();
+    expect(getBlockMock).not.toHaveBeenCalled();
+  });
+
+  it('passes BigInt() wrap on blockNumber (idempotent for bigint input)', async () => {
+    getBlockMock.mockReset();
+    getBlockMock.mockResolvedValue({ timestamp: 5n });
+    renderHook(() => useBlockTimestamp(7n));
+    await waitFor(() => expect(getBlockMock).toHaveBeenCalled());
+    expect(getBlockMock.mock.calls[0][0].blockNumber).toBe(7n);
+  });
+
+  it('refetches when blockNumber prop changes', async () => {
+    getBlockMock.mockReset();
+    // publicClient mock を fixed instance に統一 (毎 render で同 object を返す)
+    const fixedClient = { getBlock: getBlockMock };
+    usePublicClientMock.mockReturnValue(fixedClient);
+    getBlockMock.mockImplementation(({ blockNumber }: { blockNumber: bigint }) => {
+      if (blockNumber === 1n) return Promise.resolve({ timestamp: 100n });
+      if (blockNumber === 2n) return Promise.resolve({ timestamp: 200n });
+      return Promise.resolve({ timestamp: 0n });
+    });
+    const { result, rerender } = renderHook((n: bigint) => useBlockTimestamp(n), {
+      initialProps: 1n,
+    });
+    await waitFor(() => expect(result.current).toBe(100));
+    rerender(2n);
+    await waitFor(() => expect(result.current).toBe(200));
+  });
 });

--- a/packages/niji-webapp/src/hooks/useKeyPress.test.tsx
+++ b/packages/niji-webapp/src/hooks/useKeyPress.test.tsx
@@ -58,4 +58,77 @@ describe('useKeyPress', () => {
       window.dispatchEvent(new KeyboardEvent('keyup', { key: 'x' }));
     }).not.toThrow();
   });
+
+  it('is case-sensitive: A and a are different target keys', () => {
+    const { result } = renderHook(() => useKeyPress('A'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'A' }));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('handles space key (" ")', () => {
+    const { result } = renderHook(() => useKeyPress(' '));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: ' ' }));
+    });
+    expect(result.current).toBe(true);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('multiple instances of the hook are independent', () => {
+    const { result: r1 } = renderHook(() => useKeyPress('1'));
+    const { result: r2 } = renderHook(() => useKeyPress('2'));
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+    expect(r1.current).toBe(true);
+    expect(r2.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '2' }));
+    });
+    expect(r2.current).toBe(true);
+  });
+
+  it('rerunning effect on targetKey change removes old listener', () => {
+    const { result, rerender } = renderHook((k: string) => useKeyPress(k), {
+      initialProps: 'q',
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'q' }));
+    });
+    expect(result.current).toBe(true);
+
+    rerender('r');
+    // 新 targetKey に切替後、 旧 key 'q' は match しない (state 'true' 保持されるかは
+    // source の動作で keydown q 自体は target r != q なので state 変更なし)
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }));
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('keyup without prior keydown sets state to false (idempotent)', () => {
+    const { result } = renderHook(() => useKeyPress('z'));
+    expect(result.current).toBe(false);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keyup', { key: 'z' }));
+    });
+    expect(result.current).toBe(false);
+  });
 });

--- a/packages/niji-webapp/src/hooks/useScrollToLocation.test.ts
+++ b/packages/niji-webapp/src/hooks/useScrollToLocation.test.ts
@@ -80,4 +80,50 @@ describe('useScrollToLocation', () => {
       behavior: 'smooth',
     });
   });
+
+  it('applies 30 offset to element top (top 50 → top: 20)', () => {
+    locationState.hash = '#x';
+    getElementByIdMock.mockReturnValue({
+      getBoundingClientRect: () => ({ top: 50 }),
+    });
+    renderHook(() => useScrollToLocation());
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 20, behavior: 'smooth' });
+  });
+
+  it('handles element top 0 → top: -30 (offset applied unconditionally)', () => {
+    locationState.hash = '#top';
+    getElementByIdMock.mockReturnValue({
+      getBoundingClientRect: () => ({ top: 0 }),
+    });
+    renderHook(() => useScrollToLocation());
+    expect(scrollToMock).toHaveBeenCalledWith({ top: -30, behavior: 'smooth' });
+  });
+
+  it('handles negative element top (already scrolled past)', () => {
+    locationState.hash = '#above';
+    getElementByIdMock.mockReturnValue({
+      getBoundingClientRect: () => ({ top: -100 }),
+    });
+    renderHook(() => useScrollToLocation());
+    expect(scrollToMock).toHaveBeenCalledWith({ top: -130, behavior: 'smooth' });
+  });
+
+  it('strips leading "#" from hash before getElementById', () => {
+    locationState.hash = '#my-id';
+    getElementByIdMock.mockReturnValue({
+      getBoundingClientRect: () => ({ top: 10 }),
+    });
+    renderHook(() => useScrollToLocation());
+    // hash.slice(1) で `my-id` を渡す
+    expect(getElementByIdMock).toHaveBeenCalledWith('my-id');
+  });
+
+  it('always uses behavior: "smooth"', () => {
+    locationState.hash = '#smooth-test';
+    getElementByIdMock.mockReturnValue({
+      getBoundingClientRect: () => ({ top: 99 }),
+    });
+    renderHook(() => useScrollToLocation());
+    expect(scrollToMock).toHaveBeenCalledWith(expect.objectContaining({ behavior: 'smooth' }));
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 76` として既存 test 4 hooks file (`useActivateLocale` / `useBlockTimestamp` / `useKeyPress` / `useScrollToLocation`) に edge case / boundary TC を 21 件追加、 1691 → 1712 (+21、 1 skip 維持)。

通常 test 可能領域は前 PR (part 75) でほぼ完走済 (残未テストは code-gen 巨大 generated file + pages 系のみ)、 本 PR では既存 test の coverage 強化に切替。

## 詳細

### hooks/useActivateLocale.test.ts (+5 TC)

既存 4 → 9 TC へ拡張、 jotai atom 経由の locale 解決を網羅。

検証観点。

- fr-FR / xx-YY 異 locale を素通り (transformation なし)
- 2 つの独立した renderHook が atom mock chain で個別反映
- rerender 時に atom 値変更が反映される
- undefined 時は defensive default なし

### hooks/useBlockTimestamp.test.tsx (+6 TC)

既存 5 → 11 TC へ拡張、 viem getBlock 経路の境界 / dep 変更時の refetch を網羅。

検証観点。

- Number.MAX_SAFE_INTEGER 未満の巨大 timestamp で Number 化成功
- blockNumber 0n は falsy 判定で skip (getBlock 未呼出)
- blockNumber 引数なしも skip
- 同じ bigint を BigInt() でラップしても idempotent
- 引数の `blockNumber: 42n` が getBlock に正しく渡る
- blockNumber prop 変更で refetch (fixed publicClient で dep array 安定化)

### hooks/useKeyPress.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 key match の case-sensitivity / multi-hook 独立性を網羅。

検証観点。

- A (大文字) と a (小文字) は別 target (case-sensitive)
- Space key (' ') の press / release
- 2 instance ('1' / '2') が独立に state 管理
- targetKey rerender 時 useEffect 再走で listener 切替
- keydown なしで keyup のみは false 維持 (idempotent)

### hooks/useScrollToLocation.test.ts (+5 TC)

既存 5 → 10 TC へ拡張、 elementOffset 30 と hash 解析の境界を網羅。

検証観点。

- top: 50 + offset 30 → scroll top: 20
- top: 0 でも offset 30 を適用 → scroll top: -30
- negative top (-100、 既スクロール済) → scroll top: -130
- hash の leading `#` を `replace('#', '')` で削除して getElementById
- scrollTo は常に `behavior: 'smooth'`

## 解決方法

各 file は既存 mock 設定 (jotai / wagmi / react-router) を踏襲、 既存 describe ブロックに新 `it` を追加。

`useBlockTimestamp` の refetch test は `usePublicClient` mock が毎 render で新オブジェクトを返す既存設計のため、 同 test 内で `fixedClient` に差し替えて useEffect dep array を安定化 (この差し替えがないと rerender 時の chain が崩れて waitFor が timeout する)。

`useScrollToLocation` の lint fail 1 件 (prettier line 圧縮) は手動 fix で解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1691 → 1712、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1712 tests + 1 todo (1713)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier fix 1 件適用済)

Closes #483
