### PR TITLE
✅ test(niji-webapp): part 232 (components 4 file) で 4933 → 4953

### DIFF
--- a/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/LanguageSelectionModal/index.test.tsx
@@ -358,4 +358,64 @@ describe('LanguageSelectionModal', () => {
     render(<LanguageSelectionModal onDismiss={() => {}} />);
     expect(document.getElementById('overlay-root')?.children.length).toBeGreaterThanOrEqual(1);
   });
+
+  it('renders 20 instances each independently', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <LanguageSelectionModal key={i} onDismiss={() => {}} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 50 onDismiss clicks via Japanese button', () => {
+    const setLocale = vi.fn();
+    const onDismiss = vi.fn();
+    useAtomMock.mockReturnValue(['en-US', setLocale]);
+    render(<LanguageSelectionModal onDismiss={onDismiss} />);
+    const buttons = document.getElementById('overlay-root')?.querySelectorAll('div');
+    const jaBtn = Array.from(buttons ?? []).find(d => d.textContent === '日本語');
+    if (jaBtn) {
+      for (let i = 0; i < 50; i++) fireEvent.click(jaBtn);
+    }
+    expect(setLocale).toHaveBeenCalledTimes(50);
+    expect(onDismiss).toHaveBeenCalledTimes(50);
+  });
+
+  it('handles all 3 locales each fires setLocale 1 time', () => {
+    const setLocale = vi.fn();
+    useAtomMock.mockReturnValue(['en-US', setLocale]);
+    render(<LanguageSelectionModal onDismiss={() => {}} />);
+    const buttons = document.getElementById('overlay-root')?.querySelectorAll('div');
+    ['日本語', 'English', '中文'].forEach(label => {
+      const btn = Array.from(buttons ?? []).find(d => d.textContent === label);
+      if (btn) fireEvent.click(btn);
+    });
+    expect(setLocale).toHaveBeenCalledTimes(3);
+  });
+
+  it('rerender 10 times preserves modal portal', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { rerender } = render(<LanguageSelectionModal onDismiss={() => {}} />);
+    for (let i = 0; i < 10; i++) {
+      expect(() => rerender(<LanguageSelectionModal onDismiss={() => {}} />)).not.toThrow();
+    }
+  });
+
+  it('renders consistent h3 title across locale changes', () => {
+    useAtomMock.mockReturnValue(['en-US', vi.fn()]);
+    const { rerender } = render(<LanguageSelectionModal onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.querySelector('h3')?.textContent).toBe(
+      'Select Language',
+    );
+    useAtomMock.mockReturnValue(['ja-JP', vi.fn()]);
+    rerender(<LanguageSelectionModal onDismiss={() => {}} />);
+    expect(document.getElementById('overlay-root')?.querySelector('h3')?.textContent).toBe(
+      'Select Language',
+    );
+  });
 });

--- a/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalSubtitle/index.test.tsx
@@ -277,4 +277,52 @@ describe('ModalSubtitle', () => {
     );
     expect(container.children.length).toBe(1);
   });
