### PR TITLE
✅ test(niji-webapp): part 79 (proposals / usdc / number / stream tx 4 file edge case 強化) で 1761 → 1788 (Issue #489)

### DIFF
--- a/packages/niji-webapp/src/hooks/useStreamPaymentTransactions.test.ts
+++ b/packages/niji-webapp/src/hooks/useStreamPaymentTransactions.test.ts
@@ -178,4 +178,53 @@ describe('useStreamPaymentTransactions', () => {
     });
     expect(actions[0].usdcValue).toBe(0);
   });
+
+  it('USDC createStream has value="0" regardless of amount', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'USDC', amount: '100' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[0].value).toBe('0');
+  });
+
+  it('WETH createStream has value="0" (createStream is fund movement helper)', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH', amount: '5' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[0].value).toBe('0');
+  });
+
+  it('USDC sendOrRegisterDebt usdcValue mirrors createStream usdcValue', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'USDC', amount: '75' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[0].usdcValue).toBe(actions[1].usdcValue);
+  });
+
+  it('WETH transfer action has value="0" (no native value transfer)', () => {
+    const actions = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH', amount: '3' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(actions[2].value).toBe('0');
+  });
+
+  it('all actions have non-empty calldata when predictedAddress set (except deposit)', () => {
+    const usdc = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'USDC' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(usdc[0].calldata).toMatch(/^0x/);
+    expect(usdc[1].calldata).toMatch(/^0x/);
+    const weth = useStreamPaymentTransactions({
+      state: makeState({ TransferFundsCurrency: 'WETH' }),
+      predictedAddress: '0xPRED',
+    });
+    expect(weth[0].calldata).toMatch(/^0x/);
+    // deposit action calldata は '0x' literal (空 calldata)
+    expect(weth[1].calldata).toBe('0x');
+    expect(weth[2].calldata).toMatch(/^0x/);
+  });
 });

--- a/packages/niji-webapp/src/utils/numberUtils.test.ts
+++ b/packages/niji-webapp/src/utils/numberUtils.test.ts
@@ -56,4 +56,24 @@ describe('countDecimals', () => {
   it('handles MAX_SAFE_INTEGER as 0 decimals', () => {
     expect(countDecimals(Number.MAX_SAFE_INTEGER)).toBe(0);
   });
+
+  it('handles Infinity (Math.floor(Infinity) === Infinity → 0)', () => {
+    expect(countDecimals(Infinity)).toBe(0);
+  });
+
+  it('handles -Infinity', () => {
+    expect(countDecimals(-Infinity)).toBe(0);
+  });
+
+  it('handles floating point precision artifact (0.1 + 0.2 = 0.30000000000000004)', () => {
+    expect(countDecimals(0.1 + 0.2)).toBe(17);
+  });
+
+  it('handles 1e-3 scientific notation as 0.001 (3 decimals)', () => {
+    expect(countDecimals(1e-3)).toBe(3);
+  });
+
+  it('handles negative zero (-0) as integer (0 decimals)', () => {
+    expect(countDecimals(-0)).toBe(0);
+  });
 });

--- a/packages/niji-webapp/src/utils/proposals.test.ts
+++ b/packages/niji-webapp/src/utils/proposals.test.ts
@@ -127,4 +127,48 @@ describe('checkHasActiveOrPendingProposalOrCandidate', () => {
       false,
     );
   });
+
+  it('returns false when account is empty string (falsy)', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.ACTIVE, ADDR_A, '')).toBe(
+      false,
+    );
+  });
+
+  it('returns false when proposer is empty string (falsy)', () => {
+    expect(checkHasActiveOrPendingProposalOrCandidate(ProposalState.ACTIVE, '', ADDR_A)).toBe(
+      false,
+    );
+  });
+});
+
+describe('isProposalUpdatable — additional', () => {
+  it('handles 0n bounds (currentBlock 0n, updatePeriodEndBlock 0n)', () => {
+    expect(isProposalUpdatable(ProposalState.UPDATABLE, 0n, 0n)).toBe(true);
+  });
+
+  it('handles very large bigint blocks', () => {
+    const huge = 9_007_199_254_740_990n;
+    expect(isProposalUpdatable(ProposalState.PENDING, huge, huge - 1n)).toBe(true);
+    expect(isProposalUpdatable(ProposalState.PENDING, huge, huge + 1n)).toBe(false);
+  });
+
+  it('returns false for EXECUTED even within window', () => {
+    expect(isProposalUpdatable(ProposalState.EXECUTED, 100n, 50n)).toBe(false);
+  });
+});
+
+describe('checkEnoughVotes — additional', () => {
+  it('returns false when both undefined', () => {
+    expect(checkEnoughVotes(undefined, undefined)).toBe(false);
+  });
+
+  it('returns true with very large votes vs small threshold', () => {
+    expect(checkEnoughVotes(Number.MAX_SAFE_INTEGER, 1)).toBe(true);
+  });
+
+  it('returns false when threshold negative not possible but defends with strict gt', () => {
+    // negative threshold は実際にあり得ないが、 strict > で 0 vs -1 は true
+    expect(checkEnoughVotes(0, -1)).toBe(false); // 0 は falsy で短絡 false
+    expect(checkEnoughVotes(1, -1)).toBe(true);
+  });
 });

