### PR TITLE
✅ test(niji-webapp): part 95 (components footer / link / current bid / nav treasury 4 file edge case 強化) で 2107 → 2127 (Issue #521)

### DIFF
--- a/packages/niji-webapp/src/components/CurrentBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/CurrentBid/index.test.tsx
@@ -56,4 +56,40 @@ describe('CurrentBid', () => {
     expect(container.querySelector('h4')?.getAttribute('style')).toContain('brand-warm-light-text');
     expect(container.querySelector('h2')?.getAttribute('style')).toContain('brand-warm-dark-text');
   });
+
+  it('renders huge bid (1000 ETH) with Ξ prefix', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <CurrentBid currentBid={parseEther('1000')} auctionEnded={false} />,
+    );
+    expect(container.textContent).toContain('Ξ 1000.00');
+  });
+
+  it('renders 0 wei bid as "Ξ 0.00"', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={0n} auctionEnded={false} />);
+    expect(container.textContent).toContain('Ξ 0.00');
+  });
+
+  it('renders exactly 1 h2 and 1 h4 element', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />);
+    expect(container.querySelectorAll('h2').length).toBe(1);
+    expect(container.querySelectorAll('h4').length).toBe(1);
+  });
+
+  it('parseEther 0.1 ETH renders as Ξ 0.10', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <CurrentBid currentBid={parseEther('0.1')} auctionEnded={false} />,
+    );
+    expect(container.textContent).toContain('Ξ 0.10');
+  });
+
+  it('auctionEnded=true with BID_N_A still renders "-" placeholder', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(<CurrentBid currentBid={BID_N_A} auctionEnded={true} />);
+    expect(container.textContent).toContain('-');
+    expect(container.textContent).toContain('Winning bid');
+  });
 });

--- a/packages/niji-webapp/src/components/Footer.test.tsx
+++ b/packages/niji-webapp/src/components/Footer.test.tsx
@@ -87,4 +87,41 @@ describe('Footer', () => {
     const internalLinks = anchors.filter(a => a.getAttribute('href')?.startsWith('/'));
     expect(internalLinks.length).toBeGreaterThan(0);
   });
