### PR TITLE
✅ test(niji-webapp): part 192 (components 4 file) で 4129 → 4149

### DIFF
--- a/packages/niji-webapp/src/components/ModalBottomButtonRow/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalBottomButtonRow/index.test.tsx
@@ -410,4 +410,83 @@ describe('ModalBottomButtonRow', () => {
     );
     expect(container.querySelectorAll('button')[1]?.textContent?.length).toBe(200);
   });
+
+  it('renders without crash for empty prevBtnText', () => {
+    expect(() =>
+      render(
+        <ModalBottomButtonRow
+          prevBtnText=""
+          onPrevBtnClick={() => {}}
+          nextBtnText="Next"
+          onNextBtnClick={() => {}}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('5 instances render 10 buttons', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <ModalBottomButtonRow
+            key={i}
+            prevBtnText={`prev${i}`}
+            onPrevBtnClick={() => {}}
+            nextBtnText={`next${i}`}
+            onNextBtnClick={() => {}}
+          />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('button').length).toBe(10);
+  });
+
+  it('rerender from "A" to "B" updates prevBtnText', () => {
+    const { container, rerender } = render(
+      <ModalBottomButtonRow
+        prevBtnText="A"
+        onPrevBtnClick={() => {}}
+        nextBtnText="X"
+        onNextBtnClick={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button')[0]?.textContent).toBe('A');
+    rerender(
+      <ModalBottomButtonRow
+        prevBtnText="B"
+        onPrevBtnClick={() => {}}
+        nextBtnText="X"
+        onNextBtnClick={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button')[0]?.textContent).toBe('B');
+  });
+
+  it('rapid 10 next clicks invoke onNextBtnClick 10 times', () => {
+    const onNext = vi.fn();
+    const { container } = render(
+      <ModalBottomButtonRow
+        prevBtnText="P"
+        onPrevBtnClick={() => {}}
+        nextBtnText="N"
+        onNextBtnClick={onNext}
+      />,
+    );
+    const nextBtn = container.querySelectorAll('button')[1];
+    for (let i = 0; i < 10; i++) fireEvent.click(nextBtn);
+    expect(onNext).toHaveBeenCalledTimes(10);
+  });
+
+  it('renders unicode buttonText', () => {
+    const { container } = render(
+      <ModalBottomButtonRow
+        prevBtnText="戻る"
+        onPrevBtnClick={() => {}}
+        nextBtnText="次へ"
+        onNextBtnClick={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button')[0]?.textContent).toBe('戻る');
+    expect(container.querySelectorAll('button')[1]?.textContent).toBe('次へ');
+  });
 });

--- a/packages/niji-webapp/src/components/NavLocaleSwitcher/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavLocaleSwitcher/index.test.tsx
@@ -238,4 +238,38 @@ describe('NavLocaleSwitcher', () => {
     if (closeBtn) fireEvent.click(closeBtn);
     expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
   });
+
+  it('renders without crash for unknown locale', () => {
+    useAtomMock.mockReturnValue(['xx-XX', vi.fn()]);
+    expect(() => render(<NavLocaleSwitcher />)).not.toThrow();
+  });
+
+  it('renders 5 instances independently', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <NavLocaleSwitcher key={i} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="nav-button"]').length).toBe(5);
+  });
+
+  it('rerender does not crash', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { rerender } = render(<NavLocaleSwitcher />);
+    expect(() => rerender(<NavLocaleSwitcher />)).not.toThrow();
+  });
+
+  it('ja-JP locale renders Japanese label', () => {
+    useAtomMock.mockReturnValue(['ja-JP', vi.fn()]);
+    const { container } = render(<NavLocaleSwitcher />);
+    expect(container.textContent?.length).toBeGreaterThan(0);
+  });
+
+  it('zh-CN locale renders without crash', () => {
+    useAtomMock.mockReturnValue(['zh-CN', vi.fn()]);
+    expect(() => render(<NavLocaleSwitcher />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/NetworkAlert/index.test.tsx
+++ b/packages/niji-webapp/src/components/NetworkAlert/index.test.tsx
@@ -192,4 +192,41 @@ describe('NetworkAlert', () => {
     rerender(<NetworkAlert />);
     expect(switchChainMock).toHaveBeenCalledTimes(1);
   });
+
+  it('renders null when chainId matches CHAIN_ID', () => {
+    useAccountMock.mockReturnValue({ isConnected: true, chainId: 1 });
+    const { container } = render(<NetworkAlert />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not call switchChain when chainId matches CHAIN_ID', () => {
+    useAccountMock.mockReturnValue({ isConnected: true, chainId: 1 });
+    render(<NetworkAlert />);
+    expect(switchChainMock).not.toHaveBeenCalled();
+  });
+
+  it('multiple instances render null independently', () => {
+    useAccountMock.mockReturnValue({ isConnected: false, chainId: undefined });
+    const { container } = render(
+      <>
+        <NetworkAlert />
+        <NetworkAlert />
+        <NetworkAlert />
+      </>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('rerender when connected state changes does not crash', () => {
+    useAccountMock.mockReturnValue({ isConnected: false, chainId: undefined });
+    const { rerender } = render(<NetworkAlert />);
+    useAccountMock.mockReturnValue({ isConnected: true, chainId: 1 });
+    expect(() => rerender(<NetworkAlert />)).not.toThrow();
+  });
+
+  it('renders null for chainId=undefined', () => {
+    useAccountMock.mockReturnValue({ isConnected: false, chainId: undefined });
+    const { container } = render(<NetworkAlert />);
+    expect(container.firstChild).toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/NijiInfoRowButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoRowButton/index.test.tsx
@@ -268,4 +268,55 @@ describe('NijiInfoRowButton', () => {
     );
     expect(container.textContent).toBe('hello');
   });
+
+  it('renders empty btnText', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="" onClickHandler={() => {}} />,
+    );
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders 200 char long btnText', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const longStr = 'x'.repeat(200);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText={longStr} onClickHandler={() => {}} />,
+    );
+    expect(container.textContent).toBe(longStr);
+  });
+
+  it('rerender between btnText updates display', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="first" onClickHandler={() => {}} />,
+    );
+    expect(container.textContent).toBe('first');
+    rerender(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="second" onClickHandler={() => {}} />,
+    );
+    expect(container.textContent).toBe('second');
+  });
+
+  it('renders 5 instances independently', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <>
+        <NijiInfoRowButton iconImgSource="/a.png" btnText="A" onClickHandler={() => {}} />
+        <NijiInfoRowButton iconImgSource="/b.png" btnText="B" onClickHandler={() => {}} />
+        <NijiInfoRowButton iconImgSource="/c.png" btnText="C" onClickHandler={() => {}} />
+        <NijiInfoRowButton iconImgSource="/d.png" btnText="D" onClickHandler={() => {}} />
+        <NijiInfoRowButton iconImgSource="/e.png" btnText="E" onClickHandler={() => {}} />
+      </>,
+    );
+    expect(container.textContent).toBe('ABCDE');
+  });
+
+  it('renders unicode btnText', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <NijiInfoRowButton iconImgSource="/x.png" btnText="日本語" onClickHandler={() => {}} />,
+    );
+    expect(container.textContent).toBe('日本語');
+  });
 });


### PR DESCRIPTION
## Summary
part 192 で components 配下 4 file (ModalBottomButtonRow / NavLocaleSwitcher / NetworkAlert / NijiInfoRowButton) に edge case TC 追加。 4129 → 4149 (+20)。

Closes #715

## Test plan
- [x] vitest 全 pass (4149 TC)
- [x] lint pass