### PR TITLE
✅ test(niji-webapp): part 102 (components short address / vote header / proposal tx / stream payment 4 file edge case 強化) で 2249 → 2270 (Issue #535)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx
@@ -191,4 +191,37 @@ describe('StreamPaymentsPaymentDetailsStep', () => {
       'true',
     );
   });
+
+  it('title contains "Streaming Payment"', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelector('h1')?.textContent).toContain('Streaming Payment');
+  });
+
+  it('Back button fires onPrev repeatedly on multi-click', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <StreamPaymentsPaymentDetailsStep {...defaults} onPrevBtnClick={onPrev} />,
+    );
+    const backBtn = container.querySelectorAll('button')[0];
+    fireEvent.click(backBtn);
+    fireEvent.click(backBtn);
+    fireEvent.click(backBtn);
+    expect(onPrev).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders exactly 1 currency dropdown', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelectorAll('[data-testid="currency"]').length).toBe(1);
+  });
+
+  it('renders exactly 1 amount + 1 recipient input', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelectorAll('[data-testid="amount"]').length).toBe(1);
+    expect(container.querySelectorAll('[data-testid="recipient"]').length).toBe(1);
+  });
+
+  it('renders exactly 2 buttons (Back + Next)', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    expect(container.querySelectorAll('button').length).toBe(2);
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransaction.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransaction.test.tsx
@@ -78,4 +78,38 @@ describe('ProposalTransaction', () => {
     const { container } = render(<ProposalTransaction transaction={simpleTx} />);
     expect(container.querySelector('li')).not.toBeNull();
   });
+
+  it('handles different target address', () => {
+    const altTx = { ...simpleTx, target: '0xOTHER' } as never;
+    const { container } = render(<ProposalTransaction transaction={altTx} />);
+    expect(container.textContent).toContain('0xOTHER');
+  });
+
+  it('renders functionSig string in call data area', () => {
+    const customSig = {
+      target: '0xT',
+      functionSig: 'mint(address)',
+      callData: '0xR',
+      value: 0n,
+    } as never;
+    const { container } = render(<ProposalTransaction transaction={customSig} />);
+    expect(container.textContent).toContain('mint(address)');
+  });
+
+  it('renders non-zero value (1 ETH = 1e18 wei)', () => {
+    const ethTx = { ...sigTx, value: 1_000_000_000_000_000_000n } as never;
+    const { container } = render(<ProposalTransaction transaction={ethTx} />);
+    expect(container.textContent).toContain('1000000000000000000');
+  });
+
+  it('renders exactly 1 li root element', () => {
+    const { container } = render(<ProposalTransaction transaction={simpleTx} />);
+    expect(container.querySelectorAll('li').length).toBe(1);
+  });
+
+  it('simpleTx renders exactly 1 linkIfAddr for target (no callData split)', () => {
+    const { container } = render(<ProposalTransaction transaction={simpleTx} />);
+    const links = container.querySelectorAll('[data-testid="link-if-addr"]');
+    expect(links.length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/ShortAddress.test.tsx
+++ b/packages/niji-webapp/src/components/ShortAddress.test.tsx
@@ -96,4 +96,52 @@ describe('ShortAddress', () => {
       'https://example.com/alice.png',
     );
   });
+
+  it('renders no img when avatar=false (default)', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} />);
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('handles large size (64) for avatar', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} avatar={true} size={64} />);
+    expect(container.querySelector('img')?.style.width).toBe('64px');
+    expect(container.querySelector('img')?.style.height).toBe('64px');
+  });
+
+  it('handles different address (case insensitive comparison)', () => {
+    const ADDR2 = '0xABCDEF1234567890ABCDEF1234567890ABCDEF12' as const;
+    vi.mocked(useEnsName).mockReturnValue(ensReturn(null));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR2} />);
+    expect(container.textContent).toMatch(/^0x[\dA-Fa-f]{2}\.{3}[\dA-Fa-f]{4}$/);
+  });
+
+  it('renders span when avatar=true (wrapper for ENS name)', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(undefined));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} avatar={true} />);
+    expect(container.querySelectorAll('span').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders only blo avatar when ENS avatar is null', () => {
+    vi.mocked(useEnsName).mockReturnValue(ensReturn('alice.eth'));
+    vi.mocked(useEnsAvatar).mockReturnValue(ensReturn(null));
+    vi.mocked(resolveNijiContractAddress).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<ShortAddress address={ADDR} avatar={true} />);
+    // ENS avatar undefined → blo() fallback
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('data:image/png;base64,FAKE');
+  });
 });

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.test.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignalsHeader.test.tsx
@@ -47,4 +47,38 @@ describe('VoteSignalsFootnote', () => {
     const { container } = render(<VoteSignalsFootnote />);
     expect(container.querySelector('p')?.textContent).toContain('Nijis voters');
   });
