### PR TITLE
✅ test(niji-webapp): part 223 (components 4 file) で 4753 → 4773

### DIFF
--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
@@ -394,4 +394,64 @@ describe('ByLineHoverCard', () => {
     });
     expect(() => rerender(<ByLineHoverCard proposerAddress="0xA" />)).not.toThrow();
   });
+
+  it('renders 20 instances each with own proposerAddress', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <ByLineHoverCard key={i} proposerAddress={`0x${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders consecutive 5 times', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    for (let i = 0; i < 5; i++) {
+      expect(() => render(<ByLineHoverCard proposerAddress="0xA" />)).not.toThrow();
+    }
+  });
+
+  it('data with 1 delegate + 50 nijis', () => {
+    const nijiList = Array.from({ length: 50 }, (_, i) => ({ id: String(i + 1) }));
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: nijiList }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-50');
+  });
+
+  it('rerender from error to success state', () => {
+    useSubgraphQueryMock.mockReturnValueOnce({
+      data: undefined,
+      loading: false,
+      error: new Error('boom'),
+    });
+    const { container, rerender } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.textContent).toContain('Error');
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      loading: false,
+      error: undefined,
+    });
+    rerender(<ByLineHoverCard proposerAddress="0xA" />);
+    expect(container.querySelector('[data-testid="stacked"]')).not.toBeNull();
+  });
+
+  it('consistent ShortAddress text across rerenders', () => {
+    useSubgraphQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xAAA', nijiRepresented: [{ id: '1' }] }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container, rerender } = render(<ByLineHoverCard proposerAddress="0xAAA" />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xAAA');
+    rerender(<ByLineHoverCard proposerAddress="0xAAA" />);
+    expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0xAAA');
+  });
 });

--- a/packages/niji-webapp/src/components/CreateProposalButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateProposalButton/index.test.tsx
@@ -552,4 +552,107 @@ describe('CreateProposalButton', () => {
     );
     expect(container.textContent).toContain('Create Proposal');
   });
+
+  it('renders 20 instances each independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <CreateProposalButton
+            key={i}
+            isLoading={false}
+            hasActiveOrPendingProposal={false}
+            hasEnoughVote={true}
+            isFormInvalid={false}
+            handleCreateProposal={() => {}}
+          />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('button').length).toBe(20);
+  });
+
+  it('rapid 50 clicks invoke handler 50 times', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    for (let i = 0; i < 50; i++) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(50);
+  });
+
+  it('handles all 4 flag combinations', () => {
+    const flags = [true, false];
+    flags.forEach(isLoading => {
+      flags.forEach(hasActive => {
+        flags.forEach(hasEnough => {
+          flags.forEach(isFormInvalid => {
+            expect(() =>
+              render(
+                <CreateProposalButton
+                  isLoading={isLoading}
+                  hasActiveOrPendingProposal={hasActive}
+                  hasEnoughVote={hasEnough}
+                  isFormInvalid={isFormInvalid}
+                  handleCreateProposal={() => {}}
+                />,
+              ),
+            ).not.toThrow();
+          });
+        });
+      });
+    });
+  });
+
+  it('rerender all flags toggles', () => {
+    const { rerender } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(() =>
+      rerender(
+        <CreateProposalButton
+          isLoading={true}
+          hasActiveOrPendingProposal={true}
+          hasEnoughVote={false}
+          isFormInvalid={true}
+          handleCreateProposal={() => {}}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('consistent button count across rerenders', () => {
+    const { container, rerender } = render(
+      <CreateProposalButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(1);
+    rerender(
+      <CreateProposalButton
+        isLoading={true}
+        hasActiveOrPendingProposal={false}
+        hasEnoughVote={true}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelectorAll('button').length).toBe(1);
+  });
 });

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -495,4 +495,81 @@ describe('DelegateHoverCard', () => {
       render(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={-1n} />),
     ).not.toThrow();
   });
+
+  it('renders 10 instances independently', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <DelegateHoverCard
+              key={i}
+              delegateId={`delegate-0x${i}`}
+              proposalCreationBlock={BigInt(i + 1)}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 50 nijis without crash', () => {
+    const nijiList = Array.from({ length: 50 }, (_, i) => ({ id: String(i + 1) }));
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: nijiList }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-50');
+  });
+
+  it('rerender from error to success', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValueOnce({
+      data: undefined,
+      loading: false,
+      error: new Error('boom'),
+    });
+    const { rerender } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      loading: false,
+      error: undefined,
+    });
+    expect(() =>
+      rerender(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />),
+    ).not.toThrow();
+  });
+
+  it('handles consecutive 5 renders without crash', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    for (let i = 0; i < 5; i++) {
+      expect(() =>
+        render(<DelegateHoverCard delegateId={`delegate-0x${i}`} proposalCreationBlock={1n} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles empty delegateId string', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(<DelegateHoverCard delegateId="" proposalCreationBlock={1n} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/Documentation/index.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/index.test.tsx
@@ -299,4 +299,37 @@ describe('Documentation', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders Documentation 50 times consecutively', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(() => render(<Documentation />)).not.toThrow();
+    }
+  });
+
+  it('renders 30 instances together', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <Documentation key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('contains exactly 1 about-section per instance', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelectorAll('[data-testid="about-section"]').length).toBe(1);
+  });
+
+  it('contains exactly 1 art-section per instance', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelectorAll('[data-testid="art-section"]').length).toBe(1);
+  });
+
+  it('contains exactly 1 gov-section per instance', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelectorAll('[data-testid="gov-section"]').length).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
part 223 で components 配下 4 file (ByLineHoverCard / CreateProposalButton / DelegateHoverCard / Documentation) に edge case TC 追加。 4753 → 4773 (+20)。

Closes #777

## Test plan
- [x] vitest 全 pass (4773 TC)
- [x] lint pass