### PR TITLE
✅ test(niji-webapp): part 190 (components 4 file) で 4089 → 4109

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -336,4 +336,52 @@ describe('AuctionActivity', () => {
     const huge = makeAuction({ nounId: 999999n });
     expect(() => wrap(<AuctionActivity {...defaults} auction={huge as never} />)).not.toThrow();
   });
+
+  it('renders 5 instances each independently', () => {
+    expect(() => {
+      wrap(
+        <>
+          <AuctionActivity {...defaults} auction={makeAuction() as never} />
+          <AuctionActivity {...defaults} auction={makeAuction() as never} />
+          <AuctionActivity {...defaults} auction={makeAuction() as never} />
+          <AuctionActivity {...defaults} auction={makeAuction() as never} />
+          <AuctionActivity {...defaults} auction={makeAuction() as never} />
+        </>,
+      );
+    }).not.toThrow();
+  });
+
+  it('renders without crash with isLastAuction=true', () => {
+    expect(() =>
+      wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} isLastAuction={true} />),
+    ).not.toThrow();
+  });
+
+  it('renders without crash with isFirstAuction=true', () => {
+    expect(() =>
+      wrap(
+        <AuctionActivity {...defaults} auction={makeAuction() as never} isFirstAuction={true} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender does not crash (re-wrap MemoryRouter)', () => {
+    expect(() => {
+      wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+      wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    }).not.toThrow();
+  });
+
+  it('renders both first and last simultaneously without crash', () => {
+    expect(() =>
+      wrap(
+        <AuctionActivity
+          {...defaults}
+          auction={makeAuction() as never}
+          isFirstAuction={true}
+          isLastAuction={true}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -205,4 +205,39 @@ describe('AuctionActivityDateHeadline', () => {
     const { container } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
     expect(container.querySelector('div h4')).not.toBeNull();
   });
+
+  it('renders 10 instances each with own startTime', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={1735689600n + BigInt(i * 86400)} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h4').length).toBe(10);
+  });
+
+  it('rerender with new startTime updates display', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')?.textContent).toContain('2025');
+    rerender(<AuctionActivityDateHeadline startTime={1893456000n} />);
+    expect(container.querySelector('h4')?.textContent).toContain('2030');
+  });
+
+  it('renders for very large startTime (year 9999)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() => render(<AuctionActivityDateHeadline startTime={253402300799n} />)).not.toThrow();
+  });
+
+  it('renders for startTime=0n (epoch)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() => render(<AuctionActivityDateHeadline startTime={0n} />)).not.toThrow();
+  });
+
+  it('useAtomValue=false renders without crash', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() => render(<AuctionActivityDateHeadline startTime={1735689600n} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -173,4 +173,42 @@ describe('AuctionActivityNijiTitle', () => {
     rerender(<AuctionActivityNijiTitle nounId={0n} />);
     expect(container.querySelector('h1')?.textContent).toContain('0');
   });
+
+  it('renders for very large nounId (MAX_SAFE_INTEGER)', () => {
+    const { container } = render(
+      <AuctionActivityNijiTitle nounId={9007199254740991n} isCool={true} />,
+    );
+    expect(container.querySelector('h1')?.textContent).toContain('9007199254740991');
+  });
+
+  it('renders 10 instances each with own nounId', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} isCool={true} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(10);
+  });
+
+  it('rerender from id 1 to 100', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    expect(container.querySelector('h1')?.textContent).toContain('1');
+    rerender(<AuctionActivityNijiTitle nounId={100n} isCool={true} />);
+    expect(container.querySelector('h1')?.textContent).toContain('100');
+  });
+
+  it('rerender between isCool true/false changes style', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    const coolStyle = container.querySelector('h1')?.getAttribute('style');
+    rerender(<AuctionActivityNijiTitle nounId={1n} isCool={false} />);
+    expect(container.querySelector('h1')?.getAttribute('style')).not.toBe(coolStyle);
+  });
+
+  it('renders without crash with nounId=999999999n', () => {
+    expect(() =>
+      render(<AuctionActivityNijiTitle nounId={999999999n} isCool={true} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/Winner/index.test.tsx
+++ b/packages/niji-webapp/src/components/Winner/index.test.tsx
@@ -263,4 +263,47 @@ describe('Winner', () => {
     const zero = '0x0000000000000000000000000000000000000000' as const;
     expect(() => render(<Winner winner={zero} />, { wrapper: WithProviders })).not.toThrow();
   });
+
+  it('renders ShortAddress with different address', () => {
+    useAccountMock.mockReturnValue({ address: ADDR });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { container } = render(<Winner winner={'0xDIFFERENT_ADDRESS'} />, {
+      wrapper: WithProviders,
+    });
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe(
+      '0xDIFFERENT_ADDRESS',
+    );
+  });
+
+  it('renders without crash 5 times consecutively', () => {
+    useAccountMock.mockReturnValue({ address: ADDR });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    for (let i = 0; i < 5; i++) {
+      expect(() => render(<Winner winner={ADDR} />, { wrapper: WithProviders })).not.toThrow();
+    }
+  });
+
+  it('useAccount returns null address (no wallet) handled', () => {
+    useAccountMock.mockReturnValue({ address: undefined });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    expect(() => render(<Winner winner={ADDR} />, { wrapper: WithProviders })).not.toThrow();
+  });
+
+  it('rerender with different winner does not crash', () => {
+    useAccountMock.mockReturnValue({ address: ADDR });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('en-US');
+    const { rerender } = render(<Winner winner={ADDR} />, { wrapper: WithProviders });
+    expect(() => rerender(<Winner winner={'0xNEW_WINNER'} />)).not.toThrow();
+  });
+
+  it('ja-JP locale renders without crash', () => {
+    useAccountMock.mockReturnValue({ address: ADDR });
+    useAtomValueMock.mockReturnValue(true);
+    useActiveLocaleMock.mockReturnValue('ja-JP');
+    expect(() => render(<Winner winner={ADDR} />, { wrapper: WithProviders })).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 190 で components 配下 4 file (Winner / AuctionActivity / AuctionActivityDateHeadline / AuctionActivityNijiTitle) に edge case TC 追加。 4089 → 4109 (+20)。

Closes #711

## Test plan
- [x] vitest 全 pass (4109 TC)
- [x] lint pass