### PR TITLE
✅ test(niji-webapp): part 100 (components bid modal / row / dropdown / text entry 4 file edge case 強化) で 2208 → 2228 (Issue #531) — 🎉 part 100 マイルストーン

### DIFF
--- a/packages/niji-webapp/src/components/BidHistoryModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModal/index.test.tsx
@@ -101,4 +101,53 @@ describe('BidHistoryModal', () => {
     if (backdrop) fireEvent.click(backdrop);
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
+
+  it('close button fires onDismiss on repeated clicks', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const onDismiss = vi.fn();
+    render(<BidHistoryModal auction={auction} onDismiss={onDismiss} />);
+    const btn = document.getElementById('overlay-root')?.querySelector('button');
+    if (btn) {
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+    }
+    expect(onDismiss).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders 10 bid rows when 10 bids present', () => {
+    const bids = Array.from({ length: 10 }, (_, i) => ({ transactionHash: `0x${i}` }));
+    useAuctionBidsMock.mockReturnValue(bids);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelectorAll('[data-testid="row"]').length,
+    ).toBe(10);
+  });
+
+  it('renders exactly 1 NijiRoundedCorners (single instance contract)', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelectorAll('[data-testid="niji-rounded"]')
+        .length,
+    ).toBe(1);
+  });
+
+  it('null-state text omitted when bids exist', () => {
+    useAuctionBidsMock.mockReturnValue([{ transactionHash: '0x1' }]);
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.textContent).not.toContain(
+      'Bids will appear here',
+    );
+  });
+
+  it('renders for large nounId auction', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const largeAuction = { ...auction, nounId: 999999n };
+    render(<BidHistoryModal auction={largeAuction} onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelector('[data-testid="niji-rounded"]')
+        ?.textContent,
+    ).toBe('999999');
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistoryModalRow/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModalRow/index.test.tsx
@@ -92,4 +92,36 @@ describe('BidHistoryModalRow', () => {
       'https://etherscan.io/tx/0xdeadbeef',
     );
   });
