### PR TITLE
✅ test(niji-webapp): part 187 (components 4 file) で 4029 → 4049

### DIFF
--- a/packages/niji-webapp/src/components/CreateProposalButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateProposalButton/index.test.tsx
@@ -391,4 +391,85 @@ describe('CreateProposalButton', () => {
     );
     expect(container.querySelector('.spinner-border')).not.toBeNull();
   });
+
+  it('renders Create Proposal button is enabled by default', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('button')?.disabled).toBe(false);
+  });
+
+  it('renders 5 clicks invoke handler 5 times', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    for (let i = 0; i < 5; i++) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(5);
+  });
+
+  it('rerender from loading to non-loading toggles spinner', () => {
+    const { container, rerender } = render(
+      <CreateProposalButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+    rerender(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('.spinner-border')).toBeNull();
+  });
+
+  it('renders exactly 1 button element', () => {
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(1);
+  });
+
+  it('repeated 10 clicks invoke handler 10 times', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    for (let i = 0; i < 10; i++) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(10);
+  });
 });

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -350,4 +350,74 @@ describe('DelegateHoverCard', () => {
     );
     expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-1');
   });
+
+  it('renders spinner consistently while loading', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={100n} />,
+    );
+    expect(container.querySelector('.spinner-border')).not.toBeNull();
+  });
+
+  it('renders multiple instances independently with loading state', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const { container } = render(
+      <>
+        <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />
+        <DelegateHoverCard delegateId="delegate-0xB" proposalCreationBlock={2n} />
+      </>,
+    );
+    expect(container.querySelectorAll('.spinner-border').length).toBe(2);
+  });
+
+  it('renders without crash for very large proposalCreationBlock', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={9007199254740991n} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from loading to error does not crash', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValueOnce({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const { rerender } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error('boom'),
+    });
+    expect(() =>
+      rerender(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />),
+    ).not.toThrow();
+  });
+
+  it('renders for delegateId with hex prefix variations', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(<DelegateHoverCard delegateId="delegate-0xABCDEF" proposalCreationBlock={5n} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/Documentation/index.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/index.test.tsx
@@ -220,4 +220,38 @@ describe('Documentation', () => {
     expect(container.querySelectorAll('section').length).toBe(1);
     expect(container.querySelectorAll('[data-testid="about-section"]').length).toBe(1);
   });
+
+  it('renders only 1 about-header instance', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelectorAll('[data-testid="about-header"]').length).toBe(1);
+  });
+
+  it('renders only 1 art-section instance', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelectorAll('[data-testid="art-section"]').length).toBe(1);
+  });
+
+  it('renders only 1 gov-section instance', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelectorAll('[data-testid="gov-section"]').length).toBe(1);
+  });
+
+  it('renders without crash on rerender', () => {
+    const { rerender } = render(<Documentation />);
+    expect(() => rerender(<Documentation />)).not.toThrow();
+  });
+
+  it('renders 5 instances of Documentation independently', () => {
+    expect(() =>
+      render(
+        <>
+          <Documentation />
+          <Documentation />
+          <Documentation />
+          <Documentation />
+          <Documentation />
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
@@ -174,4 +174,47 @@ describe('GrayCircle', () => {
     rerender(<GrayCircle />);
     expect(container.querySelectorAll('img').length).toBe(1);
   });
+
+  it('renders 10 instances each with own img', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <GrayCircle key={i} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(10);
+  });
+
+  it('rerender from delegate to non-delegate updates className', () => {
+    const { container, rerender } = render(<GrayCircle isDelegateView={true} />);
+    expect(container.querySelector('div')?.className).not.toBe('');
+    rerender(<GrayCircle />);
+    expect(container.querySelector('div')?.className).toBe('');
+  });
+
+  it('renders without crash with explicit isDelegateView=false', () => {
+    expect(() => render(<GrayCircle isDelegateView={false} />)).not.toThrow();
+  });
+
+  it('img src is consistent across renders', () => {
+    const { container: c1 } = render(<GrayCircle />);
+    const { container: c2 } = render(<GrayCircle />);
+    expect(c1.querySelector('img')?.getAttribute('src')).toBe(
+      c2.querySelector('img')?.getAttribute('src'),
+    );
+  });
+
+  it('5 mixed isDelegateView instances render independently', () => {
+    const { container } = render(
+      <>
+        <GrayCircle isDelegateView={true} />
+        <GrayCircle isDelegateView={false} />
+        <GrayCircle />
+        <GrayCircle isDelegateView={true} />
+        <GrayCircle isDelegateView={false} />
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(5);
+  });
 });


### PR DESCRIPTION
## Summary
part 187 で components 配下 4 file (CreateProposalButton / DelegateHoverCard / Documentation / GrayCircle) に edge case TC 追加。 4029 → 4049 (+20)。

Closes #705

## Test plan
- [x] vitest 全 pass (4049 TC)
- [x] lint pass