--- a/packages/niji-webapp/src/utils/usdcUtils.test.ts
+++ b/packages/niji-webapp/src/utils/usdcUtils.test.ts
@@ -73,4 +73,44 @@ describe('human2ContractUSDCFormat edge cases', () => {
   it('rounds tiny sub-micro USDC to 0', () => {
     expect(human2ContractUSDCFormat('0.0000001')).toBe('0');
   });
+
+  it('handles scientific notation string (1e3 → 1000)', () => {
+    expect(human2ContractUSDCFormat('1e3')).toBe('1000000000');
+  });
+
+  it('handles NaN-producing input (parseFloat fails → NaN → "NaN")', () => {
+    expect(human2ContractUSDCFormat('abc')).toBe('NaN');
+  });
+
+  it('handles input that is just a decimal point ".5"', () => {
+    expect(human2ContractUSDCFormat('.5')).toBe('500000');
+  });
+});
+
+describe('contract2humanUSDCFormat edge cases', () => {
+  it('handles allDecimals=false with 0.001 → 0.001 (3 decimal toFixed)', () => {
+    expect(contract2humanUSDCFormat('1000')).toBe('0.001');
+  });
+
+  it('handles very large negative contract amount', () => {
+    expect(contract2humanUSDCFormat('-1000000000000')).toBe('-1000000.000');
+  });
+
+  it('handles 500 micro USDC (.0005 → toFixed(3) banker rounding)', () => {
+    // 500 / 1e6 = 0.0005、 toFixed(3) は banker rounding で 0.001 or 0.000 (実装依存)
+    const result = contract2humanUSDCFormat('500');
+    expect(['0.000', '0.001']).toContain(result);
+  });
+
+  it('allDecimals=true with 0 input returns "0" (no fraction)', () => {
+    expect(contract2humanUSDCFormat('0', true)).toBe('0');
+  });
+
+  it('numeric input 0 returns "0.000" (default 3 decimal)', () => {
+    expect(contract2humanUSDCFormat(0 as never)).toBe('0.000');
+  });
+
+  it('handles allDecimals=true with very large number', () => {
+    expect(contract2humanUSDCFormat('1000000000000', true)).toBe('1000000');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 79` として既存 test 4 file (`utils/proposals` / `utils/usdcUtils` / `utils/numberUtils` / `hooks/useStreamPaymentTransactions`) に edge case / boundary TC を 27 件追加、 1761 → 1788 (+27、 1 skip 維持)。

通常 test 可能領域は前 PR (part 78) でほぼ完走済 (残未テストは code-gen 巨大 generated file + pages 系のみ)、 本 PR では既存 test の coverage 強化に切替。

## 詳細

### utils/proposals.test.ts (+8 TC)

既存 22 → 30 TC へ拡張、 4 export 関数の falsy / 0n / 巨大 bigint / EXECUTED 等を網羅。

検証観点。

- checkHasActiveOrPendingProposalOrCandidate ... account 空文字 / proposer 空文字 で false
- isProposalUpdatable ... 0n bounds / 巨大 bigint 比較 / EXECUTED 内でも false
- checkEnoughVotes ... 両 undefined / MAX_SAFE_INTEGER / negative threshold 経路

### utils/usdcUtils.test.ts (+9 TC)

既存 13 → 22 TC へ拡張、 parseFloat 仕様 (scientific notation / NaN / 先頭 `.5`) と allDecimals branch を網羅。

検証観点。

- human2ContractUSDCFormat ... scientific notation (1e3) / NaN coercion / `.5` prefix
- contract2humanUSDCFormat ... allDecimals=false で 0.001 / 巨大 negative / 500 boundary (banker rounding) / allDecimals=true 0 → "0" / numeric input 0 → "0.000" / 巨大 allDecimals

### utils/numberUtils.test.ts (+5 TC)

既存 12 → 17 TC へ拡張、 Infinity / NaN-like / 浮動小数点精度の境界を網羅。

検証観点。

- Infinity / -Infinity (Math.floor(±Infinity) === ±Infinity で 0 decimals)
- 0.1 + 0.2 = 0.30000000000000004 (17 桁、 IEEE 754 精度)
- 1e-3 scientific notation を 0.001 (3 decimals)
- -0 (negative zero) で 0 decimals

### hooks/useStreamPaymentTransactions.test.ts (+5 TC)

既存 12 → 17 TC へ拡張、 各 action の value / calldata / usdcValue 整合性を網羅。

検証観点。

- USDC createStream の value="0" (createStream 自体は資金移動の helper、 native value なし)
- WETH createStream の value="0" 同様
- USDC sendOrRegisterDebt の usdcValue が createStream と mirror
- WETH transfer の value="0" (token transfer、 native value なし)
- 全 action calldata が `0x` prefix、 WETH deposit のみ `'0x'` literal (空 calldata)

## 解決方法

各 file は既存 mock / import 経路を踏襲、 既存 describe ブロックに新 `it` を追加。 numberUtils の `0.1 + 0.2 = 17 桁` は IEEE 754 の有限精度に由来する deterministic な値、 source の `toString().split('.')[1].length` で測定可能。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1761 → 1788、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1788 tests + 1 todo (1789)
- `pnpm -w lint <変更 4 file>` → 通過 (warning なし)

Closes #489
