### PR TITLE
✅ test(niji-webapp): part 237 (components 4 file) で 5033 → 5053

### DIFF
--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -572,4 +572,78 @@ describe('DelegateHoverCard', () => {
       render(<DelegateHoverCard delegateId="" proposalCreationBlock={1n} />),
     ).not.toThrow();
   });
+
+  it('renders 30 instances each independently', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <DelegateHoverCard
+              key={i}
+              delegateId={`delegate-0x${i}`}
+              proposalCreationBlock={BigInt(i + 1)}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 nijis without crash', () => {
+    const nijiList = Array.from({ length: 100 }, (_, i) => ({ id: String(i + 1) }));
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: { delegates: [{ id: '0xA', nijiRepresented: nijiList }] },
+      loading: false,
+      error: undefined,
+    });
+    const { container } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe('stack-100');
+  });
+
+  it('rerender 10 times with different delegateId', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const { rerender } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    for (let i = 0; i < 10; i++) {
+      expect(() =>
+        rerender(<DelegateHoverCard delegateId={`delegate-0x${i}`} proposalCreationBlock={1n} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles negative proposalCreationBlock', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={-100n} />),
+    ).not.toThrow();
+  });
+
+  it('handles 50 different delegateIds consecutively', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    for (let i = 0; i < 50; i++) {
+      expect(() =>
+        render(<DelegateHoverCard delegateId={`delegate-0x${i}`} proposalCreationBlock={1n} />),
+      ).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/Documentation/index.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/index.test.tsx
@@ -332,4 +332,54 @@ describe('Documentation', () => {
     const { container } = render(<Documentation />);
     expect(container.querySelectorAll('[data-testid="gov-section"]').length).toBe(1);
   });
+
+  it('renders 100 Documentation instances consecutively', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(() => render(<Documentation />)).not.toThrow();
+    }
+  });
+
+  it('renders 50 Documentation instances together', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <Documentation key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('renders within nested fragment 5 levels deep', () => {
+    expect(() =>
+      render(
+        <>
+          <>
+            <>
+              <>
+                <>
+                  <Documentation />
+                </>
+              </>
+            </>
+          </>
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 50 times same Documentation', () => {
+    const { rerender } = render(<Documentation />);
+    for (let i = 0; i < 50; i++) {
+      expect(() => rerender(<Documentation />)).not.toThrow();
+    }
+  });
+
+  it('Documentation contains both about + art + gov sections', () => {
+    const { container } = render(<Documentation />);
+    expect(container.querySelector('[data-testid="about-section"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="art-section"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="gov-section"]')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
@@ -294,4 +294,47 @@ describe('GrayCircle', () => {
       expect(() => render(<GrayCircle />)).not.toThrow();
     }
   });
+
+  it('renders 200 GrayCircle instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <GrayCircle key={i} isDelegateView={i % 2 === 0} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(200);
+  });
+
+  it('rerender 30 times preserves img across isDelegateView toggle', () => {
+    const { container, rerender } = render(<GrayCircle />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<GrayCircle isDelegateView={i % 2 === 0} />);
+      expect(container.querySelector('img')).not.toBeNull();
+    }
+  });
+
+  it('handles 50 consecutive renders without crash', () => {
+    for (let i = 0; i < 50; i++) {
+      expect(() => render(<GrayCircle isDelegateView={i % 2 === 0} />)).not.toThrow();
+    }
+  });
+
+  it('img src always matches mocked SVG data URL', () => {
+    const { container } = render(<GrayCircle />);
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'data:image/svg+xml;base64,FAKE',
+    );
+  });
+
+  it('multiple GrayCircles in nested div renders independently', () => {
+    const { container } = render(
+      <div data-testid="parent">
+        <GrayCircle isDelegateView={true} />
+        <GrayCircle isDelegateView={false} />
+        <GrayCircle isDelegateView={undefined} />
+      </div>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(3);
+  });
 });

--- a/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
@@ -282,4 +282,42 @@ describe('HorizontalStackedNijis', () => {
     const { container } = render(<HorizontalStackedNijis nounIds={ids} />);
     expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(6);
   });
+
+  it('renders 100 instances each independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <HorizontalStackedNijis key={i} nounIds={[`${i}`]} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(100);
+  });
+
+  it('handles 0 IDs renders empty wrapper', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={[]} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(0);
+  });
+
+  it('handles 5 IDs renders 5 circles (under cap)', () => {
+    const { container } = render(<HorizontalStackedNijis nounIds={['1', '2', '3', '4', '5']} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(5);
+  });
+
+  it('rerender 20 times preserves DOM count', () => {
+    const { container, rerender } = render(<HorizontalStackedNijis nounIds={['1']} />);
+    for (let i = 0; i < 20; i++) {
+      rerender(
+        <HorizontalStackedNijis nounIds={Array.from({ length: i + 1 }, (_, j) => `${j}`)} />,
+      );
+      const expected = Math.min(i + 1, 6);
+      expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(expected);
+    }
+  });
+
+  it('handles 10000 IDs caps at 6 circles', () => {
+    const ids = Array.from({ length: 10000 }, (_, i) => `${i}`);
+    const { container } = render(<HorizontalStackedNijis nounIds={ids} />);
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(6);
+  });
 });


### PR DESCRIPTION
## Summary
part 237 で components 配下 4 file (DelegateHoverCard / Documentation / GrayCircle / HorizontalStackedNijis) に edge case TC 追加。 5033 → 5053 (+20)。

Closes #805

## Test plan
- [x] vitest 全 pass (5053 TC)
- [x] lint pass