### PR TITLE
✅ test(niji-webapp): part 96 (components datepicker / createbtn / forkstatus / progressbar 4 file edge case 強化) で 2127 → 2147 (Issue #523)

### DIFF
--- a/packages/niji-webapp/src/components/BrandDatePicker/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandDatePicker/index.test.tsx
@@ -36,4 +36,37 @@ describe('BrandDatePicker', () => {
     if (input) fireEvent.change(input, { target: { value: '2025-06-23' } });
     expect(onChange).toHaveBeenCalled();
   });
+
+  it('fires onChange repeatedly for multiple date changes', () => {
+    const onChange = vi.fn();
+    const { container } = render(<BrandDatePicker onChange={onChange} />);
+    const input = container.querySelector('input');
+    if (input) {
+      fireEvent.change(input, { target: { value: '2025-01-01' } });
+      fireEvent.change(input, { target: { value: '2025-02-15' } });
+      fireEvent.change(input, { target: { value: '2025-03-31' } });
+    }
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders label span exactly once when label is provided', () => {
+    const { container } = render(<BrandDatePicker onChange={() => {}} label="Date" />);
+    expect(container.querySelectorAll('span').length).toBe(1);
+  });
+
+  it('does NOT apply invalid class when isInvalid=false (default)', () => {
+    const { container } = render(<BrandDatePicker onChange={() => {}} isInvalid={false} />);
+    expect(container.querySelector('input')?.className).not.toMatch(/invalid/i);
+  });
+
+  it('accepts non-ISO date string value (browser may reject but DOM holds it)', () => {
+    const { container } = render(<BrandDatePicker onChange={() => {}} value="not-a-date" />);
+    // input type=date は valid な値以外を保持しない (DOM 仕様)
+    expect(container.querySelector('input')).not.toBeNull();
+  });
+
+  it('renders exactly 1 input element', () => {
+    const { container } = render(<BrandDatePicker onChange={() => {}} />);
+    expect(container.querySelectorAll('input').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
@@ -87,4 +87,71 @@ describe('CreateCandidateButton', () => {
     if (btn) fireEvent.click(btn);
     expect(handle).toHaveBeenCalledTimes(1);
   });
+
+  it('isLoading=true + isFormInvalid=true で spinner 表示 + disabled', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={true}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('renders exactly 1 button element', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(1);
+  });
+
+  it('renders exactly 1 spinner when isLoading=true', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('.spinner-border').length).toBe(1);
+  });
+
+  it('does NOT fire handleCreateProposal on click when disabled', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button');
+    if (btn) fireEvent.click(btn);
+    // disabled button は click event を propagate しない
+    expect(handle).toHaveBeenCalledTimes(0);
+  });
+
+  it('hasActiveOrPendingProposal=true takes precedence over default text', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    // warning text のみが render される
+    expect(container.textContent).not.toContain('Create proposal candidate');
+    expect(container.textContent).toContain('active or pending proposal');
+  });
 });

--- a/packages/niji-webapp/src/components/ForkStatus/index.test.tsx
+++ b/packages/niji-webapp/src/components/ForkStatus/index.test.tsx
@@ -41,4 +41,37 @@ describe('ForkStatus', () => {
     const { container } = render(<ForkStatus status={ForkState.ACTIVE} className="extra" />);
     expect(container.querySelector('div')?.className).toContain('extra');
   });
+
+  it('outermost wrapper is a single <div>', () => {
+    const { container } = render(<ForkStatus status={ForkState.ACTIVE} />);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('handles empty className (no merge)', () => {
+    const { container } = render(<ForkStatus status={ForkState.ACTIVE} className="" />);
+    expect(container.querySelector('div')).not.toBeNull();
+  });
+
+  it('merges multiple class names from className prop', () => {
+    const { container } = render(
+      <ForkStatus status={ForkState.ACTIVE} className="class-a class-b" />,
+    );
+    const cls = container.querySelector('div')?.className ?? '';
+    expect(cls).toContain('class-a');
+    expect(cls).toContain('class-b');
+  });
+
+  it('renders text exactly (no extra whitespace)', () => {
+    const { container } = render(<ForkStatus status={ForkState.EXECUTED} />);
+    expect(container.querySelector('div')?.textContent).toBe('Executed');
+  });
+
+  it('all 4 status values produce distinct text outputs', () => {
+    const escrow = render(<ForkStatus status={ForkState.ESCROW} />).container.textContent;
+    const active = render(<ForkStatus status={ForkState.ACTIVE} />).container.textContent;
+    const executed = render(<ForkStatus status={ForkState.EXECUTED} />).container.textContent;
+    const undet = render(<ForkStatus status={ForkState.UNDETERMINED} />).container.textContent;
+    expect(new Set([escrow, active, executed, undet]).size).toBe(4);
+  });
 });

