### PR TITLE
✅ test(niji-webapp): part 94 (components sponsor overlay / legacy / candidate content / vote pill 4 file edge case 強化) で 2085 → 2107 (Issue #519)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsFormOverlay.test.tsx
@@ -70,4 +70,45 @@ describe('SponsorsFormOverlay', () => {
     expect(setIsForm).toHaveBeenCalledWith(false);
     expect(setPoll).toHaveBeenCalledWith(0);
   });
+
+  it('does NOT render Success banner for transactionState=Failed', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} transactionState="Failed" />);
+    expect(container.textContent).not.toContain('Success!');
+  });
+
+  it('does NOT render Success banner for transactionState=Pending', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} transactionState="Pending" />);
+    expect(container.textContent).not.toContain('Success!');
+  });
+
+  it('repeated close clicks call setIsFormDisplayed multiple times', () => {
+    const setIsForm = vi.fn();
+    const setPoll = vi.fn();
+    const { container } = render(
+      <SponsorsFormOverlay
+        {...defaults}
+        isFormDisplayed={true}
+        setIsFormDisplayed={setIsForm}
+        setDataFetchPollInterval={setPoll}
+      />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) {
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+    }
+    expect(setIsForm).toHaveBeenCalledTimes(2);
+    expect(setPoll).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders exactly 1 signature-form when isFormDisplayed=true', () => {
+    const { container } = render(<SponsorsFormOverlay {...defaults} isFormDisplayed={true} />);
+    expect(container.querySelectorAll('[data-testid="signature-form"]').length).toBe(1);
+  });
+
+  it('accepts different proposalIdToUpdate value without crash', () => {
+    expect(() =>
+      render(<SponsorsFormOverlay {...defaults} proposalIdToUpdate={42} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
+++ b/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
@@ -38,4 +38,49 @@ describe('LoadingNoun', () => {
     expect(img).not.toBeNull();
     expect(img?.getAttribute('alt')).toBe('loading noun');
   });
+
+  it('LoadingNoun img src is loading-skull URL', () => {
+    const { container } = render(<LoadingNoun />);
+    const src = container.querySelector('img')?.getAttribute('src') ?? '';
+    expect(src).toMatch(/loading-skull-noun/i);
+  });
+
+  it('LoadingNoun renders within div wrapper', () => {
+    const { container } = render(<LoadingNoun />);
+    expect(container.querySelector('div')).not.toBeNull();
+    expect(container.querySelector('div img')).not.toBeNull();
+  });
+});
+
+describe('LegacyNoun — additional edge cases', () => {
+  it('renders with empty alt (allowed for decorative use)', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="" />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('');
+  });
+
+  it('merges className + wrapperClassName simultaneously', () => {
+    const { container } = render(
+      <LegacyNoun imgPath="/x.png" alt="x" className="img-extra" wrapperClassName="wrap-extra" />,
+    );
+    expect(container.querySelector('img')?.className).toContain('img-extra');
+    expect(container.querySelector('div')?.className).toContain('wrap-extra');
+  });
+
+  it('falls back to loading skull URL prefix when imgPath is empty', () => {
+    const { container } = render(<LegacyNoun imgPath="" alt="x" />);
+    const src = container.querySelector('img')?.getAttribute('src') ?? '';
+    expect(src.length).toBeGreaterThan(0);
+    expect(src).toMatch(/loading-skull-noun/i);
+  });
+
+  it('renders exactly 1 img element', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="x" />);
+    expect(container.querySelectorAll('img').length).toBe(1);
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="x" />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalCandidateContent.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalCandidateContent.test.tsx
@@ -71,4 +71,68 @@ describe('ProposalCandidateContent', () => {
     const { container } = render(<ProposalCandidateContent proposal={baseProposal} />);
     expect(container.querySelector('[data-testid="proposal-tx"]')?.textContent).toBe('tx-count=2');
   });
+
+  it('handles 5 details (large details array)', () => {
+    const proposal5 = {
+      version: {
+        content: {
+          title: 't',
+          description: 'd',
+          details: [
+            { target: '0xA' },
+            { target: '0xB' },
+            { target: '0xC' },
+            { target: '0xD' },
+            { target: '0xE' },
+          ],
+        },
+      },
+    } as never;
+    const { container } = render(<ProposalCandidateContent proposal={proposal5} />);
+    expect(container.querySelector('[data-testid="proposal-tx"]')?.textContent).toBe('tx-count=5');
+  });
+
+  it('handles 0 details (empty array)', () => {
+    const proposal0 = {
+      version: {
+        content: { title: 't', description: 'd', details: [] },
+      },
+    } as never;
+    const { container } = render(<ProposalCandidateContent proposal={proposal0} />);
+    expect(container.querySelector('[data-testid="proposal-tx"]')?.textContent).toBe('tx-count=0');
+  });
+
+  it('Description heading appears before Proposed Transactions heading', () => {
+    const { container } = render(<ProposalCandidateContent proposal={baseProposal} />);
+    const html = container.innerHTML;
+    const descIdx = html.indexOf('Description');
+    const txIdx = html.indexOf('Proposed Transactions');
+    expect(descIdx).toBeLessThan(txIdx);
+  });
+
+  it('handles empty title (still passes "[]" prefix to ReactMarkdown)', () => {
+    const proposalNoTitle = {
+      version: {
+        content: { title: '', description: 'body', details: [] },
+      },
+    } as never;
+    const { container } = render(<ProposalCandidateContent proposal={proposalNoTitle} />);
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe('[]body');
+  });
+
+  it('handles multi-line description', () => {
+    const proposalMultiLine = {
+      version: {
+        content: {
+          title: 't',
+          description: 'line1\nline2\nline3',
+          details: [],
+        },
+      },
+    } as never;
+    const { container } = render(<ProposalCandidateContent proposal={proposalMultiLine} />);
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe(
+      '[t]line1\nline2\nline3',
+    );
+  });
 });

--- a/packages/niji-webapp/src/components/VoteStatusPill/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteStatusPill/index.test.tsx
@@ -31,4 +31,41 @@ describe('VoteStatusPill', () => {
     const { container } = render(<VoteStatusPill status="success" text={<span>nested</span>} />);
     expect(container.querySelector('span')?.textContent).toBe('nested');
   });
+
+  it('renders empty text without crashing', () => {
+    const { container } = render(<VoteStatusPill status="success" text="" />);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('renders numeric text (auto stringified)', () => {
+    const { container } = render(<VoteStatusPill status="success" text={42 as never} />);
+    expect(container.querySelector('div')?.textContent).toBe('42');
+  });
+
+  it('renders Fragment text containing multiple nodes', () => {
+    const { container } = render(
+      <VoteStatusPill
+        status="success"
+        text={
+          <>
+            <span>a</span>
+            <span>b</span>
+          </>
+        }
+      />,
+    );
+    expect(container.querySelectorAll('span').length).toBe(2);
+  });
+
+  it('empty status falls to pending (default branch)', () => {
+    const { container } = render(<VoteStatusPill status="" text="x" />);
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toMatch(/pending/i);
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<VoteStatusPill status="success" text="x" />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 94` として既存 test 4 component (`SponsorsFormOverlay` / `LegacyNoun` / `ProposalCandidateContent` / `VoteStatusPill`) に edge case / contract pin TC を 22 件追加、 2085 → 2107 (+22、 1 skip 維持)。

これまでの part 71-93 で utils / hooks / Modal / 件数 3-5 帯 component を強化し 2085 達成済み、 本 PR では同 pattern を残薄 test 4 file に展開。

## 詳細

### components/CandidateSponsors/SponsorsFormOverlay.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 transactionState 別 / multi-click / 単一性 / props passthrough を pin。

検証観点。

- transactionState 'Failed' / 'Pending' でも Success banner 非表示
- 連続 close click で setIsFormDisplayed / setDataFetchPollInterval が複数回
- signature-form 1 個ぴったり
- 異 proposalIdToUpdate でクラッシュなし

### components/LegacyNoun/index.test.tsx (+7 TC)

既存 6 → 12 TC へ拡張、 LoadingNoun 詳細 / 空 alt / className combo / DOM 構造を pin。

検証観点。

- LoadingNoun img src は loading-skull URL
- LoadingNoun は div wrapper を持つ
- 空 alt (decorative)
- className + wrapperClassName 同時指定
- imgPath 空で loading skull に fallback
- img 1 個 / outermost 単一 `<div>`

### components/ProposalContent/ProposalCandidateContent.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 details count / heading 順序 / title edge を pin。

検証観点。

- 5 details で tx-count=5
- 0 details で tx-count=0
- Description heading が Proposed Transactions より先
- empty title → `[]body` prefix (processProposalDescriptionText 経路)
- multi-line description 保持

### components/VoteStatusPill/index.test.tsx (+5 TC)

既存 5 → 10 TC へ拡張、 text 多様性 / status default branch / 単一性を pin。

検証観点。

- 空 text で空 textContent
- 数値 text を string 化
- Fragment text 多 span
- 空 status は default branch (pending) へ落ちる
- outermost 単一 `<div>`

## 解決方法

各 file は既存 mock パターンを踏襲、 既存 describe ブロックに新 it を追加。 lint auto-fix で prettier 整形 3 件解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2085 → 2107、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2107 tests + 1 todo (2108)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier auto-fix 適用済)

Closes #519
