### PR TITLE
✅ test(niji-webapp): part 216 (components 4 file) で 4612 → 4632

### DIFF
--- a/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/SolidColorBackgroundModal/index.test.tsx
@@ -328,4 +328,67 @@ describe('SolidColorBackgroundModal', () => {
     );
     expect(document.getElementById('overlay-root')?.textContent).toContain('日本語');
   });
+
+  it('Backdrop renders 10 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 10 }, (_, i) => (
+          <Backdrop key={i} show={true} onDismiss={() => {}} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="transition"]').length).toBe(10);
+  });
+
+  it('renders 5 SolidColorBackgroundModal instances each with own content', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <SolidColorBackgroundModal
+              key={i}
+              show={true}
+              onDismiss={() => {}}
+              content={<p>{`item-${i}`}</p>}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('Backdrop with show=false renders nothing', () => {
+    const { container } = render(<Backdrop show={false} onDismiss={vi.fn()} />);
+    expect(container.querySelector('[data-testid="transition"]')).toBeNull();
+  });
+
+  it('show=true to false rerender removes content from overlay', () => {
+    const { rerender } = render(
+      <SolidColorBackgroundModal
+        show={true}
+        onDismiss={() => {}}
+        content={<p data-testid="x">a</p>}
+      />,
+    );
+    expect(
+      document.getElementById('overlay-root')?.querySelector('[data-testid="x"]'),
+    ).not.toBeNull();
+    rerender(
+      <SolidColorBackgroundModal
+        show={false}
+        onDismiss={() => {}}
+        content={<p data-testid="x">a</p>}
+      />,
+    );
+    expect(document.getElementById('overlay-root')?.querySelector('[data-testid="x"]')).toBeNull();
+  });
+
+  it('renders consistent content node type across rerenders', () => {
+    const { rerender } = render(
+      <SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<p>v1</p>} />,
+    );
+    expect(document.getElementById('overlay-root')?.querySelector('p')?.textContent).toBe('v1');
+    rerender(<SolidColorBackgroundModal show={true} onDismiss={() => {}} content={<p>v2</p>} />);
+    expect(document.getElementById('overlay-root')?.querySelector('p')?.textContent).toBe('v2');
+  });
 });

--- a/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
+++ b/packages/niji-webapp/src/components/StartOrEndTime/index.test.tsx
@@ -258,4 +258,47 @@ describe('StartOrEndTime', () => {
       render(<StartOrEndTime startTime={-1000} endTime={Math.floor(Date.now() / 1000) + 3600} />),
     ).not.toThrow();
   });
+
+  it('renders 10 instances independently without crash', () => {
+    const now = Math.floor(Date.now() / 1000);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <StartOrEndTime key={i} startTime={now + i * 100} endTime={now + i * 100 + 3600} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles startTime way in the future (year 2100)', () => {
+    const year2100 = 4102444800;
+    expect(() =>
+      render(<StartOrEndTime startTime={year2100} endTime={year2100 + 3600} />),
+    ).not.toThrow();
+  });
+
+  it('handles startTime + endTime both 0 (treated as ended)', () => {
+    const { container } = render(<StartOrEndTime startTime={0} endTime={0} />);
+    expect(container.textContent).toContain('ended');
+  });
+
+  it('renders consistent text across rerenders with same input', () => {
+    const start = Math.floor(Date.now() / 1000) + 3600;
+    const end = start + 3600;
+    const { container, rerender } = render(<StartOrEndTime startTime={start} endTime={end} />);
+    const initial = container.textContent;
+    rerender(<StartOrEndTime startTime={start} endTime={end} />);
+    expect(container.textContent).toBe(initial);
+  });
+
+  it('renders 5 instances each starting in the future', () => {
+    const now = Math.floor(Date.now() / 1000);
+    for (let i = 0; i < 5; i++) {
+      const start = now + 3600 + i * 1000;
+      const { container } = render(<StartOrEndTime startTime={start} endTime={start + 3600} />);
+      expect(container.textContent).toContain('starts');
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/StreamWithdrawModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/StreamWithdrawModal/index.test.tsx
@@ -367,4 +367,41 @@ describe('StreamWithdrawModal', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders 5 instances each independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <StreamWithdrawModal key={i} {...baseProps} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders for elapsedTime=0', () => {
+    hookState.elapsedTime = 0;
+    expect(() => render(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    hookState.elapsedTime = 50;
+  });
+
+  it('renders for elapsedTime=100 (complete)', () => {
+    hookState.elapsedTime = 100;
+    expect(() => render(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    hookState.elapsedTime = 50;
+  });
+
+  it('rerender does not crash 5 times', () => {
+    const { rerender } = render(<StreamWithdrawModal {...baseProps} />);
+    for (let i = 0; i < 5; i++) {
+      expect(() => rerender(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    }
+  });
+
+  it('renders with withdrawTokensState status changes', () => {
+    hookState.withdrawTokensState = { status: 'Mining' };
+    expect(() => render(<StreamWithdrawModal {...baseProps} />)).not.toThrow();
+    hookState.withdrawTokensState = { status: 'None' };
+  });
 });

--- a/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNiji/index.test.tsx
@@ -281,4 +281,53 @@ describe('TightStackedCircleNiji', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders 10 instances each independently', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() =>
+      render(
+        <svg>
+          {Array.from({ length: 10 }, (_, i) => (
+            <TightStackedCircleNiji key={i} nounId={i} index={i % 3} square={55} shift={3} />
+          ))}
+        </svg>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles shift=0 without crash', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() => renderSvg({ nounId: 1, index: 0, square: 55, shift: 0 })).not.toThrow();
+  });
+
+  it('handles shift=100 without crash', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    expect(() => renderSvg({ nounId: 1, index: 0, square: 55, shift: 100 })).not.toThrow();
+  });
+
+  it('rerender does not crash 5 times', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    const { rerender } = render(
+      <svg>
+        <TightStackedCircleNiji nounId={1} index={0} square={55} shift={3} />
+      </svg>,
+    );
+    for (let i = 0; i < 5; i++) {
+      expect(() =>
+        rerender(
+          <svg>
+            <TightStackedCircleNiji nounId={i + 1} index={i % 3} square={55} shift={3} />
+          </svg>,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('renders consistent loading state across multiple renders', () => {
+    useNounSeedMock.mockReturnValue(undefined);
+    for (let i = 0; i < 5; i++) {
+      const { container } = renderSvg({ nounId: i, index: i, square: 55, shift: 3 });
+      expect(container.querySelector('[data-testid="loading-noun"]')).not.toBeNull();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 216 で components 配下 4 file (SolidColorBackgroundModal / StartOrEndTime / StreamWithdrawModal / TightStackedCircleNiji) に edge case TC 追加。 4612 → 4632 (+20)。

Closes #763

## Test plan
- [x] vitest 全 pass (4632 TC)
- [x] lint pass