### PR TITLE
✅ test(niji-webapp): part 77 (utils color / log / token / text 4 file edge case 強化) で 1712 → 1736 (Issue #485)

### DIFF
--- a/packages/niji-webapp/src/utils/colorResponsiveUIUtils.test.ts
+++ b/packages/niji-webapp/src/utils/colorResponsiveUIUtils.test.ts
@@ -25,4 +25,29 @@ describe('shouldUseStateBg', () => {
   it('returns false for empty pathname', () => {
     expect(shouldUseStateBg({ pathname: '' })).toBe(false);
   });
+
+  it('returns true for "/nounders" path (includes("/noun") substring match)', () => {
+    // includes は substring 一致なので /nounders も /noun を含む
+    expect(shouldUseStateBg({ pathname: '/nounders' })).toBe(true);
+  });
+
+  it('is case-sensitive: "/Noun" does NOT match', () => {
+    expect(shouldUseStateBg({ pathname: '/Noun/1' })).toBe(false);
+  });
+
+  it('returns true for nested path "/noun/1/edit"', () => {
+    expect(shouldUseStateBg({ pathname: '/noun/1/edit' })).toBe(true);
+  });
+
+  it('returns true for nested "/auction/5/bid"', () => {
+    expect(shouldUseStateBg({ pathname: '/auction/5/bid' })).toBe(true);
+  });
+
+  it('returns true for substring match in "/forks/auction-x"', () => {
+    expect(shouldUseStateBg({ pathname: '/forks/auction-x' })).toBe(true);
+  });
+
+  it('returns false for path that only resembles "noun" without slash', () => {
+    expect(shouldUseStateBg({ pathname: '/nope' })).toBe(false);
+  });
 });

--- a/packages/niji-webapp/src/utils/logParsing.test.ts
+++ b/packages/niji-webapp/src/utils/logParsing.test.ts
@@ -52,4 +52,43 @@ describe('keyToFilter', () => {
       topics: ['0x1', '0x2'],
     });
   });
+
+  it('parses multiple flat topics from key', () => {
+    const result = keyToFilter('0xabc:0xa-0xb-0xc');
+    expect(result.topics).toEqual(['0xa', '0xb', '0xc']);
+  });
+
+  it('parses mixed flat + nested topics from key', () => {
+    const result = keyToFilter('0xabc:0x1-0x2;0x3');
+    expect(result.topics).toEqual(['0x1', ['0x2', '0x3']]);
+  });
+});
+
+describe('filterToKey — additional edge cases', () => {
+  it('returns ":" for fully empty filter (no address, no topics)', () => {
+    expect(filterToKey({})).toBe(':');
+  });
+
+  it('joins multiple top-level topics with dash, nested with semicolon', () => {
+    expect(filterToKey({ address: '0xa', topics: [['0x1', '0x2'], '0x3'] })).toBe(
+      '0xa:0x1;0x2-0x3',
+    );
+  });
+
+  it('handles mix of null + non-null topics', () => {
+    expect(filterToKey({ address: '0xa', topics: [null, '0x1'] })).toBe('0xa:\0-0x1');
+  });
+
+  it('ignores fromBlock — only address + topics influence key', () => {
+    const withFromBlock = filterToKey({ address: '0xa', topics: ['0x1'], fromBlock: 100 });
+    const withoutFromBlock = filterToKey({ address: '0xa', topics: ['0x1'] });
+    expect(withFromBlock).toBe(withoutFromBlock);
+  });
+});
+
+describe('logParsing round-trip', () => {
+  it('round-trip preserves nested topics (OR groups)', () => {
+    const original = { address: '0xabc', topics: [['0x1', '0x2']] };
+    expect(keyToFilter(filterToKey(original))).toEqual(original);
+  });
 });

--- a/packages/niji-webapp/src/utils/processProposalDescriptionText.test.ts
+++ b/packages/niji-webapp/src/utils/processProposalDescriptionText.test.ts
@@ -51,4 +51,31 @@ describe('processProposalDescriptionText', () => {
   it('handles title with special markdown chars', () => {
     expect(processProposalDescriptionText('# Hash Header body', '# Hash Header')).toBe(' body');
   });
+
+  it('handles description with consecutive newlines after title', () => {
+    expect(processProposalDescriptionText('Title\n\n\nbody', 'Title')).toBe('\n\n\nbody');
+  });
+
+  it('handles title at end of description', () => {
+    expect(processProposalDescriptionText('body Title', 'Title')).toBe('body ');
+  });
+
+  it('handles 1-char title at start (single character match)', () => {
+    expect(processProposalDescriptionText('Abody', 'A')).toBe('body');
+  });
+
+  it('handles title containing regex replacement sigil ($&, $1) as literal', () => {
+    // $& は String.replace の sigil だが、 search pattern 側は literal なので removal は素直
+    // result 側の treatment は source `''` 直接挿入で sigil は問題ない
+    expect(processProposalDescriptionText('Hello $& world', '$&')).toBe('Hello  world');
+  });
+
+  it('handles emoji-containing title', () => {
+    expect(processProposalDescriptionText('🎉 Proposal text', '🎉 Proposal')).toBe(' text');
+  });
+
+  it('replaces only first instance even with overlapping titles', () => {
+    // 重複 title 'aa' を 'a' で removal、 最初の 'a' のみ removal
+    expect(processProposalDescriptionText('aaaa', 'a')).toBe('aaa');
+  });
 });

