### PR TITLE
✅ test(niji-webapp): part 202 (components 4 file) で 4331 → 4351

### DIFF
--- a/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
@@ -258,4 +258,58 @@ describe('LanguageSelectionModal', () => {
     render(<LanguageSelectionModal onDismiss={() => {}} />);
     expect(document.getElementById('overlay-root')?.querySelectorAll('svg').length).toBe(1);
   });
+
+  it('renders 3 instances independently in same DOM', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    expect(() =>
+      render(
+        <>
+          <LanguageSelectionModal onDismiss={() => {}} />
+          <LanguageSelectionModal onDismiss={() => {}} />
+          <LanguageSelectionModal onDismiss={() => {}} />
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender preserves modal structure', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { rerender } = render(<LanguageSelectionModal onDismiss={() => {}} />);
+    useAtomMock.mockReturnValue(['ja-JP', vi.fn()]);
+    expect(() => rerender(<LanguageSelectionModal onDismiss={() => {}} />)).not.toThrow();
+  });
+
+  it('all 3 locale buttons accessible by text', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    const overlay = document.getElementById('overlay-root');
+    const text = overlay?.textContent ?? '';
+    expect(text).toContain('日本語');
+    expect(text).toContain('English');
+    expect(text).toContain('中文');
+  });
+
+  it('setLocale + onDismiss fire both on Japanese click', () => {
+    const setLocale = vi.fn();
+    const onDismiss = vi.fn();
+    useAtomMock.mockReturnValue(['en-US', setLocale]);
+    render(<LanguageSelectionModal onDismiss={onDismiss} />);
+    const buttons = document.getElementById('overlay-root')?.querySelectorAll('div');
+    const jaBtn = Array.from(buttons ?? []).find(d => d.textContent === '日本語');
+    if (jaBtn) fireEvent.click(jaBtn);
+    expect(setLocale).toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalled();
+  });
+
+  it('all 3 different locale clicks each trigger setLocale', () => {
+    const setLocale = vi.fn();
+    useAtomMock.mockReturnValue(['en-US', setLocale]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    const buttons = document.getElementById('overlay-root')?.querySelectorAll('div');
+    ['日本語', 'English', '中文'].forEach(label => {
+      const btn = Array.from(buttons ?? []).find(d => d.textContent === label);
+      if (btn) fireEvent.click(btn);
+    });
+    expect(setLocale).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
@@ -196,4 +196,46 @@ describe('ModalSubtitle', () => {
     const { container } = render(<ModalSubtitle>日本語テスト</ModalSubtitle>);
     expect(container.textContent).toBe('日本語テスト');
   });
+
+  it('renders 50 char text exactly', () => {
+    const str50 = 'x'.repeat(50);
+    const { container } = render(<ModalSubtitle>{str50}</ModalSubtitle>);
+    expect(container.textContent).toBe(str50);
+  });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<ModalSubtitle>{42}</ModalSubtitle>);
+    expect(container.textContent).toBe('42');
+  });
+
+  it('renders deeply nested 3 levels', () => {
+    const { container } = render(
+      <ModalSubtitle>
+        <span>
+          <strong>
+            <em data-testid="deep">deep</em>
+          </strong>
+        </span>
+      </ModalSubtitle>,
+    );
+    expect(container.querySelector('[data-testid="deep"]')?.textContent).toBe('deep');
+  });
+
+  it('renders 7 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 7 }, (_, i) => (
+          <ModalSubtitle key={i}>{`text-${i}`}</ModalSubtitle>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(7);
+  });
+
+  it('rerender same content idempotent', () => {
+    const { container, rerender } = render(<ModalSubtitle>same</ModalSubtitle>);
+    const initial = container.innerHTML;
+    rerender(<ModalSubtitle>same</ModalSubtitle>);
+    expect(container.innerHTML).toBe(initial);
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
@@ -188,4 +188,46 @@ describe('ModalTitle', () => {
     const { container } = render(<ModalTitle>日本語タイトル</ModalTitle>);
     expect(container.querySelector('h1')?.textContent).toBe('日本語タイトル');
   });
+
+  it('renders 50 char title exactly', () => {
+    const str50 = 'x'.repeat(50);
+    const { container } = render(<ModalTitle>{str50}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe(str50);
+  });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<ModalTitle>{42}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe('42');
+  });
+
+  it('renders deeply nested 3 levels in h1', () => {
+    const { container } = render(
+      <ModalTitle>
+        <span>
+          <strong>
+            <em data-testid="deep">deep</em>
+          </strong>
+        </span>
+      </ModalTitle>,
+    );
+    expect(container.querySelector('h1 [data-testid="deep"]')?.textContent).toBe('deep');
+  });
+
+  it('renders 7 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 7 }, (_, i) => (
+          <ModalTitle key={i}>{`title-${i}`}</ModalTitle>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(7);
+  });
+
+  it('rerender same content idempotent', () => {
+    const { container, rerender } = render(<ModalTitle>same</ModalTitle>);
+    const initial = container.innerHTML;
+    rerender(<ModalTitle>same</ModalTitle>);
+    expect(container.innerHTML).toBe(initial);
+  });
 });

--- a/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
@@ -334,4 +334,62 @@ describe('NavDropDown', () => {
     expect(btns[0].textContent).toBe('One');
     expect(btns[1].textContent).toBe('Two');
   });
+
+  it('renders 10 instances each independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <NavDropDown key={i} buttonText={`btn-${i}`}>
+            <span>x</span>
+          </NavDropDown>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="nav-button"]').length).toBe(10);
+  });
+
+  it('renders unicode buttonText', () => {
+    const { container } = render(
+      <NavDropDown buttonText="日本語ボタン">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe('日本語ボタン');
+  });
+
+  it('renders extremely long buttonText (300 char)', () => {
+    const longText = 'x'.repeat(300);
+    const { container } = render(
+      <NavDropDown buttonText={longText}>
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(longText);
+  });
+
+  it('renders multiple children (Fragment)', () => {
+    const { container } = render(
+      <NavDropDown buttonText="X">
+        <span>A</span>
+        <span>B</span>
+        <span>C</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
+  });
+
+  it('rerender same buttonText idempotent', () => {
+    const { container, rerender } = render(
+      <NavDropDown buttonText="same">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    const initial = container.querySelector('[data-testid="nav-button"]')?.textContent;
+    rerender(
+      <NavDropDown buttonText="same">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(initial);
+  });
 });


### PR DESCRIPTION
## Summary
part 202 で components 配下 4 file (LanguageSelectionModal / ModalSubtitle / ModalTitle / NavDropdown) に edge case TC 追加。 4331 → 4351 (+20)。

Closes #735

## Test plan
- [x] vitest 全 pass (4351 TC)
- [x] lint pass