### PR TITLE
✅ test(niji-webapp): part 108 (components niji content / submit update / auction activity / auction nav 4 file edge case 強化) で 2371 → 2391 (Issue #547)

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -188,4 +188,47 @@ describe('AuctionActivity', () => {
     );
     expect(container.querySelector('[data-testid="bid-history-btn"]')).not.toBeNull();
   });
+
+  it('renders Holder for non-last + ended auction (no Winner fallback)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const endedAuction = makeAuction({ endTime: 1n });
+    const { container } = wrap(
+      <AuctionActivity {...defaults} isLastAuction={false} auction={endedAuction as never} />,
+    );
+    expect(container.querySelector('[data-testid="holder"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="winner"]')).toBeNull();
+  });
+
+  it('renders Winner for last + ended auction with bidder', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const endedAuction = makeAuction({ endTime: 1n, bidder: '0xBIDDER' });
+    const { container } = wrap(
+      <AuctionActivity {...defaults} isLastAuction={true} auction={endedAuction as never} />,
+    );
+    expect(container.querySelector('[data-testid="winner"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="holder"]')).toBeNull();
+  });
+
+  it('renders AuctionTimer (last + active auction)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="auction-timer"]')).not.toBeNull();
+  });
+
+  it('renders date-headline in all common render paths', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="date-headline"]')).not.toBeNull();
+  });
+
+  it('renders title-wrap as child of wrapper', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    expect(container.querySelector('[data-testid="title-wrap"]')).not.toBeNull();
+    expect(
+      container
+        .querySelector('[data-testid="wrapper"]')
+        ?.querySelector('[data-testid="title-wrap"]'),
+    ).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionNavigation/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionNavigation/index.test.tsx
@@ -189,4 +189,85 @@ describe('AuctionNavigation Component', () => {
     expect(prevButton.className).toContain('leftArrowCool');
     expect(nextButton.className).toContain('rightArrowCool');
   });
+
+  it('ignores keys other than ArrowLeft/ArrowRight', () => {
+    const onPrev = vi.fn();
+    const onNext = vi.fn();
+    render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={false}
+        onPrevAuctionClick={onPrev}
+        onNextAuctionClick={onNext}
+      />,
+    );
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+    fireEvent.keyDown(document, { key: 'a' });
+    expect(onPrev).not.toHaveBeenCalled();
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it('rapid prev clicks invoke handler N times', () => {
+    const onPrev = vi.fn();
+    render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={false}
+        onPrevAuctionClick={onPrev}
+        onNextAuctionClick={vi.fn()}
+      />,
+    );
+    const prevBtn = screen.getByText('←');
+    fireEvent.click(prevBtn);
+    fireEvent.click(prevBtn);
+    fireEvent.click(prevBtn);
+    expect(onPrev).toHaveBeenCalledTimes(3);
+  });
+
+  it('rapid next clicks invoke handler N times', () => {
+    const onNext = vi.fn();
+    render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={false}
+        onPrevAuctionClick={vi.fn()}
+        onNextAuctionClick={onNext}
+      />,
+    );
+    const nextBtn = screen.getByText('→');
+    fireEvent.click(nextBtn);
+    fireEvent.click(nextBtn);
+    expect(onNext).toHaveBeenCalledTimes(2);
+  });
+
+  it('disabled prev click does not invoke handler', () => {
+    const onPrev = vi.fn();
+    render(
+      <AuctionNavigation
+        isFirstAuction={true}
+        isLastAuction={false}
+        onPrevAuctionClick={onPrev}
+        onNextAuctionClick={vi.fn()}
+      />,
+    );
+    const prevBtn = screen.getByText('←');
+    fireEvent.click(prevBtn);
+    expect(onPrev).not.toHaveBeenCalled();
+  });
+
+  it('disabled next click does not invoke handler', () => {
+    const onNext = vi.fn();
+    render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={true}
+        onPrevAuctionClick={vi.fn()}
+        onNextAuctionClick={onNext}
+      />,
+    );
+    const nextBtn = screen.getByText('→');
+    fireEvent.click(nextBtn);
+    expect(onNext).not.toHaveBeenCalled();
+  });
 });

--- a/packages/niji-webapp/src/components/CandidateSponsors/SubmitUpdateProposal.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SubmitUpdateProposal.test.tsx
@@ -169,4 +169,48 @@ describe('SubmitUpdateProposal', () => {
     fireEvent.click(tryAgain!);
     expect(container.textContent).not.toContain('rpc failed');
   });