--- a/packages/niji-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.test.ts
+++ b/packages/niji-webapp/src/utils/tokenBuyerContractUtils/tokenBuyer.test.ts
@@ -78,4 +78,35 @@ describe('useEthNeeded', () => {
     renderHook(() => useEthNeeded('0xADDR', 0));
     expect(lastCallOpts().args).toEqual([0n, 5000n]);
   });
+
+  it('returns toString() of very large ethNeeded (1e30 magnitude)', () => {
+    const huge = 1_000_000_000_000_000_000_000_000n;
+    useReadNijiTokenBuyerEthNeededMock.mockReturnValue({ data: huge });
+    const { result } = renderHook(() => useEthNeeded('0xADDR', 1));
+    expect(result.current).toBe(huge.toString());
+  });
+
+  it('BUFFER_BPS is always 5000n at args[1] regardless of additionalTokens', () => {
+    renderHook(() => useEthNeeded('0xADDR', 1));
+    expect(lastCallOpts().args[1]).toBe(5000n);
+    renderHook(() => useEthNeeded('0xADDR', 9999));
+    expect(lastCallOpts().args[1]).toBe(5000n);
+  });
+
+  it('skip=undefined behaves as false (enabled=true)', () => {
+    renderHook(() => useEthNeeded('0xADDR', 10, undefined));
+    expect(lastCallOpts().query.enabled).toBe(true);
+  });
+
+  it('returns undefined when hook returns null data (falsy)', () => {
+    useReadNijiTokenBuyerEthNeededMock.mockReturnValue({ data: null });
+    const { result } = renderHook(() => useEthNeeded('0xADDR', 10));
+    expect(result.current).toBeUndefined();
+  });
+
+  it('disabled hook returns undefined consistently (skip + valid address)', () => {
+    useReadNijiTokenBuyerEthNeededMock.mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useEthNeeded('0xADDR', 10, true));
+    expect(result.current).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 77` として既存 test 4 file (`utils/colorResponsiveUIUtils` / `utils/logParsing` / `utils/tokenBuyerContractUtils/tokenBuyer` / `utils/processProposalDescriptionText`) に edge case / boundary TC を 24 件追加、 1712 → 1736 (+24、 1 skip 維持)。

通常 test 可能領域は前 PR (part 76) でほぼ完走済 (残未テストは code-gen 巨大 generated file + pages 系のみ)、 本 PR では既存 test の coverage 強化に切替。

## 詳細

### utils/colorResponsiveUIUtils.test.ts (+6 TC)

既存 5 → 11 TC へ拡張、 `includes('/noun')` の substring match 仕様 / case-sensitivity / 階層 path を網羅。

検証観点。

- `/nounders` も substring 一致で true (設計仕様 pin)
- `/Noun/1` は case-sensitive で false
- `/noun/1/edit` / `/auction/5/bid` 等の nested path で true
- `/forks/auction-x` も `/auction` substring 一致で true
- `/nope` は match なしで false

### utils/logParsing.test.ts (+7 TC)

既存 10 → 17 TC へ拡張、 flat / nested / mixed topics の双方向 + 完全 empty / fromBlock 無視を網羅。

検証観点。

- `keyToFilter` で flat 3 topics をパース
- `keyToFilter` で flat + nested 混在を正しくパース
- `filterToKey({})` は `':'` (両側空)
- `filterToKey` で nested topics は `;` 区切り、 top-level は `-` 区切り
- null + 非 null mixed topics の挙動 (`\0-0x1`)
- `fromBlock` は key 生成に影響しない (address + topics のみ)
- nested topics (OR groups) round-trip 完全一致

### utils/tokenBuyerContractUtils/tokenBuyer.test.ts (+6 TC)

既存 10 → 16 TC へ拡張、 巨大値 / 固定 BUFFER_BPS / skip と data の falsy 経路を網羅。

検証観点。

- 巨大 ethNeeded (1e24) を toString で正しく文字列化
- BUFFER_BPS = 5000n が常に args[1] に固定
- skip=undefined は false 扱いで enabled=true
- hook data = null の falsy 経路で undefined
- skip=true + valid address でも data falsy なら undefined consistency

### utils/processProposalDescriptionText.test.ts (+6 TC)

既存 11 → 17 TC へ拡張、 String.prototype.replace の literal pattern 仕様 / 位置 / 重複を網羅。

検証観点。

- 連続改行後の title removal で前 newline 保持
- 末尾位置の title (description 後ろに付く形) → trailing space 残る
- 1 char title でも先頭 1 個のみ remove
- regex replacement sigil (`$&` / `$1`) は search pattern 側 literal、 replacement `''` で安全
- emoji を含む title (`🎉 Proposal`) で Unicode safe
- 重複文字 (`aaaa` から `a` 1 個 removal) で残り 3 a 保持

## 解決方法

各 file は既存 import 経路 + mock 設定 (`@niji/sdk/react` for tokenBuyer) を踏襲、 既存 describe ブロックに新 it を追加。 lint fail 1 件 (prettier line 圧縮) は手動 fix で解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1712 → 1736、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1736 tests + 1 todo (1737)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier fix 1 件適用済)

Closes #485
