### PR TITLE
✅ test(niji-webapp): part 199 (components 4 file) で 4270 → 4290

### DIFF
--- a/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
+++ b/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
@@ -218,4 +218,44 @@ describe('StartOrEndTime', () => {
     const { container } = render(<StartOrEndTime startTime={past} endTime={evenMorePast} />);
     expect(container.textContent).toContain('ended');
   });
+
+  it('renders 5 instances each without crash', () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <StartOrEndTime key={i} startTime={now + i * 100} endTime={now + i * 100 + 3600} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from starting to ending state', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const { container, rerender } = render(
+      <StartOrEndTime startTime={now + 3600} endTime={now + 7200} />,
+    );
+    expect(container.textContent).toContain('starts');
+    rerender(<StartOrEndTime startTime={now - 3600} endTime={now + 3600} />);
+    expect(container.textContent).toContain('ends');
+  });
+
+  it('handles startTime=0 (epoch) + endTime in future', () => {
+    expect(() =>
+      render(<StartOrEndTime startTime={0} endTime={Math.floor(Date.now() / 1000) + 3600} />),
+    ).not.toThrow();
+  });
+
+  it('handles very large endTime (year 2100)', () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(() => render(<StartOrEndTime startTime={now} endTime={4102444800} />)).not.toThrow();
+  });
+
+  it('handles negative startTime (pre-epoch) without crash', () => {
+    expect(() =>
+      render(<StartOrEndTime startTime={-1000} endTime={Math.floor(Date.now() / 1000) + 3600} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/StreamWithdrawModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/StreamWithdrawModal/index.test.tsx
@@ -332,4 +332,39 @@ describe('StreamWithdrawModal', () => {
       render(<StreamWithdrawModal {...baseProps} tokenAddress={'0xABCDEF' as `0x${string}`} />),
     ).not.toThrow();
   });
+
+  it('renders without crash with 0 withdrawable balance', () => {
+    hookState.withdrawableBalance = 0n;
+    expect(() => render(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    hookState.withdrawableBalance = 5_000_000n;
+  });
+
+  it('renders without crash for very large balance', () => {
+    hookState.withdrawableBalance = 1_000_000_000_000_000_000_000n;
+    expect(() => render(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    hookState.withdrawableBalance = 5_000_000n;
+  });
+
+  it('renders without crash with elapsedTime=100', () => {
+    hookState.elapsedTime = 100;
+    expect(() => render(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    hookState.elapsedTime = 50;
+  });
+
+  it('rerender does not crash', () => {
+    const { rerender } = render(<StreamWithdrawModal {...baseProps} />);
+    expect(() => rerender(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+  });
+
+  it('renders 3 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          <StreamWithdrawModal {...baseProps} />
+          <StreamWithdrawModal {...baseProps} />
+          <StreamWithdrawModal {...baseProps} />
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
@@ -246,4 +246,39 @@ describe('TightStackedCircleNiji', () => {
     );
     expect(container.querySelector('image')?.getAttribute('href')).toBe('data:loaded');
   });
+
+  it('renders without crash for nounId=0', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() => renderSvg({ nounId: 0, index: 0, square: 55, shift: 3 })).not.toThrow();
+  });
+
+  it('renders without crash for large nounId', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() => renderSvg({ nounId: 99999, index: 0, square: 55, shift: 3 })).not.toThrow();
+  });
+
+  it('renders for different index values (1, 2)', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() => renderSvg({ nounId: 1, index: 1, square: 55, shift: 3 })).not.toThrow();
+    expect(() => renderSvg({ nounId: 1, index: 2, square: 55, shift: 3 })).not.toThrow();
+  });
+
+  it('renders for different square sizes (10, 100)', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() => renderSvg({ nounId: 1, index: 0, square: 10, shift: 3 })).not.toThrow();
+    expect(() => renderSvg({ nounId: 1, index: 0, square: 100, shift: 3 })).not.toThrow();
+  });
+
+  it('renders multiple instances independently', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() =>
+      render(
+        <svg>
+          <TightStackedCircleNiji nounId={1} index={0} square={55} shift={3} />
+          <TightStackedCircleNiji nounId={2} index={1} square={55} shift={3} />
+          <TightStackedCircleNiji nounId={3} index={2} square={55} shift={3} />
+        </svg>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/VoteModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteModal/index.test.tsx
@@ -276,4 +276,35 @@ describe('VoteModal', () => {
   it('availableVotes=0 still renders modal', () => {
     expect(() => render(<VoteModal {...baseProps} availableVotes={0} />)).not.toThrow();
   });
+
+  it('renders without crash with very large availableVotes (1M)', () => {
+    expect(() => render(<VoteModal {...baseProps} availableVotes={1000000} />)).not.toThrow();
+  });
+
+  it('rerender does not crash', () => {
+    const { rerender } = render(<VoteModal {...baseProps} />);
+    expect(() => rerender(<VoteModal {...baseProps} availableVotes={5} />)).not.toThrow();
+  });
+
+  it('renders 3 instances each independently', () => {
+    expect(() =>
+      render(
+        <>
+          <VoteModal {...baseProps} />
+          <VoteModal {...baseProps} />
+          <VoteModal {...baseProps} />
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders without crash with negative availableVotes', () => {
+    expect(() => render(<VoteModal {...baseProps} availableVotes={-1} />)).not.toThrow();
+  });
+
+  it('renders consecutive 5 times without crash', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(() => render(<VoteModal {...baseProps} />)).not.toThrow();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 199 で components 配下 4 file (StartOrEndTime / StreamWithdrawModal / TightStackedCircleNiji / VoteModal) に edge case TC 追加。 4270 → 4290 (+20)。

Closes #729

## Test plan
- [x] vitest 全 pass (4290 TC)
- [x] lint pass