### PR TITLE
✅ test(niji-webapp): part 211 (components 4 file) で 4511 → 4531

### DIFF
--- a/packages/niji-webapp/src/components/BidHistoryBtn/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryBtn/index.test.tsx
@@ -255,4 +255,46 @@ describe('BidHistoryBtn Component (isCool=true)', () => {
     const { container } = render(<BidHistoryBtn onClick={vi.fn()} />);
     expect(container.children.length).toBe(1);
   });
+
+  it('renders 30 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <BidHistoryBtn key={i} onClick={vi.fn()} />
+        ))}
+      </>,
+    );
+    expect(container.children.length).toBe(30);
+  });
+
+  it('click event provides MouseEvent with target', () => {
+    let receivedTarget: EventTarget | null = null;
+    const onClick = (e: { target: EventTarget }) => {
+      receivedTarget = e.target;
+    };
+    const { container } = render(<BidHistoryBtn onClick={onClick} />);
+    fireEvent.click(container.firstElementChild as HTMLElement);
+    expect(receivedTarget).not.toBeNull();
+  });
+
+  it('repeated 50 clicks invoke onClick 50 times', () => {
+    const onClick = vi.fn();
+    const { container } = render(<BidHistoryBtn onClick={onClick} />);
+    const outer = container.firstElementChild as HTMLElement;
+    for (let i = 0; i < 50; i++) fireEvent.click(outer);
+    expect(onClick).toHaveBeenCalledTimes(50);
+  });
+
+  it('text wrapper inner div has className', () => {
+    const { container } = render(<BidHistoryBtn onClick={vi.fn()} />);
+    const inner = container.firstElementChild?.firstElementChild as HTMLDivElement;
+    expect(inner.className).toBeTruthy();
+  });
+
+  it('renders consistent text across rerenders', () => {
+    const { container, rerender } = render(<BidHistoryBtn onClick={vi.fn()} />);
+    expect(container.textContent).toBe('View all bids');
+    rerender(<BidHistoryBtn onClick={vi.fn()} />);
+    expect(container.textContent).toBe('View all bids');
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistoryItem/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryItem/index.test.tsx
@@ -293,4 +293,43 @@ describe('BidHistoryItem Component', () => {
     const extBid = { ...mockBid, extended: true };
     expect(() => render(<BidHistoryItem bid={extBid} classes={mockClasses} />)).not.toThrow();
   });
+
+  it('renders 10 instances each with distinct values', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <BidHistoryItem
+            key={i}
+            bid={{ ...mockBid, value: BigInt(i + 1) * 1_000_000_000_000_000_000n }}
+            classes={mockClasses}
+          />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="truncated-amount"]').length).toBe(10);
+  });
+
+  it('renders without crash for fractional value (1 wei)', () => {
+    const wei = { ...mockBid, value: 1n };
+    expect(() => render(<BidHistoryItem bid={wei} classes={mockClasses} />)).not.toThrow();
+  });
+
+  it('rerender different value updates amount', () => {
+    const { rerender } = render(<BidHistoryItem bid={mockBid} classes={mockClasses} />);
+    const updated = { ...mockBid, value: 10n * 1_000_000_000_000_000_000n };
+    rerender(<BidHistoryItem bid={updated} classes={mockClasses} />);
+    expect(screen.getByTestId('truncated-amount')).toHaveTextContent(
+      'Amount: 10000000000000000000',
+    );
+  });
+
+  it('renders without crash for empty classes object', () => {
+    expect(() => render(<BidHistoryItem bid={mockBid} classes={{}} />)).not.toThrow();
+  });
+
+  it('renders consistently across 5 sequential renders', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(() => render(<BidHistoryItem bid={mockBid} classes={mockClasses} />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistoryModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModal/index.test.tsx
@@ -307,4 +307,47 @@ describe('BidHistoryModal', () => {
     render(<BidHistoryModal auction={auction} onDismiss={onDismiss} />);
     expect(onDismiss).not.toHaveBeenCalled();
   });
+
+  it('renders 10 bids list', () => {
+    useAuctionBidsMock.mockReturnValue(
+      Array.from({ length: 10 }, (_, i) => ({ transactionHash: `0x${i}` })),
+    );
+    render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    expect(
+      document.getElementById('overlay-root')?.querySelectorAll('[data-testid="row"]').length,
+    ).toBe(10);
+  });
+
+  it('renders for very large nounId auction', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const huge = { ...auction, nounId: 9007199254740991n };
+    expect(() => render(<BidHistoryModal auction={huge} onDismiss={() => {}} />)).not.toThrow();
+  });
+
+  it('rerender with new auction does not crash', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const { rerender } = render(<BidHistoryModal auction={auction} onDismiss={() => {}} />);
+    const newAuction = { ...auction, nounId: 99n };
+    expect(() =>
+      rerender(<BidHistoryModal auction={newAuction} onDismiss={() => {}} />),
+    ).not.toThrow();
+  });
+
+  it('Backdrop fires onDismiss on multiple clicks', () => {
+    const onDismiss = vi.fn();
+    const { container } = render(<Backdrop onDismiss={onDismiss} />);
+    const div = container.querySelector('div');
+    if (div) {
+      fireEvent.click(div);
+      fireEvent.click(div);
+      fireEvent.click(div);
+    }
+    expect(onDismiss).toHaveBeenCalledTimes(3);
+  });
+
+  it('renders for 0n nounId auction', () => {
+    useAuctionBidsMock.mockReturnValue([]);
+    const zero = { ...auction, nounId: 0n };
+    expect(() => render(<BidHistoryModal auction={zero} onDismiss={() => {}} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistoryModalRow/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryModalRow/index.test.tsx
@@ -275,4 +275,45 @@ describe('BidHistoryModalRow', () => {
     vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
     expect(() => render(<BidHistoryModalRow bid={bid} index={99} />)).not.toThrow();
   });
+
+  it('renders 5 rows independently', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container } = render(
+      <>
+        {Array.from({ length: 5 }, (_, i) => (
+          <BidHistoryModalRow key={i} bid={bid} index={i} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('a').length).toBe(5);
+  });
+
+  it('renders ENS with 100 char long name', () => {
+    const longName = 'a'.repeat(100) + '.eth';
+    vi.mocked(useReverseENSLookUp).mockReturnValue(longName);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<BidHistoryModalRow bid={bid} index={1} />);
+    expect(container.textContent).toContain('aaaa');
+  });
+
+  it('rerender index changes (trophy toggle)', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const { container, rerender } = render(<BidHistoryModalRow bid={bid} index={0} />);
+    expect(container.querySelectorAll('img').length).toBe(2);
+    rerender(<BidHistoryModalRow bid={bid} index={3} />);
+    expect(container.querySelectorAll('img').length).toBe(1);
+  });
+
+  it('renders for 1 wei value as "Ξ 0.00"', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const wei = { ...bid, value: 1n };
+    const { container } = render(<BidHistoryModalRow bid={wei} index={1} />);
+    expect(container.textContent).toContain('Ξ');
+  });
+
+  it('renders without crash for very long transactionHash', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    const longHash = { ...bid, transactionHash: '0x' + 'a'.repeat(500) };
+    expect(() => render(<BidHistoryModalRow bid={longHash} index={1} />)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 211 で components 配下 4 file (BidHistoryBtn / BidHistoryItem / BidHistoryModal / BidHistoryModalRow) に edge case TC 追加。 4511 → 4531 (+20)。

Closes #753

## Test plan
- [x] vitest 全 pass (4531 TC)
- [x] lint pass