+
+  it('renders 100 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <ModalSubtitle key={i}>{`sub-${i}`}</ModalSubtitle>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('div').length).toBe(100);
+  });
+
+  it('handles deeply nested children (5 levels)', () => {
+    const { container } = render(
+      <ModalSubtitle>
+        <span>
+          <strong>
+            <em>
+              <small>
+                <i data-testid="deep">5</i>
+              </small>
+            </em>
+          </strong>
+        </span>
+      </ModalSubtitle>,
+    );
+    expect(container.querySelector('[data-testid="deep"]')?.textContent).toBe('5');
+  });
+
+  it('renders 5000 char long text', () => {
+    const longStr = 'x'.repeat(5000);
+    const { container } = render(<ModalSubtitle>{longStr}</ModalSubtitle>);
+    expect(container.querySelector('div')?.textContent).toBe(longStr);
+  });
+
+  it('rerender preserves single div wrapper count', () => {
+    const { container, rerender } = render(<ModalSubtitle>a</ModalSubtitle>);
+    expect(container.children.length).toBe(1);
+    for (let i = 0; i < 10; i++) {
+      rerender(<ModalSubtitle>{`item-${i}`}</ModalSubtitle>);
+      expect(container.children.length).toBe(1);
+    }
+  });
+
+  it('handles Symbol value as React children (renders empty)', () => {
+    // Symbol は React で render 対象外、 crash しないことだけ確認
+    expect(() => render(<ModalSubtitle>{Symbol('x') as never}</ModalSubtitle>)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTitle/index.test.tsx
@@ -268,4 +268,50 @@ describe('ModalTitle', () => {
     );
     expect(container.querySelector('h1')).not.toBeNull();
   });
+
+  it('renders 100 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <ModalTitle key={i}>{`title-${i}`}</ModalTitle>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(100);
+  });
+
+  it('handles deeply nested children (5 levels)', () => {
+    const { container } = render(
+      <ModalTitle>
+        <span>
+          <strong>
+            <em>
+              <small>
+                <i data-testid="deep">5</i>
+              </small>
+            </em>
+          </strong>
+        </span>
+      </ModalTitle>,
+    );
+    expect(container.querySelector('h1 [data-testid="deep"]')?.textContent).toBe('5');
+  });
+
+  it('renders 5000 char long title', () => {
+    const longStr = 'x'.repeat(5000);
+    const { container } = render(<ModalTitle>{longStr}</ModalTitle>);
+    expect(container.querySelector('h1')?.textContent).toBe(longStr);
+  });
+
+  it('rerender preserves h1 element type 10 times', () => {
+    const { container, rerender } = render(<ModalTitle>a</ModalTitle>);
+    for (let i = 0; i < 10; i++) {
+      rerender(<ModalTitle>{`item-${i}`}</ModalTitle>);
+      expect(container.querySelector('h1')).not.toBeNull();
+    }
+  });
+
+  it('renders without crash with Symbol children', () => {
+    expect(() => render(<ModalTitle>{Symbol('x') as never}</ModalTitle>)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
@@ -452,4 +452,73 @@ describe('NavDropDown', () => {
     );
     expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe('A');
   });
+
+  it('renders 100 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <NavDropDown key={i} buttonText={`btn-${i}`}>
+            <span>x</span>
+          </NavDropDown>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="nav-button"]').length).toBe(100);
+  });
+
+  it('rerender 20 times preserves nav-button structure', () => {
+    const { container, rerender } = render(
+      <NavDropDown buttonText="initial">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    for (let i = 0; i < 20; i++) {
+      rerender(
+        <NavDropDown buttonText={`update-${i}`}>
+          <span>x</span>
+        </NavDropDown>,
+      );
+      expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(
+        `update-${i}`,
+      );
+    }
+  });
+
+  it('renders 500 char long buttonText', () => {
+    const long = 'a'.repeat(500);
+    const { container } = render(
+      <NavDropDown buttonText={long}>
+        <span>x</span>
+      </NavDropDown>,
+    );
+    expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(long);
+  });
+
+  it('renders within outer div parent', () => {
+    expect(() =>
+      render(
+        <div data-testid="parent">
+          <NavDropDown buttonText="X">
+            <span>x</span>
+          </NavDropDown>
+        </div>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders consistent dropdown wrapper across 10 rerenders', () => {
+    const { container, rerender } = render(
+      <NavDropDown buttonText="X">
+        <span>x</span>
+      </NavDropDown>,
+    );
+    for (let i = 0; i < 10; i++) {
+      rerender(
+        <NavDropDown buttonText={`item-${i}`}>
+          <span>x</span>
+        </NavDropDown>,
+      );
+      expect(container.querySelector('.dropdown')).not.toBeNull();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 232 で components 配下 4 file (LanguageSelectionModal / ModalSubtitle / ModalTitle / NavDropdown) に edge case TC 追加。 4933 → 4953 (+20)。

Closes #795

## Test plan
- [x] vitest 全 pass (4953 TC)
- [x] lint pass