### PR TITLE
✅ test(niji-webapp): part 90 (components niji title / timer / start end / truncated 4 file edge case 強化) で 2005 → 2025 (Issue #511)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -34,4 +34,33 @@ describe('AuctionActivityNijiTitle', () => {
     const { container } = render(<AuctionActivityNijiTitle nounId={1n} />);
     expect(container.querySelector('h1')?.getAttribute('style')).toContain('brand-warm-dark-text');
   });
+
+  it('handles 0n nounId', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={0n} />);
+    expect(container.querySelector('h1')?.textContent).toContain('0');
+  });
+
+  it('handles MAX_SAFE_INTEGER bigint', () => {
+    const huge = 9_007_199_254_740_991n;
+    const { container } = render(<AuctionActivityNijiTitle nounId={huge} />);
+    expect(container.querySelector('h1')?.textContent).toContain(huge.toString());
+  });
+
+  it('renders exactly 1 h1 element', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1n} />);
+    expect(container.querySelectorAll('h1').length).toBe(1);
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1n} />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('h1 always has style attribute with color property', () => {
+    const { container: cool } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    const { container: warm } = render(<AuctionActivityNijiTitle nounId={1n} isCool={false} />);
+    expect(cool.querySelector('h1')?.getAttribute('style')).toContain('color');
+    expect(warm.querySelector('h1')?.getAttribute('style')).toContain('color');
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionTimer/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionTimer/index.test.tsx
@@ -74,4 +74,32 @@ describe('AuctionTimer Component', () => {
     // Should render "Auction ended" text without error
     expect(screen.getAllByText('Auction ended').length).toBeGreaterThan(0);
   });
+
+  it('renders for settled=true auction', () => {
+    const settled = { ...mockAuction(0), settled: true };
+    expect(() => render(<AuctionTimer auction={settled} auctionEnded={true} />)).not.toThrow();
+  });
+
+  it('handles large nounId (10000n)', () => {
+    const large = { ...mockAuction(3600), nounId: 10000n };
+    expect(() => render(<AuctionTimer auction={large} auctionEnded={false} />)).not.toThrow();
+  });
+
+  it('handles auction 1 second to end', () => {
+    render(<AuctionTimer auction={mockAuction(1)} auctionEnded={false} />);
+    expect(screen.getByText(/Auction ends in|Time left/)).toBeInTheDocument();
+  });
+
+  it('handles zero-bidder auction (no bid yet)', () => {
+    const zeroBidder = {
+      ...mockAuction(3600),
+      bidder: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+    };
+    expect(() => render(<AuctionTimer auction={zeroBidder} auctionEnded={false} />)).not.toThrow();
+  });
+
+  it('handles 0n amount auction', () => {
+    const zeroAmt = { ...mockAuction(3600), amount: 0n };
+    expect(() => render(<AuctionTimer auction={zeroAmt} auctionEnded={false} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
+++ b/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
@@ -44,4 +44,34 @@ describe('StartOrEndTime', () => {
     // start in past, end = 0 → in past too → ended
     expect(container.textContent).toContain('ended');
   });
+
+  it('handles startTime === endTime (both in future, treated as starts)', () => {
+    const ts = Math.floor(Date.now() / 1000) + 3600;
+    const { container } = render(<StartOrEndTime startTime={ts} endTime={ts} />);
+    // start = end = future、 まだ始まっていない → starts
+    expect(container.textContent).toContain('starts');
+  });
+
+  it('handles very large timestamps (year 2100)', () => {
+    const year2100 = 4102444800; // 2100-01-01 UTC
+    const { container } = render(<StartOrEndTime startTime={year2100} endTime={year2100 + 3600} />);
+    expect(container.textContent).toContain('starts');
+  });
+
+  it('handles both 0 (epoch 1970, in past)', () => {
+    const { container } = render(<StartOrEndTime startTime={0} endTime={0} />);
+    expect(container.textContent).toContain('ended');
+  });
+
+  it('handles negative startTime (before epoch, in past)', () => {
+    const pastEnd = Math.floor(Date.now() / 1000) - 100;
+    const { container } = render(<StartOrEndTime startTime={-1000} endTime={pastEnd} />);
+    expect(container.textContent).toContain('ended');
+  });
+
+  it('does not crash when startTime > endTime (anomaly)', () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    const past = Math.floor(Date.now() / 1000) - 3600;
+    expect(() => render(<StartOrEndTime startTime={future} endTime={past} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/TruncatedAmount/index.test.tsx
+++ b/packages/niji-webapp/src/components/TruncatedAmount/index.test.tsx
@@ -29,4 +29,32 @@ describe('TruncatedAmount', () => {
     const { container } = render(<TruncatedAmount amount={parseEther('100')} />);
     expect(container.textContent).toBe('Ξ 100.00');
   });
+
+  it('formats huge amount (1000 ETH) to "Ξ 1000.00"', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('1000')} />);
+    expect(container.textContent).toBe('Ξ 1000.00');
+  });
+
+  it('rounds 0.005 ETH to "Ξ 0.01" (toFixed half-up)', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('0.005')} />);
+    expect(container.textContent).toBe('Ξ 0.01');
+  });
+
+  it('rounds 0.999 ETH to "Ξ 1.00" (toFixed rounding up)', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('0.999')} />);
+    expect(container.textContent).toBe('Ξ 1.00');
+  });
+
+  it('formats 0.01 ETH to "Ξ 0.01" (1 cent boundary)', () => {
+    const { container } = render(<TruncatedAmount amount={parseEther('0.01')} />);
+    expect(container.textContent).toBe('Ξ 0.01');
+  });
+
+  it('output always starts with "Ξ" prefix', () => {
+    const cases = [0n, parseEther('0.5'), parseEther('1'), parseEther('1000')];
+    cases.forEach(amount => {
+      const { container } = render(<TruncatedAmount amount={amount} />);
+      expect(container.textContent?.startsWith('Ξ')).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 90` として既存 test 4 component (`AuctionActivityNijiTitle` / `AuctionTimer` / `StartOrEndTime` / `TruncatedAmount`) に edge case / contract pin TC を 20 件追加、 2005 → 2025 (+20、 1 skip 維持)。

これまでの part 71-89 で utils / hooks / Modal / 件数 3-5 帯 component を強化し 2000 マイルストーン到達済み、 本 PR では件数 5 帯への展開を継続。

## 詳細

### components/AuctionActivityNijiTitle/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 bigint 境界 / DOM 構造 / style 一貫性を pin。

検証観点。

- 0n nounId 正しく "0" 表示
- MAX_SAFE_INTEGER bigint 表示
- h1 element ちょうど 1 個
- outermost 単一 `<div>` wrapper
- cool/warm 両モードで style に `color` プロパティ含む

### components/StartOrEndTime/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 時刻境界 / 異常入力を pin。

検証観点。

- startTime === endTime + future で "starts" branch
- year 2100 timestamp で正しく動作
- 両方 0 (epoch 1970) で "ended"
- negative startTime + past endTime で "ended"
- startTime > endTime (anomaly) でクラッシュなし

### components/TruncatedAmount/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 巨大 / round 境界 / Ξ prefix 一貫性を pin。

検証観点。

- 1000 ETH → "Ξ 1000.00"
- 0.005 ETH → "Ξ 0.01" (toFixed half-up rounding)
- 0.999 ETH → "Ξ 1.00" (rounding up)
- 0.01 ETH → "Ξ 0.01" (1 cent boundary)
- 出力は常に `Ξ` prefix で開始 (0n / 0.5 / 1 / 1000 ETH 全部)

### components/AuctionTimer/index.test.tsx (+6 TC)

既存 5 → 11 TC へ拡張、 auction 状態 / 境界値 / nounId 巨大を pin。

検証観点。

- settled=true auction で render 完了
- 10000n nounId
- 1 sec to end (smallest positive timeLeft)
- zero address bidder (no bid yet)
- 0n amount

## 解決方法

各 file は既存 mock / `render` パターンを踏襲、 既存 describe ブロックに新 it を追加。 TruncatedAmount で初期 expectation を floor 切捨てと想定していたが、 実装は `toFixed(2)` の half-up rounding 仕様 (`0.005 → 0.01`, `0.999 → 1.00`) と判明したため expected を pin。 lint auto-fix で prettier 整形 6 件解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2005 → 2025、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2025 tests + 1 todo (2026)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier auto-fix 適用済)

Closes #511
