### PR TITLE
✅ test(niji-webapp): part 193 (components 4 file) で 4149 → 4169

### DIFF
--- a/packages/niji-webapp/src/components/Bid/index.test.tsx
+++ b/packages/niji-webapp/src/components/Bid/index.test.tsx
@@ -339,4 +339,48 @@ describe('Bid', () => {
     fireEvent.change(input, { target: { value: '0.01' } });
     expect(input.value).toBe('0.01');
   });
+
+  it('renders 5 instances each without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <Bid key={i} auction={makeAuction() as never} auctionEnded={false} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from auctionEnded=false to true does not crash', () => {
+    const { rerender } = render(<Bid auction={makeAuction() as never} auctionEnded={false} />);
+    expect(() =>
+      rerender(<Bid auction={makeAuction() as never} auctionEnded={true} />),
+    ).not.toThrow();
+  });
+
+  it('renders without crash when account is undefined', () => {
+    hookState.account = undefined;
+    expect(() =>
+      render(<Bid auction={makeAuction() as never} auctionEnded={false} />),
+    ).not.toThrow();
+    hookState.account = '0xUSER';
+  });
+
+  it('renders without crash when minBidIncPercentage is undefined', () => {
+    hookState.minBidIncPercentage = undefined;
+    expect(() =>
+      render(<Bid auction={makeAuction() as never} auctionEnded={false} />),
+    ).not.toThrow();
+    hookState.minBidIncPercentage = 5n;
+  });
+
+  it('input change rapid 5 events updates value', () => {
+    const { container } = render(<Bid auction={makeAuction() as never} auctionEnded={false} />);
+    const input = container.querySelector('input') as HTMLInputElement;
+    for (let i = 0; i < 5; i++) {
+      fireEvent.change(input, { target: { value: `${i}.01` } });
+    }
+    expect(input.value).toBe('4.01');
+  });
 });

--- a/packages/niji-webapp/src/components/NijisTransition/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijisTransition/index.test.tsx
@@ -332,4 +332,61 @@ describe('NijisTransition', () => {
     );
     expect(container.querySelector('[data-testid="nested"]')?.textContent).toBe('nested');
   });
+
+  it('renders without crash with null children', () => {
+    expect(() =>
+      render(
+        <NijisTransition show={true} transitionStyes={styles}>
+          {null}
+        </NijisTransition>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders 5 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <NijisTransition key={i} show={true} transitionStyes={styles}>
+            <div>item-{i}</div>
+          </NijisTransition>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="motion-div"]').length).toBe(5);
+  });
+
+  it('rerender from "A" to "B" updates content', () => {
+    const { container, rerender } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        A
+      </NijisTransition>,
+    );
+    expect(container.textContent).toContain('A');
+    rerender(
+      <NijisTransition show={true} transitionStyes={styles}>
+        B
+      </NijisTransition>,
+    );
+    expect(container.textContent).toContain('B');
+  });
+
+  it('renders 300 char long content', () => {
+    const longStr = 'x'.repeat(300);
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        {longStr}
+      </NijisTransition>,
+    );
+    expect(container.textContent).toContain(longStr);
+  });
+
+  it('renders unicode content', () => {
+    const { container } = render(
+      <NijisTransition show={true} transitionStyes={styles}>
+        {'日本語'}
+      </NijisTransition>,
+    );
+    expect(container.textContent).toContain('日本語');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalContent/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalContent/index.test.tsx
@@ -242,4 +242,42 @@ describe('ProposalContent extra cases', () => {
     );
     expect(container.querySelectorAll('[data-testid="markdown"]').length).toBe(5);
   });
+
+  it('renders without crash with empty details array', () => {
+    expect(() =>
+      render(<ProposalContent description="# body" title="T1" details={[] as never} />),
+    ).not.toThrow();
+  });
+
+  it('rerender from description "A" to "B" updates markdown', () => {
+    const { container, rerender } = render(
+      <ProposalContent description="A" title="T" details={details} />,
+    );
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe('[T]A');
+    rerender(<ProposalContent description="B" title="T" details={details} />);
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toBe('[T]B');
+  });
+
+  it('renders 200 char long description', () => {
+    const longStr = 'x'.repeat(200);
+    const { container } = render(
+      <ProposalContent description={longStr} title="T" details={details} />,
+    );
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toContain(longStr);
+  });
+
+  it('renders unicode description', () => {
+    const { container } = render(
+      <ProposalContent description="日本語提案" title="T" details={details} />,
+    );
+    expect(container.querySelector('[data-testid="markdown"]')?.textContent).toContain(
+      '日本語提案',
+    );
+  });
+
+  it('linkIfAddress + transactionLink + transactionIconLink utils are exported', () => {
+    expect(typeof linkIfAddress).toBe('function');
+    expect(typeof transactionLink).toBe('function');
+    expect(typeof transactionIconLink).toBe('function');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalStatus/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalStatus/index.test.tsx
@@ -199,4 +199,48 @@ describe('ProposalStatus', () => {
     rerender(<ProposalStatus status={ProposalState.ACTIVE} />);
     expect(container.innerHTML).toBe(firstHTML);
   });
+
+  it('renders 10 instances each with own status', () => {
+    const { container } = render(
+      <>
+        {cases.slice(0, 10).map(([status], i) => (
+          <ProposalStatus key={i} status={status} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(10);
+  });
+
+  it('rerender from PENDING to ACTIVE updates status text', () => {
+    const { container, rerender } = render(<ProposalStatus status={ProposalState.PENDING} />);
+    expect(container.textContent).toContain('Pending');
+    rerender(<ProposalStatus status={ProposalState.ACTIVE} />);
+    expect(container.textContent).toContain('Active');
+  });
+
+  it('rerender to undefined defaults to Undetermined', () => {
+    const { container, rerender } = render(<ProposalStatus status={ProposalState.ACTIVE} />);
+    rerender(<ProposalStatus status={undefined} />);
+    expect(container.textContent).toContain('Undetermined');
+  });
+
+  it('all 12 statuses each render distinct text', () => {
+    const { container } = render(
+      <>
+        {cases.map(([status], i) => (
+          <ProposalStatus key={i} status={status} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(12);
+  });
+
+  it('custom className is preserved across rerenders', () => {
+    const { container, rerender } = render(
+      <ProposalStatus status={ProposalState.ACTIVE} className="custom-cls" />,
+    );
+    expect(container.querySelector('div')?.className).toContain('custom-cls');
+    rerender(<ProposalStatus status={ProposalState.EXECUTED} className="custom-cls" />);
+    expect(container.querySelector('div')?.className).toContain('custom-cls');
+  });
 });


### PR DESCRIPTION
## Summary
part 193 で components 配下 4 file (NijisTransition / ProposalContent / ProposalStatus / Bid) に edge case TC 追加。 4149 → 4169 (+20)。

Closes #717

## Test plan
- [x] vitest 全 pass (4169 TC)
- [x] lint pass