### PR TITLE
✅ test(niji-webapp): part 229 (components 4 file) で 4873 → 4893

### DIFF
--- a/packages/niji-webapp/src/components/CandidateCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateCard/index.test.tsx
@@ -298,4 +298,54 @@ describe('CandidateCard', () => {
       ).not.toThrow();
     }
   });
+
+  it('renders 30 instances each independently', () => {
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <CandidateCard
+              key={i}
+              candidate={{ ...baseCandidate, id: `c-${i}` } as never}
+              nounsRequired={i}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles candidate with proposerVotes=999999', () => {
+    const c = { ...baseCandidate, proposerVotes: 999999 } as never;
+    expect(() => wrap(<CandidateCard candidate={c} nounsRequired={3} />)).not.toThrow();
+  });
+
+  it('handles candidate without title', () => {
+    const c = {
+      ...baseCandidate,
+      version: { content: { title: '', contentSignatures: [] } },
+    } as never;
+    expect(() => wrap(<CandidateCard candidate={c} nounsRequired={3} />)).not.toThrow();
+  });
+
+  it('multiple instances in single wrap renders distinct links', () => {
+    const c1 = { ...baseCandidate, id: 'unique-1' } as never;
+    const c2 = { ...baseCandidate, id: 'unique-2' } as never;
+    const { container } = wrap(
+      <>
+        <CandidateCard candidate={c1} nounsRequired={2} />
+        <CandidateCard candidate={c2} nounsRequired={2} />
+      </>,
+    );
+    expect(container.querySelectorAll('a').length).toBe(2);
+  });
+
+  it('renders 1 anchor per instance consistently', () => {
+    for (let i = 0; i < 5; i++) {
+      const { container } = wrap(
+        <CandidateCard candidate={{ ...baseCandidate, id: `c-${i}` } as never} nounsRequired={i} />,
+      );
+      expect(container.querySelectorAll('a').length).toBe(1);
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/CreateCandidateButton/index.test.tsx
@@ -563,4 +563,90 @@ describe('CreateCandidateButton', () => {
     );
     expect(container.textContent).toContain('Create proposal candidate');
   });
+
+  it('renders 30 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <CreateCandidateButton
+            key={i}
+            isLoading={false}
+            hasActiveOrPendingProposal={false}
+            isFormInvalid={false}
+            handleCreateProposal={() => {}}
+          />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('button').length).toBe(30);
+  });
+
+  it('rapid 50 clicks fire 50 times', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={handle}
+      />,
+    );
+    const btn = container.querySelector('button')!;
+    for (let i = 0; i < 50; i++) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(50);
+  });
+
+  it('all 8 flag combinations render without crash', () => {
+    const flags = [true, false];
+    flags.forEach(isLoading => {
+      flags.forEach(hasActive => {
+        flags.forEach(isFormInvalid => {
+          expect(() =>
+            render(
+              <CreateCandidateButton
+                isLoading={isLoading}
+                hasActiveOrPendingProposal={hasActive}
+                isFormInvalid={isFormInvalid}
+                handleCreateProposal={() => {}}
+              />,
+            ),
+          ).not.toThrow();
+        });
+      });
+    });
+  });
+
+  it('renders consistent text across 10 rerenders', () => {
+    const { container, rerender } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    for (let i = 0; i < 10; i++) {
+      rerender(
+        <CreateCandidateButton
+          isLoading={false}
+          hasActiveOrPendingProposal={false}
+          isFormInvalid={false}
+          handleCreateProposal={() => {}}
+        />,
+      );
+      expect(container.textContent).toContain('Create proposal candidate');
+    }
+  });
+
+  it('renders without spinner when isLoading=false', () => {
+    const { container } = render(
+      <CreateCandidateButton
+        isLoading={false}
+        hasActiveOrPendingProposal={false}
+        isFormInvalid={false}
+        handleCreateProposal={() => {}}
+      />,
+    );
+    expect(container.querySelector('.spinner-border')).toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/CurrentBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/CurrentBid/index.test.tsx
@@ -313,4 +313,52 @@ describe('CurrentBid', () => {
     rerender(<CurrentBid currentBid={parseEther('5')} auctionEnded={false} />);
     expect(container.textContent).toContain('Current bid');
   });
+
+  it('renders 30 instances each independently', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <CurrentBid key={i} currentBid={parseEther(`${i + 1}`)} auctionEnded={false} />
+        ))}
+      </>,
+    );
+    expect(container.children.length).toBe(30);
+  });
+
+  it('rerender all states preserves text class', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(
+      <CurrentBid currentBid={parseEther('1')} auctionEnded={false} />,
+    );
+    expect(container.textContent).toContain('Current bid');
+    rerender(<CurrentBid currentBid={parseEther('1')} auctionEnded={true} />);
+    expect(container.textContent).toContain('Winning bid');
+    rerender(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />);
+    expect(container.textContent).toContain('Current bid');
+  });
+
+  it('renders huge bid (1M ETH) preserves "bid" text', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <CurrentBid currentBid={parseEther('1000000')} auctionEnded={false} />,
+    );
+    expect(container.textContent).toContain('Current bid');
+  });
+
+  it('renders for very small fractional 0.00001 ETH', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(<CurrentBid currentBid={parseEther('0.00001')} auctionEnded={false} />),
+    ).not.toThrow();
+  });
+
+  it('cool variant + warm variant rerender does not crash', () => {
+    useAtomValueMock.mockReturnValueOnce(true);
+    const { rerender } = render(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />);
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      rerender(<CurrentBid currentBid={parseEther('1')} auctionEnded={false} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/CurrentDelegatePannel/index.test.tsx
+++ b/packages/niji-webapp/src/components/CurrentDelegatePannel/index.test.tsx
@@ -444,4 +444,80 @@ describe('CurrentDelegatePannel', () => {
     );
     expect(container.querySelector('[data-testid="short"]')?.textContent).toBe('0x');
   });
+
+  it('renders 30 instances each independently', () => {
+    useAccountMock.mockReturnValue({ address: '0xA' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: '0xDELEG' });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <CurrentDelegatePannel
+              key={i}
+              onPrimaryBtnClick={() => {}}
+              onSecondaryBtnClick={() => {}}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender all combinations of account/delegate', () => {
+    const cases = [
+      { addr: '0xA', delegate: '0xDELEG' },
+      { addr: '0xA', delegate: undefined },
+      { addr: undefined, delegate: undefined },
+      { addr: '0xB', delegate: '0xDELEG2' },
+    ];
+    useAccountMock.mockReturnValue({ address: cases[0].addr });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: cases[0].delegate });
+    const { rerender } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+    );
+    cases.slice(1).forEach(c => {
+      useAccountMock.mockReturnValue({ address: c.addr });
+      useReadNijiTokenDelegatesMock.mockReturnValue({ data: c.delegate });
+      expect(() =>
+        rerender(
+          <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  it('rapid 30 close button clicks invoke handler 30 times', () => {
+    useAccountMock.mockReturnValue({ address: '0xA' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const onSec = vi.fn();
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={onSec} />,
+    );
+    const buttons = container.querySelectorAll('button');
+    for (let i = 0; i < 30; i++) fireEvent.click(buttons[0]);
+    expect(onSec).toHaveBeenCalledTimes(30);
+  });
+
+  it('rapid 30 primary clicks invoke handler 30 times', () => {
+    useAccountMock.mockReturnValue({ address: '0xA' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: undefined });
+    const onPri = vi.fn();
+    const { container } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={onPri} onSecondaryBtnClick={() => {}} />,
+    );
+    const buttons = container.querySelectorAll('button');
+    for (let i = 0; i < 30; i++) fireEvent.click(buttons[1]);
+    expect(onPri).toHaveBeenCalledTimes(30);
+  });
+
+  it('h1 title element preserved across rerenders', () => {
+    useAccountMock.mockReturnValue({ address: '0xA' });
+    useReadNijiTokenDelegatesMock.mockReturnValue({ data: '0xDELEG' });
+    const { container, rerender } = render(
+      <CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />,
+    );
+    expect(container.querySelector('h1')).not.toBeNull();
+    rerender(<CurrentDelegatePannel onPrimaryBtnClick={() => {}} onSecondaryBtnClick={() => {}} />);
+    expect(container.querySelector('h1')).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
part 229 で components 配下 4 file (CandidateCard / CreateCandidateButton / CurrentBid / CurrentDelegatePannel) に edge case TC 追加。 4873 → 4893 (+20)。

Closes #789

## Test plan
- [x] vitest 全 pass (4893 TC)
- [x] lint pass