### PR TITLE
✅ test(niji-webapp): part 224 (components 4 file) で 4773 → 4793

### DIFF
--- a/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
@@ -260,4 +260,38 @@ describe('GrayCircle', () => {
     rerender(<GrayCircle isDelegateView={true} />);
     expect(container.querySelector('img')?.getAttribute('src')).toBe(initial);
   });
+
+  it('GrayCircle renders 100 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <GrayCircle key={i} isDelegateView={i % 2 === 0} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(100);
+  });
+
+  it('rerender preserves img alt across isDelegateView toggle', () => {
+    const { container, rerender } = render(<GrayCircle />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('');
+    rerender(<GrayCircle isDelegateView={true} />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('');
+  });
+
+  it('isDelegateView=true wraps img in className with content', () => {
+    const { container } = render(<GrayCircle isDelegateView={true} />);
+    expect(container.querySelector('div')?.className).toBeTruthy();
+  });
+
+  it('isDelegateView=undefined defaults to non-delegate', () => {
+    const { container } = render(<GrayCircle isDelegateView={undefined} />);
+    expect(container.querySelector('div')?.className).toBe('');
+  });
+
+  it('renders without crash 30 times consecutively', () => {
+    for (let i = 0; i < 30; i++) {
+      expect(() => render(<GrayCircle />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
@@ -248,4 +248,38 @@ describe('HorizontalStackedNijis', () => {
     const { container } = render(<HorizontalStackedNijis nounIds={['42', '100', '200']} />);
     expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(3);
   });
+
+  it('handles 50 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <HorizontalStackedNijis key={i} nounIds={[`${i}`]} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(50);
+  });
+
+  it('handles 0 IDs renders empty (no circles)', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={[]} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(0);
+  });
+
+  it('handles 2 IDs renders 2 circles', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={['1', '2']} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(2);
+  });
+
+  it('rerender from 1 to 5 IDs increases circles', () => {
+    const { container, rerender } = render(<HorizontalStackedNijis nounIds={['1']} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(1);
+    rerender(<HorizontalStackedNijis nounIds={['1', '2', '3', '4', '5']} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(5);
+  });
+
+  it('handles "9999" max IDs caps at 6', () => {
+    const ids = Array.from({ length: 9999 }, (_, i) => String(i + 1));
+    const { container } = render(<HorizontalStackedNijis nounIds={ids} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(6);
+  });
 });

--- a/packages/niji-webapp/src/components/MinBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/MinBid/index.test.tsx
@@ -247,4 +247,41 @@ describe('MinBid', () => {
     rerender(<MinBid minBid={parseEther('5')} onClick={() => {}} />);
     expect(container.querySelector('img')).not.toBeNull();
   });
+
+  it('renders 20 MinBid instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 20 }, (_, i) => (
+          <MinBid key={i} minBid={parseEther(`${i + 1}`)} onClick={vi.fn()} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(20);
+  });
+
+  it('renders for boundary 1 wei (smallest positive)', () => {
+    const { container } = render(<MinBid minBid={1n} onClick={() => {}} />);
+    expect(container.textContent).toContain('Ξ');
+  });
+
+  it('rerender from 0n to fractional ETH', () => {
+    const { container, rerender } = render(<MinBid minBid={0n} onClick={() => {}} />);
+    expect(container.textContent).not.toContain('Ξ 0.50');
+    rerender(<MinBid minBid={parseEther('0.5')} onClick={() => {}} />);
+    expect(container.textContent).toContain('Ξ 0.50');
+  });
+
+  it('img alt attribute consistent across renders', () => {
+    const { container, rerender } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    const alt1 = container.querySelector('img')?.getAttribute('alt');
+    rerender(<MinBid minBid={parseEther('5')} onClick={() => {}} />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe(alt1);
+  });
+
+  it('h3 element preserved across rerenders', () => {
+    const { container, rerender } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    expect(container.querySelector('h3')).not.toBeNull();
+    rerender(<MinBid minBid={parseEther('100')} onClick={() => {}} />);
+    expect(container.querySelector('h3')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
@@ -246,4 +246,42 @@ describe('ModalLabel', () => {
     expect(container.querySelector('div')?.textContent).toContain('inner');
     expect(container.querySelector('div')?.textContent).toContain('suffix');
   });
+
+  it('renders 50 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <ModalLabel key={i}>{`label-${i}`}</ModalLabel>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(50);
+  });
+
+  it('renders array children', () => {
+    const { container } = render(<ModalLabel>{['a', 'b']}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('ab');
+  });
+
+  it('renders 1000 char long content', () => {
+    const longStr = 'x'.repeat(1000);
+    const { container } = render(<ModalLabel>{longStr}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe(longStr);
+  });
+
+  it('rerender preserves div wrapper element', () => {
+    const { container, rerender } = render(<ModalLabel>x</ModalLabel>);
+    expect(container.children.length).toBe(1);
+    rerender(<ModalLabel>y</ModalLabel>);
+    expect(container.children.length).toBe(1);
+  });
+
+  it('renders unicode label across 5 rerenders', () => {
+    const { container, rerender } = render(<ModalLabel>{'絵文字'}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent).toBe('絵文字');
+    for (let i = 0; i < 5; i++) {
+      rerender(<ModalLabel>{`item-${i}-日本語`}</ModalLabel>);
+      expect(container.querySelector('div')?.textContent).toBe(`item-${i}-日本語`);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 224 で components 配下 4 file (GrayCircle / HorizontalStackedNijis / MinBid / ModalLabel) に edge case TC 追加。 4773 → 4793 (+20)。

Closes #779

## Test plan
- [x] vitest 全 pass (4793 TC)
- [x] lint pass