### PR TITLE
✅ test(niji-webapp): part 83 (components sponsor / dropdown / doc / theme 4 file edge case 強化) で 1859 → 1881 (Issue #497)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/CandidateSponsorImage.test.tsx
@@ -21,4 +21,42 @@ describe('CandidateSponsorImage', () => {
     expect(div).not.toBeNull();
     expect(div?.querySelector('[data-testid="niji-image"]')).not.toBeNull();
   });
+
+  it('renders 0n nounId correctly', () => {
+    const { container } = render(<CandidateSponsorImage nounId={0n} />);
+    expect(container.querySelector('[data-testid="niji-image"]')?.textContent).toBe('0');
+  });
+
+  it('renders very large bigint nounId', () => {
+    const huge = 9_007_199_254_740_991n; // Number.MAX_SAFE_INTEGER as bigint
+    const { container } = render(<CandidateSponsorImage nounId={huge} />);
+    expect(container.querySelector('[data-testid="niji-image"]')?.textContent).toBe(
+      huge.toString(),
+    );
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<CandidateSponsorImage nounId={1n} />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('renders exactly 1 NijiImage child', () => {
+    const { container } = render(<CandidateSponsorImage nounId={1n} />);
+    expect(container.querySelectorAll('[data-testid="niji-image"]').length).toBe(1);
+  });
+
+  it('applies CSS module className on wrapper div', () => {
+    const { container } = render(<CandidateSponsorImage nounId={1n} />);
+    const className = container.querySelector('div')?.className;
+    expect(className).toBeTruthy();
+    expect(className?.length).toBeGreaterThan(0);
+  });
+
+  it('multiple renders with different nounIds produce isolated trees', () => {
+    const { container: c1 } = render(<CandidateSponsorImage nounId={1n} />);
+    const { container: c2 } = render(<CandidateSponsorImage nounId={2n} />);
+    expect(c1.querySelector('[data-testid="niji-image"]')?.textContent).toBe('1');
+    expect(c2.querySelector('[data-testid="niji-image"]')?.textContent).toBe('2');
+  });
 });

--- a/packages/niji-webapp/src/components/Documentation/ArtAndTraitsSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/ArtAndTraitsSection.test.tsx
@@ -37,4 +37,36 @@ describe('ArtAndTraitsSection', () => {
     expect(text).toContain('Hat');
     expect(text).toContain('Hair');
   });
+
+  it('renders at least 3 accordion items (Traits / On-Chain Artwork / Seeder Contract)', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    const items = container.querySelectorAll('.accordion-item');
+    expect(items.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('contains On-Chain Artwork section content', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    expect(container.textContent).toContain('On-Chain Artwork');
+  });
+
+  it('contains Seeder Contract section', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    expect(container.textContent).toContain('Seeder Contract');
+  });
+
+  it('mentions pseudo-random generation via keccak256', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    expect(container.textContent).toContain('keccak256');
+  });
+
+  it('mentions run-length encoding (RLE) compression strategy', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    expect(container.textContent).toContain('run-length encoding');
+  });
+
+  it('lists trait keys ul wraps multiple li elements (>= 6)', () => {
+    const { container } = wrap(<ArtAndTraitsSection />);
+    const ulItems = container.querySelectorAll('ul li');
+    expect(ulItems.length).toBeGreaterThanOrEqual(6);
+  });
 });

--- a/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
@@ -48,4 +48,57 @@ describe('NavDropDown', () => {
     );
     expect(container.querySelector('.dropdown')).not.toBeNull();
   });
+
+  it('renders empty buttonText without crashing', () => {
+    const { container } = render(
+      <NavDropDown buttonText="">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe('');
+  });
+
+  it('renders without throwing when given multiple ReactNode children', () => {
+    // collapsed Dropdown は children DOM を遅延 mount、 jsdom default で hidden。
+    // 例外なく render 完了するかを pin する。
+    expect(() => {
+      render(
+        <NavDropDown buttonText="Menu">
+          <span>a</span>
+          <span>b</span>
+          <span>c</span>
+        </NavDropDown>,
+      );
+    }).not.toThrow();
+  });
+
+  it('exactly 1 Dropdown rendered', () => {
+    const { container } = render(
+      <NavDropDown buttonText="Menu">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelectorAll('.dropdown').length).toBe(1);
+  });
+
+  it('renders 1 nav-button regardless of children count', () => {
+    const { container } = render(
+      <NavDropDown buttonText="Menu">
+        <span>a</span>
+        <span>b</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelectorAll('[data-testid="nav-button"]').length).toBe(1);
+  });
+
+  it('long buttonText is forwarded as-is', () => {
+    const long = 'a'.repeat(200);
+    const { container } = render(
+      <NavDropDown buttonText={long}>
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(long);
+  });
 });

