### PR TITLE
✅ test(niji-webapp): part 183 (components 4 file) で 3949 → 3969

### DIFF
--- a/packages/niji-webapp/src/components/BrandDatePicker/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandDatePicker/index.test.tsx
@@ -105,4 +105,40 @@ describe('BrandDatePicker', () => {
     rerender(<BrandDatePicker onChange={() => {}} label="B" />);
     expect(container.querySelector('span')?.textContent).toBe('B');
   });
+
+  it('isInvalid rerender to false removes invalid class', () => {
+    const { container, rerender } = render(<BrandDatePicker onChange={() => {}} isInvalid />);
+    expect(container.querySelector('input')?.className).toMatch(/invalid/i);
+    rerender(<BrandDatePicker onChange={() => {}} isInvalid={false} />);
+    expect(container.querySelector('input')?.className).not.toMatch(/invalid/i);
+  });
+
+  it('onChange handler fires at least once on user input', () => {
+    const onChange = vi.fn();
+    const { container } = render(<BrandDatePicker onChange={onChange} />);
+    const inp = container.querySelector('input')!;
+    fireEvent.change(inp, { target: { value: '2025-06-15' } });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('renders without value prop (empty input)', () => {
+    const { container } = render(<BrandDatePicker onChange={() => {}} />);
+    expect(container.querySelector('input')?.value).toBe('');
+  });
+
+  it('multiple instances render independently', () => {
+    const { container } = render(
+      <>
+        <BrandDatePicker onChange={() => {}} label="Start" value="2025-01-01" />
+        <BrandDatePicker onChange={() => {}} label="End" value="2025-12-31" />
+      </>,
+    );
+    const inputs = container.querySelectorAll('input');
+    expect(inputs[0]?.value).toBe('2025-01-01');
+    expect(inputs[1]?.value).toBe('2025-12-31');
+  });
+
+  it('label with empty string renders without crash', () => {
+    expect(() => render(<BrandDatePicker onChange={() => {}} label="" />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/ForkStatus/index.test.tsx
+++ b/packages/niji-webapp/src/components/ForkStatus/index.test.tsx
@@ -108,4 +108,50 @@ describe('ForkStatus', () => {
     const { container } = render(<ForkStatus status={99 as never} />);
     expect(container.textContent).toBe('Undetermined');
   });
+
+  it('rerender from ESCROW to ACTIVE updates text', () => {
+    const { container, rerender } = render(<ForkStatus status={ForkState.ESCROW} />);
+    expect(container.textContent).toBe('In Escrow');
+    rerender(<ForkStatus status={ForkState.ACTIVE} />);
+    expect(container.textContent).toBe('Forking');
+  });
+
+  it('rerender to undefined (default to Undetermined)', () => {
+    const { container, rerender } = render(<ForkStatus status={ForkState.EXECUTED} />);
+    expect(container.textContent).toBe('Executed');
+    rerender(<ForkStatus />);
+    expect(container.textContent).toBe('Undetermined');
+  });
+
+  it('all 5 statuses each render distinct text', () => {
+    const { container } = render(
+      <>
+        <ForkStatus status={ForkState.ESCROW} />
+        <ForkStatus status={ForkState.ACTIVE} />
+        <ForkStatus status={ForkState.EXECUTED} />
+        <ForkStatus status={ForkState.UNDETERMINED} />
+        <ForkStatus />
+      </>,
+    );
+    expect(container.textContent).toContain('In Escrow');
+    expect(container.textContent).toContain('Forking');
+    expect(container.textContent).toContain('Executed');
+  });
+
+  it('renders 10 ESCROW instances', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <ForkStatus key={i} status={ForkState.ESCROW} />
+        ))}
+      </>,
+    );
+    expect((container.textContent?.match(/In Escrow/g) ?? []).length).toBe(10);
+  });
+
+  it('ACTIVE status renders exactly "Forking" not "Active"', () => {
+    const { container } = render(<ForkStatus status={ForkState.ACTIVE} />);
+    expect(container.textContent).toBe('Forking');
+    expect(container.textContent).not.toBe('Active');
+  });
 });

