### PR TITLE
✅ test(niji-webapp): part 104 (components funccall select / proposal modal / stream payment / votecard 4 file edge case 強化) で 2291 → 2311 (Issue #539)

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/index.test.tsx
@@ -314,6 +314,94 @@ describe('ProposalActionModal', () => {
     );
     expect(container.querySelector('[data-testid="function-args"]')).not.toBeNull();
   });
+
+  it('FUNCTION_CALL_SELECT prev returns to SELECT_ACTION_TYPE', () => {
+    selectStepMock.mockImplementationOnce(
+      ({ onNextBtnClick }: { onNextBtnClick: (e?: number) => void }) => (
+        <div data-testid="select-action">
+          <button
+            data-testid="goto-fn"
+            onClick={() => onNextBtnClick(ProposalActionCreationStep.FUNCTION_CALL_SELECT_FUNCTION)}
+          />
+        </div>
+      ),
+    );
+    const { container } = render(<ProposalActionModal {...baseProps} />);
+    fireEvent.click(container.querySelector('[data-testid="goto-fn"]') as HTMLButtonElement);
+    fireEvent.click(
+      container.querySelector('[data-testid="function-select-prev"]') as HTMLButtonElement,
+    );
+    expect(container.querySelector('[data-testid="select-action"]')).not.toBeNull();
+  });
+
+  it('STREAM_PAYMENT_PAYMENT_DETAILS prev returns to SELECT_ACTION_TYPE', () => {
+    selectStepMock.mockImplementationOnce(
+      ({ onNextBtnClick }: { onNextBtnClick: (e?: number) => void }) => (
+        <div data-testid="select-action">
+          <button
+            data-testid="goto-stream"
+            onClick={() =>
+              onNextBtnClick(ProposalActionCreationStep.STREAM_PAYMENT_PAYMENT_DETAILS)
+            }
+          />
+        </div>
+      ),
+    );
+    const { container } = render(<ProposalActionModal {...baseProps} />);
+    fireEvent.click(container.querySelector('[data-testid="goto-stream"]') as HTMLButtonElement);
+    fireEvent.click(
+      container.querySelector('[data-testid="stream-payment-prev"]') as HTMLButtonElement,
+    );
+    expect(container.querySelector('[data-testid="select-action"]')).not.toBeNull();
+  });
+
+  it('FUNCTION_CALL_REVIEW non-tx (numeric) does not call onActionAdd', () => {
+    selectStepMock.mockImplementationOnce(
+      ({ onNextBtnClick }: { onNextBtnClick: (e?: number) => void }) => (
+        <div data-testid="select-action">
+          <button
+            data-testid="goto-fn-review"
+            onClick={() => onNextBtnClick(ProposalActionCreationStep.FUNCTION_CALL_REVIEW)}
+          />
+        </div>
+      ),
+    );
+    const { container } = render(<ProposalActionModal {...baseProps} />);
+    fireEvent.click(container.querySelector('[data-testid="goto-fn-review"]') as HTMLButtonElement);
+    fireEvent.click(
+      container.querySelector('[data-testid="function-review-next-with-num"]') as HTMLButtonElement,
+    );
+    expect(onActionAddMock).not.toHaveBeenCalled();
+  });
+
+  it('STREAM_PAYMENT_REVIEW non-tx (numeric) does not call onActionAdd', () => {
+    selectStepMock.mockImplementationOnce(
+      ({ onNextBtnClick }: { onNextBtnClick: (e?: number) => void }) => (
+        <div data-testid="select-action">
+          <button
+            data-testid="goto-stream-review"
+            onClick={() => onNextBtnClick(ProposalActionCreationStep.STREAM_PAYMENT_REVIEW)}
+          />
+        </div>
+      ),
+    );
+    const { container } = render(<ProposalActionModal {...baseProps} />);
+    fireEvent.click(
+      container.querySelector('[data-testid="goto-stream-review"]') as HTMLButtonElement,
+    );
+    fireEvent.click(
+      container.querySelector('[data-testid="stream-review-next-with-num"]') as HTMLButtonElement,
+    );
+    expect(onActionAddMock).not.toHaveBeenCalled();
+  });
+
+  it('renders nothing harmful when show toggles false then true (re-mount)', () => {
+    const { container, rerender } = render(<ProposalActionModal {...baseProps} show={false} />);
+    expect(container.querySelector('[data-testid="solid-modal"]')).toBeNull();
+    rerender(<ProposalActionModal {...baseProps} show={true} />);
+    expect(container.querySelector('[data-testid="solid-modal"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="select-action"]')).not.toBeNull();
+  });
 });
 
 // dummy reference to silence unused warning

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.test.tsx
@@ -250,4 +250,60 @@ describe('FunctionCallSelectFunctionStep', () => {
     expect(options).toContain('approve');
     expect(options).not.toContain('Transfer');
   });
