### PR TITLE
✅ test(niji-webapp): part 84 (components governance / funccall / date / titlenav 4 file edge case 強化) で 1881 → 1904 (Issue #499)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -40,4 +40,44 @@ describe('AuctionActivityDateHeadline', () => {
     const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
     expect(container.querySelector('div h4')).not.toBeNull();
   });
+
+  it('renders exactly 1 h4 element', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelectorAll('h4').length).toBe(1);
+  });
+
+  it('handles 0n startTime (Unix epoch)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<AuctionActivityDateHeadline startTime={0n} />);
+    expect(container.querySelector('h4')?.textContent).toContain('January');
+    expect(container.querySelector('h4')?.textContent).toContain('1970');
+  });
+
+  it('handles large startTime (year 2100)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    // 2100-01-01 UTC = 4102444800
+    const { container } = render(<AuctionActivityDateHeadline startTime={4102444800n} />);
+    expect(container.querySelector('h4')?.textContent).toContain('2100');
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('wrapper div has CSS module className', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('div')?.className).toBeTruthy();
+  });
+
+  it('h4 receives MMMM DD, YYYY format (month name + day + year)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    // 1735689600 = 2025-01-01 UTC
+    const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')?.textContent).toMatch(/January\s+0?1.*2025/);
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionTitleAndNavWrapper/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionTitleAndNavWrapper/index.test.tsx
@@ -53,4 +53,46 @@ describe('AuctionTitleAndNavWrapper Component', () => {
     expect(screen.getByTestId('first-child')).toBeInTheDocument();
     expect(screen.getByTestId('second-child')).toBeInTheDocument();
   });
+
+  it('renders numeric children inside Col', () => {
+    const { container } = render(<AuctionTitleAndNavWrapper>{42}</AuctionTitleAndNavWrapper>);
+    expect(container.textContent).toBe('42');
+  });
+
+  it('renders array children concatenated', () => {
+    const { container } = render(
+      <AuctionTitleAndNavWrapper>{['a', 'b', 'c']}</AuctionTitleAndNavWrapper>,
+    );
+    expect(container.textContent).toBe('abc');
+  });
+
+  it('renders null children without crashing', () => {
+    const { container } = render(<AuctionTitleAndNavWrapper>{null}</AuctionTitleAndNavWrapper>);
+    expect(container.textContent).toBe('');
+  });
+
+  it('outermost wrapper is single element with col-lg-12', () => {
+    const { container } = render(<AuctionTitleAndNavWrapper>x</AuctionTitleAndNavWrapper>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.className).toContain('col-lg-12');
+  });
+
+  it('applies CSS module className alongside Bootstrap col class', () => {
+    const { container } = render(<AuctionTitleAndNavWrapper>x</AuctionTitleAndNavWrapper>);
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toContain(classes.auctionTitleAndNavContainer);
+    expect(wrapper?.className).toContain('col-lg-12');
+  });
+
+  it('renders Fragment children unwrapped', () => {
+    const { container } = render(
+      <AuctionTitleAndNavWrapper>
+        <>
+          <span>x</span>
+          <span>y</span>
+        </>
+      </AuctionTitleAndNavWrapper>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(2);
+  });
 });

--- a/packages/niji-webapp/src/components/Documentation/GovernanceSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/GovernanceSection.test.tsx
@@ -33,4 +33,36 @@ describe('GovernanceSection', () => {
     const { container } = wrap(<GovernanceSection />);
     expect(container.textContent).toContain('Nijiders');
   });
+
+  it('renders exactly 4 ul li (veto criteria list)', () => {
+    const { container } = wrap(<GovernanceSection />);
+    const items = container.querySelectorAll('ul li');
+    expect(items.length).toBe(4);
+  });
+
+  it('mentions "veto" as a governance keyword', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect(container.textContent).toContain('veto');
+  });
+
+  it('mentions Niji Foundation as steward of veto power', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect(container.textContent).toContain('Niji Foundation');
+  });
+
+  it('mentions "smart contracts" in veto criteria', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect(container.textContent).toContain('smart contracts');
+  });
+
+  it('mentions treasury multiple times (>= 2 occurrences)', () => {
+    const { container } = wrap(<GovernanceSection />);
+    const matches = container.textContent?.match(/treasury/gi) ?? [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders extensive long-form content (> 1000 chars)', () => {
+    const { container } = wrap(<GovernanceSection />);
+    expect((container.textContent ?? '').length).toBeGreaterThan(1000);
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallReviewStep/FunctionCallReviewStep.test.ts
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallReviewStep/FunctionCallReviewStep.test.ts
@@ -215,4 +215,93 @@ describe('handleActionAdd', () => {
       }),
     );
   });
