### PR TITLE
✅ test(niji-webapp): part 219 (components 4 file) で 4672 → 4692

### DIFF
--- a/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
@@ -238,4 +238,43 @@ describe('ModalSubtitle', () => {
     rerender(<ModalSubtitle>same</ModalSubtitle>);
     expect(container.innerHTML).toBe(initial);
   });
+
+  it('renders array children (multiple text nodes)', () => {
+    const { container } = render(<ModalSubtitle>{['a', 'b', 'c']}</ModalSubtitle>);
+    expect(container.querySelector('div')?.textContent).toBe('abc');
+  });
+
+  it('renders 50 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <ModalSubtitle key={i}>{`text-${i}`}</ModalSubtitle>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(50);
+  });
+
+  it('preserves single div wrapper across mounts', () => {
+    const { container } = render(<ModalSubtitle>x</ModalSubtitle>);
+    expect(container.children.length).toBe(1);
+    expect(container.firstElementChild?.tagName).toBe('DIV');
+  });
+
+  it('renders 1000 char long text', () => {
+    const longStr = 'x'.repeat(1000);
+    const { container } = render(<ModalSubtitle>{longStr}</ModalSubtitle>);
+    expect(container.querySelector('div')?.textContent).toBe(longStr);
+  });
+
+  it('rerender from text to JSX preserves wrapper div', () => {
+    const { container, rerender } = render(<ModalSubtitle>plain</ModalSubtitle>);
+    expect(container.children.length).toBe(1);
+    rerender(
+      <ModalSubtitle>
+        <span>jsx</span>
+      </ModalSubtitle>,
+    );
+    expect(container.children.length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
@@ -230,4 +230,42 @@ describe('ModalTitle', () => {
     rerender(<ModalTitle>same</ModalTitle>);
     expect(container.innerHTML).toBe(initial);
   });
+
+  it('renders array children (multiple text nodes)', () => {
+    const { container } = render(<ModalTitle>{['a', 'b', 'c']}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe('abc');
+  });
+
+  it('renders 50 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <ModalTitle key={i}>{`title-${i}`}</ModalTitle>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(50);
+  });
+
+  it('preserves h1 element type across mounts', () => {
+    const { container } = render(<ModalTitle>x</ModalTitle>);
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
+
+  it('renders 1000 char long title', () => {
+    const longStr = 'x'.repeat(1000);
+    const { container } = render(<ModalTitle>{longStr}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe(longStr);
+  });
+
+  it('rerender from text to JSX preserves h1', () => {
+    const { container, rerender } = render(<ModalTitle>plain</ModalTitle>);
+    expect(container.querySelector('h1')).not.toBeNull();
+    rerender(
+      <ModalTitle>
+        <span>jsx</span>
+      </ModalTitle>,
+    );
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
@@ -392,4 +392,64 @@ describe('NavDropDown', () => {
     );
     expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(initial);
   });
+
+  it('renders 50 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <NavDropDown key={i} buttonText={`btn-${i}`}>
+            <span>x</span>
+          </NavDropDown>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="nav-button"]').length).toBe(50);
+  });
+
+  it('renders nested NavDropDown without crash', () => {
+    expect(() =>
+      render(
+        <NavDropDown buttonText="outer">
+          <NavDropDown buttonText="inner">
+            <span>x</span>
+          </NavDropDown>
+        </NavDropDown>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender from no icon to icon', () => {
+    const { container, rerender } = render(
+      <NavDropDown buttonText="x">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
+    rerender(
+      <NavDropDown buttonText="x" buttonIcon={<span data-testid="ic" />}>
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
+  });
+
+  it('renders empty children', () => {
+    const { container } = render(<NavDropDown buttonText="x">{null}</NavDropDown>);
+    expect(container.querySelector('[data-testid="nav-button"]')).not.toBeNull();
+  });
+
+  it('renders consistent buttonText with rerenders', () => {
+    const { container, rerender } = render(
+      <NavDropDown buttonText="A">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe('A');
+    rerender(
+      <NavDropDown buttonText="A">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe('A');
+  });
 });

--- a/packages/niji-webapp/src/components/ProposalEditor/index.test.tsx
+++ b/packages/niji-webapp/src/components/ProposalEditor/index.test.tsx
@@ -242,4 +242,42 @@ describe('ProposalEditor', () => {
     expect((container.querySelector('input') as HTMLInputElement)?.value).toBe('second');
     expect((container.querySelector('textarea') as HTMLTextAreaElement)?.value).toBe('b');
   });
+
+  it('renders 10 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <ProposalEditor key={i} {...defaults} title={`t${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 20 body input events fire handler 20 times', () => {
+    const onInput = vi.fn();
+    const { container } = render(<ProposalEditor {...defaults} onBodyInput={onInput} />);
+    const textarea = container.querySelector('textarea')!;
+    for (let i = 0; i < 20; i++) fireEvent.input(textarea, { target: { value: `v${i}` } });
+    expect(onInput).toHaveBeenCalledTimes(20);
+  });
+
+  it('isCandidate=true preserves Candidate label', () => {
+    const { container } = render(<ProposalEditor {...defaults} isCandidate={true} />);
+    expect(container.textContent).toContain('Candidate');
+  });
+
+  it('rerender from Candidate to Proposal switches label', () => {
+    const { container, rerender } = render(<ProposalEditor {...defaults} isCandidate={true} />);
+    expect(container.textContent).toContain('Candidate');
+    rerender(<ProposalEditor {...defaults} isCandidate={false} />);
+    expect(container.textContent).toContain('Proposal');
+  });
+
+  it('renders single input + textarea element type', () => {
+    const { container } = render(<ProposalEditor {...defaults} />);
+    expect(container.querySelectorAll('input').length).toBe(1);
+    expect(container.querySelectorAll('textarea').length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
part 219 で components 配下 4 file (ModalSubtitle / ModalTitle / NavDropdown / ProposalEditor) に edge case TC 追加。 4672 → 4692 (+20)。

Closes #769

## Test plan
- [x] vitest 全 pass (4692 TC)
- [x] lint pass