### PR TITLE
✅ test(niji-webapp): part 201 (components 4 file) で 4311 → 4331

### DIFF
--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
@@ -327,4 +327,47 @@ describe('DelegateGroupedNijiImageVoteTable', () => {
     );
     expect(container.querySelectorAll('td').length).toBe(12);
   });
+
+  it('handles 50 delegates (numPages = floor(50/12)+1 = 5)', () => {
+    const data = Array.from({ length: 50 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    expect(container.querySelector('[data-testid="num-pages"]')?.textContent).toBe('5');
+  });
+
+  it('renders 12 cells consistently for 1 delegate', () => {
+    const data1 = Array.from({ length: 1 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data1} />,
+    );
+    expect(container.querySelectorAll('td').length).toBe(12);
+  });
+
+  it('handles support type 0 (against)', () => {
+    const data = [makeVote('0xA', ['1'], 0)];
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles support type 2 (abstain)', () => {
+    const data = [makeVote('0xA', ['1'], 2)];
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles delegate with no nijis (empty nijiRepresented)', () => {
+    const data = [makeVote('0xA', [])];
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/DelegationCandidateVoteCountInfo/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegationCandidateVoteCountInfo/index.test.tsx
@@ -240,4 +240,52 @@ describe('DelegationCandidateVoteCountInfo', () => {
     expect(container.textContent).toContain('a');
     expect(container.textContent).toContain('5 Votes');
   });
+
+  it('voteCount=2 with isLoading=false renders "2 Votes"', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="x" voteCount={2} isLoading={false} />,
+    );
+    expect(container.textContent).toContain('2 Votes');
+  });
+
+  it('voteCount=Infinity renders verbatim', () => {
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text="x" voteCount={Infinity} isLoading={false} />,
+    );
+    expect(container.textContent).toContain('Infinity');
+  });
+
+  it('rerender from isLoading=true to false hides svg', () => {
+    const { container, rerender } = render(
+      <DelegationCandidateVoteCountInfo text="x" voteCount={5} isLoading={true} />,
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+    rerender(<DelegationCandidateVoteCountInfo text="x" voteCount={5} isLoading={false} />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('renders 7 instances each with distinct text', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 7 }, (_, i) => (
+          <DelegationCandidateVoteCountInfo
+            key={i}
+            text={`name-${i}`}
+            voteCount={i}
+            isLoading={false}
+          />
+        ))}
+      </>,
+    );
+    expect(container.textContent).toContain('name-0');
+    expect(container.textContent).toContain('name-6');
+  });
+
+  it('extremely long text renders verbatim', () => {
+    const longText = 'a'.repeat(500);
+    const { container } = render(
+      <DelegationCandidateVoteCountInfo text={longText} voteCount={1} isLoading={false} />,
+    );
+    expect(container.textContent).toContain(longText);
+  });
 });

--- a/packages/niji-webapp/src/components/EditProposalButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/EditProposalButton/index.test.tsx
@@ -216,4 +216,49 @@ describe('EditProposalButton', () => {
     );
     expect(container.querySelector('.spinner-border')).not.toBeNull();
   });
+
+  it('renders 5 instances each independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <EditProposalButton key={i} {...defaults} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('button').length).toBe(5);
+  });
+
+  it('threshold=1000 with no enough votes shows "1001 votes"', () => {
+    const { container } = render(
+      <EditProposalButton {...defaults} hasEnoughVote={false} proposalThreshold={1000} />,
+    );
+    expect(container.textContent).toContain('1001 votes to submit a proposal');
+  });
+
+  it('isFormInvalid disables button', () => {
+    const { container } = render(<EditProposalButton {...defaults} isFormInvalid={true} />);
+    expect(container.querySelector('button')?.disabled).toBe(true);
+  });
+
+  it('multiple consecutive clicks fire handler N times', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <EditProposalButton {...defaults} handleCreateProposal={handle} />,
+    );
+    const btn = container.querySelector('button')!;
+    for (let i = 0; i < 20; i++) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(20);
+  });
+
+  it('isCandidate + hasEnoughVote=false + threshold=2 shows "3 votes"', () => {
+    const { container } = render(
+      <EditProposalButton
+        {...defaults}
+        isCandidate={true}
+        hasEnoughVote={false}
+        proposalThreshold={2}
+      />,
+    );
+    expect(container.textContent).toContain('3 votes to submit a proposal');
+  });
 });

--- a/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
+++ b/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
@@ -242,4 +242,45 @@ describe('EnsOrLongAddress', () => {
     const { container } = render(<EnsOrLongAddress address={ADDR} />);
     expect(container.textContent).toBe(longName);
   });
+
+  it('renders for empty ENS string falls back to address', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('');
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+  });
+
+  it('renders ENS with very short name', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('a.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe('a.eth');
+  });
+
+  it('renders 20 instances each with own ENS', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('shared.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <EnsOrLongAddress key={i} address={ADDR} />
+        ))}
+      </>,
+    );
+    expect(container.textContent).toBe('shared.eth'.repeat(20));
+  });
+
+  it('blocklist takes precedence when ENS is set', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('bad.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(true);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+    expect(container.textContent).not.toContain('bad.eth');
+  });
+
+  it('different address sets different short address fallback', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const otherAddr = '0x1111111111111111111111111111111111111111';
+    const { container } = render(<EnsOrLongAddress address={otherAddr} />);
+    expect(container.textContent).toBe(otherAddr);
+  });
 });


### PR DESCRIPTION
## Summary
part 201 で components 配下 4 file (DelegateGroupedNijiImageVoteTable / DelegationCandidateVoteCountInfo / EditProposalButton / EnsOrLongAddress) に edge case TC 追加。 4311 → 4331 (+20)。

Closes #733

## Test plan
- [x] vitest 全 pass (4331 TC)
- [x] lint pass