### PR TITLE
✅ test(niji-webapp): part 234 (components 4 file) で 4973 → 4993

### DIFF
--- a/packages/niji-webapp/src/components/ChangeDelegatePanel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ChangeDelegatePanel/index.test.tsx
@@ -404,4 +404,52 @@ describe('ChangeDelegatePanel', () => {
     expect(() => render(<ChangeDelegatePanel onDismiss={vi.fn()} />)).not.toThrow();
     hookState.accountVotes = 5;
   });
+
+  it('renders 20 instances each independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <ChangeDelegatePanel key={i} onDismiss={vi.fn()} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 20 times preserves component', () => {
+    const { rerender } = render(<ChangeDelegatePanel onDismiss={vi.fn()} />);
+    for (let i = 0; i < 20; i++) {
+      expect(() => rerender(<ChangeDelegatePanel onDismiss={vi.fn()} />)).not.toThrow();
+    }
+  });
+
+  it('handles ensResolved variations', () => {
+    hookState.ensResolved = '0xABC123';
+    expect(() => render(<ChangeDelegatePanel onDismiss={vi.fn()} />)).not.toThrow();
+    hookState.ensResolved = undefined;
+    expect(() => render(<ChangeDelegatePanel onDismiss={vi.fn()} />)).not.toThrow();
+  });
+
+  it('handles all delegateState statuses', () => {
+    const statuses: DelegateStatus[] = [
+      'None',
+      'PendingSignature',
+      'Mining',
+      'Success',
+      'Fail',
+      'Exception',
+    ];
+    statuses.forEach(status => {
+      hookState.delegateState = { status };
+      expect(() => render(<ChangeDelegatePanel onDismiss={vi.fn()} />)).not.toThrow();
+    });
+    hookState.delegateState = { status: 'None' };
+  });
+
+  it('handles userDelegatee variations', () => {
+    hookState.userDelegatee = '0xDIFFERENT';
+    expect(() => render(<ChangeDelegatePanel onDismiss={vi.fn()} />)).not.toThrow();
+    hookState.userDelegatee = '0xOLD';
+  });
 });

--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
@@ -437,4 +437,60 @@ describe('DelegateGroupedNijiImageVoteTable', () => {
     );
     expect(container.querySelectorAll('td').length).toBe(12);
   });
