### PR TITLE
✅ test(niji-webapp): part 88 (components nijiders / lang / settle / tight stacked 4 file edge case 強化) で 1965 → 1985 (Issue #507)

### DIFF
--- a/packages/niji-webapp/src/components/Documentation/NijidersRewardSection.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/NijidersRewardSection.test.tsx
@@ -47,4 +47,40 @@ describe('NijidersRewardSection', () => {
     );
     expect(a?.getAttribute('href')).toBe('https://twitter.com/carrot_init');
   });
+
+  it('all 10 links point to twitter.com domain', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    const links = Array.from(container.querySelectorAll('a'));
+    expect(links.length).toBe(10);
+    links.forEach(a => {
+      expect(a.getAttribute('href')?.startsWith('https://twitter.com/')).toBe(true);
+    });
+  });
+
+  it('all 10 URLs are unique (no duplicates)', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    const urls = Array.from(container.querySelectorAll('a')).map(a => a.getAttribute('href'));
+    const unique = new Set(urls);
+    expect(unique.size).toBe(10);
+  });
+
+  it('all handles start with @', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    const links = Array.from(container.querySelectorAll('a'));
+    links.forEach(a => {
+      expect(a.textContent?.startsWith('@')).toBe(true);
+    });
+  });
+
+  it('mentions "Niji DAO" and "auction proceeds" context', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    expect(container.textContent).toContain('Niji DAO');
+    expect(container.textContent).toContain('auction proceeds');
+  });
+
+  it('mentions "Every 10th Niji" + 5 years vesting context', () => {
+    const { container } = wrap(<NijidersRewardSection />);
+    expect(container.textContent).toContain('Every 10th Niji');
+    expect(container.textContent).toContain('5 years');
+  });
 });