+
+  it('uses 0n value when amount is undefined / empty', () => {
+    const state: ProposalActionModalState = {
+      actionType: ProposalActionType.LUMP_SUM,
+      address: '0x6a024f521f83906671e1a23a8B6c560be7e980F4',
+    };
+
+    handleActionAdd(state, mockOnActionAdd);
+
+    expect(mockOnActionAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 0n,
+        calldata: '0x',
+      }),
+    );
+  });
+
+  it('encodes 0-argument function (renounceOwnership)', () => {
+    const state: ProposalActionModalState = {
+      actionType: ProposalActionType.FUNCTION_CALL,
+      address: '0xa58e81fe9b61b5c3fe2afd33cf304c454abfc7cb',
+      abi: ensReverseRegistrarAbi,
+      function: 'renounceOwnership',
+      amount: '0',
+      args: [],
+    };
+
+    handleActionAdd(state, mockOnActionAdd);
+
+    expect(mockOnActionAdd).toHaveBeenCalledOnce();
+    expect(mockOnActionAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signature: 'renounceOwnership()',
+        decodedCalldata: '[]',
+      }),
+    );
+  });
+
+  it('parses large amount via parseEther (1000 ETH = 1e21 wei)', () => {
+    const state: ProposalActionModalState = {
+      actionType: ProposalActionType.LUMP_SUM,
+      address: '0xa58e81fe9b61b5c3fe2afd33cf304c454abfc7cb',
+      amount: '1000',
+    };
+
+    handleActionAdd(state, mockOnActionAdd);
+
+    expect(mockOnActionAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 1_000_000_000_000_000_000_000n,
+      }),
+    );
+  });
+
+  it('encodes setController with 2 inputs (address + bool)', () => {
+    const state: ProposalActionModalState = {
+      actionType: ProposalActionType.FUNCTION_CALL,
+      address: '0xa58e81fe9b61b5c3fe2afd33cf304c454abfc7cb',
+      abi: ensReverseRegistrarAbi,
+      function: 'setController',
+      amount: '0',
+      args: ['0x0000000000000000000000000000000000000001', true],
+    };
+
+    handleActionAdd(state, mockOnActionAdd);
+
+    expect(mockOnActionAdd).toHaveBeenCalledOnce();
+    expect(mockOnActionAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signature: 'setController(address,bool)',
+      }),
+    );
+  });
+
+  it('amount string with decimal point parses correctly (0.5 ETH)', () => {
+    const state: ProposalActionModalState = {
+      actionType: ProposalActionType.LUMP_SUM,
+      address: '0xa58e81fe9b61b5c3fe2afd33cf304c454abfc7cb',
+      amount: '0.5',
+    };
+
+    handleActionAdd(state, mockOnActionAdd);
+
+    expect(mockOnActionAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: 500_000_000_000_000_000n,
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 84` として既存 test 4 component (`Documentation/GovernanceSection` / `FunctionCallReviewStep` / `AuctionActivityDateHeadline` / `AuctionTitleAndNavWrapper`) に edge case / contract pin TC を 23 件追加、 1881 → 1904 (+23、 1 skip 維持)。

これまでの part 71-83 で utils / hooks / Modal / 件数 3 帯 component を強化済み、 本 PR では同 pattern を残薄 test 4 file に展開。

## 詳細

### components/Documentation/GovernanceSection.test.tsx (+6 TC)

既存 3 → 9 TC へ拡張、 文章構造 + 重要 keyword 出現を pin。

検証観点。

- `<ul><li>` 4 個ぴったり (veto 条件 list)
- "veto" 単語含む
- "Niji Foundation" 含む (veto power の保持主体)
- "smart contracts" 含む (audit 言及)
- "treasury" 複数出現 (>= 2)
- 本文 >1000 chars (long-form content)

### components/ProposalActionsModal/steps/FunctionCallReviewStep/FunctionCallReviewStep.test.ts (+5 TC)

既存 2 → 7 TC へ拡張、 handleActionAdd の境界を pin。

検証観点。

- amount undefined で value=0n
- 0 引数 function (renounceOwnership) で signature=`renounceOwnership()`
- 1000 ETH amount で `1_000_000_000_000_000_000_000n` wei
- 2 input function (setController address+bool) で signature=`setController(address,bool)`
- 0.5 ETH (decimal string) で `500_000_000_000_000_000n` wei

### components/AuctionActivityDateHeadline/index.test.tsx (+6 TC)

既存 4 → 10 TC へ拡張、 startTime 境界と DOM 構造を pin。

検証観点。

- h4 ちょうど 1 個
- 0n startTime → "January" + "1970" (Unix epoch)
- 巨大 startTime (4102444800n = 2100-01-01) → "2100"
- outermost 単一 `<div>`
- wrapper div に CSS module className
- h4 textContent が `MMMM DD, YYYY` パターンに合致

### components/AuctionTitleAndNavWrapper/index.test.tsx (+6 TC)

既存 4 → 10 TC へ拡張、 children 多様性と Bootstrap Col className 構造を pin。

検証観点。

- 数値 / array / null children
- outermost に `col-lg-12` Bootstrap class
- CSS module className と Bootstrap class 併存
- Fragment 多 span children

## 解決方法

各 file は既存 mock / `render` パターンを踏襲、 既存 describe ブロックに新 `it` を追加。 mock 既存設定維持、 新規追加なし。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1881 → 1904、 1 skip 維持)
- lint 通過 (warning 2 件は既存 baseline、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1904 tests + 1 todo (1905)
- `pnpm -w lint <変更 4 file>` → 通過 (error なし)

Closes #499