+
+  it('shows error message when status=Exception (same path as Fail)', () => {
+    hookState.updateProposalBySigsState = { status: 'Exception', errorMessage: 'tx exception' };
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    expect(container.textContent).toContain('tx exception');
+  });
+
+  it('Submit update call includes reason field from textarea state', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: 'reason text' } });
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Submit update',
+    );
+    fireEvent.click(submitBtn!);
+    const call = updateProposalBySigsMock.mock.calls[0][0];
+    expect(call.args).toContain('reason text');
+  });
+
+  it('Submit update call uses proposalIdToUpdate prop (converted to bigint)', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} proposalIdToUpdate="99" />);
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Submit update',
+    );
+    fireEvent.click(submitBtn!);
+    const call = updateProposalBySigsMock.mock.calls[0][0];
+    expect(call.args).toContain(99n);
+  });
+
+  it('renders 2 target rows when candidate has 2 targets', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} />);
+    // verify sorted sigs length passed to updateProposalBySigs
+    const submitBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent?.trim() === 'Submit update',
+    );
+    fireEvent.click(submitBtn!);
+    const call = updateProposalBySigsMock.mock.calls[0][0];
+    expect(call.args[1].length).toBe(2);
+  });
+
+  it('handles empty signature array gracefully', () => {
+    const { container } = wrap(<SubmitUpdateProposal {...baseProps} signatures={[] as never} />);
+    expect(container.textContent).toContain('Update proposal');
+  });
 });

--- a/packages/niji-webapp/src/components/NijiContent/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijiContent/index.test.tsx
@@ -220,4 +220,58 @@ describe('NijiContent', () => {
     fireEvent.click(container.querySelector('[data-testid="settle-btn"]')!);
     expect(writeContractMock).toHaveBeenCalledWith({});
   });
+
+  it('renders AuctionNavigation prev/next buttons', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    const { container } = wrap(<NijiContent {...defaults} />);
+    expect(container.querySelector('[data-testid="auction-nav"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="prev-btn"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="next-btn"]')).not.toBeNull();
+  });
+
+  it('prev-btn click invokes onPrevAuctionClick', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    const { container } = wrap(<NijiContent {...defaults} />);
+    fireEvent.click(container.querySelector('[data-testid="prev-btn"]')!);
+    expect(prevClickMock).toHaveBeenCalled();
+  });
+
+  it('next-btn click invokes onNextAuctionClick', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    const { container } = wrap(<NijiContent {...defaults} />);
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(nextClickMock).toHaveBeenCalled();
+  });
+
+  it('ignores non-arrow key events (no prev/next invocation)', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    wrap(<NijiContent {...defaults} />);
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'ArrowUp' });
+    expect(prevClickMock).not.toHaveBeenCalled();
+    expect(nextClickMock).not.toHaveBeenCalled();
+  });
+
+  it('renders nounder title pieces (date-headline and niji-title) inside title wrap', () => {
+    resetState();
+    useAtomValueMock.mockReturnValue(true);
+    useAccountMock.mockReturnValue({ address: undefined });
+    useBlockMock.mockReturnValue({ data: { timestamp: 0n } });
+    const { container } = wrap(<NijiContent {...defaults} />);
+    expect(container.querySelector('[data-testid="title-wrap"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="date-headline"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="niji-title"]')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

niji-webapp vitest 拡張 part 108。
件数 9-10 帯 component 4 file に edge case TC を計 +20 件追加し、 2371 → **2391** 達成。

## 対象 4 file (現状 → 目標)

- `NijiContent/index.test.tsx` (9 → 14)
- `CandidateSponsors/SubmitUpdateProposal.test.tsx` (9 → 14)
- `AuctionActivity/index.test.tsx` (10 → 15)
- `AuctionNavigation/index.test.tsx` (10 → 15)

## 追加 edge case 概要

| file | 追加 5 件 |
|---|---|
| NijiContent | AuctionNavigation 描画 / prev click / next click / 非 arrow key ignore / title-wrap 子要素 |
| SubmitUpdateProposal | Exception status error / reason 含む call / proposalIdToUpdate bigint / signers 2 件 / 空 signatures |
| AuctionActivity | 非 last+ended で Holder / last+ended で Winner / AuctionTimer / date-headline / title-wrap 階層 |
| AuctionNavigation | 非 arrow key ignore / rapid prev 3 連 / rapid next 2 連 / disabled prev / disabled next |

## 修正経緯 (3 件 fail → 全 PASS)

- SubmitUpdateProposal: `proposalIdToUpdate` は bigint 変換 (99n) で渡される
- AuctionActivity Winner/Holder: `auctionEnded=true` 経路でのみ render → `endTime=1n` (past) で再現

## Test plan

- [x] vitest `pnpm test -- --run` 全 PASS
- [x] 全体 2391 件 PASS + 1 todo (前回 2371 → +20)
- [x] `pnpm -w lint` 4 file 0 errors (prettier --fix 1 件)
- [x] 既存 TC 破壊なし

Refs #547