+
+  it('renders 20 instances each independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <DelegateGroupedNijiImageVoteTable
+              key={i}
+              {...baseProps}
+              filteredDelegateGroupedVoteData={[makeVote(`0x${i}`, [String(i)])]}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 delegates renders 9 pages', () => {
+    const data = Array.from({ length: 100 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    expect(container.querySelector('[data-testid="num-pages"]')?.textContent).toBe('9');
+  });
+
+  it('rapid 10 right + 10 left clicks navigate pages', () => {
+    const data = Array.from({ length: 30 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    for (let i = 0; i < 2; i++) fireEvent.click(container.querySelector('[data-testid="right"]')!);
+    expect(container.querySelector('[data-testid="current-page"]')?.textContent).toBe('2');
+    for (let i = 0; i < 2; i++) fireEvent.click(container.querySelector('[data-testid="left"]')!);
+    expect(container.querySelector('[data-testid="current-page"]')?.textContent).toBe('0');
+  });
+
+  it('rerender with empty data returns to single page', () => {
+    const data = Array.from({ length: 30 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container, rerender } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    expect(container.querySelector('[data-testid="num-pages"]')?.textContent).toBe('3');
+    rerender(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={[]} />,
+    );
+    expect(container.querySelector('[data-testid="num-pages"]')?.textContent).toBe('1');
+  });
+
+  it('handles support type 0/1/2 mix', () => {
+    const data = [makeVote('0xA', ['1'], 0), makeVote('0xB', ['2'], 1), makeVote('0xC', ['3'], 2)];
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/Holder/index.test.tsx
+++ b/packages/niji-webapp/src/components/Holder/index.test.tsx
@@ -468,4 +468,58 @@ describe('Holder', () => {
     });
     expect(container.textContent).toBe('');
   });
+
+  it('renders 20 instances each independently', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({ loading: true, error: undefined, data: undefined });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <Holder key={i} nounId={BigInt(i)} />
+          ))}
+        </>,
+        { wrapper: WithProviders },
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 20 times preserves component', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({ loading: true, error: undefined, data: undefined });
+    const { rerender } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    for (let i = 0; i < 20; i++) {
+      expect(() => rerender(<Holder nounId={BigInt(i)} />)).not.toThrow();
+    }
+  });
+
+  it('handles 0xZERO_ADDRESS owner', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValue({
+      loading: false,
+      error: undefined,
+      data: { noun: { owner: { id: '0x0000000000000000000000000000000000000000' } } },
+    });
+    expect(() => render(<Holder nounId={1n} />, { wrapper: WithProviders })).not.toThrow();
+  });
+
+  it('rerender from data to loading state', () => {
+    useAtomValueMock.mockReturnValue(true);
+    useSubgraphQueryMock.mockReturnValueOnce({
+      loading: false,
+      error: undefined,
+      data: { noun: { owner: { id: '0xOWNER' } } },
+    });
+    const { rerender } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    useSubgraphQueryMock.mockReturnValue({ loading: true, error: undefined, data: undefined });
+    expect(() => rerender(<Holder nounId={1n} />)).not.toThrow();
+  });
+
+  it('useAtomValue cool/warm rerender variations', () => {
+    useAtomValueMock.mockReturnValueOnce(true);
+    useSubgraphQueryMock.mockReturnValue({ loading: true, error: undefined, data: undefined });
+    const { rerender } = render(<Holder nounId={1n} />, { wrapper: WithProviders });
+    useAtomValueMock.mockReturnValue(false);
+    expect(() => rerender(<Holder nounId={1n} />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
+++ b/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
@@ -278,4 +278,41 @@ describe('LegacyNoun — additional edge cases', () => {
     const longPath = '/' + 'a'.repeat(1000) + '.png';
     expect(() => render(<LegacyNoun imgPath={longPath} alt="x" />)).not.toThrow();
   });
+
+  it('LegacyNoun renders 100 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <LegacyNoun key={i} imgPath={`/img${i}.png`} alt={`alt-${i}`} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(100);
+  });
+
+  it('LegacyNoun rerender preserves img across imgPath changes', () => {
+    const { container, rerender } = render(<LegacyNoun imgPath="/x.png" alt="x" />);
+    expect(container.querySelector('img')).not.toBeNull();
+    for (let i = 0; i < 10; i++) {
+      rerender(<LegacyNoun imgPath={`/img${i}.png`} alt={`alt-${i}`} />);
+      expect(container.querySelector('img')).not.toBeNull();
+    }
+  });
+
+  it('LegacyNoun handles className + wrapperClassName both', () => {
+    const { container } = render(
+      <LegacyNoun imgPath="/x.png" alt="x" className="cls1" wrapperClassName="wrap1" />,
+    );
+    expect(container.querySelector('img')?.className).toContain('cls1');
+    expect(container.querySelector('div')?.className).toContain('wrap1');
+  });
+
+  it('LegacyNoun handles symbol-like imgPath', () => {
+    expect(() => render(<LegacyNoun imgPath="/<>&.png" alt="x" />)).not.toThrow();
+  });
+
+  it('LegacyNoun handles unicode alt text', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="日本語ALT文字列" />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('日本語ALT文字列');
+  });
 });


### PR DESCRIPTION
## Summary
part 234 で components 配下 4 file (ChangeDelegatePanel / DelegateGroupedNijiImageVoteTable / Holder / LegacyNoun) に edge case TC 追加。 4973 → 4993 (+20)。

Closes #799

## Test plan
- [x] vitest 全 pass (4993 TC)
- [x] lint pass