--- a/packages/niji-webapp/src/components/VoteProgressBar/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteProgressBar/index.test.tsx
@@ -47,4 +47,39 @@ describe('VoteProgressBar', () => {
     const inner = container.querySelectorAll('div')[1];
     expect(inner?.getAttribute('style')).toContain('width: 100%');
   });
+
+  it('handles 1% (small but non-zero)', () => {
+    const { container } = render(<VoteProgressBar variant={VoteCardVariant.FOR} percentage={1} />);
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 1%');
+  });
+
+  it('handles 99% (boundary just below 100)', () => {
+    const { container } = render(<VoteProgressBar variant={VoteCardVariant.FOR} percentage={99} />);
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 99%');
+  });
+
+  it('renders exactly 1 outer + 1 inner div', () => {
+    const { container } = render(<VoteProgressBar variant={VoteCardVariant.FOR} percentage={50} />);
+    expect(container.querySelectorAll('div').length).toBe(2);
+  });
+
+  it('handles 50% (midpoint)', () => {
+    const { container } = render(
+      <VoteProgressBar variant={VoteCardVariant.AGAINST} percentage={50} />,
+    );
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 50%');
+    expect(inner?.className).toMatch(/against/i);
+  });
+
+  it('handles 25% with ABSTAIN variant', () => {
+    const { container } = render(
+      <VoteProgressBar variant={VoteCardVariant.ABSTAIN} percentage={25} />,
+    );
+    const inner = container.querySelectorAll('div')[1];
+    expect(inner?.getAttribute('style')).toContain('width: 25%');
+    expect(inner?.className).toMatch(/abstain/i);
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 96` として既存 test 4 component (`BrandDatePicker` / `CreateCandidateButton` / `ForkStatus` / `VoteProgressBar`) に edge case / contract pin TC を 20 件追加、 2127 → 2147 (+20、 1 skip 維持)。

これまでの part 71-95 で utils / hooks / Modal / 件数 3-5 帯 component を強化し 2127 達成済み、 本 PR では件数 6 帯への展開を継続。

## 詳細

### components/BrandDatePicker/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 onChange 反復 / DOM 構造 / invalid 真偽差 / 値 corner case を pin。

検証観点。

- 連続 3 change で onChange 3 回
- label 指定時 span ちょうど 1 個
- isInvalid=false で invalid class なし
- 非 ISO date string も DOM crash なし
- input element 1 個

### components/CreateCandidateButton/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 状態組合せ / DOM 単一性 / disabled 経路を pin。

検証観点。

- isLoading=true + isFormInvalid=true で spinner 表示 + disabled
- button 1 個
- spinner 1 個 (isLoading=true 時)
- disabled button で onClick 抑止
- hasActiveOrPendingProposal=true で warning text のみ (default text 非表示)

### components/ForkStatus/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 wrapper 構造 / className combo / 4 status distinct を pin。

検証観点。

- outermost 単一 `<div>`
- 空 className でも crash なし
- 多重 className を merge
- textContent 厳密一致 ('Executed')
- 4 status (ESCROW / ACTIVE / EXECUTED / UNDETERMINED) すべて distinct text

### components/VoteProgressBar/index.test.tsx (+5 TC)

既存 6 → 11 TC へ拡張、 percentage 境界 / DOM 構造 / variant + percentage combo を pin。

検証観点。

- 1% / 99% boundary
- outer + inner で div 2 個ぴったり
- 50% AGAINST variant
- 25% ABSTAIN variant

## 解決方法

各 file は既存 mock パターンを踏襲、 既存 describe ブロックに新 it を追加。 lint auto-fix で prettier 整形 2 件解消。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2127 → 2147、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2147 tests + 1 todo (2148)
- `pnpm -w lint <変更 4 file>` → 通過 (prettier auto-fix 適用済)

Closes #523
