### PR TITLE
✅ test(niji-webapp): part 191 (components 4 file) で 4109 → 4129

### DIFF
--- a/packages/niji-webapp/src/components/AuctionNavigation/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionNavigation/index.test.tsx
@@ -423,4 +423,86 @@ describe('AuctionNavigation Component', () => {
       for (let i = 0; i < 10; i++) fireEvent.keyDown(document, { key: 'ArrowLeft' });
     }).not.toThrow();
   });
+
+  it('renders 5 instances each with own handlers', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <AuctionNavigation
+            key={i}
+            isFirstAuction={false}
+            isLastAuction={false}
+            onPrevAuctionClick={vi.fn()}
+            onNextAuctionClick={vi.fn()}
+          />
+        ))}
+      </>,
+    );
+    const prevButtons = container.querySelectorAll('button');
+    expect(prevButtons.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('rerender from isFirst=false to true updates state', () => {
+    const { rerender } = render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={false}
+        onPrevAuctionClick={vi.fn()}
+        onNextAuctionClick={vi.fn()}
+      />,
+    );
+    expect(() =>
+      rerender(
+        <AuctionNavigation
+          isFirstAuction={true}
+          isLastAuction={false}
+          onPrevAuctionClick={vi.fn()}
+          onNextAuctionClick={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders without crash with both first and last true', () => {
+    expect(() =>
+      render(
+        <AuctionNavigation
+          isFirstAuction={true}
+          isLastAuction={true}
+          onPrevAuctionClick={vi.fn()}
+          onNextAuctionClick={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 10 prev clicks invoke onPrev 10 times', () => {
+    const onPrev = vi.fn();
+    const { container } = render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={false}
+        onPrevAuctionClick={onPrev}
+        onNextAuctionClick={vi.fn()}
+      />,
+    );
+    const buttons = container.querySelectorAll('button');
+    for (let i = 0; i < 10; i++) fireEvent.click(buttons[0]);
+    expect(onPrev).toHaveBeenCalledTimes(10);
+  });
+
+  it('rapid 10 next clicks invoke onNext 10 times', () => {
+    const onNext = vi.fn();
+    const { container } = render(
+      <AuctionNavigation
+        isFirstAuction={false}
+        isLastAuction={false}
+        onPrevAuctionClick={vi.fn()}
+        onNextAuctionClick={onNext}
+      />,
+    );
+    const buttons = container.querySelectorAll('button');
+    for (let i = 0; i < 10; i++) fireEvent.click(buttons[1]);
+    expect(onNext).toHaveBeenCalledTimes(10);
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionTimer/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionTimer/index.test.tsx
@@ -219,4 +219,39 @@ describe('AuctionTimer Component', () => {
     const huge = { ...mockAuction(3600), amount: 999_999_999_999_999_999n };
     expect(() => render(<AuctionTimer auction={huge} auctionEnded={false} />)).not.toThrow();
   });
+
+  it('renders without crash for auctionEnded=true', () => {
+    expect(() =>
+      render(<AuctionTimer auction={mockAuction(0)} auctionEnded={true} />),
+    ).not.toThrow();
+  });
+
+  it('renders 5 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <AuctionTimer key={i} auction={mockAuction(3600)} auctionEnded={false} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from auctionEnded=false to true', () => {
+    const { rerender } = render(<AuctionTimer auction={mockAuction(3600)} auctionEnded={false} />);
+    expect(() =>
+      rerender(<AuctionTimer auction={mockAuction(3600)} auctionEnded={true} />),
+    ).not.toThrow();
+  });
+
+  it('renders without crash for small bid amount', () => {
+    const small = { ...mockAuction(3600), amount: 1n };
+    expect(() => render(<AuctionTimer auction={small} auctionEnded={false} />)).not.toThrow();
+  });
+
+  it('renders without crash for very small endTime', () => {
+    const tiny = { ...mockAuction(0), endTime: 1n };
+    expect(() => render(<AuctionTimer auction={tiny} auctionEnded={true} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionTitleAndNavWrapper/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionTitleAndNavWrapper/index.test.tsx
@@ -215,4 +215,51 @@ describe('AuctionTitleAndNavWrapper Component', () => {
     const { container } = render(<AuctionTitleAndNavWrapper>{0}</AuctionTitleAndNavWrapper>);
     expect(container.textContent).toBe('0');
   });
+
+  it('renders empty string children', () => {
+    const { container } = render(<AuctionTitleAndNavWrapper>{''}</AuctionTitleAndNavWrapper>);
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders 200 char long content', () => {
+    const longStr = 'x'.repeat(200);
+    const { container } = render(<AuctionTitleAndNavWrapper>{longStr}</AuctionTitleAndNavWrapper>);
+    expect(container.textContent).toBe(longStr);
+  });
+
+  it('rerender from text to nested element', () => {
+    const { container, rerender } = render(
+      <AuctionTitleAndNavWrapper>simple</AuctionTitleAndNavWrapper>,
+    );
+    expect(container.textContent).toBe('simple');
+    rerender(
+      <AuctionTitleAndNavWrapper>
+        <span>nested</span>
+      </AuctionTitleAndNavWrapper>,
+    );
+    expect(container.textContent).toBe('nested');
+  });
+
+  it('renders 5 instances independently', () => {
+    const { container } = render(
+      <>
+        <AuctionTitleAndNavWrapper>A</AuctionTitleAndNavWrapper>
+        <AuctionTitleAndNavWrapper>B</AuctionTitleAndNavWrapper>
+        <AuctionTitleAndNavWrapper>C</AuctionTitleAndNavWrapper>
+        <AuctionTitleAndNavWrapper>D</AuctionTitleAndNavWrapper>
+        <AuctionTitleAndNavWrapper>E</AuctionTitleAndNavWrapper>
+      </>,
+    );
+    expect(container.textContent).toBe('ABCDE');
+  });
+
+  it('renders multiple sibling children', () => {
+    const { container } = render(
+      <AuctionTitleAndNavWrapper>
+        <span>X</span>
+        <span>Y</span>
+      </AuctionTitleAndNavWrapper>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(2);
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistory/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistory/index.test.tsx
@@ -280,4 +280,47 @@ describe('BidHistory Component', () => {
     render(<BidHistory auctionId="1" max={10} classes={mockClasses} />);
     expect(useAuctionBids).toHaveBeenCalledTimes(1);
   });
+
+  it('renders without crash with empty bids array', () => {
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    expect(() => render(<BidHistory auctionId={1n} max={5} classes={mockClasses} />)).not.toThrow();
+  });
+
+  it('renders max=10 bids when 10 provided', () => {
+    const bids = Array.from({ length: 10 }, (_, i) => ({
+      value: BigInt(i + 1) * 1000000000000000000n,
+      sender: `0x${i.toString().padStart(40, '0')}` as Address,
+      transactionHash: `0xhash${i}` as Address,
+      timestamp: BigInt(1000000 + i),
+    }));
+    vi.mocked(useAuctionBids).mockReturnValue(bids);
+    const { container } = render(<BidHistory auctionId={1n} max={10} classes={mockClasses} />);
+    expect(container.querySelectorAll('[data-testid="bid-history-item"]').length).toBe(10);
+  });
+
+  it('rerender with different auctionId calls useAuctionBids again', () => {
+    vi.mocked(useAuctionBids).mockClear();
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    const { rerender } = render(<BidHistory auctionId={1n} max={5} classes={mockClasses} />);
+    rerender(<BidHistory auctionId={2n} max={5} classes={mockClasses} />);
+    expect(useAuctionBids).toHaveBeenCalledTimes(2);
+  });
+
+  it('renders without crash for max=0', () => {
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    expect(() => render(<BidHistory auctionId={1n} max={0} classes={mockClasses} />)).not.toThrow();
+  });
+
+  it('renders 5 instances independently', () => {
+    vi.mocked(useAuctionBids).mockReturnValue([]);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <BidHistory key={i} auctionId={BigInt(i)} max={5} classes={mockClasses} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 191 で components 配下 4 file (AuctionNavigation / AuctionTimer / AuctionTitleAndNavWrapper / BidHistory) に edge case TC 追加。 4109 → 4129 (+20)。

Closes #713

## Test plan
- [x] vitest 全 pass (4129 TC)
- [x] lint pass