### PR TITLE
✅ test(niji-webapp): part 111 (components funccall review / auction / byline hover / holder 4 file edge case 強化) で 2431 → 2451 (Issue #553)

### DIFF
--- a/packages/niji-webapp/src/components/Auction/index.test.tsx
+++ b/packages/niji-webapp/src/components/Auction/index.test.tsx
@@ -147,4 +147,44 @@ describe('Auction', () => {
     const { container } = wrap(<Auction auction={makeAuction(5n)} />);
     expect(container.querySelector('[data-testid="auction-activity"]')).toBeNull();
   });
+
+  it('isFirstAuction=false for nounId > 0', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(3n)} />);
+    expect(container.querySelector('[data-testid="prev"]')?.disabled).toBe(false);
+  });
+
+  it('isLastAuction=false when nounId < lastAuctionNounId', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(3n)} />);
+    expect(container.querySelector('[data-testid="next"]')?.disabled).toBe(false);
+  });
+
+  it('first auction prev click does not navigate (button is disabled)', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    navigateMock.mockReset();
+    const { container } = wrap(<Auction auction={makeAuction(0n)} />);
+    const prevBtn = container.querySelector('[data-testid="prev"]') as HTMLButtonElement;
+    expect(prevBtn.disabled).toBe(true);
+    fireEvent.click(prevBtn);
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('renders NijiWithSeed for large bigint nounId', () => {
+    useAtomValueMock.mockReturnValue(1000n);
+    isNounderMock.mockReturnValue(false);
+    const { container } = wrap(<Auction auction={makeAuction(999n)} />);
+    expect(container.querySelector('[data-testid="niji-with-seed"]')?.textContent).toBe('999');
+  });
+
+  it('Nounder auction (nounId=0, isNounder=true) does not render AuctionActivity', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(true);
+    const { container } = wrap(<Auction auction={makeAuction(0n)} />);
+    expect(container.querySelector('[data-testid="auction-activity"]')).toBeNull();
+    expect(container.querySelector('[data-testid="niji-content"]')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
@@ -125,4 +125,56 @@ describe('ByLineHoverCard', () => {
     const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
     expect(container.querySelector('.spinner-border')).toBeNull();
   });
+
+  it('does not render error message when error is undefined', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.textContent).not.toContain('Error');
+  });
+
+  it('renders stacked with 10 nijis', () => {
+    const nijiList = Array.from({ length: 10 }, (_, i) => ({ id: String(i + 1) }));
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: nijiList }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-10');
+  });
+
+  it('loading=true takes precedence over data (still spinner)', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      loading: true,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('loading=true takes precedence over error (spinner shown, error skipped)', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      loading: true,
+      error: new Error('boom'),
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+    expect(container.textContent).not.toContain('Error');
+  });
+
+  it('different proposerAddress does not change rendering of stacked content', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xB', nijiRepresented: [{ id: '7' }, { id: '8' }] }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xB" />);
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-2');
+  });
 });

--- a/packages/niji-webapp/src/components/Holder/index.test.tsx
+++ b/packages/niji-webapp/src/components/Holder/index.test.tsx
@@ -129,4 +129,59 @@ describe('Holder', () => {
     const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
     expect(container.textContent).toContain('Niji info');
   });
+
+  it('Nounders branch with data shows non-empty render', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { noun: { owner: { id: '0xOWNER' } } },
+    });
+    const { container } = render(<Holder nounId={1n} isNounders={true} />, {
+      wrapper: WithProviders,
+    });
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+
+  it('does not render ShortAddress while loading', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({ loading: true, error: undefined, data: undefined });
+    const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    expect(container.querySelector('[data-testid="short"]')).toBeNull();
+  });
+
+  it('does not render ShortAddress when error is set', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: new Error('rpc'),
+      data: undefined,
+    });
+    const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    expect(container.querySelector('[data-testid="short"]')).toBeNull();
+  });
+
+  it('renders ShortAddress with different owner address (0xABC)', async () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { noun: { owner: { id: '0xABC' } } },
+    });
+    const { container } = render(<Holder nounId={5n} />, { wrapper: WithProviders });
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xABC');
+    });
+  });
+
+  it('atom value false also renders error path without crashing', () => {
+    useAtomValueMock.mockReturnValue(false);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: new Error('rpc'),
+      data: undefined,
+    });
+    const { container } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    expect(container.textContent).toContain('Failed to fetch');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.test.tsx
@@ -207,4 +207,91 @@ describe('FunctionCallReviewStep', () => {
     fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
     expect(onNext).toHaveBeenCalledTimes(1);
   });
