### PR TITLE
✅ test(niji-webapp): part 81 (Modal 4 component edge case / contract pin 強化) で 1811 → 1837 (Issue #493)

### DIFF
--- a/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
@@ -13,4 +13,44 @@ describe('ModalLabel', () => {
     const { container } = render(<ModalLabel />);
     expect(container.querySelector('div')?.textContent).toBe('');
   });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<ModalLabel>{42}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('42');
+  });
+
+  it('renders falsy 0 as "0" (numeric children quirk in React)', () => {
+    const { container } = render(<ModalLabel>{0}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('0');
+  });
+
+  it('does NOT render boolean children (true / false → empty)', () => {
+    const { container: ct1 } = render(<ModalLabel>{true}</ModalLabel>);
+    expect(ct1.querySelector('div')?.textContent).toBe('');
+    const { container: ct2 } = render(<ModalLabel>{false}</ModalLabel>);
+    expect(ct2.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('does NOT render null children', () => {
+    const { container } = render(<ModalLabel>{null}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('renders array of children concatenated', () => {
+    const { container } = render(<ModalLabel>{['a', 'b', 'c']}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('abc');
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<ModalLabel>x</ModalLabel>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('applies CSS module className (non-empty class string)', () => {
+    const { container } = render(<ModalLabel>x</ModalLabel>);
+    const className = container.querySelector('div')?.className;
+    expect(className).toBeTruthy();
+    expect(className?.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
@@ -17,4 +17,46 @@ describe('ModalSubtitle', () => {
     );
     expect(container.querySelector('span')?.textContent).toBe('nested');
   });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<ModalSubtitle>{123}</ModalSubtitle>);
+    expect(container.querySelector('div')?.textContent).toBe('123');
+  });
+
+  it('renders long children content', () => {
+    const long = 'a'.repeat(500);
+    const { container } = render(<ModalSubtitle>{long}</ModalSubtitle>);
+    expect(container.querySelector('div')?.textContent?.length).toBe(500);
+  });
+
+  it('does NOT render boolean / null children', () => {
+    const { container: ct1 } = render(<ModalSubtitle>{true}</ModalSubtitle>);
+    expect(ct1.querySelector('div')?.textContent).toBe('');
+    const { container: ct2 } = render(<ModalSubtitle>{null}</ModalSubtitle>);
+    expect(ct2.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<ModalSubtitle>x</ModalSubtitle>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('applies CSS module className', () => {
+    const { container } = render(<ModalSubtitle>x</ModalSubtitle>);
+    const className = container.querySelector('div')?.className;
+    expect(className).toBeTruthy();
+  });
+
+  it('renders Fragment children unwrapped', () => {
+    const { container } = render(
+      <ModalSubtitle>
+        <>
+          <span>a</span>
+          <span>b</span>
+        </>
+      </ModalSubtitle>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(2);
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
@@ -13,4 +13,50 @@ describe('ModalTextPrimary', () => {
     const { container } = render(<ModalTextPrimary />);
     expect(container.querySelector('div')?.textContent).toBe('');
   });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<ModalTextPrimary>{7}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('7');
+  });
+
+  it('renders 0 as "0" (numeric falsy still renders)', () => {
+    const { container } = render(<ModalTextPrimary>{0}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('0');
+  });
+
+  it('renders array children concatenated', () => {
+    const { container } = render(<ModalTextPrimary>{['x', 'y', 'z']}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('xyz');
+  });
+
+  it('renders Fragment children', () => {
+    const { container } = render(
+      <ModalTextPrimary>
+        <>
+          <span>a</span>
+          <em>b</em>
+        </>
+      </ModalTextPrimary>,
+    );
+    expect(container.querySelector('span')?.textContent).toBe('a');
+    expect(container.querySelector('em')?.textContent).toBe('b');
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<ModalTextPrimary>x</ModalTextPrimary>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('applies CSS module className', () => {
+    const { container } = render(<ModalTextPrimary>x</ModalTextPrimary>);
+    const className = container.querySelector('div')?.className;
+    expect(className).toBeTruthy();
+    expect(className?.length).toBeGreaterThan(0);
+  });
+
+  it('does NOT render undefined children', () => {
+    const { container } = render(<ModalTextPrimary>{undefined}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
@@ -17,4 +17,39 @@ describe('ModalTitle', () => {
     );
     expect(container.querySelector('h1 span')?.textContent).toBe('nested');
   });
+
+  it('renders exactly 1 <h1> element', () => {
+    const { container } = render(<ModalTitle>Title</ModalTitle>);
+    expect(container.querySelectorAll('h1').length).toBe(1);
+  });
+
+  it('outermost wrapper is a single <div> containing <h1>', () => {
+    const { container } = render(<ModalTitle>x</ModalTitle>);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+    expect(container.firstElementChild?.firstElementChild?.tagName).toBe('H1');
+  });
+
+  it('renders numeric children inside h1', () => {
+    const { container } = render(<ModalTitle>{99}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe('99');
+  });
+
+  it('applies CSS module className on wrapper div', () => {
+    const { container } = render(<ModalTitle>x</ModalTitle>);
+    const className = container.querySelector('div')?.className;
+    expect(className).toBeTruthy();
+    expect(className?.length).toBeGreaterThan(0);
+  });
+
+  it('h1 inherits default heading level 1 (a11y semantic)', () => {
+    const { container } = render(<ModalTitle>Accessible</ModalTitle>);
+    const h1 = container.querySelector('h1');
+    expect(h1?.tagName).toBe('H1');
+    expect(h1?.textContent).toBe('Accessible');
+  });
+
+  it('renders array of children inside h1', () => {
+    const { container } = render(<ModalTitle>{['Hello', ' ', 'World']}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe('Hello World');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 81` として既存 test 4 modal component (`ModalLabel` / `ModalTitle` / `ModalSubtitle` / `ModalTextPrimary`) に rendering / children / className contract pin TC を 26 件追加、 1811 → 1837 (+26、 1 skip 維持)。

これまでの part 71-80 で utils / hooks 系はほぼ完走済み、 本 PR では薄 test (件数 2) の小型 modal components を契約 pin で拡張、 React 標準 children semantics (boolean / null / array / Fragment / numeric) を明示固定。

## 詳細

### components/ModalLabel/index.test.tsx (+7 TC)

既存 2 → 9 TC へ拡張、 children の React 標準 semantics + wrapper 構造を pin。

検証観点。

- 数値 children を string 化レンダリング
- 0 (falsy 数値) は "0" として render される (React 仕様)
- boolean (true/false) と null は render されない (React 標準)
- array children を concatenate
- outermost wrapper は単一 `<div>`
- CSS module 経由の className 適用

### components/ModalTitle/index.test.tsx (+7 TC)

既存 2 → 9 TC へ拡張、 `<div><h1>` ネスト構造と h1 単一性を pin。

検証観点。

- `<h1>` element がちょうど 1 個
- outermost が `<div>`、 直下に `<h1>`
- 数値 children を h1 内に render
- array children を h1 内で concatenate
- wrapper div に className 適用
- h1 は a11y 上 default heading level 1

### components/ModalSubtitle/index.test.tsx (+6 TC)

既存 2 → 8 TC へ拡張、 children 多様性と Fragment 経路を pin。

検証観点。

- 数値 children
- 500 char 長文 children でも文字数保持
- boolean / null children は render されない
- 単一 `<div>` wrapper
- className 適用
- Fragment 経由の複数 span は両方 render

### components/ModalTextPrimary/index.test.tsx (+7 TC)

既存 2 → 9 TC へ拡張、 falsy 値挙動と Fragment を pin。

検証観点。

- 数値 children
- 0 (falsy) は "0" として render
- array children を concatenate
- Fragment 経由で span + em の混在 children
- 単一 `<div>` wrapper
- CSS module 経由 className 非空
- undefined children は render されない

## 解決方法

各 file は既存 @testing-library/react の `render` パターンを踏襲、 既存 describe ブロックに新 `it` を追加。 純粋 React component / mock 不要。 children の React 標準 semantics (boolean / null / undefined は不可視、 0 / 数値 / array は可視) を contract pin、 wrapper 単一性 + className 適用も併せて固定。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1811 → 1837、 1 skip 維持)
- lint 通過、 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1837 tests + 1 todo (1838)
- `pnpm -w lint <変更 4 file>` → 通過 (warning なし)

Closes #493
