### PR TITLE
✅ test(niji-webapp): part 93 (components bid item / candidate / locale / transition 4 file edge case 強化) で 2065 → 2085 (Issue #517)

### DIFF
--- a/packages/niji-webapp/src/components/BidHistoryItem/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryItem/index.test.tsx
@@ -121,4 +121,33 @@ describe('BidHistoryItem Component', () => {
     // Reset window width
     window.innerWidth = 1200;
   });
+
+  it('renders large amount (1e24 wei) via TruncatedAmount', () => {
+    const huge = { ...mockBid, value: 1_000_000_000_000_000_000_000_000n };
+    render(<BidHistoryItem bid={huge} classes={mockClasses} />);
+    expect(screen.getByTestId('truncated-amount')).toHaveTextContent('1000000000000000000000000');
+  });
+
+  it('renders extended=true bid normally (no visual difference at item level)', () => {
+    const ext = { ...mockBid, extended: true };
+    render(<BidHistoryItem bid={ext} classes={mockClasses} />);
+    expect(screen.getByTestId('short-address')).toBeInTheDocument();
+    expect(screen.getByTestId('truncated-amount')).toBeInTheDocument();
+  });
+
+  it('link has rel="noreferrer" for external safety', () => {
+    render(<BidHistoryItem bid={mockBid} classes={mockClasses} />);
+    expect(screen.getByRole('link').getAttribute('rel')).toBe('noreferrer');
+  });
+
+  it('link target is "_blank" for new tab', () => {
+    render(<BidHistoryItem bid={mockBid} classes={mockClasses} />);
+    expect(screen.getByRole('link').getAttribute('target')).toBe('_blank');
+  });
+
+  it('handles short transaction hash format (no normalization)', () => {
+    const shortHash = { ...mockBid, transactionHash: '0xshort' };
+    render(<BidHistoryItem bid={shortHash} classes={mockClasses} />);
+    expect(screen.getByRole('link').getAttribute('href')).toBe('https://etherscan.io/tx/0xshort');
+  });
 });

--- a/packages/niji-webapp/src/components/CandidateCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/index.test.tsx
@@ -66,4 +66,35 @@ describe('CandidateCard', () => {
     const { container } = wrap(<CandidateCard candidate={candidate} nounsRequired={3} />);
     expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('');
   });
+
+  it('passes candidate.requiredVotes (3) to sponsors regardless of nounsRequired prop', () => {
+    // candidate.requiredVotes=3 を component 内で優先、 nounsRequired prop は ignore される経路
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={99} />);
+    expect(container.querySelector('[data-testid="sponsors"]')?.textContent).toBe('req-3');
+  });
+
+  it('handles unicode title (Japanese)', () => {
+    const candidate = {
+      ...baseCandidate,
+      version: { content: { title: '日本語タイトル', contentSignatures: [] } },
+    } as never;
+    const { container } = wrap(<CandidateCard candidate={candidate} nounsRequired={3} />);
+    expect(container.textContent).toContain('日本語タイトル');
+  });
+
+  it('handles different candidate.id in link path', () => {
+    const candidate = { ...baseCandidate, id: 'cand-xyz-99' } as never;
+    const { container } = wrap(<CandidateCard candidate={candidate} nounsRequired={3} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/candidates/cand-xyz-99');
+  });
+
+  it('renders exactly 1 anchor (internal link)', () => {
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={3} />);
+    expect(container.querySelectorAll('a').length).toBe(1);
+  });
+
+  it('renders relativeTimestamp string (mocked "1 day ago")', () => {
+    const { container } = wrap(<CandidateCard candidate={baseCandidate} nounsRequired={3} />);
+    expect(container.textContent).toContain('1 day ago');
+  });
 });

--- a/packages/niji-webapp/src/components/NavLocaleSwitcher/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavLocaleSwitcher/index.test.tsx
@@ -74,4 +74,39 @@ describe('NavLocaleSwitcher', () => {
     const { container } = render(<NavLocaleSwitcher />);
     expect(container.querySelector('[data-testid="lang-modal"]')).toBeNull();
   });
+
+  it('renders for ja-JP locale without crash', () => {
+    useAtomMock.mockReturnValue(['ja-JP', vi.fn()]);
+    expect(() => render(<NavLocaleSwitcher />)).not.toThrow();
+  });
+
+  it('renders for zh-CN locale without crash', () => {
+    useAtomMock.mockReturnValue(['zh-CN', vi.fn()]);
+    expect(() => render(<NavLocaleSwitcher />)).not.toThrow();
+  });
+
+  it('renders exactly 1 dropdown wrapper', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    expect(container.querySelectorAll('.dropdown').length).toBe(1);
+  });
+
+  it('reopens modal after close + click again', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    const wrapper = container.querySelector('[data-testid="nav-button"]')?.parentElement;
+    if (wrapper) fireEvent.click(wrapper);
+    expect(container.querySelector('[data-testid="lang-modal"]')).not.toBeNull();
+    const closeBtn = container.querySelector('[data-testid="lang-modal"] button');
+    if (closeBtn) fireEvent.click(closeBtn);
+    if (wrapper) fireEvent.click(wrapper);
+    expect(container.querySelector('[data-testid="lang-modal"]')).not.toBeNull();
+  });
+
+  it('renders 1+ nav-button (mobile + desktop variants)', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    const buttons = container.querySelectorAll('[data-testid="nav-button"]');
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
 });