+
+  it('renders exactly 1 of each social icon (no duplicates)', () => {
+    const { container } = wrap(<Footer />);
+    expect(container.querySelectorAll('[data-testid="discord-icon"]').length).toBe(1);
+    expect(container.querySelectorAll('[data-testid="farcaster-icon"]').length).toBe(1);
+    expect(container.querySelectorAll('[data-testid="github-icon"]').length).toBe(1);
+    expect(container.querySelectorAll('[data-testid="x-icon"]').length).toBe(1);
+  });
+
+  it('all etherscan links use https:// scheme', () => {
+    const { container } = wrap(<Footer />);
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const etherscanLinks = anchors.filter(a => a.getAttribute('href')?.includes('etherscan.io'));
+    etherscanLinks.forEach(a => {
+      expect(a.getAttribute('href')?.startsWith('https://')).toBe(true);
+    });
+  });
+
+  it('copyright text contains "Niji DAO" string', () => {
+    const { container } = wrap(<Footer />);
+    expect(container.textContent).toContain('Niji DAO');
+  });
+
+  it('renders multiple internal links (>= 2)', () => {
+    const { container } = wrap(<Footer />);
+    const anchors = Array.from(container.querySelectorAll('a'));
+    const internal = anchors.filter(a => a.getAttribute('href')?.startsWith('/'));
+    expect(internal.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('noggles-icon appears within copyright area (textContent includes Niji DAO)', () => {
+    const { container } = wrap(<Footer />);
+    const noggles = container.querySelector('[data-testid="noggles-icon"]');
+    expect(noggles).not.toBeNull();
+    // sibling text に Niji DAO の copyright が出る contract pin
+    expect(container.textContent).toContain('Niji DAO');
+  });
 });

--- a/packages/niji-webapp/src/components/Link/index.test.tsx
+++ b/packages/niji-webapp/src/components/Link/index.test.tsx
@@ -34,4 +34,40 @@ describe('Link', () => {
     const { container } = render(<Link text={<span>nested</span>} url="/x" leavesPage={false} />);
     expect(container.querySelector('a span')?.textContent).toBe('nested');
   });
+
+  it('renders numeric text auto-stringified', () => {
+    const { container } = render(<Link text={42 as never} url="/x" leavesPage={false} />);
+    expect(container.querySelector('a')?.textContent).toBe('42');
+  });
+
+  it('handles empty url (href="")', () => {
+    const { container } = render(<Link text="x" url="" leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('');
+  });
+
+  it('renders Fragment text with multiple nodes', () => {
+    const { container } = render(
+      <Link
+        text={
+          <>
+            <span>a</span>
+            <span>b</span>
+          </>
+        }
+        url="/x"
+        leavesPage={false}
+      />,
+    );
+    expect(container.querySelectorAll('a span').length).toBe(2);
+  });
+
+  it('rel="noreferrer" is maintained even when leavesPage=false', () => {
+    const { container } = render(<Link text="x" url="/x" leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('rel')).toBe('noreferrer');
+  });
+
+  it('renders exactly 1 anchor element', () => {
+    const { container } = render(<Link text="x" url="/x" leavesPage={true} />);
+    expect(container.querySelectorAll('a').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/NavBarTreasury/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBarTreasury/index.test.tsx
@@ -67,4 +67,45 @@ describe('NavBarTreasury', () => {
     expect(wHeader).toMatch(/white/i);
     expect(cHeader).not.toMatch(/whiteTreasuryHeader/);
   });
+
+  it('renders huge balance (1_000_000_000) with thousands separator', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="1000000000" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    expect(container.textContent).toContain('1,000,000,000');
+  });
+
+  it('renders balance 0 (still shows "0")', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="0" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    expect(container.textContent).toContain('0');
+  });
+
+  it('always renders Ξ prefix regardless of style', () => {
+    const styles = [
+      NavBarButtonStyle.WHITE_INFO,
+      NavBarButtonStyle.WARM_INFO,
+      NavBarButtonStyle.COOL_INFO,
+    ];
+    styles.forEach(style => {
+      const { container } = render(<NavBarTreasury treasuryBalance="100" treasuryStyle={style} />);
+      expect(container.textContent).toContain('Ξ');
+    });
+  });
+
+  it('formats 4-digit balance with comma (1,000)', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="1000" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    expect(container.textContent).toContain('1,000');
+  });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(
+      <NavBarTreasury treasuryBalance="100" treasuryStyle={NavBarButtonStyle.WHITE_INFO} />,
+    );
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 95` として既存 test 4 component (`Footer` / `Link` / `CurrentBid` / `NavBarTreasury`) に edge case / contract pin TC を 20 件追加、 2107 → 2127 (+20、 1 skip 維持)。

これまでの part 71-94 で utils / hooks / Modal / 件数 3-5 帯 component を強化し 2107 達成済み、 本 PR では件数 6 帯への展開を継続。

## 詳細

### components/Footer.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 social icon 単一性 / etherscan link scheme / copyright 構造を pin。

検証観点。

- 4 social icon (discord / farcaster / github / x) 各 1 個ぴったり
- 全 etherscan link が `https://` で始まる
- copyright text に "Niji DAO" 含む
- 内部 link 2+ 個
- noggles icon と copyright text が同 component に共存

### components/Link/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 text 多様性 / 空 url / a 単一性を pin。

検証観点。

- 数値 text を auto-stringify
- 空 url で href=""
- Fragment text 多 span
- rel="noreferrer" は leavesPage=false でも維持
- a 1 個ぴったり

### components/CurrentBid/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 bid 境界 / DOM 構造 / heading combo を pin。

検証観点。

- 1000 ETH bid → "Ξ 1000.00"
- 0n bid → "Ξ 0.00"
- h2 / h4 各 1 個
- 0.1 ETH → "Ξ 0.10"
- BID_N_A + auctionEnded=true で "-" + "Winning bid" 共存

### components/NavBarTreasury/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 balance 巨大 / 0 / format / Ξ prefix / wrapper 構造を pin。

検証観点。

- balance "1000000000" → "1,000,000,000" (thousands separator)
- balance "0" → "0" 表示
- Ξ prefix 全 style (WHITE / WARM / COOL) で表示
- balance "1000" → "1,000" format
- outermost 単一 `<div>` wrapper

## 解決方法

各 file は既存 mock パターンを踏襲、 既存 describe ブロックに新 it を追加。 lint auto-fix で prettier 整形 1 件解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2107 → 2127、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2127 tests + 1 todo (2128)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier auto-fix 適用済)

Closes #521
