### PR TITLE
✅ test(niji-webapp): part 109 (components bid history / candidate header / proposal tx diffs / delegate grouped 4 file edge case 強化) で 2391 → 2411 (Issue #549)

### DIFF
--- a/packages/niji-webapp/src/components/BidHistory/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistory/index.test.tsx
@@ -170,4 +170,38 @@ describe('BidHistory Component', () => {
     const item = screen.getByTestId('bid-history-item');
     expect(item).toHaveTextContent('Cool: yes');
   });
+
+  it('list role element is rendered always (even with no bids)', () => {
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    render(<BidHistory auctionId="1" max={10} classes={mockClasses} />);
+    expect(screen.getByRole('list')).toBeInTheDocument();
+  });
+
+  it('renders 0 bid items when max=0', () => {
+    vi.mocked(useAuctionBids).mockReturnValue(mockBids);
+    render(<BidHistory auctionId="1" max={0} classes={mockClasses} />);
+    expect(screen.queryAllByTestId('bid-history-item').length).toBe(0);
+  });
+
+  it('handles auctionId="0" (BigInt(0))', () => {
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    render(<BidHistory auctionId="0" max={10} classes={mockClasses} />);
+    expect(useAuctionBids).toHaveBeenCalledWith(0n);
+  });
+
+  it('preserves desc order even when bids initially unordered', () => {
+    const unordered = [mockBids[2], mockBids[0], mockBids[1]];
+    vi.mocked(useAuctionBids).mockReturnValue(unordered);
+    render(<BidHistory auctionId="1" max={10} classes={mockClasses} />);
+    const items = screen.getAllByTestId('bid-history-item');
+    expect(items[0]).toHaveTextContent('3000000000000000000');
+    expect(items[1]).toHaveTextContent('2000000000000000000');
+    expect(items[2]).toHaveTextContent('1000000000000000000');
+  });
+
+  it('applies bidCollection class to list element', () => {
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    render(<BidHistory auctionId="1" max={10} classes={mockClasses} />);
+    expect(screen.getByRole('list')).toHaveClass(mockClasses.bidCollection);
+  });
 });

--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
@@ -159,4 +159,52 @@ describe('DelegateGroupedNijiImageVoteTable', () => {
     );
     expect(container.querySelectorAll('[data-testid="pager"]').length).toBe(1);
   });