--- a/packages/niji-webapp/src/components/NijisTransition/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijisTransition/index.test.tsx
@@ -75,4 +75,68 @@ describe('NijisTransition', () => {
     const { container } = render(<NijisTransition show={true} transitionStyes={styles} />);
     expect(container.querySelector('[data-testid="motion-div"]')).not.toBeNull();
   });
+
+  it('fires onClick on repeated clicks (3 times)', () => {
+    const onClick = vi.fn();
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles} onClick={onClick}>
+        <span>x</span>
+      </NijisTransition>,
+    );
+    const div = container.querySelector('[data-testid="motion-div"]');
+    if (div) {
+      fireEvent.click(div);
+      fireEvent.click(div);
+      fireEvent.click(div);
+    }
+    expect(onClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles empty className', () => {
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles} className="">
+        <span>x</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('[data-testid="motion-div"]')?.className).toBe('');
+  });
+
+  it('renders numeric children', () => {
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        {42}
+      </NijisTransition>,
+    );
+    expect(container.querySelector('[data-testid="motion-div"]')?.textContent).toBe('42');
+  });
+
+  it('renders exactly 1 motion-div when show=true', () => {
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        <span>x</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelectorAll('[data-testid="motion-div"]').length).toBe(1);
+  });
+
+  it('toggle show: true → false → true via rerender', () => {
+    const { container, rerender } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        <span>x</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('span')).not.toBeNull();
+    rerender(
+      <NijisTransition show={false} transitionStyes={styles}>
+        <span>x</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('span')).toBeNull();
+    rerender(
+      <NijisTransition show={true} transitionStyes={styles}>
+        <span>x</span>
+      </NijisTransition>,
+    );
+    expect(container.querySelector('span')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 93` として既存 test 4 component (`BidHistoryItem` / `CandidateCard` / `NavLocaleSwitcher` / `NijisTransition`) に edge case / contract pin TC を 20 件追加、 2065 → 2085 (+20、 1 skip 維持)。

これまでの part 71-92 で utils / hooks / Modal / 件数 3-5 帯 component を強化し 2065 達成済み、 本 PR では同 pattern を残薄 test 4 file に展開。

## 詳細

### components/BidHistoryItem/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 巨大 amount / extended / link 属性 / txhash format を pin。

検証観点。

- 1e24 wei (1M ETH) amount を TruncatedAmount に passthrough
- extended=true bid も item レベルでは差なく render
- link `rel="noreferrer"` (external safety)
- link `target="_blank"` (new tab)
- 短い transactionHash (`0xshort`) でも href verbatim

### components/CandidateCard/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 candidate field 優先 / unicode / id 形式 / 単一 anchor / 時刻文字列を pin。

検証観点。

- candidate.requiredVotes (3) を component が優先、 nounsRequired prop は ignore
- 日本語 Unicode title 含む
- 異 candidate.id (`cand-xyz-99`) で `/candidates/{id}` link path
- `<a>` 要素 1 個ぴったり
- relativeTimestamp mock の "1 day ago" を表示

### components/NavLocaleSwitcher/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 各 locale crash なし / dropdown 単一 / modal reopen を pin。

検証観点。

- ja-JP / zh-CN locale でも crash なし
- `.dropdown` 要素 1 個ぴったり
- modal close 後に再 click で reopen
- nav-button が 1+ 個 (mobile + desktop variants)

### components/NijisTransition/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 multi-click / className 空 / 数値 children / show toggle を pin。

検証観点。

- 連続 3 click で onClick 3 回
- 空 className でも motion-div 受領
- 数値 children を render
- show=true 時 motion-div 1 個
- show prop true → false → true rerender で span 表示 toggle

## 解決方法

各 file は既存 mock パターンを踏襲、 既存 describe ブロックに新 it を追加。 CandidateCard で nounsRequired=0 想定の test を作ったが、 component は candidate.requiredVotes を優先する経路と判明し、 prop ignore contract pin に修正。 lint auto-fix で prettier 整形 2 件解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2065 → 2085、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2085 tests + 1 todo (2086)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier auto-fix 適用済)

Closes #517