+
+  it('initial ETH input is empty when state.amount is undefined', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const ethInput = container.querySelector(
+      '[data-testid="input-Included ETH (optional)"]',
+    ) as HTMLInputElement;
+    expect(ethInput.value).toBe('');
+  });
+
+  it('renders empty dropdown when abi has only events (no functions)', () => {
+    const eventOnlyAbi = [{ type: 'event', name: 'Transfer' }];
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, abi: eventOnlyAbi } as never}
+      />,
+    );
+    const dropdown = container.querySelector(
+      '[data-testid="dropdown-Select Contract Function"]',
+    ) as HTMLSelectElement;
+    expect(dropdown.options.length).toBe(0);
+  });
+
+  it('allows dropdown selection change', () => {
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, abi: sampleAbi } as never}
+      />,
+    );
+    const dropdown = container.querySelector(
+      '[data-testid="dropdown-Select Contract Function"]',
+    ) as HTMLSelectElement;
+    fireEvent.change(dropdown, { target: { value: 'approve' } });
+    expect(dropdown.value).toBe('approve');
+  });
+
+  it('does not trigger fetch for empty address input', () => {
+    const { container } = render(<FunctionCallSelectFunctionStep {...baseProps} />);
+    const addressInput = container.querySelector(
+      '[data-testid="input-Contract Address"]',
+    ) as HTMLInputElement;
+    fireEvent.change(addressInput, { target: { value: '' } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('populates ABI filename "etherscan-abi-download.json" when state.abi pre-supplied', () => {
+    const { container } = render(
+      <FunctionCallSelectFunctionStep
+        {...baseProps}
+        state={{ ...baseProps.state, address: validAddress, abi: sampleAbi } as never}
+      />,
+    );
+    const abiUpload = container.querySelector('[data-testid="abi-upload"]');
+    expect(abiUpload?.getAttribute('data-filename')).toBe('etherscan-abi-download.json');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx
@@ -224,4 +224,47 @@ describe('StreamPaymentsPaymentDetailsStep', () => {
     const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
     expect(container.querySelectorAll('button').length).toBe(2);
   });
+
+  it('Next remains disabled when only amount is filled (recipient empty)', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="amount"]')!, {
+      target: { value: '100' },
+    });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('Next remains disabled when only recipient is filled (amount empty)', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: ADDR },
+    });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('Next remains disabled when recipient address is invalid even with amount filled', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    fireEvent.change(container.querySelector('[data-testid="amount"]')!, {
+      target: { value: '100' },
+    });
+    fireEvent.change(container.querySelector('[data-testid="recipient"]')!, {
+      target: { value: '0xBAD' },
+    });
+    expect(container.querySelector('[data-testid="next-btn"]')?.disabled).toBe(true);
+  });
+
+  it('amount input accepts decimal values', () => {
+    const { container } = render(<StreamPaymentsPaymentDetailsStep {...defaults} />);
+    const amountInput = container.querySelector('[data-testid="amount"]') as HTMLInputElement;
+    fireEvent.change(amountInput, { target: { value: '0.5' } });
+    expect(amountInput.value).toBe('0.5');
+  });
+
+  it('recipient input is not marked invalid when address is fully cleared to empty string', () => {
+    const { container } = render(
+      <StreamPaymentsPaymentDetailsStep {...defaults} state={{ address: '' } as never} />,
+    );
+    expect(container.querySelector('[data-testid="recipient"]')?.getAttribute('data-invalid')).toBe(
+      'false',
+    );
+  });
 });