+
+  it('renders exactly 1 p element', () => {
+    const { container } = render(<VoteSignalsFootnote />);
+    expect(container.querySelectorAll('p').length).toBe(1);
+  });
+});
+
+describe('VoteSignalsHeader — additional', () => {
+  it('renders exactly 1 h2 element', () => {
+    const { container } = render(<VoteSignalsHeader />);
+    expect(container.querySelectorAll('h2').length).toBe(1);
+  });
+
+  it('isCandidate=true text-xl is verbatim class match', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={true} />);
+    const cls = container.querySelector('h2')?.className ?? '';
+    expect(cls.split(/\s+/).includes('text-xl')).toBe(true);
+  });
+
+  it('isCandidate undefined defaults to non-candidate (Pre-voting feedback)', () => {
+    const { container } = render(<VoteSignalsHeader />);
+    expect(container.textContent).toContain('Pre-voting feedback');
+    expect(container.querySelector('p')).not.toBeNull();
+  });
+
+  it('isCandidate=true hides description paragraph entirely', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={true} />);
+    expect(container.querySelectorAll('p').length).toBe(0);
+  });
+
+  it('description paragraph contains "Nijis voters" when isCandidate=false', () => {
+    const { container } = render(<VoteSignalsHeader isCandidate={false} />);
+    expect(container.querySelector('p')?.textContent).toContain('Nijis voters');
+  });
 });


### PR DESCRIPTION
## 概要

`webapp part 102` として既存 test 4 component (`ShortAddress` / `VoteSignalsHeader` / `ProposalTransaction` / `StreamPaymentsPaymentDetailsStep`) に edge case / contract pin TC を 21 件追加、 2249 → 2270 (+21、 1 skip 維持)。

これまでの part 71-101 で utils / hooks / Modal / 件数 3-7 帯 component を強化し 2249 達成済み、 本 PR では件数 7 帯への展開を継続。

## 詳細

### components/ShortAddress.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 avatar 経路 / size / address case / fallback を pin。

検証観点。

- avatar=false (default) で img なし
- size=64 で width/height '64px'
- 異 address case (大文字) で short address format
- avatar=true で span >= 1
- ENS avatar null で blo fallback src

### components/VoteSignals/VoteSignalsHeader.test.tsx (+6 TC)

既存 7 → 13 TC へ拡張、 Footnote / h2 / class verbatim / branch 別を pin。

検証観点。

- VoteSignalsFootnote p 1 個
- h2 element 1 個
- isCandidate=true で text-xl verbatim class
- undefined isCandidate で default (Pre-voting feedback)
- isCandidate=true で p 0 個
- isCandidate=false で p に "Nijis voters" 含む

### components/ProposalContent/ProposalTransaction.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 target 異種 / functionSig 別 / value 巨大 / DOM 単一性を pin。

検証観点。

- 異 target address でも passthrough
- `mint(address)` functionSig render
- 1e18 wei (1 ETH) value 表示
- li 1 個ぴったり
- simpleTx で linkIfAddr 1 個のみ (callData split なし経路)

### components/StreamPaymentsPaymentDetailsStep/index.test.tsx (+5 TC)

既存 7 → 12 TC へ拡張、 title text / multi-click / DOM 単一性を pin。

検証観点。

- title に "Streaming Payment" 含む
- 連続 3 Back click で onPrev 3 回
- currency dropdown 1 個
- amount + recipient 各 1 個
- button 2 個ぴったり

## 解決方法

各 file は既存 mock パターンを踏襲、 既存 describe ブロックに新 it を追加。 ShortAddress の span 単一性 test が avatar=false の場合に Fragment 経由になり span 0 個と判明、 expected を `avatar=true で span >= 1` に修正。

## 影響範囲

- 変更 file 4 件、 すべて test ファイル (production source 0 件変更)
- vitest 全 200 file pass 維持 (2249 → 2270、 1 skip 維持)
- lint 通過 (warning のみ、 error なし)
- 既存 type error は master でも発生 (本 PR 由来ゼロ、 既存 known issue)

## 動作確認

- `pnpm vitest run` → 199 file pass + 1 skip = 200 file、 2270 tests + 1 todo (2271)
- `pnpm -w lint <変更 4 file>` → 通過 (warning のみ)

Closes #535
