### PR TITLE
✅ test(niji-webapp): part 198 (components 4 file) で 4250 → 4270

### DIFF
--- a/packages/niji-webapp/src/components/ProposalActionsModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalActionsModal/index.test.tsx
@@ -465,6 +465,36 @@ describe('ProposalActionModal', () => {
     );
     expect(container.querySelectorAll('[data-testid="solid-modal"]').length).toBe(2);
   });
+
+  it('renders 5 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <ProposalActionModal key={i} {...baseProps} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="solid-modal"]').length).toBe(5);
+  });
+
+  it('renders without crash with show=false', () => {
+    expect(() => render(<ProposalActionModal {...baseProps} show={false} />)).not.toThrow();
+  });
+
+  it('rerender from show=false to true does not crash', () => {
+    const { rerender } = render(<ProposalActionModal {...baseProps} show={false} />);
+    expect(() => rerender(<ProposalActionModal {...baseProps} show={true} />)).not.toThrow();
+  });
+
+  it('renders consecutive 10 times without crash', () => {
+    for (let i = 0; i < 10; i++) {
+      expect(() => render(<ProposalActionModal {...baseProps} />)).not.toThrow();
+    }
+  });
+
+  it('renders without crash with default baseProps', () => {
+    expect(() => render(<ProposalActionModal {...baseProps} />)).not.toThrow();
+  });
 });
 
 // dummy reference to silence unused warning

--- a/packages/niji-webapp/src/components/ProposalTransactions/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalTransactions/index.test.tsx
@@ -270,4 +270,75 @@ describe('ProposalTransactions', () => {
     );
     expect(container.querySelectorAll('button').length).toBe(5);
   });
+
+  it('renders 10 transactions without crash', () => {
+    const tenDetails = Array.from({ length: 10 }, (_, i) => makeTx(`fn${i}()`, `0x${i}`)) as never;
+    expect(() =>
+      render(
+        <ProposalTransactions
+          proposalTransactions={tenDetails}
+          onRemoveProposalTransaction={() => {}}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders 0 transactions with empty array', () => {
+    expect(() =>
+      render(
+        <ProposalTransactions
+          proposalTransactions={[] as never}
+          onRemoveProposalTransaction={() => {}}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender with new details count updates rendering', () => {
+    const initial = [makeTx('a()', '0x')] as never;
+    const updated = [makeTx('a()', '0x'), makeTx('b()', '0x'), makeTx('c()', '0x')] as never;
+    const { rerender } = render(
+      <ProposalTransactions
+        proposalTransactions={initial}
+        onRemoveProposalTransaction={() => {}}
+      />,
+    );
+    expect(() =>
+      rerender(
+        <ProposalTransactions
+          proposalTransactions={updated}
+          onRemoveProposalTransaction={() => {}}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders multiple instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          <ProposalTransactions
+            proposalTransactions={[makeTx('a()', '0x')] as never}
+            onRemoveProposalTransaction={() => {}}
+          />
+          <ProposalTransactions
+            proposalTransactions={[makeTx('b()', '0x')] as never}
+            onRemoveProposalTransaction={() => {}}
+          />
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders without crash for very long signature string', () => {
+    const longSig = 'x'.repeat(500) + '()';
+    expect(() =>
+      render(
+        <ProposalTransactions
+          proposalTransactions={[makeTx(longSig, '0x')] as never}
+          onRemoveProposalTransaction={() => {}}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/Proposals/index.test.tsx
+++ b/packages/niji-webapp/src/components/Proposals/index.test.tsx
@@ -388,4 +388,34 @@ describe('Proposals', () => {
     wagmiState.account = undefined;
     expect(() => wrap(<Proposals proposals={[]} nounsRequired={2} />)).not.toThrow();
   });
+
+  it('renders with nounsRequired=0', () => {
+    expect(() => wrap(<Proposals proposals={[]} nounsRequired={0} />)).not.toThrow();
+  });
+
+  it('renders with nounsRequired=1000 (large)', () => {
+    expect(() => wrap(<Proposals proposals={[]} nounsRequired={1000} />)).not.toThrow();
+  });
+
+  it('renders without crash for empty proposals array (with container check)', () => {
+    const { container } = wrap(<Proposals proposals={[]} nounsRequired={2} />);
+    expect(container).not.toBeNull();
+  });
+
+  it('renders multiple instances each independently', () => {
+    expect(() =>
+      wrap(
+        <>
+          <Proposals proposals={[]} nounsRequired={2} />
+          <Proposals proposals={[]} nounsRequired={3} />
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders consecutive 5 times without crash', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(() => wrap(<Proposals proposals={[]} nounsRequired={i} />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.test.tsx
@@ -290,4 +290,42 @@ describe('SolidColorBackgroundModal', () => {
     );
     expect(document.getElementById('overlay-root')?.querySelectorAll('span').length).toBe(3);
   });
+
+  it('renders without crash with show=false', () => {
+    expect(() =>
+      render(<SolidColorBackgroundModal show={false} onDismiss={() => {}} content={<>x</>} />),
+    ).not.toThrow();
+  });
+
+  it('renders 500 char long content', () => {
+    const longStr = 'x'.repeat(500);
+    render(
+      <SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<div>{longStr}</div>} />,
+    );
+    expect(document.getElementById('overlay-root')?.textContent).toContain(longStr);
+  });
+
+  it('rerender from show=false to true does not crash', () => {
+    const { rerender } = render(
+      <SolidColorBackgroundModal show={false} onDismiss={() => {}} content={<>x</>} />,
+    );
+    expect(() =>
+      rerender(<SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<>x</>} />),
+    ).not.toThrow();
+  });
+
+  it('renders without crash 5 times consecutively', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(() =>
+        render(<SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<>x</>} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('renders unicode content', () => {
+    render(
+      <SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<>{'日本語'}</>} />,
+    );
+    expect(document.getElementById('overlay-root')?.textContent).toContain('日本語');
+  });
 });


### PR DESCRIPTION
## Summary
part 198 で components 配下 4 file (ProposalActionsModal / Proposals / ProposalTransactions / SolidColorBackgroundModal) に edge case TC 追加。 4250 → 4270 (+20)。

Closes #727

## Test plan
- [x] vitest 全 pass (4270 TC)
- [x] lint pass