### PR TITLE
✅ test(niji-webapp): part 80 (utils 極小 4 file edge case / contract pin 強化) で 1788 → 1811 (Issue #491)

### DIFF
--- a/packages/niji-webapp/src/utils/constants.test.ts
+++ b/packages/niji-webapp/src/utils/constants.test.ts
@@ -6,4 +6,28 @@ describe('constants', () => {
   it('exports AVERAGE_BLOCK_TIME_IN_SECS as 12', () => {
     expect(AVERAGE_BLOCK_TIME_IN_SECS).toBe(12);
   });
+
+  it('AVERAGE_BLOCK_TIME_IN_SECS is a number type', () => {
+    expect(typeof AVERAGE_BLOCK_TIME_IN_SECS).toBe('number');
+  });
+
+  it('AVERAGE_BLOCK_TIME_IN_SECS is integer (no decimals)', () => {
+    expect(Math.floor(AVERAGE_BLOCK_TIME_IN_SECS)).toBe(AVERAGE_BLOCK_TIME_IN_SECS);
+    expect(Number.isInteger(AVERAGE_BLOCK_TIME_IN_SECS)).toBe(true);
+  });
+
+  it('AVERAGE_BLOCK_TIME_IN_SECS is positive', () => {
+    expect(AVERAGE_BLOCK_TIME_IN_SECS).toBeGreaterThan(0);
+  });
+
+  it('AVERAGE_BLOCK_TIME_IN_SECS reflects Ethereum post-merge ~12 sec slot time', () => {
+    // Ethereum mainnet PoS slot は 12 秒、 history-consistent な仕様 pin
+    expect(AVERAGE_BLOCK_TIME_IN_SECS).toBeGreaterThanOrEqual(12);
+    expect(AVERAGE_BLOCK_TIME_IN_SECS).toBeLessThanOrEqual(15);
+  });
+
+  it('AVERAGE_BLOCK_TIME_IN_SECS is immutable (re-import returns same value)', async () => {
+    const reimported = await import('./constants');
+    expect(reimported.AVERAGE_BLOCK_TIME_IN_SECS).toBe(AVERAGE_BLOCK_TIME_IN_SECS);
+  });
 });

--- a/packages/niji-webapp/src/utils/grayBackgroundSVG.test.ts
+++ b/packages/niji-webapp/src/utils/grayBackgroundSVG.test.ts
@@ -15,4 +15,33 @@ describe('getGrayBackgroundSVG', () => {
   it('returns the same value on multiple calls (pure constant)', () => {
     expect(getGrayBackgroundSVG()).toBe(getGrayBackgroundSVG());
   });
+
+  it('return type is string', () => {
+    expect(typeof getGrayBackgroundSVG()).toBe('string');
+  });
+
+  it('MIME portion is exactly image/svg+xml', () => {
+    expect(getGrayBackgroundSVG()).toContain('image/svg+xml');
+  });
+
+  it('declares base64 encoding in the data URI', () => {
+    expect(getGrayBackgroundSVG()).toContain(';base64,');
+  });
+
+  it('has non-empty base64 portion after the comma', () => {
+    const portion = getGrayBackgroundSVG().split(',')[1];
+    expect(portion.length).toBeGreaterThan(0);
+  });
+
+  it('strict identity across calls (=== operator)', () => {
+    const a = getGrayBackgroundSVG();
+    const b = getGrayBackgroundSVG();
+    expect(a === b).toBe(true);
+  });
+
+  it('contains valid base64 characters only after comma', () => {
+    const portion = getGrayBackgroundSVG().split(',')[1];
+    // base64 文字セット (A-Z, a-z, 0-9, +, /, =、 加えて意図せず含まれた空白/inline 改行を許容)
+    expect(/^[\d\s+/=A-Za-z]+$/.test(portion)).toBe(true);
+  });
 });

--- a/packages/niji-webapp/src/utils/history.test.ts
+++ b/packages/niji-webapp/src/utils/history.test.ts
@@ -11,4 +11,29 @@ describe('nounPath', () => {
   it('handles negative id (no validation)', () => {
     expect(nounPath(-1)).toBe('/niji/-1');
   });
+
+  it('handles 0 id (boundary)', () => {
+    expect(nounPath(0)).toBe('/niji/0');
+  });
+
+  it('handles MAX_SAFE_INTEGER id', () => {
+    expect(nounPath(Number.MAX_SAFE_INTEGER)).toBe(`/niji/${Number.MAX_SAFE_INTEGER}`);
+  });
+
+  it('handles fractional id (no validation, template literal stringifies)', () => {
+    expect(nounPath(0.5)).toBe('/niji/0.5');
+  });
+
+  it('handles NaN id → "/niji/NaN" (template literal converts NaN to "NaN")', () => {
+    expect(nounPath(NaN)).toBe('/niji/NaN');
+  });
+
+  it('handles Infinity → "/niji/Infinity"', () => {
+    expect(nounPath(Infinity)).toBe('/niji/Infinity');
+  });
+
+  it('uses fixed /niji/ prefix (contract pin)', () => {
+    expect(nounPath(1).startsWith('/niji/')).toBe(true);
+    expect(nounPath(999999).startsWith('/niji/')).toBe(true);
+  });
 });

--- a/packages/niji-webapp/src/utils/nounBgColors.test.ts
+++ b/packages/niji-webapp/src/utils/nounBgColors.test.ts
@@ -14,4 +14,34 @@ describe('nounBgColors', () => {
   it('grey and beige are distinct', () => {
     expect(grey).not.toBe(beige);
   });
+
+  it('both colors are 7 chars total (# + 6 hex)', () => {
+    expect(grey).toHaveLength(7);
+    expect(beige).toHaveLength(7);
+  });
+
+  it('both colors start with # prefix', () => {
+    expect(grey.startsWith('#')).toBe(true);
+    expect(beige.startsWith('#')).toBe(true);
+  });
+
+  it('hex portion is lowercase a-f / 0-9 only', () => {
+    expect(/^#[\da-f]{6}$/.test(grey)).toBe(true);
+    expect(/^#[\da-f]{6}$/.test(beige)).toBe(true);
+  });
+
+  it('hex portion is parseable as integer (24-bit color)', () => {
+    expect(parseInt(grey.slice(1), 16)).not.toBeNaN();
+    expect(parseInt(beige.slice(1), 16)).not.toBeNaN();
+  });
+
+  it('grey and beige are anagrams of each other (d5d7e1 vs e1d7d5 reversed pairs)', () => {
+    // 仕様の偶然ではなく明示的に pin (palette 設計 contract)
+    expect(grey.slice(1).split('').sort().join('')).toBe(beige.slice(1).split('').sort().join(''));
+  });
+
+  it('exports are string type', () => {
+    expect(typeof grey).toBe('string');
+    expect(typeof beige).toBe('string');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 80` として既存 test 4 極小 file (`utils/constants` / `utils/history` / `utils/grayBackgroundSVG` / `utils/nounBgColors`) に edge case / boundary / contract pin TC を 23 件追加、 1788 → 1811 (+23、 1 skip 維持)。

これまでの part 71-79 で utils / hooks 系はほぼ完走済み、 本 PR では source 1-7 行の極小 file を対象に「仕様 contract pin」 を中心に拡張。

## 詳細

### utils/constants.test.ts (+5 TC)

既存 1 → 6 TC へ拡張、 `AVERAGE_BLOCK_TIME_IN_SECS` の型 / 範囲 / immutable contract を pin。

検証観点。

- `typeof === 'number'`
- 整数 (`Math.floor === value` + `Number.isInteger`)
- 正値 (> 0)
- Ethereum mainnet PoS slot 12-15 sec の history-consistent 範囲
- 再 import で同値 (immutable)

### utils/history.test.ts (+6 TC)

既存 2 → 8 TC へ拡張、 `nounPath` の template literal 仕様を網羅。

検証観点。

- 0 (boundary)
- MAX_SAFE_INTEGER (Number 上限近傍)
- 0.5 (fractional、 validation なし)
- NaN → `/niji/NaN` (template literal の NaN.toString())
- Infinity → `/niji/Infinity`
- prefix `/niji/` 固定 contract

### utils/grayBackgroundSVG.test.ts (+6 TC)

既存 3 → 9 TC へ拡張、 data URI の構造 (MIME / encoding / payload) を pin。

検証観点。

- return type が string
- MIME 部分が `image/svg+xml`
- `;base64,` encoding declaration
- comma 後の base64 portion 非空
- 多重呼出で strict identity (`===`)
- base64 文字セット (`[\d\s+/=A-Za-z]+`) のみ

### utils/nounBgColors.test.ts (+6 TC)

既存 3 → 9 TC へ拡張、 hex color の構造とパレット設計 contract を pin。

検証観点。

- 7 chars total length (`#` + 6 hex)
- `#` prefix
- lowercase a-f / 0-9 のみ (`/^#[\da-f]{6}$/`)
- parseInt(slice(1), 16) が valid (24bit color)
- grey と beige は同じ文字構成の anagram (`d5d7e1` ⇄ `e1d7d5`、 palette 設計上の双対関係 pin)
- string export type

## 解決方法

各 file は既存 import 経路を再利用、 既存 describe ブロックに新 it を追加。 純粋関数 / constant export のため mock 不要。

lint fix 3 件 (`unicorn/better-regex` で `[0-9]` → `\d` に最適化要求) を手動修正で解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1788 → 1811、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1811 tests + 1 todo (1812)
- `pnpm -w lint <変更 4 file>` → 通過 (unicorn fix 3 件適用済)

Closes #491
