### PR TITLE
✅ test(niji-webapp): part 231 (components 4 file) で 4913 → 4933

### DIFF
--- a/packages/niji-webapp/src/components/BrandDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandDropdown/index.test.tsx
@@ -457,4 +457,70 @@ describe('BrandDropdown', () => {
     );
     expect((container.querySelector('select') as HTMLSelectElement)?.value).toBe('b');
   });
+
+  it('renders 30 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <BrandDropdown key={i} onChange={() => {}} value="a">
+            {opts}
+          </BrandDropdown>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('select').length).toBe(30);
+  });
+
+  it('rapid 50 change events fire 50 times', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <BrandDropdown onChange={onChange} value="a">
+        {opts}
+      </BrandDropdown>,
+    );
+    const select = container.querySelector('select') as HTMLSelectElement;
+    for (let i = 0; i < 50; i++) {
+      fireEvent.change(select, { target: { value: i % 2 === 0 ? 'a' : 'b' } });
+    }
+    expect(onChange).toHaveBeenCalledTimes(50);
+  });
+
+  it('renders 100 char long label', () => {
+    const long = 'x'.repeat(100);
+    const { container } = render(
+      <BrandDropdown onChange={() => {}} value="a" label={long}>
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelector('span')?.textContent).toBe(long);
+  });
+
+  it('renders with many child options (20)', () => {
+    const manyOpts = Array.from({ length: 20 }, (_, i) => (
+      <option key={i} value={`opt-${i}`}>
+        Option {i}
+      </option>
+    ));
+    const { container } = render(
+      <BrandDropdown onChange={() => {}} value="opt-0">
+        {manyOpts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelectorAll('option').length).toBe(20);
+  });
+
+  it('rerender preserves select element type', () => {
+    const { container, rerender } = render(
+      <BrandDropdown onChange={() => {}} value="a">
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelector('select')).not.toBeNull();
+    rerender(
+      <BrandDropdown onChange={() => {}} value="b">
+        {opts}
+      </BrandDropdown>,
+    );
+    expect(container.querySelector('select')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/CandidateSponsors/index.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.test.tsx
@@ -432,4 +432,42 @@ describe('CandidateSponsors', () => {
       expect(() => render(<CandidateSponsors {...baseProps} />)).not.toThrow();
     }
   });
+
+  it('renders 30 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <CandidateSponsors key={i} {...baseProps} blockNumber={BigInt(i + 1)} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles requiredVotes=0 + voteCount=0', () => {
+    const c = makeCandidate({ requiredVotes: 0, voteCount: 0 });
+    expect(() => render(<CandidateSponsors {...baseProps} candidate={c} />)).not.toThrow();
+  });
+
+  it('handles 100 contentSignatures', () => {
+    const sigs = Array.from({ length: 100 }, (_, i) => ({ id: `sig-${i}` }));
+    const c = makeCandidate({ contentSignatures: sigs as never });
+    expect(() => render(<CandidateSponsors {...baseProps} candidate={c} />)).not.toThrow();
+  });
+
+  it('rerender does not crash 10 times', () => {
+    const { rerender } = render(<CandidateSponsors {...baseProps} />);
+    for (let i = 0; i < 10; i++) {
+      expect(() =>
+        rerender(<CandidateSponsors {...baseProps} blockNumber={BigInt(i)} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles isAccountSigner true variant', () => {
+    hookState.isAccountSigner = true;
+    expect(() => render(<CandidateSponsors {...baseProps} />)).not.toThrow();
+    hookState.isAccountSigner = false;
+  });
 });

--- a/packages/niji-webapp/src/components/EditProposalButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/EditProposalButton/index.test.tsx
@@ -300,4 +300,52 @@ describe('EditProposalButton', () => {
     rerender(<EditProposalButton {...defaults} isFormInvalid={false} />);
     expect(container.querySelector('button')?.disabled).toBe(false);
   });
+
+  it('renders 30 instances each independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <EditProposalButton key={i} {...defaults} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('button').length).toBe(30);
+  });
+
+  it('threshold=999 with no enough votes shows "1000 votes"', () => {
+    const { container } = render(
+      <EditProposalButton {...defaults} hasEnoughVote={false} proposalThreshold={999} />,
+    );
+    expect(container.textContent).toContain('1000 votes to submit a proposal');
+  });
+
+  it('isCandidate=true + threshold=5 shows "6 votes"', () => {
+    const { container } = render(
+      <EditProposalButton
+        {...defaults}
+        isCandidate={true}
+        hasEnoughVote={false}
+        proposalThreshold={5}
+      />,
+    );
+    expect(container.textContent).toContain('6 votes to submit a proposal');
+  });
+
+  it('renders consistent button element across 20 rerenders', () => {
+    const { container, rerender } = render(<EditProposalButton {...defaults} />);
+    for (let i = 0; i < 20; i++) {
+      rerender(<EditProposalButton {...defaults} />);
+      expect(container.querySelector('button')).not.toBeNull();
+    }
+  });
+
+  it('rapid 100 clicks invoke handler 100 times', () => {
+    const handle = vi.fn();
+    const { container } = render(
+      <EditProposalButton {...defaults} handleCreateProposal={handle} />,
+    );
+    const btn = container.querySelector('button')!;
+    for (let i = 0; i < 100; i++) fireEvent.click(btn);
+    expect(handle).toHaveBeenCalledTimes(100);
+  });
 });

--- a/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
+++ b/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
@@ -329,4 +329,53 @@ describe('EnsOrLongAddress', () => {
     rerender(<EnsOrLongAddress address={addr2} />);
     expect(container.textContent).toBe(addr2);
   });
+
+  it('renders 30 instances each independently', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('alice.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(
+      <>
+        {Array.from({ length: 30 }, (_, i) => (
+          <EnsOrLongAddress key={i} address={ADDR} />
+        ))}
+      </>,
+    );
+    expect(container.textContent).toBe('alice.eth'.repeat(30));
+  });
+
+  it('handles 200 char long ENS name', () => {
+    const longName = 'x'.repeat(200) + '.eth';
+    vi.mocked(useReverseENSLookUp).mockReturnValue(longName);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(longName);
+  });
+
+  it('rerender ENS from defined to undefined fallback to address', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValueOnce('alice.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container, rerender } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe('alice.eth');
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    rerender(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+  });
+
+  it('rerender containsBlockedText from false to true falls back to address', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('name.eth');
+    vi.mocked(containsBlockedText).mockReturnValueOnce(false);
+    const { container, rerender } = render(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe('name.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(true);
+    rerender(<EnsOrLongAddress address={ADDR} />);
+    expect(container.textContent).toBe(ADDR);
+  });
+
+  it('handles 100 consecutive renders without crash', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('alice.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    for (let i = 0; i < 100; i++) {
+      expect(() => render(<EnsOrLongAddress address={ADDR} />)).not.toThrow();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 231 で components 配下 4 file (BrandDropdown / CandidateSponsors / EditProposalButton / EnsOrLongAddress) に edge case TC 追加。 4913 → 4933 (+20)。

Closes #793

## Test plan
- [x] vitest 全 pass (4933 TC)
- [x] lint pass