### PR TITLE
✅ test(niji-webapp): part 210 (components 4 file) で 4491 → 4511

### DIFF
--- a/packages/niji-webapp/src/components/ABIUpload/index.test.tsx
+++ b/packages/niji-webapp/src/components/ABIUpload/index.test.tsx
@@ -367,4 +367,71 @@ describe('ABIUpload Component', () => {
       rerender(<ABIUpload abiFileName="x" isValid={true} isInvalid={false} onChange={vi.fn()} />),
     ).not.toThrow();
   });
+
+  it('renders 10 instances independently each with own state (no crash)', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <ABIUpload
+              key={i}
+              abiFileName={`file${i}.json`}
+              isValid={i % 2 === 0}
+              isInvalid={i % 3 === 0}
+              onChange={vi.fn()}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from isInvalid=true to false', () => {
+    const { rerender } = render(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={true} onChange={vi.fn()} />,
+    );
+    let input = screen.getByLabelText(/abi/i) as HTMLInputElement;
+    expect(input.className).toContain('is-invalid');
+    rerender(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={false} onChange={vi.fn()} />,
+    );
+    input = screen.getByLabelText(/abi/i) as HTMLInputElement;
+    expect(input.className).not.toContain('is-invalid');
+  });
+
+  it('rapid 10 file change events fire 10 times', () => {
+    const handleChange = vi.fn();
+    render(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={false} onChange={handleChange} />,
+    );
+    const input = screen.getByLabelText(/abi/i) as HTMLInputElement;
+    for (let i = 0; i < 10; i++) {
+      fireEvent.change(input, {
+        target: { files: [new File([`c${i}`], `f${i}.json`, { type: 'application/json' })] },
+      });
+    }
+    expect(handleChange).toHaveBeenCalledTimes(10);
+  });
+
+  it('handles 500 char long fileName', () => {
+    const longName = 'a'.repeat(500) + '.json';
+    expect(() =>
+      render(
+        <ABIUpload abiFileName={longName} isValid={false} isInvalid={false} onChange={vi.fn()} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders unicode fileName', () => {
+    expect(() =>
+      render(
+        <ABIUpload
+          abiFileName="日本語.json"
+          isValid={false}
+          isInvalid={false}
+          onChange={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -240,4 +240,44 @@ describe('AuctionActivityDateHeadline', () => {
     useAtomValueMock.mockReturnValue(false);
     expect(() => render(<AuctionActivityDateHeadline startTime={1735689600n} />)).not.toThrow();
   });
+
+  it('renders 20 instances independently with same startTime', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={1735689600n} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h4').length).toBe(20);
+  });
+
+  it('renders March startTime (2025-03-15)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const marchTime = 1742000000n;
+    const { container } = render(<AuctionActivityDateHeadline startTime={marchTime} />);
+    expect(container.querySelector('h4')?.textContent).toContain('2025');
+  });
+
+  it('renders June startTime (2025-06-15)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const juneTime = 1750000000n;
+    const { container } = render(<AuctionActivityDateHeadline startTime={juneTime} />);
+    expect(container.querySelector('h4')?.textContent).toContain('2025');
+  });
+
+  it('renders 10 consecutive different startTimes', () => {
+    useAtomValueMock.mockReturnValue(true);
+    for (let i = 0; i < 10; i++) {
+      const time = 1735689600n + BigInt(i * 86400);
+      expect(() => render(<AuctionActivityDateHeadline startTime={time} />)).not.toThrow();
+    }
+  });
+
+  it('rerender to past startTime (1970)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(() => rerender(<AuctionActivityDateHeadline startTime={0n} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -211,4 +211,37 @@ describe('AuctionActivityNijiTitle', () => {
       render(<AuctionActivityNijiTitle nounId={999999999n} isCool={true} />),
     ).not.toThrow();
   });
+
+  it('renders 20 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} isCool={i % 2 === 0} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(20);
+  });
+
+  it('renders 0n nounId without crash', () => {
+    expect(() => render(<AuctionActivityNijiTitle nounId={0n} isCool={true} />)).not.toThrow();
+  });
+
+  it('renders negative nounId (-1n)', () => {
+    expect(() => render(<AuctionActivityNijiTitle nounId={-1n} isCool={true} />)).not.toThrow();
+  });
+
+  it('rerender preserves h1 element type', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    expect(container.querySelector('h1')).not.toBeNull();
+    rerender(<AuctionActivityNijiTitle nounId={2n} isCool={false} />);
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
+
+  it('consecutive 5 renders all show "Niji" prefix', () => {
+    for (let i = 0; i < 5; i++) {
+      const { container } = render(<AuctionActivityNijiTitle nounId={BigInt(i)} isCool={true} />);
+      expect(container.querySelector('h1')?.textContent).toContain('Niji');
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/Bid/index.test.tsx
+++ b/packages/niji-webapp/src/components/Bid/index.test.tsx
@@ -383,4 +383,44 @@ describe('Bid', () => {
     }
     expect(input.value).toBe('4.01');
   });
+
+  it('renders 5 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <Bid key={i} auction={makeAuction() as never} auctionEnded={false} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders without crash for nounId=0n auction', () => {
+    expect(() =>
+      render(<Bid auction={makeAuction({ nounId: 0n }) as never} auctionEnded={false} />),
+    ).not.toThrow();
+  });
+
+  it('renders without crash for nounId=999999n', () => {
+    expect(() =>
+      render(<Bid auction={makeAuction({ nounId: 999999n }) as never} auctionEnded={false} />),
+    ).not.toThrow();
+  });
+
+  it('renders consecutive 5 times without crash', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(() =>
+        render(<Bid auction={makeAuction() as never} auctionEnded={false} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('renders for placeBid isPending=true', () => {
+    hookState.placeBid.isPending = true;
+    expect(() =>
+      render(<Bid auction={makeAuction() as never} auctionEnded={false} />),
+    ).not.toThrow();
+    hookState.placeBid.isPending = false;
+  });
 });


### PR DESCRIPTION
## Summary
part 210 で components 配下 4 file (AuctionActivityDateHeadline / AuctionActivityNijiTitle / ABIUpload / Bid) に edge case TC 追加。 4491 → 4511 (+20)。

Closes #751

## Test plan
- [x] vitest 全 pass (4511 TC)
- [x] lint pass