--- a/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
@@ -63,4 +63,45 @@ describe('LanguageSelectionModal', () => {
     expect(setLocale).toHaveBeenCalledWith('ja-JP');
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it('clicking English button calls setLocale("en-US")', () => {
+    const setLocale = vi.fn();
+    const onDismiss = vi.fn();
+    useAtomMock.mockReturnValue(['ja-JP', setLocale]);
+    render(<LanguageSelectionModal onDismiss={onDismiss} />);
+    const overlay = document.getElementById('overlay-root');
+    const buttons = overlay?.querySelectorAll('div');
+    const enBtn = Array.from(buttons ?? []).find(d => d.textContent === 'English');
+    if (enBtn) fireEvent.click(enBtn);
+    expect(setLocale).toHaveBeenCalledWith('en-US');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('clicking 中文 button calls setLocale("zh-CN")', () => {
+    const setLocale = vi.fn();
+    const onDismiss = vi.fn();
+    useAtomMock.mockReturnValue(['en-US', setLocale]);
+    render(<LanguageSelectionModal onDismiss={onDismiss} />);
+    const overlay = document.getElementById('overlay-root');
+    const buttons = overlay?.querySelectorAll('div');
+    const zhBtn = Array.from(buttons ?? []).find(d => d.textContent === '中文');
+    if (zhBtn) fireEvent.click(zhBtn);
+    expect(setLocale).toHaveBeenCalledWith('zh-CN');
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders 3 languages regardless of active locale', () => {
+    useAtomMock.mockReturnValue(['zh-CN', vi.fn()]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    const text = document.getElementById('overlay-root')?.textContent ?? '';
+    expect(text).toContain('日本語');
+    expect(text).toContain('English');
+    expect(text).toContain('中文');
+  });
+
+  it('exactly 1 modal h3 title rendered', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.querySelectorAll('h3').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/SettleManuallyBtn/index.test.tsx
+++ b/packages/niji-webapp/src/components/SettleManuallyBtn/index.test.tsx
@@ -57,4 +57,48 @@ describe('SettleManuallyBtn', () => {
     );
     expect(container.querySelector('p button')).not.toBeNull();
   });
+
+  it('fires settleAuctionHandler on multiple clicks', () => {
+    const handler = vi.fn();
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={handler} auction={auction} />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) {
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+    }
+    expect(handler).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders with huge bid amount', () => {
+    const huge = { ...auction, amount: 1_000_000_000_000_000_000_000_000n };
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={() => {}} auction={huge} />,
+    );
+    expect(container.textContent).toContain('Settle');
+  });
+
+  it('renders exactly 1 button element', () => {
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={() => {}} auction={auction} />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(1);
+  });
+
+  it('outermost wrapper is a single <p>', () => {
+    const { container } = render(
+      <SettleManuallyBtn settleAuctionHandler={() => {}} auction={auction} />,
+    );
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('P');
+  });
+
+  it('handles nounId=0n auction', () => {
+    const zeroId = { ...auction, nounId: 0n };
+    expect(() =>
+      render(<SettleManuallyBtn settleAuctionHandler={() => {}} auction={zeroId} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
@@ -55,4 +55,52 @@ describe('TightStackedCircleNiji', () => {
     expect(circle?.getAttribute('cx')).toBe('34'); // 28 + 2*3
     expect(circle?.getAttribute('cy')).toBe('28'); // 55 - 21 - 2*3
   });
+
+  it('index 0 produces cx=28, cy=34 (square 55 - 21)', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'x' });
+    const { container } = renderSvg({ nounId: 1, index: 0, square: 55, shift: 3 });
+    const circle = container.querySelector('circle');
+    expect(circle?.getAttribute('cx')).toBe('28'); // 28 + 0*3
+    expect(circle?.getAttribute('cy')).toBe('34'); // 55 - 21 - 0*3
+  });
+
+  it('square 100 + shift 5 produces shifted positions', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'x' });
+    const { container } = renderSvg({ nounId: 1, index: 1, square: 100, shift: 5 });
+    const circle = container.querySelector('circle');
+    expect(circle?.getAttribute('cx')).toBe('33'); // 28 + 1*5
+    expect(circle?.getAttribute('cy')).toBe('74'); // 100 - 21 - 1*5
+  });
+
+  it('image href passes through getNiji image verbatim', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'data:custom-svg' });
+    const { container } = renderSvg({ nounId: 1, index: 0, square: 55, shift: 3 });
+    expect(container.querySelector('image')?.getAttribute('href')).toBe('data:custom-svg');
+  });
+
+  it('exactly 1 LoadingNoun when seed undefined (no extra circles/images)', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    const { container } = renderSvg({ nounId: 1, index: 0, square: 55, shift: 3 });
+    expect(container.querySelectorAll('[data-testid="loading-noun"]').length).toBe(1);
+    expect(container.querySelector('image')).toBeNull();
+  });
+
+  it('renders circle + image when seed present (no LoadingNoun)', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'x' });
+    const { container } = renderSvg({ nounId: 1, index: 0, square: 55, shift: 3 });
+    expect(container.querySelector('[data-testid="loading-noun"]')).toBeNull();
+    expect(container.querySelector('circle')).not.toBeNull();
+    expect(container.querySelector('image')).not.toBeNull();
+  });
+
+  it('circle id reflects different nounIds (numeric stringification)', () => {
+    useNounSeedMock.mockReturnValue({});
+    getNijiMock.mockReturnValue({ image: 'x' });
+    const { container } = renderSvg({ nounId: 9999, index: 0, square: 55, shift: 3 });
+    expect(container.querySelector('circle')?.getAttribute('id')).toBe('9999');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 88` として既存 test 4 component (`Documentation/NijidersRewardSection` / `LanguageSelectionModal` / `SettleManuallyBtn` / `TightStackedCircleNiji`) に edge case / contract pin TC を 20 件追加、 1965 → 1985 (+20、 1 skip 維持)。

これまでの part 71-87 で utils / hooks / Modal / 件数 3-4 帯 component を強化済み、 本 PR では同 pattern を残薄 test 4 file に展開。

## 詳細

### components/Documentation/NijidersRewardSection.test.tsx (+5 TC)

既存 4 → 9 TC へ拡張、 10 Nijiders link の domain / unique / format / 周辺文脈を pin。

検証観点。

- 10 link 全て `https://twitter.com/` domain
- 10 URL が完全 unique
- 各 handle が `@` prefix
- "Niji DAO" / "auction proceeds" 言及
- "Every 10th Niji" + "5 years" vesting 言及

### components/LanguageSelectionModal/index.test.tsx (+4 TC)

既存 4 → 8 TC へ拡張、 各言語 click → setLocale の対応と 3 言語 invariant を pin。

検証観点。

- English click → `setLocale('en-US')` + onDismiss
- 中文 click → `setLocale('zh-CN')` + onDismiss
- active locale が zh-CN でも 3 言語表示
- modal title `<h3>` 1 個ぴったり

### components/SettleManuallyBtn/index.test.tsx (+5 TC)

既存 4 → 9 TC へ拡張、 多重 click / 巨大 amount / 構造を pin。

検証観点。

- 連続 3 click で settleAuctionHandler 3 回
- 1e24 wei (~1M ETH) amount でも render 完了
- button element ちょうど 1 個
- outermost 単一 `<p>` wrapper
- nounId=0n auction でクラッシュなし

### components/TightStackedCircleNiji/index.test.tsx (+6 TC)

既存 4 → 10 TC へ拡張、 position 計算 / seed 経路 / DOM 構造を pin。

検証観点。

- index 0 で cx=28, cy=square-21
- square 100 + shift 5 + index 1 で cx=33, cy=74
- image href が getNiji image を verbatim passthrough
- seed undefined で LoadingNoun 1 個のみ (image なし)
- seed あり時に circle + image (LoadingNoun なし)
- nounId 9999 → circle id="9999"

## 解決方法

各 file は既存 mock / `render` パターンを踏襲、 既存 describe ブロックに新 it を追加。 mock 既存設定維持、 新規追加なし。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (1965 → 1985、 1 skip 維持)
- lint 通過 (warning 8 件は既存 baseline、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 1985 tests + 1 todo (1986)
- `pnpm -w lint <変更 4 file>` → 通過 (error なし)

Closes #507