--- a/packages/niji-webapp/src/components/Link/index.test.tsx
+++ b/packages/niji-webapp/src/components/Link/index.test.tsx
@@ -107,4 +107,39 @@ describe('Link', () => {
     const { container } = render(<Link text="日本語" url="/x" leavesPage={false} />);
     expect(container.querySelector('a')?.textContent).toBe('日本語');
   });
+
+  it('rerender from leavesPage=true to false updates target', () => {
+    const { container, rerender } = render(<Link text="x" url="/x" leavesPage={true} />);
+    expect(container.querySelector('a')?.getAttribute('target')).toBe('_blank');
+    rerender(<Link text="x" url="/x" leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('target')).toBe('_self');
+  });
+
+  it('rerender url updates href', () => {
+    const { container, rerender } = render(<Link text="x" url="/a" leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/a');
+    rerender(<Link text="x" url="/b" leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('/b');
+  });
+
+  it('renders 10 instances each with own url', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <Link key={i} text={`l${i}`} url={`/url${i}`} leavesPage={false} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('a').length).toBe(10);
+  });
+
+  it('renders empty text without crash', () => {
+    expect(() => render(<Link text="" url="/x" leavesPage={false} />)).not.toThrow();
+  });
+
+  it('renders 500 char long url', () => {
+    const longUrl = 'https://example.com/' + 'a'.repeat(500);
+    const { container } = render(<Link text="x" url={longUrl} leavesPage={false} />);
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(longUrl);
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalStatusCopy/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalStatusCopy/index.test.tsx
@@ -126,4 +126,54 @@ describe('ProposalStatusCopy', () => {
     expect(container.textContent).toContain('Active');
     expect(container.textContent).toContain('Executed');
   });
+
+  it('rerender from PENDING to ACTIVE updates text', () => {
+    const { container, rerender } = render(
+      <ProposalStatusCopy proposal={makeProposal(ProposalState.PENDING)} />,
+    );
+    expect(container.textContent).toContain('Pending');
+    rerender(<ProposalStatusCopy proposal={makeProposal(ProposalState.ACTIVE)} />);
+    expect(container.textContent).toContain('Active');
+  });
+
+  it('rerender to VETOED state shows Vetoed text', () => {
+    const { container, rerender } = render(
+      <ProposalStatusCopy proposal={makeProposal(ProposalState.ACTIVE)} />,
+    );
+    rerender(<ProposalStatusCopy proposal={makeProposal(ProposalState.VETOED)} />);
+    expect(container.textContent).toContain('Vetoed');
+  });
+
+  it('renders 5 instances of CANCELLED', () => {
+    const { container } = render(
+      <>
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.CANCELLED)} />
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.CANCELLED)} />
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.CANCELLED)} />
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.CANCELLED)} />
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.CANCELLED)} />
+      </>,
+    );
+    expect((container.textContent?.match(/Canceled/g) ?? []).length).toBe(5);
+  });
+
+  it('all 3 finished states render distinct texts', () => {
+    const { container } = render(
+      <>
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.EXPIRED)} />
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.DEFEATED)} />
+        <ProposalStatusCopy proposal={makeProposal(ProposalState.QUEUED)} />
+      </>,
+    );
+    expect(container.textContent).toContain('Expired');
+    expect(container.textContent).toContain('Defeated');
+    expect(container.textContent).toContain('Queued');
+  });
+
+  it('SUCCEEDED state renders Succeeded text', () => {
+    const { container } = render(
+      <ProposalStatusCopy proposal={makeProposal(ProposalState.SUCCEEDED)} />,
+    );
+    expect(container.textContent).toBe('Succeeded');
+  });
 });


### PR DESCRIPTION
## Summary
part 183 で components 配下 4 file (ProposalStatusCopy / BrandDatePicker / ForkStatus / Link) に edge case TC 追加。 3949 → 3969 (+20)。

Closes #697

## Test plan
- [x] vitest 全 pass (3969 TC)
- [x] lint pass