+
+  it('renders address via ShortAddress', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={{ abi, function: 'noArg', address: ADDR, amount: '0', args: [] } as never}
+      />,
+    );
+    const shorts = container.querySelectorAll('[data-testid="short"]');
+    const found = Array.from(shorts).some(s => s.textContent === ADDR);
+    expect(found).toBe(true);
+  });
+
+  it('shows function name "transfer" in review content', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '1000'],
+          } as never
+        }
+      />,
+    );
+    expect(container.textContent).toContain('transfer');
+  });
+
+  it('Back button click is independent of state args', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        onPrevBtnClick={onPrev}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '0',
+            args: [ADDR, '999'],
+          } as never
+        }
+      />,
+    );
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders large argument values without crash', () => {
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        state={
+          {
+            abi,
+            function: 'transfer',
+            address: ADDR,
+            amount: '999999999999999999',
+            args: [ADDR, '999999999999999999'],
+          } as never
+        }
+      />,
+    );
+    expect(container.textContent).toContain('999999999999999999');
+  });
+
+  it('Next + Back click sequence works in any order', () => {
+    const onPrev = vi.fn();
+    const onNext = vi.fn();
+    const { container } = render(
+      <FunctionCallReviewStep
+        {...defaults}
+        onPrevBtnClick={onPrev}
+        onNextBtnClick={onNext}
+        state={{ abi, function: 'noArg', address: ADDR, amount: '0', args: [] } as never}
+      />,
+    );
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    fireEvent.click(container.querySelectorAll('button')[0]);
+    fireEvent.click(container.querySelector('[data-testid="next-btn"]')!);
+    expect(onNext).toHaveBeenCalledTimes(2);
+    expect(onPrev).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

niji-webapp vitest 拡張 part 111。
件数 8-9 帯 component 4 file に edge case TC を計 +20 件追加し、 2431 → **2451** 達成。

## 対象 4 file (現状 → 目標)

- `ProposalActionsModal/steps/FunctionCallReviewStep/index.test.tsx` (8 → 13)
- `Auction/index.test.tsx` (9 → 14)
- `ByLineHoverCard/index.test.tsx` (9 → 14)
- `Holder/index.test.tsx` (9 → 14)

## 追加 edge case 概要

| file | 追加 5 件 |
|---|---|
| FunctionCallReviewStep | ShortAddress 描画 / function 名表示 / Back state 独立 / 大引数値 / Next + Back 順序 |
| Auction | isFirstAuction=false / isLastAuction=false / first prev disabled click / large bigint / Nounder 経路非 AuctionActivity |
| ByLineHoverCard | error 未設定で Error 非表示 / 10 nijis / loading > error 優先 / 4 経路順序 / 別 proposerAddress |
| Holder | Nounders + data render / loading 中 ShortAddress 非表示 / error 中 ShortAddress 非表示 / 別 owner 0xABC / atom false |

## 修正経緯 (1 件 fail → 全 PASS)

ByLineHoverCard: source の `if (loading || ...)` が `if (error)` より先で early return → 「loading takes precedence」 軸に書き換え。

## Test plan

- [x] vitest `pnpm test -- --run` 全 PASS
- [x] 全体 2451 件 PASS + 1 todo (前回 2431 → +20)
- [x] `pnpm -w lint` 4 file 0 errors
- [x] 既存 TC 破壊なし

Refs #553