+
+  it('right arrow does not advance past last page', () => {
+    const data = Array.from({ length: 5 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    // numPages = 1, right arrow disabled (only 1 page)
+    expect(container.querySelector('[data-testid="right"]')?.disabled).toBe(true);
+  });
+
+  it('renders multi-page setup with 30 delegates (numPages = floor(30/12)+1 = 3)', () => {
+    const data = Array.from({ length: 30 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    expect(container.querySelector('[data-testid="num-pages"]')?.textContent).toBe('3');
+  });
+
+  it('left arrow stays disabled at page=0 when right click is not used', () => {
+    const data = Array.from({ length: 24 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    expect(container.querySelector('[data-testid="left"]')?.disabled).toBe(true);
+  });
+
+  it('left arrow click returns from page 1 back to page 0', () => {
+    const data = Array.from({ length: 15 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="right"]')!);
+    expect(container.querySelector('[data-testid="current-page"]')?.textContent).toBe('1');
+    fireEvent.click(container.querySelector('[data-testid="left"]')!);
+    expect(container.querySelector('[data-testid="current-page"]')?.textContent).toBe('0');
+  });
+
+  it('respects propId passed in baseProps (no crash for propId=999)', () => {
+    const data = [makeVote('0xA', ['1'])];
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable
+        propId={999}
+        proposalCreationBlock={100n}
+        filteredDelegateGroupedVoteData={data}
+      />,
+    );
+    expect(container.querySelectorAll('[data-testid="hover"]').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalContent/ProposalTransactionsDiffs.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/ProposalTransactionsDiffs.test.tsx
@@ -157,4 +157,81 @@ describe('ProposalTransactionsDiffs', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders without crash for bigint values', () => {
+    const old = [makeTx('0xA', 'transfer', 1000000n) as never];
+    const ne = [makeTx('0xA', 'transfer', 2000000n) as never];
+    expect(() =>
+      render(
+        <ProposalTransactionsDiffs
+          oldTransactions={old}
+          newTransactions={ne}
+          activeVersionNumber={2}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles activeVersionNumber large (999)', () => {
+    expect(() =>
+      render(
+        <ProposalTransactionsDiffs
+          oldTransactions={[makeTx('0xA') as never]}
+          newTransactions={[makeTx('0xB') as never]}
+          activeVersionNumber={999}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles non-empty callData differences without crash', () => {
+    const old = [makeTx('0xA', 'transfer', 0n, '0x00') as never];
+    const ne = [makeTx('0xA', 'transfer', 0n, '0xDEADBEEF') as never];
+    expect(() =>
+      render(
+        <ProposalTransactionsDiffs
+          oldTransactions={old}
+          newTransactions={ne}
+          activeVersionNumber={1}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('identical arrays produce same length output (1 entry)', () => {
+    const same = [makeTx('0xA') as never];
+    const { container } = render(
+      <ProposalTransactionsDiffs
+        oldTransactions={same}
+        newTransactions={same}
+        activeVersionNumber={1}
+      />,
+    );
+    const totalElements =
+      container.querySelectorAll('[data-testid="diff"]').length +
+      container.querySelectorAll('[data-testid="tx"]').length;
+    expect(totalElements).toBeGreaterThanOrEqual(1);
+  });
+
+  it('handles old > new where excess old transactions become diff entries', () => {
+    const old = [
+      makeTx('0xA') as never,
+      makeTx('0xB') as never,
+      makeTx('0xC') as never,
+      makeTx('0xD') as never,
+    ];
+    const ne = [makeTx('0xA') as never];
+    const { container } = render(
+      <ProposalTransactionsDiffs
+        oldTransactions={old}
+        newTransactions={ne}
+        activeVersionNumber={1}
+      />,
+    );
+    const totalElements =
+      container.querySelectorAll('[data-testid="diff"]').length +
+      container.querySelectorAll('[data-testid="tx"]').length;
+    // 4 (longer = old)
+    expect(totalElements).toBeGreaterThanOrEqual(4);
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalHeader/CandidateHeader.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalHeader/CandidateHeader.test.tsx
@@ -161,4 +161,52 @@ describe('CandidateHeader', () => {
     const { container } = wrap(<CandidateHeader {...defaults} isActiveForVoting={true} />);
     expect(container.textContent?.length).toBeGreaterThan(0);
   });
+
+  it('renders without title gracefully when title is empty string', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} title="" />);
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
+
+  it('renders HoverCard wrapper for proposer (ShortAddress + tx-link inside)', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    const hover = container.querySelector('[data-testid="hover"]');
+    expect(hover).not.toBeNull();
+    expect(hover?.querySelector('[data-testid="short"]')).not.toBeNull();
+  });
+
+  it('renders Version 5 with history link when versionsCount=5', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} versionsCount={5} />);
+    expect(container.textContent).toContain('Version 5');
+    expect(container.querySelector('a[href="/candidates/cand-1/history/"]')).not.toBeNull();
+  });
+
+  it('history link href uses provided id (cand-99)', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('en-US');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} id="cand-99" versionsCount={2} />);
+    expect(container.querySelector('a[href="/candidates/cand-99/history/"]')).not.toBeNull();
+  });
+
+  it('renders zh-CN locale layout without crash', () => {
+    useBlockNumberMock.mockReturnValue({ data: 100n });
+    useActiveLocaleMock.mockReturnValue('zh-CN');
+    isMobileMock.mockReturnValue(false);
+    useUserVotesAsOfBlockMock.mockReturnValue(5);
+    const { container } = wrap(<CandidateHeader {...defaults} />);
+    expect(container.textContent).toContain('My Candidate');
+  });
 });


### PR DESCRIPTION
## Summary

niji-webapp vitest 拡張 part 109。
件数 9-11 帯 component 4 file に edge case TC を計 +20 件追加し、 2391 → **2411** 達成。

## 対象 4 file (現状 → 目標)

- `BidHistory/index.test.tsx` (10 → 15)
- `ProposalHeader/CandidateHeader.test.tsx` (9 → 14)
- `ProposalContent/ProposalTransactionsDiffs.test.tsx` (9 → 14)
- `DelegateGroupedNijiImageVoteTable/index.test.tsx` (11 → 16)

## 追加 edge case 概要

| file | 追加 5 件 |
|---|---|
| BidHistory | list role 常在 / max=0 で 0 item / auctionId=0n / desc 順保証 / bidCollection class |
| CandidateHeader | 空 title h1 / HoverCard 内 ShortAddress / Version 5 link / id=cand-99 href / zh-CN locale |
| ProposalTransactionsDiffs | bigint value / activeVersionNumber=999 / callData 差分 / 同一配列 / old > new 4 entries |
| DelegateGroupedNijiImageVoteTable | 右 arrow 末尾 disable / 30 delegates numPages=3 / page=0 で left disable / left arrow 戻る / propId=999 |

## 修正経緯 (1 件 fail → 全 PASS)

CandidateHeader: `ByLineHoverCard` は HoverCard callback prop 内 render される設計 → mock callback 非呼出で byline 描画なし → 「HoverCard 内 ShortAddress」 軸に書き換え。
prettier --fix 1 件適用。

## Test plan

- [x] vitest `pnpm test -- --run` 全 PASS
- [x] 全体 2411 件 PASS + 1 todo (前回 2391 → +20)
- [x] `pnpm -w lint` 4 file 0 errors
- [x] 既存 TC 破壊なし

Refs #549
