### PR TITLE
✅ test(niji-webapp): part 207 (components 4 file) で 4430 → 4450

### DIFF
--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -420,4 +420,79 @@ describe('DelegateHoverCard', () => {
       render(<DelegateHoverCard delegateId="delegate-0xABCDEF" proposalCreationBlock={5n} />),
     ).not.toThrow();
   });
+
+  it('renders without crash with delegateId empty string', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(<DelegateHoverCard delegateId="" proposalCreationBlock={1n} />),
+    ).not.toThrow();
+  });
+
+  it('renders 5 instances with different delegate IDs', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <DelegateHoverCard
+              key={i}
+              delegateId={`delegate-0x${i}`}
+              proposalCreationBlock={BigInt(i + 1)}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from error to loading recovers', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValueOnce({
+      data: undefined,
+      loading: false,
+      error: new Error('first'),
+    });
+    const { rerender } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      rerender(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />),
+    ).not.toThrow();
+  });
+
+  it('handles delegate data with 20 nijis', () => {
+    const nijiList = Array.from({ length: 20 }, (_, i) => ({ id: String(i + 1) }));
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: nijiList }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-20');
+  });
+
+  it('handles negative proposalCreationBlock (-1n)', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={-1n} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/Documentation/index.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/index.test.tsx
@@ -254,4 +254,49 @@ describe('Documentation', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders Documentation 20 times consecutively without crash', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(() => render(<Documentation />)).not.toThrow();
+    }
+  });
+
+  it('renders Documentation 10 instances together', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <Documentation key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender same component 5 times', () => {
+    const { rerender } = render(<Documentation />);
+    for (let i = 0; i < 5; i++) {
+      expect(() => rerender(<Documentation />)).not.toThrow();
+    }
+  });
+
+  it('renders Documentation without crash when wrapped in Fragment', () => {
+    expect(() =>
+      render(
+        <>
+          <Documentation />
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('Documentation renders within a div parent', () => {
+    expect(() =>
+      render(
+        <div data-testid="parent">
+          <Documentation />
+        </div>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
@@ -217,4 +217,47 @@ describe('GrayCircle', () => {
     );
     expect(container.querySelectorAll('img').length).toBe(5);
   });
+
+  it('renders 20 GrayCircles independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <GrayCircle key={i} isDelegateView={i % 2 === 0} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(20);
+  });
+
+  it('GrayCircle renders within Fragment with sibling', () => {
+    const { container } = render(
+      <>
+        <span>before</span>
+        <GrayCircle />
+        <span>after</span>
+      </>,
+    );
+    expect(container.textContent).toContain('before');
+    expect(container.textContent).toContain('after');
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('GrayCircle alt is empty string (decorative)', () => {
+    const { container } = render(<GrayCircle />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('');
+  });
+
+  it('multiple rerenders preserve img src', () => {
+    const { container, rerender } = render(<GrayCircle />);
+    const src1 = container.querySelector('img')?.getAttribute('src');
+    rerender(<GrayCircle />);
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(src1);
+  });
+
+  it('img element preserved across isDelegateView toggle', () => {
+    const { container, rerender } = render(<GrayCircle />);
+    const initial = container.querySelector('img')?.getAttribute('src');
+    rerender(<GrayCircle isDelegateView={true} />);
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(initial);
+  });
 });

--- a/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
@@ -213,4 +213,39 @@ describe('HorizontalStackedNijis', () => {
     const longId = '9'.repeat(100);
     expect(() => render(<HorizontalStackedNijis nounIds={[longId]} />)).not.toThrow();
   });
+
+  it('renders 4 IDs as 4 circles (under cap)', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={['1', '2', '3', '4']} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(4);
+  });
+
+  it('renders 6 IDs as exactly 6 circles (at cap)', () => {
+    const { container } = render(
+      <HorizontalStackedNijis nounIds={['1', '2', '3', '4', '5', '6']} />,
+    );
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(6);
+  });
+
+  it('renders 7 IDs caps at 6', () => {
+    const { container } = render(
+      <HorizontalStackedNijis nounIds={['1', '2', '3', '4', '5', '6', '7']} />,
+    );
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(6);
+  });
+
+  it('renders 10 instances each independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <HorizontalStackedNijis key={i} nounIds={[`${i}`]} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(10);
+  });
+
+  it('renders 3 IDs with 3 circles', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={['42', '100', '200']} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
part 207 で components 配下 4 file (DelegateHoverCard / Documentation / GrayCircle / HorizontalStackedNijis) に edge case TC 追加。 4430 → 4450 (+20)。

Closes #745

## Test plan
- [x] vitest 全 pass (4450 TC)
- [x] lint pass