### PR TITLE
✅ test(niji-webapp): part 226 (components 4 file) で 4813 → 4833

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -430,4 +430,60 @@ describe('AuctionActivity', () => {
       wrap(<AuctionActivity {...defaults} auction={makeAuction({ nounId: 1000000n }) as never} />),
     ).not.toThrow();
   });
+
+  it('renders AuctionActivity 30 times consecutively', () => {
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('renders 10 AuctionActivity instances in single wrap', () => {
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <AuctionActivity
+              key={i}
+              {...defaults}
+              auction={makeAuction({ nounId: BigInt(i + 1) }) as never}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders without crash with displayGraphDepComps=false + isLastAuction=false', () => {
+    expect(() =>
+      wrap(
+        <AuctionActivity
+          {...defaults}
+          displayGraphDepComps={false}
+          isLastAuction={false}
+          auction={makeAuction() as never}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders with 0n nounId auction', () => {
+    expect(() =>
+      wrap(<AuctionActivity {...defaults} auction={makeAuction({ nounId: 0n }) as never} />),
+    ).not.toThrow();
+  });
+
+  it('renders without crash for ended + first + last all true', () => {
+    expect(() =>
+      wrap(
+        <AuctionActivity
+          {...defaults}
+          isFirstAuction={true}
+          isLastAuction={true}
+          auction={makeAuction({ endTime: 1n }) as never}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -280,4 +280,46 @@ describe('AuctionActivityDateHeadline', () => {
     const { rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
     expect(() => rerender(<AuctionActivityDateHeadline startTime={0n} />)).not.toThrow();
   });
+
+  it('renders 50 instances independently', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const baseTime = 1735689600n;
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={baseTime + BigInt(i * 86400)} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h4').length).toBe(50);
+  });
+
+  it('handles startTime 1n (very early epoch)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() => render(<AuctionActivityDateHeadline startTime={1n} />)).not.toThrow();
+  });
+
+  it('rerender preserves h4 element', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')).not.toBeNull();
+    rerender(<AuctionActivityDateHeadline startTime={1893456000n} />);
+    expect(container.querySelector('h4')).not.toBeNull();
+  });
+
+  it('renders consistent h4 element count (=1) across rerenders', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelectorAll('h4').length).toBe(1);
+    rerender(<AuctionActivityDateHeadline startTime={1893456000n} />);
+    expect(container.querySelectorAll('h4').length).toBe(1);
+  });
+
+  it('renders 5 different time eras consecutively', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const eras = [1n, 1000n, 1735689600n, 4102444800n, 9007199254740991n];
+    eras.forEach(time => {
+      expect(() => render(<AuctionActivityDateHeadline startTime={time} />)).not.toThrow();
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -244,4 +244,40 @@ describe('AuctionActivityNijiTitle', () => {
       expect(container.querySelector('h1')?.textContent).toContain('Niji');
     }
   });
+
+  it('renders 50 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i + 1)} isCool={i % 2 === 0} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(50);
+  });
+
+  it('renders for 0n + isCool=true', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={0n} isCool={true} />);
+    expect(container.querySelector('h1')?.textContent).toContain('0');
+  });
+
+  it('renders for 0n + isCool=false', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={0n} isCool={false} />);
+    expect(container.querySelector('h1')?.textContent).toContain('0');
+  });
+
+  it('renders consistent style across rerenders with same isCool', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    const style1 = container.querySelector('h1')?.getAttribute('style');
+    rerender(<AuctionActivityNijiTitle nounId={2n} isCool={true} />);
+    expect(container.querySelector('h1')?.getAttribute('style')).toBe(style1);
+  });
+
+  it('renders 5 consecutive renders without crash', () => {
+    for (let i = 0; i < 5; i++) {
+      expect(() =>
+        render(<AuctionActivityNijiTitle nounId={BigInt(i)} isCool={i % 2 === 0} />),
+      ).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/TightStackedCircleNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/TightStackedCircleNijis/index.test.tsx
@@ -245,4 +245,37 @@ describe('TightStackedCircleNijis', () => {
     const ids = Array.from({ length: 50 }, (_, i) => i);
     expect(() => render(<TightStackedCircleNijis nounIds={ids} />)).not.toThrow();
   });
+
+  it('renders 30 TightStackedCircleNijis independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <TightStackedCircleNijis key={i} nounIds={[i, i + 1, i + 2]} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('svg').length).toBe(30);
+  });
+
+  it('handles 0 ids renders 0 circles', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[]} />);
+    expect(container.querySelectorAll('circle').length).toBe(0);
+  });
+
+  it('handles only 1 id renders 1 circle', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[42]} />);
+    expect(container.querySelectorAll('circle').length).toBe(1);
+  });
+
+  it('cap at 3 for 3+ ids (boundary)', () => {
+    const { container } = render(<TightStackedCircleNijis nounIds={[1, 2, 3]} />);
+    expect(container.querySelectorAll('circle').length).toBe(3);
+  });
+
+  it('rerender from empty to 3 ids increases circles', () => {
+    const { container, rerender } = render(<TightStackedCircleNijis nounIds={[]} />);
+    expect(container.querySelectorAll('circle').length).toBe(0);
+    rerender(<TightStackedCircleNijis nounIds={[10, 20, 30]} />);
+    expect(container.querySelectorAll('circle').length).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
part 226 で components 配下 4 file (TightStackedCircleNijis / AuctionActivity / AuctionActivityDateHeadline / AuctionActivityNijiTitle) に edge case TC 追加。 4813 → 4833 (+20)。

Closes #783

## Test plan
- [x] vitest 全 pass (4833 TC)
- [x] lint pass