--- a/packages/niji-webapp/src/components/VoteCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCard/index.test.tsx
@@ -303,4 +303,85 @@ describe('VoteCard', () => {
     const table = container.querySelector('[data-testid="delegate-grouped"]');
     expect(table?.getAttribute('data-count')).toBe('0');
   });
+
+  it('triggers lookupNNSOrENS multiple times for multiple new delegates', async () => {
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+      { delegate: '0xBBB' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['2'] },
+      { delegate: '0xCCC' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['3'] },
+    ];
+    render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    await waitFor(() => {
+      expect(lookupNNSOrENSMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  it('filters out non-matching variant entries from voter count display', () => {
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 1 as const, nijiRepresented: ['1'] },
+      { delegate: '0xBBB' as `0x${string}`, supportDetailed: 0 as const, nijiRepresented: ['2'] },
+      { delegate: '0xCCC' as `0x${string}`, supportDetailed: 2 as const, nijiRepresented: ['3'] },
+    ];
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.ABSTAIN}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    expect(container.textContent).toContain('voter');
+    const table = container.querySelector('[data-testid="delegate-grouped"]');
+    expect(table?.getAttribute('data-count')).toBe('1');
+  });
+
+  it('does not fail when delegateGroupedVoteData entries do not match any variant', () => {
+    const delegateData = [
+      { delegate: '0xAAA' as `0x${string}`, supportDetailed: 0 as const, nijiRepresented: ['1'] },
+    ];
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal()}
+        percentage={50}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={delegateData}
+      />,
+    );
+    expect(container.textContent).not.toContain('voters');
+    const table = container.querySelector('[data-testid="delegate-grouped"]');
+    expect(table?.getAttribute('data-count')).toBe('0');
+  });
+
+  it('passes percentage=0 to VoteProgressBar without rendering issue', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal({ forCount: 0 })}
+        percentage={0}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    const bar = container.querySelector('[data-testid="vote-progress"]');
+    expect(bar?.getAttribute('data-percentage')).toBe('0');
+  });
+
+  it('passes percentage=100 to VoteProgressBar for full bar case', () => {
+    const { container } = render(
+      <VoteCard
+        proposal={makeProposal({ forCount: 100 })}
+        percentage={100}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={undefined}
+      />,
+    );
+    const bar = container.querySelector('[data-testid="vote-progress"]');
+    expect(bar?.getAttribute('data-percentage')).toBe('100');
+  });
 });


### PR DESCRIPTION
## Summary

niji-webapp vitest 拡張 part 104。
件数 8+ 帯 component 4 file に edge case TC を計 +20 件追加し、 2291 → **2311** 達成。

## 対象 4 file (現状 → 目標)

- `ProposalActionsModal/index.test.tsx` (12 → 17)
- `ProposalActionsModal/steps/FunctionCallSelectFunctionStep/index.test.tsx` (11 → 16)
- `ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.test.tsx` (12 → 17)
- `VoteCard/index.test.tsx` (14 → 19)

## 追加 edge case 概要

| file | 追加 5 件 |
|---|---|
| FunctionCallSelectFunctionStep | ETH 初期空 / event-only ABI 無関数 / dropdown 切替 / 空 address fetch なし / state.abi filename |
| ProposalActionsModal | FUNCTION_CALL_SELECT prev / STREAM_PAYMENT prev / FUNCTION_CALL_REVIEW non-tx / STREAM_PAYMENT_REVIEW non-tx / show toggle re-mount |
| StreamPaymentsPaymentDetailsStep | amount-only disabled / recipient-only disabled / invalid address + amount disabled / 小数許容 / empty address invalid=false |
| VoteCard | 複数 delegate lookup 並列 / 異 variant filter / no-match 表示なし / percentage=0 / percentage=100 |

## Test plan

- [x] vitest 実走 `pnpm test -- --run src/components/ProposalActionsModal src/components/VoteCard` 全 PASS
- [x] 全体 2311 件 PASS + 1 todo (前回 2291 → +20)
- [x] `pnpm -w lint` 4 file 0 errors
- [x] 既存 TC 破壊なし (追加のみ)

Refs #539
