### PR TITLE
✅ test(niji-webapp): part 87 (components hover / minbid / navbar / spinner 4 file edge case 強化) で 1944 → 1965 (Issue #505)

### DIFF
--- a/packages/niji-webapp/src/components/HoverCard.test.tsx
+++ b/packages/niji-webapp/src/components/HoverCard.test.tsx
@@ -47,4 +47,61 @@ describe('HoverCard', () => {
     // span 経由でも tip-abc 文字は確認されない (closed state)
     expect(container.textContent).toBe('Trigger');
   });
+
+  it('accepts different id prop without crashing', () => {
+    expect(() =>
+      render(
+        <HoverCard hoverCardContent={() => <></>} tip="t" id="custom-id">
+          x
+        </HoverCard>,
+        { wrapper: WithProviders },
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders Fragment children unwrapped (multiple inline nodes)', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={() => <></>} tip="t" id="x">
+        <>
+          <em>a</em>
+          <strong>b</strong>
+        </>
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    expect(container.querySelector('em')?.textContent).toBe('a');
+    expect(container.querySelector('strong')?.textContent).toBe('b');
+  });
+
+  it('renders empty trigger label without crashing', () => {
+    expect(() =>
+      render(
+        <HoverCard hoverCardContent={() => <></>} tip="t" id="x">
+          {''}
+        </HoverCard>,
+        { wrapper: WithProviders },
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders the trigger span exactly once at default (closed) state', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={() => <></>} tip="t" id="x">
+        Trigger
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    const spans = container.querySelectorAll('span');
+    expect(spans.length).toBe(1);
+  });
+
+  it('renders numeric children inside trigger span', () => {
+    const { container } = render(
+      <HoverCard hoverCardContent={() => <></>} tip="t" id="x">
+        {42}
+      </HoverCard>,
+      { wrapper: WithProviders },
+    );
+    expect(container.querySelector('span')?.textContent).toBe('42');
+  });
 });

--- a/packages/niji-webapp/src/components/MinBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/MinBid/index.test.tsx
@@ -33,4 +33,39 @@ describe('MinBid', () => {
     if (wrapper) fireEvent.click(wrapper);
     expect(onClick).toHaveBeenCalledTimes(1);
   });
+
+  it('handles very large minBid (1M ETH = 1e24 wei)', () => {
+    const { container } = render(<MinBid minBid={parseEther('1000000')} onClick={() => {}} />);
+    expect(container.textContent).toContain('You must bid at least');
+    expect(container.textContent).toContain('Ξ');
+  });
+
+  it('fires onClick multiple times for repeated clicks', () => {
+    const onClick = vi.fn();
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={onClick} />);
+    const wrapper = container.querySelector('div');
+    if (wrapper) {
+      fireEvent.click(wrapper);
+      fireEvent.click(wrapper);
+      fireEvent.click(wrapper);
+    }
+    expect(onClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('img alt is "Pointer noun"', () => {
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('Pointer noun');
+  });
+
+  it('renders exactly 1 h3 element', () => {
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.querySelectorAll('h3').length).toBe(1);
+  });
+
+  it('outermost wrapper is single <div> with onClick handler', () => {
+    const onClick = vi.fn();
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={onClick} />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
 });

--- a/packages/niji-webapp/src/components/NavBar/NavBarItem/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBar/NavBarItem/index.test.tsx
@@ -27,4 +27,44 @@ describe('NavBarItem', () => {
     const { container } = render(<NavBarItem>x</NavBarItem>);
     expect(container.querySelector('div')).not.toBeNull();
   });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<NavBarItem>{99}</NavBarItem>);
+    expect(container.querySelector('div')?.textContent).toBe('99');
+  });
+
+  it('renders Fragment children unwrapped', () => {
+    const { container } = render(
+      <NavBarItem>
+        <>
+          <span>a</span>
+          <span>b</span>
+        </>
+      </NavBarItem>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(2);
+  });
+
+  it('handles empty className prop', () => {
+    const { container } = render(<NavBarItem className="">x</NavBarItem>);
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+
+  it('fires onClick on repeated clicks', () => {
+    const onClick = vi.fn();
+    const { container } = render(<NavBarItem onClick={onClick}>x</NavBarItem>);
+    const div = container.querySelector('div');
+    if (div) {
+      fireEvent.click(div);
+      fireEvent.click(div);
+      fireEvent.click(div);
+    }
+    expect(onClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('outermost wrapper is exactly 1 <div>', () => {
+    const { container } = render(<NavBarItem>x</NavBarItem>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
 });

--- a/packages/niji-webapp/src/components/Spinner.test.tsx
+++ b/packages/niji-webapp/src/components/Spinner.test.tsx
@@ -31,4 +31,42 @@ describe('Spinner', () => {
     expect(svg?.getAttribute('class')).toContain('size-4');
     expect(svg?.getAttribute('class')).not.toContain('size-10');
   });
+
+  it('renders default size-10 when className is undefined', () => {
+    const { container } = render(<Spinner />);
+    expect(container.querySelector('svg')?.getAttribute('class')).toContain('size-10');
+  });
+
+  it('handles empty className (default classes preserved)', () => {
+    const { container } = render(<Spinner className="" />);
+    const cls = container.querySelector('svg')?.getAttribute('class') ?? '';
+    expect(cls).toContain('animate-spin');
+    expect(cls).toContain('size-10');
+  });
+
+  it('merges multiple custom classes (text-* + m-*)', () => {
+    const { container } = render(<Spinner className="m-2 text-blue-500" />);
+    const cls = container.querySelector('svg')?.getAttribute('class') ?? '';
+    expect(cls).toContain('text-blue-500');
+    expect(cls).toContain('m-2');
+  });
+
+  it('overrides size-* with size-2', () => {
+    const { container } = render(<Spinner className="size-2" />);
+    const cls = container.querySelector('svg')?.getAttribute('class') ?? '';
+    expect(cls).toContain('size-2');
+    expect(cls).not.toContain('size-10');
+  });
+
+  it('overrides size-* with size-16', () => {
+    const { container } = render(<Spinner className="size-16" />);
+    const cls = container.querySelector('svg')?.getAttribute('class') ?? '';
+    expect(cls).toContain('size-16');
+    expect(cls).not.toContain('size-10');
+  });
+
+  it('renders exactly 1 svg (single instance contract)', () => {
+    const { container } = render(<Spinner />);
+    expect(container.querySelectorAll('svg').length).toBe(1);
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 87` として既存 test 4 component (`HoverCard` / `MinBid` / `NavBarItem` / `Spinner`) に edge case / contract pin TC を 21 件追加、 1944 → 1965 (+21、 1 skip 維持)。

これまでの part 71-86 で utils / hooks / Modal / 件数 3-4 帯 component を強化済み、 本 PR では同 pattern を残薄 test 4 file に展開。

## 詳細

### components/HoverCard.test.tsx (+5 TC)

既存 4 → 9 TC へ拡張、 props 多様性と trigger span 単一性を pin。

検証観点。

- 異 id prop で crash なし
- Fragment children unwrap (em / strong 同時 render)
- 空文字 trigger でも crash なし
- closed state では trigger span が 1 個のみ
- 数値 children を string 化レンダー

### components/MinBid/index.test.tsx (+5 TC)

既存 4 → 9 TC へ拡張、 minBid 境界 / event handler / DOM attribute を pin。

検証観点。

- 1M ETH minBid でも render 完了 (Ξ + "You must bid at least")
- 連続 3 click で onClick 3 回
- img alt="Pointer noun" 固定
- h3 element ちょうど 1 個
- outermost 単一 `<div>` (onClick handler 配置先)

### components/NavBar/NavBarItem/index.test.tsx (+5 TC)

既存 4 → 9 TC へ拡張、 children 多様性 / className / 連続 click を pin。

検証観点。

- 数値 children / Fragment children
- 空 className でも crash なし
- onClick 連続 3 click
- outermost 単一 `<div>`

### components/Spinner.test.tsx (+6 TC)

既存 4 → 10 TC へ拡張、 tailwind-merge の挙動と各 size override を pin。

検証観点。

- className undefined / 空文字で default 維持
- multi class merge (`m-2 text-blue-500`)
- size override 別パターン (size-2 / size-16 で size-10 上書き)
- svg element ちょうど 1 個

## 解決方法

各 file は既存 mock / `render` パターンを踏襲、 既存 describe ブロックに新 it を追加。 lint auto-fix で prettier 整形 2 件解消 (MinBid の line wrapping、 Spinner の class order)。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1944 → 1965、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1965 tests + 1 todo (1966)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier auto-fix 適用済)

Closes #505