+
+  it('renders large amount (1000 ETH)', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const large = { ...bid, value: parseEther('1000') };
+    const { container } = render(<BidHistoryModalRow bid={large} index={1} />);
+    expect(container.textContent).toContain('Ξ 1000.00');
+  });
+
+  it('renders avatar img for different sender', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const diff = { ...bid, sender: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as `0x${string}` };
+    const { container } = render(<BidHistoryModalRow bid={diff} index={1} />);
+    expect(container.querySelector(`img[alt="${diff.sender}"]`)).not.toBeNull();
+  });
+
+  it('extended=true bid renders normally', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const ext = { ...bid, extended: true };
+    expect(() => render(<BidHistoryModalRow bid={ext} index={1} />)).not.toThrow();
+  });
+
+  it('handles large timestamp (year 2200+)', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const future = { ...bid, timestamp: 7_258_118_400n };
+    expect(() => render(<BidHistoryModalRow bid={future} index={1} />)).not.toThrow();
+  });
+
+  it('renders exactly 1 anchor element (etherscan link)', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    expect(container.querySelectorAll('a').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/BrandDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandDropdown/index.test.tsx
@@ -80,4 +80,62 @@ describe('BrandDropdown', () => {
     expect(chev?.getAttribute('style')).toContain('right: 20px');
     expect(chev?.getAttribute('style')).toContain('top: 5px');
   });
+
+  it('fires onChange repeatedly across multiple changes', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <BrandDropdown onChange={onChange} value="a">
+        {opts}
+      </BrandDropdown>,
+    );
+    const select = container.querySelector('select');
+    if (select) {
+      fireEvent.change(select, { target: { value: 'b' } });
+      fireEvent.change(select, { target: { value: 'a' } });
+      fireEvent.change(select, { target: { value: 'b' } });
+    }
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders 1 option for single-option case', () => {
+    const { container } = render(
+      <BrandDropdown onChange={() => {}} value="a">
+        <option value="a">A</option>
+      </BrandDropdown>,
+    );
+    expect(container.querySelectorAll('option').length).toBe(1);
+  });
+
+  it('renders exactly 1 select element', () => {
+    const { container } = render(
+      <BrandDropdown onChange={() => {}} value="a">
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelectorAll('select').length).toBe(1);
+  });
+
+  it('value forward updates select.value on rerender', () => {
+    const { container, rerender } = render(
+      <BrandDropdown onChange={() => {}} value="a">
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelector('select')?.value).toBe('a');
+    rerender(
+      <BrandDropdown onChange={() => {}} value="b">
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelector('select')?.value).toBe('b');
+  });
+
+  it('label span exactly 1 when label provided', () => {
+    const { container } = render(
+      <BrandDropdown onChange={() => {}} value="a" label="Choose">
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/BrandTextEntry/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandTextEntry/index.test.tsx
@@ -48,4 +48,37 @@ describe('BrandTextEntry', () => {
     if (input) fireEvent.change(input, { target: { value: 'hi' } });
     expect(onChange).toHaveBeenCalledTimes(1);
   });
+
+  it('fires onChange repeatedly across multiple changes', () => {
+    const onChange = vi.fn();
+    const { container } = render(<BrandTextEntry onChange={onChange} />);
+    const input = container.querySelector('input');
+    if (input) {
+      fireEvent.change(input, { target: { value: 'a' } });
+      fireEvent.change(input, { target: { value: 'ab' } });
+      fireEvent.change(input, { target: { value: 'abc' } });
+    }
+    expect(onChange).toHaveBeenCalledTimes(3);
+  });
+
+  it('handles large value string (1000 chars)', () => {
+    const long = 'a'.repeat(1000);
+    const { container } = render(<BrandTextEntry onChange={() => {}} value={long} />);
+    expect(container.querySelector('input')?.value.length).toBe(1000);
+  });
+
+  it('forwards type="email"', () => {
+    const { container } = render(<BrandTextEntry onChange={() => {}} type="email" />);
+    expect(container.querySelector('input')?.getAttribute('type')).toBe('email');
+  });
+
+  it('renders exactly 1 input element', () => {
+    const { container } = render(<BrandTextEntry onChange={() => {}} />);
+    expect(container.querySelectorAll('input').length).toBe(1);
+  });
+
+  it('does NOT apply invalid class when isInvalid=false (default)', () => {
+    const { container } = render(<BrandTextEntry onChange={() => {}} isInvalid={false} />);
+    expect(container.querySelector('input')?.className).not.toMatch(/invalid/i);
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 100` として既存 test 4 component (`BidHistoryModal` / `BidHistoryModalRow` / `BrandDropdown` / `BrandTextEntry`) に edge case / contract pin TC を 20 件追加、 2208 → 2228 (+20、 1 skip 維持)。

🎉 **part 100 マイルストーン到達** (本 session で part 71-100 を完走、 29 PR 連続成功、 1571 → 2228、 +657 件)。

## 詳細

### components/BidHistoryModal/index.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 multi-click / bid 数 / DOM 単一性 / null-state 条件 / large nounId を pin。

検証観点。

- 連続 3 close click で onDismiss 3 回
- 10 bids 渡しで 10 row 表示
- NijiRoundedCorners 1 個ぴったり
- bids あり時に null-state text 非表示
- 999999n nounId でも overlay 表示

### components/BidHistoryModalRow/index.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 amount 巨大 / sender 異種 / extended / timestamp 大 / a 単一性を pin。

検証観点。

- 1000 ETH amount → "Ξ 1000.00"
- 異 sender address で avatar alt 一致
- extended=true bid でもクラッシュなし
- year 2200 timestamp でもクラッシュなし
- anchor 1 個ぴったり

### components/BrandDropdown/index.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 multi-change / option count / select 単一 / value rerender / span 単一を pin。

検証観点。

- 連続 3 onChange
- single option case
- select 1 個ぴったり
- value rerender で select.value 更新
- label 指定時 span 1 個

### components/BrandTextEntry/index.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 multi-change / large value / type variation / 単一性 / invalid false を pin。

検証観点。

- 連続 3 onChange
- 1000 char value 保持
- type=email forward
- input 1 個ぴったり
- isInvalid=false で invalid class なし

## 解決方法

各 file は既存 mock パターンを踏襲、 既存 describe ブロックに新 it を追加。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2208 → 2228、 1 skip 維持)
- 🎉 **part 100 マイルストーン到達** (part 71-100 累計 +657 件、 29 PR 連続成功)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2228 tests + 1 todo (2229)
- `pnpm -w lint <変更 4 file>` → 通過 (warning のみ)

Closes #531
