### PR TITLE
✅ test(niji-webapp): part 106 (components proposal header / proposals / vote signals / change delegate 4 file edge case 強化) で 2331 → 2351 (Issue #543)

### DIFF
--- a/packages/niji-webapp/src/components/ChangeDelegatePanel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ChangeDelegatePanel/index.test.tsx
@@ -229,4 +229,47 @@ describe('ChangeDelegatePanel', () => {
     );
     expect(container.querySelector('[data-testid="brand-spinner"]')).not.toBeNull();
   });
+
+  it('Mining state shows "delegating to a new account" copy (CHANGING view)', () => {
+    hookState.delegateState = { status: 'Mining' };
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('delegated');
+  });
+
+  it('Mining state renders View on Etherscan button', () => {
+    hookState.delegateState = {
+      status: 'Mining',
+      transaction: { hash: '0xtx123' },
+    };
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const etherscanBtn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('View on Etherscan'),
+    );
+    expect(etherscanBtn).not.toBeUndefined();
+  });
+
+  it('Exception status shows failure title (same path as Fail)', () => {
+    hookState.delegateState = { status: 'Exception', errorMessage: 'rpc down' };
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).toContain('Delegate Update Failed');
+  });
+
+  it('passes typed input address directly to delegateVotes (does not auto-resolve ENS)', () => {
+    delegateVotesMock.mockReset();
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: validAddress } });
+    const buttons = Array.from(container.querySelectorAll('button'));
+    const delegateBtn = buttons.find(b => b.textContent?.includes('Delegate'));
+    fireEvent.click(delegateBtn!);
+    expect(delegateVotesMock).toHaveBeenCalledWith({ args: [validAddress] });
+  });
+
+  it('does not show threshold warning when accountVotes after delegation still meets threshold', () => {
+    hookState.accountVotes = 100;
+    hookState.nounTokenBalance = 5;
+    hookState.proposalThreshold = 1;
+    const { container } = render(<ChangeDelegatePanel onDismiss={dismissMock} />);
+    expect(container.textContent).not.toContain('less than');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalHeader/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalHeader/index.test.tsx
@@ -234,4 +234,44 @@ describe('ProposalHeader', () => {
     const { container } = wrap(<ProposalHeader {...baseProps} />);
     expect(container.textContent).not.toContain('Version');
   });
+
+  it('hides Submit vote button when isActiveForVoting=false', () => {
+    const { container } = wrap(<ProposalHeader {...baseProps} isActiveForVoting={false} />);
+    expect(container.textContent).not.toContain('Submit vote');
+  });
+
+  it('shows "voted Against" alert when hasVoted + proposalVote=Against', () => {
+    hookState.hasVoted = true;
+    hookState.proposalVote = 'Against';
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('You voted');
+    expect(container.textContent).toContain('Against');
+  });
+
+  it('shows "Abstained" alert when hasVoted + proposalVote=Abstain', () => {
+    hookState.hasVoted = true;
+    hookState.proposalVote = 'Abstain';
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    expect(container.textContent).toContain('Abstained');
+  });
+
+  it('submit button click triggers submitButtonClickHandler when enabled', () => {
+    submitMock.mockReset();
+    const { container } = wrap(<ProposalHeader {...baseProps} />);
+    const btn = Array.from(container.querySelectorAll('button')).find(b =>
+      b.textContent?.includes('Submit vote'),
+    );
+    if (btn) btn.click();
+    expect(submitMock).toHaveBeenCalled();
+  });
+
+  it('renders multi-signer "Sponsored by" with 3 ShortAddress entries', () => {
+    const proposal = makeProposal({
+      signers: [{ id: '0xS1' }, { id: '0xS2' }, { id: '0xS3' }],
+    });
+    const { container } = wrap(<ProposalHeader {...baseProps} proposal={proposal} />);
+    const addresses = container.querySelectorAll('[data-testid="short-address"]');
+    // 1 (proposer) + 3 (signers) = 4
+    expect(addresses.length).toBeGreaterThanOrEqual(4);
+  });
 });

--- a/packages/niji-webapp/src/components/Proposals/index.test.tsx
+++ b/packages/niji-webapp/src/components/Proposals/index.test.tsx
@@ -265,4 +265,50 @@ describe('Proposals', () => {
     );
     expect(candidatesTab).toBeUndefined();
   });
+
+  it('default tab is Proposals (location.hash empty)', () => {
+    locationMock.hash = '';
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('No proposals found');
+    expect(container.textContent).not.toContain('No candidates found');
+  });
+
+  it('Proposals tab navigation back to /vote (no hash) when clicked', () => {
+    locationMock.hash = '#candidates';
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    const proposalsTab = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Proposals',
+    );
+    expect(proposalsTab).not.toBeUndefined();
+    fireEvent.click(proposalsTab!);
+    expect(navigateMock).toHaveBeenCalledWith('/vote');
+  });
+
+  it('renders multiple CandidateCard entries when candidates list has many', () => {
+    locationMock.hash = '#candidates';
+    candidatesAtomState.current = [
+      { id: 'cand-1', proposalIdToUpdate: '0' },
+      { id: 'cand-2', proposalIdToUpdate: '0' },
+      { id: 'cand-3', proposalIdToUpdate: '0' },
+    ];
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.querySelectorAll('[data-testid="candidate-card"]').length).toBe(3);
+  });
+
+  it('shows "Submit Proposal" copy when account has votes equal to threshold', () => {
+    wagmiState.account = '0xUSER';
+    tokenState.userVotes = 1;
+    daoState.proposalThreshold = 0;
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container.textContent).toContain('Submit Proposal');
+  });
+
+  it('renders single proposal correctly (1-element list)', () => {
+    const proposals = [
+      { id: '99', title: 'Solo', status: 1, startBlock: 50n, endBlock: 200n, eta: '0' },
+    ] as never;
+    const { container } = wrap(<Proposals proposals={proposals} nounsRequired={2} />);
+    expect(container.textContent).toContain('Solo');
+    expect(container.textContent).not.toContain('No proposals found');
+  });
 });

