### PR TITLE
✅ test(niji-webapp): part 208 (components 4 file) で 4450 → 4470

### DIFF
--- a/packages/niji-webapp/src/components/MinBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/MinBid/index.test.tsx
@@ -208,4 +208,43 @@ describe('MinBid', () => {
     expect(container.textContent).toContain('Ξ 1.00');
     expect(container.textContent).toContain('Ξ 2.00');
   });
+
+  it('renders 10 instances each with own onClick', () => {
+    const handlers = Array.from({ length: 10 }, () => vi.fn());
+    const { container } = render(
+      <>
+        {handlers.map((h, i) => (
+          <MinBid key={i} minBid={parseEther(`${i + 1}`)} onClick={h} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(10);
+  });
+
+  it('rapid 20 clicks fire 20 times', () => {
+    const onClick = vi.fn();
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={onClick} />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    for (let i = 0; i < 20; i++) fireEvent.click(wrapper);
+    expect(onClick).toHaveBeenCalledTimes(20);
+  });
+
+  it('rerender from 0 to 1 ETH shows amount', () => {
+    const { container, rerender } = render(<MinBid minBid={0n} onClick={() => {}} />);
+    expect(container.textContent).not.toContain('Ξ');
+    rerender(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.textContent).toContain('Ξ 1.00');
+  });
+
+  it('renders very small fractional 0.001 ETH', () => {
+    const { container } = render(<MinBid minBid={parseEther('0.001')} onClick={() => {}} />);
+    expect(container.textContent).toContain('Ξ');
+  });
+
+  it('img element preserved across rerenders', () => {
+    const { container, rerender } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.querySelector('img')).not.toBeNull();
+    rerender(<MinBid minBid={parseEther('5')} onClick={() => {}} />);
+    expect(container.querySelector('img')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
@@ -209,4 +209,41 @@ describe('ModalLabel', () => {
     const { container } = render(<ModalLabel>{'絵文字-日本語'}</ModalLabel>);
     expect(container.querySelector('div')?.textContent).toBe('絵文字-日本語');
   });
+
+  it('renders boolean false children as empty', () => {
+    const { container } = render(<ModalLabel>{false}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('renders null children as empty', () => {
+    const { container } = render(<ModalLabel>{null}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('renders 20 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <ModalLabel key={i}>{`label-${i}`}</ModalLabel>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(20);
+  });
+
+  it('renders special characters', () => {
+    const { container } = render(<ModalLabel>{'<>&"\''}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('<>&"\'');
+  });
+
+  it('renders mixed text + nested element', () => {
+    const { container } = render(
+      <ModalLabel>
+        prefix-<span>inner</span>-suffix
+      </ModalLabel>,
+    );
+    expect(container.querySelector('div')?.textContent).toContain('prefix');
+    expect(container.querySelector('div')?.textContent).toContain('inner');
+    expect(container.querySelector('div')?.textContent).toContain('suffix');
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
@@ -215,4 +215,41 @@ describe('ModalTextPrimary', () => {
     const { container } = render(<ModalTextPrimary>{'日本語テキスト'}</ModalTextPrimary>);
     expect(container.querySelector('div')?.textContent).toBe('日本語テキスト');
   });
+
+  it('renders 20 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <ModalTextPrimary key={i}>{`primary-${i}`}</ModalTextPrimary>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(20);
+  });
+
+  it('renders special characters verbatim', () => {
+    const { container } = render(<ModalTextPrimary>{'<>&"\''}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('<>&"\'');
+  });
+
+  it('renders numeric children as string', () => {
+    const { container } = render(<ModalTextPrimary>{99999}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('99999');
+  });
+
+  it('renders null children as empty', () => {
+    const { container } = render(<ModalTextPrimary>{null}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent).toBe('');
+  });
+
+  it('renders mixed text + nested element', () => {
+    const { container } = render(
+      <ModalTextPrimary>
+        before <strong>middle</strong> after
+      </ModalTextPrimary>,
+    );
+    expect(container.querySelector('div')?.textContent).toContain('before');
+    expect(container.querySelector('div')?.textContent).toContain('middle');
+    expect(container.querySelector('div')?.textContent).toContain('after');
+  });
 });

--- a/packages/niji-webapp/src/components/NijiContent/index.test.tsx
+++ b/packages/niji-webapp/src/components/NijiContent/index.test.tsx
@@ -436,4 +436,67 @@ describe('NijiContent', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders multiple consecutive rerenders without crash', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { rerender } = render(
+      <MemoryRouter>
+        <NijiContent nounId={1n} auctionId={1n} isCool={false} />
+      </MemoryRouter>,
+    );
+    for (let i = 2; i < 7; i++) {
+      expect(() =>
+        rerender(
+          <MemoryRouter>
+            <NijiContent nounId={BigInt(i)} auctionId={BigInt(i)} isCool={false} />
+          </MemoryRouter>,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('renders 10 instances independently', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <MemoryRouter>
+        {Array.from({ length: 10 }, (_, i) => (
+          <NijiContent key={i} nounId={BigInt(i)} auctionId={BigInt(i)} isCool={false} />
+        ))}
+      </MemoryRouter>,
+    );
+    expect(container.querySelectorAll('[data-testid="niji-title"]').length).toBe(10);
+  });
+
+  it('renders without crash for very large nounId (1 billion)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <NijiContent nounId={1000000000n} auctionId={1n} isCool={false} />
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders without crash for nounId !== auctionId', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <NijiContent nounId={1n} auctionId={999n} isCool={false} />
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('isCool=true + useAtomValue=true both true renders', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(
+        <MemoryRouter>
+          <NijiContent nounId={1n} auctionId={1n} isCool={true} />
+        </MemoryRouter>,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 208 で components 配下 4 file (MinBid / ModalLabel / ModalTextPrimary / NijiContent) に edge case TC 追加。 4450 → 4470 (+20)。

Closes #747

## Test plan
- [x] vitest 全 pass (4470 TC)
- [x] lint pass