--- a/packages/niji-webapp/src/components/ThemeProvider.test.tsx
+++ b/packages/niji-webapp/src/components/ThemeProvider.test.tsx
@@ -52,4 +52,49 @@ describe('ThemeProvider', () => {
     expect(spans[0].textContent).toBe('a');
     expect(spans[1].textContent).toBe('b');
   });
+
+  it('forwards different attribute value to NextThemesProvider', () => {
+    const { container } = render(
+      <ThemeProvider attribute="data-theme">
+        <span>x</span>
+      </ThemeProvider>,
+    );
+    expect(
+      container
+        .querySelector('[data-testid="next-themes-provider"]')
+        ?.getAttribute('data-attribute'),
+    ).toBe('data-theme');
+  });
+
+  it('renders numeric children', () => {
+    const { container } = render(<ThemeProvider>{42}</ThemeProvider>);
+    expect(container.querySelector('[data-testid="next-themes-provider"]')?.textContent).toBe('42');
+  });
+
+  it('does not crash with null children', () => {
+    const { container } = render(<ThemeProvider>{null}</ThemeProvider>);
+    expect(container.querySelector('[data-testid="next-themes-provider"]')).not.toBeNull();
+  });
+
+  it('renders exactly 1 next-themes-provider instance', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>x</span>
+      </ThemeProvider>,
+    );
+    expect(container.querySelectorAll('[data-testid="next-themes-provider"]').length).toBe(1);
+  });
+
+  it('renders empty attribute when not provided', () => {
+    const { container } = render(
+      <ThemeProvider>
+        <span>x</span>
+      </ThemeProvider>,
+    );
+    expect(
+      container
+        .querySelector('[data-testid="next-themes-provider"]')
+        ?.getAttribute('data-attribute'),
+    ).toBe('');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 83` として既存 test 4 component (`CandidateSponsorImage` / `NavDropdown` / `Documentation/ArtAndTraitsSection` / `ThemeProvider`) に rendering / contract pin / props passthrough TC を 22 件追加、 1859 → 1881 (+22、 1 skip 維持)。

これまでの part 71-82 で utils / hooks / Modal / 件数 3 帯 component (BrandSpinner / EnsOrLongAddress / BidHistoryBtn / AuctionActivityWrapper) を強化済み、 本 PR では同 pattern を残薄 test 4 file に展開。

## 詳細

### components/CandidateCard/CandidateSponsorImage.test.tsx (+6 TC)

既存 2 → 8 TC へ拡張、 bigint nounId の境界 + wrapper 構造を pin。

検証観点。

- 0n nounId 正しくレンダリング
- MAX_SAFE_INTEGER bigint
- outermost wrapper は単一 `<div>`
- NijiImage child 1 個のみ
- CSS module className 非空
- 異 nounId の多重 renderHook で独立した tree

### components/NavDropdown/index.test.tsx (+5 TC)

既存 3 → 8 TC へ拡張、 buttonText の境界と Dropdown 単一性を pin。

検証観点。

- 空文字 buttonText でもクラッシュなし
- 多重 ReactNode children でクラッシュなし (collapsed Dropdown は jsdom で children 不可視)
- `.dropdown` 1 個 (root 単一)
- nav-button 1 個 (children 数に依存しない)
- 200 char long buttonText forward-pass

### components/Documentation/ArtAndTraitsSection.test.tsx (+6 TC)

既存 3 → 9 TC へ拡張、 accordion 構造と本文内容を pin。

検証観点。

- accordion item が 3 個以上 (Niji Traits / On-Chain Artwork / Niji Seeder Contract)
- `On-Chain Artwork` heading 含む
- `Seeder Contract` heading 含む
- `keccak256` 文字列を本文中に含む (シーダー擬似乱数仕様)
- `run-length encoding` 文字列を含む (圧縮戦略仕様)
- ul > li が 6 個以上 (trait keys list)

### components/ThemeProvider.test.tsx (+5 TC)

既存 3 → 8 TC へ拡張、 props passthrough と children 多様性を pin。

検証観点。

- `attribute="data-theme"` で別属性値を forward
- 数値 children render
- null children でクラッシュなし
- next-themes-provider が 1 instance のみ
- attribute prop なしの default は空文字

## 解決方法

各 file は既存 mock / `render` パターンを踏襲、 既存 describe ブロックに新 `it` を追加。 mock 既存設定維持、 新規追加なし。 NavDropdown の Dropdown.Menu は jsdom 上 collapsed で hidden DOM のため、 「クラッシュなく render 完了する」 contract を pin する方針を採用。

`CandidateSponsorImage` の line 33 prettier fix 1 件を手動修正で解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1859 → 1881、 1 skip 維持)
- lint 通過 (warning 4 件は既存 baseline、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1881 tests + 1 todo (1882)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier fix 1 件適用済)

Closes #497