--- a/packages/niji-webapp/src/components/VoteSignals/VoteSignals.test.tsx
+++ b/packages/niji-webapp/src/components/VoteSignals/VoteSignals.test.tsx
@@ -203,4 +203,38 @@ describe('VoteSignals', () => {
     fireEvent.click(formBtn);
     expect(sendProposalFeedbackMock).not.toHaveBeenCalled();
   });
+
+  it('shows VoteSignalsPending while candidate transaction is Mining (isCandidate=true)', () => {
+    feedbackState.candidate = { status: 'Mining' };
+    const { container } = render(<VoteSignals {...baseProps} isCandidate={true} />);
+    expect(container.querySelector('[data-testid="vote-signals-pending"]')).not.toBeNull();
+  });
+
+  it('renders header in all valid render paths', () => {
+    const { container } = render(<VoteSignals {...baseProps} />);
+    expect(container.querySelector('[data-testid="signals-header"]')).not.toBeNull();
+  });
+
+  it('VoteSignalGroup forwards feedback length to each group', () => {
+    useVoteSignalsFeedbackState.forFeedback = [{ a: 1 }, { b: 2 }];
+    useVoteSignalsFeedbackState.againstFeedback = [{ c: 3 }];
+    useVoteSignalsFeedbackState.abstainFeedback = [];
+    const { container } = render(<VoteSignals {...baseProps} />);
+    expect(container.querySelector('[data-testid="signal-group-1"]')?.textContent).toBe('2');
+    expect(container.querySelector('[data-testid="signal-group-0"]')?.textContent).toBe('1');
+    expect(container.querySelector('[data-testid="signal-group-2"]')?.textContent).toBe('0');
+  });
+
+  it('toast.error fires when sendCandidateFeedbackState=Fail (isCandidate=true)', () => {
+    feedbackState.candidate = { status: 'Fail', errorMessage: 'cand failed' };
+    render(<VoteSignals {...baseProps} isCandidate={true} />);
+    expect(toastErrorMock).toHaveBeenCalledWith('cand failed');
+  });
+
+  it('handleRefetch fires when candidate status=Success (isCandidate=true)', () => {
+    feedbackState.candidate = { status: 'Success' };
+    const refetch = vi.fn();
+    render(<VoteSignals {...baseProps} isCandidate={true} handleRefetch={refetch} />);
+    expect(refetch).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

niji-webapp vitest 拡張 part 106。
件数 12-15 帯 component 4 file に edge case TC を計 +20 件追加し、 2331 → **2351** 達成。

## 対象 4 file (現状 → 目標)

- `ProposalHeader/index.test.tsx` (15 → 20)
- `Proposals/index.test.tsx` (12 → 17)
- `VoteSignals/VoteSignals.test.tsx` (13 → 18)
- `ChangeDelegatePanel/index.test.tsx` (14 → 19)

## 追加 edge case 概要

| file | 追加 5 件 |
|---|---|
| ProposalHeader | isActiveForVoting=false で Submit vote 非表示 / Against vote alert / Abstained alert / Submit click handler / 多 signer ShortAddress |
| Proposals | default tab / Proposals tab navigate `/vote` (hash 削除) / 多 candidate render / threshold=0 で Submit 表示 / 単発 proposal |
| VoteSignals | candidate Mining pending / header 描画 / feedback 数 forward / candidate Fail toast / candidate Success refetch |
| ChangeDelegatePanel | Mining copy 表示 / Mining Etherscan button / Exception failure title / typed input 直渡し / 充足 threshold で warning なし |

## 修正経緯 (途中 5 件 fail → 全 PASS)

実装整合性 verify で 5 件の fail を検知 → source 確認後に書き換えて pass。

- ProposalHeader Abstain は `You voted` ではなく `Abstained` 動詞使用
- Proposals tab navigate は `/vote#proposals` ではなく `/vote` (hash 削除経路)
- ChangeDelegatePanel BrandSpinner は Mining 中ではなく delegateTo SPINNER 段階限定
- ChangeDelegatePanel `delegateVotes` は typed input をそのまま渡す (ENS 自動解決なし)

## Test plan

- [x] vitest `pnpm test -- --run` 全 PASS
- [x] 全体 2351 件 PASS + 1 todo (前回 2331 → +20)
- [x] `pnpm -w lint` 4 file 0 errors
- [x] 既存 TC 破壊なし

Refs #543
