### PR TITLE
✅ test(niji-webapp): part 110 (components niji / vote modal / sponsors list / create candidate 4 file edge case 強化) で 2411 → 2431 (Issue #551)

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/SponsorsList.test.tsx
@@ -209,4 +209,49 @@ describe('SponsorsList', () => {
     );
     expect(container.querySelectorAll('[data-testid="original-signature"]')).toHaveLength(1);
   });
+
+  it('Sponsor button absent when connectedAccountNounVotes=0', () => {
+    const { container } = wrap(<SponsorsList {...baseProps} connectedAccountNounVotes={0} />);
+    const sponsorBtn = Array.from(container.querySelectorAll('button')).find(
+      b => b.textContent === 'Sponsor',
+    );
+    expect(sponsorBtn).toBeUndefined();
+  });
+
+  it('renders no placeholder when requiredVotes <= voteCount', () => {
+    const candidate = makeCandidate({
+      contentSignatures: [makeSignature()],
+      requiredVotes: 1,
+      voteCount: 1,
+    });
+    const { container } = wrap(<SponsorsList {...baseProps} candidate={candidate} />);
+    const placeholders = Array.from(container.querySelectorAll('li')).filter(li =>
+      li.className.includes('placeholder'),
+    );
+    expect(placeholders).toHaveLength(0);
+  });
+
+  it('renders correct count when many signatures (5 entries)', () => {
+    const candidate = makeCandidate({
+      contentSignatures: Array.from({ length: 5 }, (_, i) =>
+        makeSignature({ signerId: `0xS${i}` }),
+      ),
+    });
+    const { container } = wrap(<SponsorsList {...baseProps} candidate={candidate} />);
+    expect(container.querySelectorAll('[data-testid="signature"]')).toHaveLength(5);
+  });
+
+  it('hides Submit onchain button when threshold not met', () => {
+    const { container } = wrap(
+      <SponsorsList {...baseProps} isProposer={true} isThresholdMet={false} />,
+    );
+    expect(container.textContent).not.toContain('Submit onchain');
+  });
+
+  it('hides Submit onchain button when not proposer (even if threshold met)', () => {
+    const { container } = wrap(
+      <SponsorsList {...baseProps} isProposer={false} isThresholdMet={true} />,
+    );
+    expect(container.textContent).not.toContain('Submit onchain');
+  });
 });

--- a/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
@@ -154,4 +154,77 @@ describe('CreateCandidateButton', () => {
     expect(container.textContent).not.toContain('Create proposal candidate');
     expect(container.textContent).toContain('active or pending proposal');
   });
+
+  it('isLoading=true でも button タグ自体は 1 つだけ存在', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(1);
+  });
+
+  it('multi-click on enabled button fires handler N 回', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(3);
+  });
+
+  it('isFormInvalid=true で disable + click 時 handler 呼ばれない', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={true}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    fireEvent.click(btn);
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  it('isLoading=true 単独では disabled にならない (Spinner 表示のみ、 click 可能)', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    expect(btn.disabled).toBe(false);
+    fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(1);
+  });
+
+  it('hasActiveOrPendingProposal=true 時に warning text + button disabled の両立', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.textContent).toContain('active or pending proposal');
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
 });

--- a/packages/niji-webapp/src/components/Niji.test.tsx
+++ b/packages/niji-webapp/src/components/Niji.test.tsx
@@ -172,4 +172,34 @@ describe('Niji', () => {
     wrap(<NijiWithSeed nounId={1n} onLoadSeed={onLoadSeedMock} />);
     expect(onLoadSeedMock).not.toHaveBeenCalled();
   });
