### PR TITLE
✅ test(niji-webapp): part 82 (components spinner / ens / bid / wrapper 4 file edge case 強化) で 1837 → 1859 (Issue #495)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
@@ -24,4 +24,44 @@ describe('AuctionActivityWrapper', () => {
     );
     expect(container.querySelector('span')?.textContent).toBe('nested');
   });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<AuctionActivityWrapper>{42}</AuctionActivityWrapper>);
+    expect(container.querySelector('div')?.textContent).toBe('42');
+  });
+
+  it('renders array children concatenated', () => {
+    const { container } = render(
+      <AuctionActivityWrapper>{['a', 'b', 'c']}</AuctionActivityWrapper>,
+    );
+    expect(container.querySelector('div')?.textContent).toBe('abc');
+  });
+
+  it('renders Fragment children unwrapped', () => {
+    const { container } = render(
+      <AuctionActivityWrapper>
+        <>
+          <span>x</span>
+          <span>y</span>
+        </>
+      </AuctionActivityWrapper>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(2);
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<AuctionActivityWrapper>x</AuctionActivityWrapper>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('className matches Tailwind utility exactly (max-lg:mx-4, no extras)', () => {
+    const { container } = render(<AuctionActivityWrapper>x</AuctionActivityWrapper>);
+    expect(container.querySelector('div')?.className).toBe('max-lg:mx-4');
+  });
+
+  it('renders null children as empty content (no crash)', () => {
+    const { container } = render(<AuctionActivityWrapper>{null}</AuctionActivityWrapper>);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistoryBtn/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryBtn/index.test.tsx
@@ -38,4 +38,41 @@ describe('BidHistoryBtn Component (isCool=true)', () => {
     const wrapper = screen.getByText('View all bids').parentElement;
     expect(wrapper?.className).toBeDefined();
   });
+
+  it('calls onClick multiple times for repeated clicks', () => {
+    const onClick = vi.fn();
+    render(<BidHistoryBtn onClick={onClick} />);
+    const text = screen.getByText('View all bids');
+    fireEvent.click(text);
+    fireEvent.click(text);
+    fireEvent.click(text);
+    expect(onClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not crash when onClick is noop', () => {
+    expect(() => {
+      render(<BidHistoryBtn onClick={() => {}} />);
+      fireEvent.click(screen.getByText('View all bids'));
+    }).not.toThrow();
+  });
+
+  it('renders only the single localized text node', () => {
+    const { container } = render(<BidHistoryBtn onClick={vi.fn()} />);
+    // outer wrapper > inner wrapper > text
+    expect(container.textContent).toBe('View all bids');
+  });
+
+  it('text wrapper is nested inside outer wrapper (2-level div)', () => {
+    const { container } = render(<BidHistoryBtn onClick={vi.fn()} />);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+    expect(container.firstElementChild?.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('onClick is attached to the outer wrapper (not inner text wrapper)', () => {
+    const onClick = vi.fn();
+    const { container } = render(<BidHistoryBtn onClick={onClick} />);
+    const outerDiv = container.firstElementChild as HTMLDivElement;
+    fireEvent.click(outerDiv);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/niji-webapp/src/components/BrandSpinner/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandSpinner/index.test.tsx
@@ -22,4 +22,44 @@ describe('BrandSpinner', () => {
     expect(container.querySelector('svg path')).not.toBeNull();
     expect(container.querySelector('svg circle')).not.toBeNull();
   });
+
+  it('svg uses fill="none"', () => {
+    const { container } = render(<BrandSpinner />);
+    expect(container.querySelector('svg')?.getAttribute('fill')).toBe('none');
+  });
+
+  it('svg has xmlns set to W3C SVG namespace', () => {
+    const { container } = render(<BrandSpinner />);
+    expect(container.querySelector('svg')?.getAttribute('xmlns')).toBe(
+      'http://www.w3.org/2000/svg',
+    );
+  });
+
+  it('path uses stroke "black" with strokeWidth 4', () => {
+    const { container } = render(<BrandSpinner />);
+    const path = container.querySelector('svg path');
+    expect(path?.getAttribute('stroke')).toBe('black');
+    // React は camelCase strokeWidth を DOM 上 stroke-width に変換
+    expect(path?.getAttribute('stroke-width')).toBe('4');
+  });
+
+  it('circle has cx=12.5 cy=12.5 r=10.5', () => {
+    const { container } = render(<BrandSpinner />);
+    const circle = container.querySelector('svg circle');
+    expect(circle?.getAttribute('cx')).toBe('12.5');
+    expect(circle?.getAttribute('cy')).toBe('12.5');
+    expect(circle?.getAttribute('r')).toBe('10.5');
+  });
+
+  it('circle has opacity 0.2 (background ring contract)', () => {
+    const { container } = render(<BrandSpinner />);
+    expect(container.querySelector('svg circle')?.getAttribute('opacity')).toBe('0.2');
+  });
+
+  it('renders exactly 1 svg, 1 path, 1 circle (single instance contract)', () => {
+    const { container } = render(<BrandSpinner />);
+    expect(container.querySelectorAll('svg').length).toBe(1);
+    expect(container.querySelectorAll('svg path').length).toBe(1);
+    expect(container.querySelectorAll('svg circle').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
+++ b/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
@@ -36,4 +36,42 @@ describe('EnsOrLongAddress', () => {
     const { container } = render(<EnsOrLongAddress address={ADDR} />);
     expect(container.textContent).toBe(ADDR);
   });
+
+  it('falls back to long address when ENS is empty string', () => {
+    // '' は ens && truthy ガードで falsy 扱い、 address にフォールバック
+    vi.mocked(useReverseENSLookUp).mockReturnValue('');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+  });
+
+  it('passes the address argument to useReverseENSLookUp', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('x.eth');
+    render(<EnsOrLongAddress address={ADDR} />);
+    expect(useReverseENSLookUp).toHaveBeenCalledWith(ADDR);
+  });
+
+  it('calls containsBlockedText with English language code', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('alice.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    render(<EnsOrLongAddress address={ADDR} />);
+    expect(containsBlockedText).toHaveBeenCalledWith('alice.eth', 'en');
+  });
+
+  it('calls containsBlockedText with empty string when ENS is undefined', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    render(<EnsOrLongAddress address={ADDR} />);
+    // `ens || ''` で undefined は '' になる
+    expect(containsBlockedText).toHaveBeenCalledWith('', 'en');
+  });
+
+  it('renders different address when prop changes', () => {
+    const ADDR_B = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container: c1 } = render(<EnsOrLongAddress address={ADDR} />);
+    const { container: c2 } = render(<EnsOrLongAddress address={ADDR_B} />);
+    expect(c1.textContent).toBe(ADDR);
+    expect(c2.textContent).toBe(ADDR_B);
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 82` として既存 test 4 component (`BrandSpinner` / `EnsOrLongAddress` / `BidHistoryBtn` / `AuctionActivityWrapper`) に rendering / contract pin / interaction TC を 22 件追加、 1837 → 1859 (+22、 1 skip 維持)。

これまでの part 71-81 で utils / hooks / Modal 系はほぼ完走済み、 本 PR では薄 test (件数 3) の小型 components を契約 pin で拡張、 SVG attribute / mock 引数 / event handler 位置 / className 厳密一致を明示固定。

## 詳細

### components/BrandSpinner/index.test.tsx (+6 TC)

既存 3 → 9 TC へ拡張、 SVG attribute と単一要素 contract を pin。

検証観点。

- `<svg fill="none">`
- `xmlns="http://www.w3.org/2000/svg"` (W3C SVG namespace)
- `<path>` の `stroke="black"` と `stroke-width="4"` (React camelCase → DOM)
- `<circle>` の `cx=12.5` / `cy=12.5` / `r=10.5`
- `<circle opacity="0.2">` (背景リング contract)
- svg / path / circle がそれぞれ 1 個 (単一インスタンス)

### components/EnsOrLongAddress/index.test.tsx (+5 TC)

既存 3 → 8 TC へ拡張、 mock 関数の引数経路と props 変更時の re-render を pin。

検証観点。

- 空文字 ens (`''`) は falsy 扱いで address フォールバック
- `useReverseENSLookUp` への address 引数渡し
- `containsBlockedText` への `'en'` 言語 code 渡し
- ens が undefined のとき `''` を `containsBlockedText` に渡す (`ens || ''` 経路)
- address prop 変更で render 内容も変わる

### components/BidHistoryBtn/index.test.tsx (+5 TC)

既存 3 → 8 TC へ拡張、 event handler の位置 / multi-call / 構造 contract を pin。

検証観点。

- 連続 3 回クリックで onClick 3 回呼出
- noop onClick (`() => {}`) でクラッシュなし
- localized text は 1 個のみ (`'View all bids'`)
- 2 階層 `<div><div>...</div></div>` nest 構造
- onClick は **outer wrapper** に attach (inner text wrapper でなく) — outer click でも発火

### components/AuctionActivityWrapper/index.test.tsx (+6 TC)

既存 3 → 9 TC へ拡張、 children 多様性と className 厳密一致を pin。

検証観点。

- 数値 / array / Fragment 経由の children 全て render
- 単一 `<div>` wrapper
- className が `'max-lg:mx-4'` に **厳密一致** (余分な class なし)
- null children は空 textContent でクラッシュなし

## 解決方法

各 file は既存 `render` / `vi.mock` パターンを踏襲、 既存 describe ブロックに新 `it` を追加。 mock 既存設定維持、 新規追加なし。 BidHistoryBtn の outer-wrapper onClick attachment は inner text 要素クリックでも outer event handler が起動する React event bubbling の標準動作を pin する経路。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1837 → 1859、 1 skip 維持)
- lint 通過 (warning 1 件は既存 `beforeAll` 引数で `use` prefix 関連、 既存 baseline)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1859 tests + 1 todo (1860)
- `pnpm -w lint <変更 4 file>` → 通過 (warning 1 件のみ、 error なし)

Closes #495