+
+  it('default link uses /niji/{nounId} path (different ids)', () => {
+    const { container } = wrap(<DefaultLinkedNiji nounId={123n} />);
+    expect(container.querySelector('a[href="/niji/123"]')).not.toBeNull();
+  });
+
+  it('LinkedNiji default render does not require an alt prop (auto-alt)', () => {
+    const { container } = wrap(<DefaultLinkedNiji nounId={42n} />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.alt).toContain('Niji');
+  });
+
+  it('Niji renders empty alt string when alt prop is "" provided explicitly', () => {
+    const { container } = render(<Niji nounId={5n} alt="" />);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.alt).toBe('');
+  });
+
+  it('NijiCircular default (no border prop) does not apply border class', () => {
+    const { container } = wrap(<NijiCircular nounId={1n} />);
+    const img = container.querySelector('img');
+    expect(img?.className).not.toContain('circle-border');
+  });
+
+  it('NijiWithSeed calls onLoadSeed when single nonzero seed field is set', () => {
+    hookState.fetchedSeed = { background: 0, body: 0, accessory: 0, head: 0, glasses: 1 };
+    const onLoadSeedMock = vi.fn();
+    wrap(<NijiWithSeed nounId={1n} onLoadSeed={onLoadSeedMock} />);
+    expect(onLoadSeedMock).toHaveBeenCalledWith(hookState.fetchedSeed);
+  });
 });

--- a/packages/niji-webapp/src/components/VoteModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteModal/index.test.tsx
@@ -188,4 +188,40 @@ describe('VoteModal', () => {
     });
     expect(onHideMock).toHaveBeenCalled();
   });
+
+  it('does not render modal content when show=false', () => {
+    const { container } = render(<VoteModal {...baseProps} show={false} />);
+    expect(container.querySelector('[data-testid="solid-modal"]')).toBeNull();
+  });
+
+  it('auto-closes after success of castRefundableVoteWithReason', () => {
+    hookState.castRefundableVoteWithReasonState = { status: 'Success' };
+    render(<VoteModal {...baseProps} />);
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(onHideMock).toHaveBeenCalled();
+  });
+
+  it('shows failure copy when castRefundableVoteWithReasonState=Fail', () => {
+    hookState.castRefundableVoteWithReasonState = {
+      status: 'Fail',
+      errorMessage: 'reason boom',
+    };
+    const { container } = render(<VoteModal {...baseProps} />);
+    expect(container.textContent).toContain('There was an error voting');
+    expect(container.textContent).toContain('reason boom');
+  });
+
+  it('renders for prop without crash for very large proposalId', () => {
+    const { container } = render(<VoteModal {...baseProps} proposalId="999999" />);
+    expect(container.textContent).toContain('Vote on Prop 999999');
+  });
+
+  it('handles Exception status same as Fail (error copy)', () => {
+    hookState.castRefundableVoteState = { status: 'Exception', errorMessage: 'rpc dead' };
+    const { container } = render(<VoteModal {...baseProps} />);
+    expect(container.textContent).toContain('There was an error voting');
+    expect(container.textContent).toContain('rpc dead');
+  });
 });


### PR DESCRIPTION
## Summary

niji-webapp vitest 拡張 part 110。
件数 11-14 帯 component 4 file に edge case TC を計 +20 件追加し、 2411 → **2431** 達成。

## 対象 4 file (現状 → 目標)

- `Niji.test.tsx` (14 → 19)
- `VoteModal/index.test.tsx` (12 → 17)
- `CandidateSponsors/SponsorsList.test.tsx` (12 → 17)
- `CreateCandidateButton/index.test.tsx` (11 → 16)

## 追加 edge case 概要

| file | 追加 5 件 |
|---|---|
| Niji | 異 nounId link / 自動 alt / 空 alt / NijiCircular default no border / 1 field nonzero seed onLoad |
| VoteModal | show=false 非描画 / withReason success 自動 close / withReason Fail copy / 大 proposalId / Exception=Fail copy |
| SponsorsList | votes=0 で Sponsor 非表示 / 充足時 placeholder なし / 5 sigs render / threshold 未充足 hide submit / 非 proposer hide submit |
| CreateCandidateButton | isLoading 中 button 1 件 / multi-click 3 回 / isFormInvalid disable click 無効 / isLoading 単独 click 可能 / warning + disabled 両立 |

## 修正経緯 (1 件 fail → 全 PASS)

CreateCandidateButton: `isLoading` は disabled に含まれない設計 (`disabled={isFormInvalid || hasActiveOrPendingProposal}`) → 「Spinner 表示中も click 可能」 軸に書き換え。

## Test plan

- [x] vitest `pnpm test -- --run` 全 PASS
- [x] 全体 2431 件 PASS + 1 todo (前回 2411 → +20)
- [x] `pnpm -w lint` 4 file 0 errors
- [x] 既存 TC 破壊なし

Refs #551
