### PR TITLE
✅ test(niji-webapp): part 240 (components 4 file) で 5093 → 5113

### DIFF
--- a/packages/niji-webapp/src/components/ABIUpload/index.test.tsx
+++ b/packages/niji-webapp/src/components/ABIUpload/index.test.tsx
@@ -506,4 +506,81 @@ describe('ABIUpload Component', () => {
     );
     expect(container.querySelector('label')?.className).toBe(labelCls);
   });
+
+  it('renders 50 ABIUpload instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <ABIUpload
+              key={i}
+              abiFileName={`file${i}.json`}
+              isValid={false}
+              isInvalid={false}
+              onChange={vi.fn()}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 100 change events fire 100 times', () => {
+    const handleChange = vi.fn();
+    render(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={false} onChange={handleChange} />,
+    );
+    const input = screen.getByLabelText(/abi/i) as HTMLInputElement;
+    for (let i = 0; i < 100; i++) {
+      fireEvent.change(input, {
+        target: { files: [new File([`c${i}`], `f${i}.json`, { type: 'application/json' })] },
+      });
+    }
+    expect(handleChange).toHaveBeenCalledTimes(100);
+  });
+
+  it('rerender 30 times preserves input element', () => {
+    const { rerender } = render(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={false} onChange={vi.fn()} />,
+    );
+    for (let i = 0; i < 30; i++) {
+      rerender(
+        <ABIUpload
+          abiFileName={`file${i}.json`}
+          isValid={i % 2 === 0}
+          isInvalid={i % 3 === 0}
+          onChange={vi.fn()}
+        />,
+      );
+      expect(screen.getByLabelText(/abi/i)).not.toBeNull();
+    }
+  });
+
+  it('handles unicode filename across renders', () => {
+    expect(() =>
+      render(
+        <ABIUpload
+          abiFileName="日本語ファイル.json"
+          isValid={false}
+          isInvalid={false}
+          onChange={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different filenames sequentially', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(() =>
+        render(
+          <ABIUpload
+            abiFileName={`file${i}.json`}
+            isValid={false}
+            isInvalid={false}
+            onChange={vi.fn()}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -322,4 +322,48 @@ describe('AuctionActivityDateHeadline', () => {
       expect(() => render(<AuctionActivityDateHeadline startTime={time} />)).not.toThrow();
     });
   });
+
+  it('renders 50 instances independently', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={1735689600n + BigInt(i * 86400)} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h4').length).toBe(50);
+  });
+
+  it('rerender 30 times preserves h4', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<AuctionActivityDateHeadline startTime={1735689600n + BigInt(i * 86400)} />);
+      expect(container.querySelector('h4')).not.toBeNull();
+    }
+  });
+
+  it('handles 100 consecutive renders without crash', () => {
+    useAtomValueMock.mockReturnValue(true);
+    for (let i = 0; i < 100; i++) {
+      expect(() =>
+        render(<AuctionActivityDateHeadline startTime={1735689600n + BigInt(i)} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('renders for very large startTime (year 9999)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() => render(<AuctionActivityDateHeadline startTime={253402300799n} />)).not.toThrow();
+  });
+
+  it('switches isCool true/false preserves h4 element', () => {
+    useAtomValueMock.mockReturnValueOnce(true);
+    const { container, rerender } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')).not.toBeNull();
+    useAtomValueMock.mockReturnValue(false);
+    rerender(<AuctionActivityDateHeadline startTime={1735689600n} />);
+    expect(container.querySelector('h4')).not.toBeNull();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -280,4 +280,43 @@ describe('AuctionActivityNijiTitle', () => {
       ).not.toThrow();
     }
   });
+
+  it('renders 100 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} isCool={i % 2 === 0} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(100);
+  });
+
+  it('rerender 30 times preserves h1', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={1n} isCool={true} />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<AuctionActivityNijiTitle nounId={BigInt(i)} isCool={i % 2 === 0} />);
+      expect(container.querySelector('h1')).not.toBeNull();
+    }
+  });
+
+  it('handles negative bigint nounId (-1n)', () => {
+    expect(() => render(<AuctionActivityNijiTitle nounId={-1n} isCool={true} />)).not.toThrow();
+  });
+
+  it('handles very large nounId (1e18)', () => {
+    const { container } = render(
+      <AuctionActivityNijiTitle nounId={BigInt('1000000000000000000')} isCool={true} />,
+    );
+    expect(container.querySelector('h1')?.textContent).toContain('1000000000000000000');
+  });
+
+  it('renders 5 different isCool variants consecutively', () => {
+    for (let i = 0; i < 5; i++) {
+      const { container } = render(
+        <AuctionActivityNijiTitle nounId={BigInt(i)} isCool={i % 2 === 0} />,
+      );
+      expect(container.querySelector('h1')?.textContent).toContain('Niji');
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/BidHistoryBtn/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidHistoryBtn/index.test.tsx
@@ -338,4 +338,57 @@ describe('BidHistoryBtn Component (isCool=true)', () => {
     const inner = container.firstElementChild?.firstElementChild as HTMLElement;
     expect(inner.className.length).toBeGreaterThan(0);
   });
+
+  it('renders 200 instances independently', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <BidHistoryBtn key={i} onClick={vi.fn()} />
+        ))}
+      </>,
+    );
+    expect(container.children.length).toBe(200);
+  });
+
+  it('rapid 200 clicks invoke onClick 200 times', () => {
+    const onClick = vi.fn();
+    const { container } = render(<BidHistoryBtn onClick={onClick} />);
+    const outer = container.firstElementChild as HTMLElement;
+    for (let i = 0; i < 200; i++) fireEvent.click(outer);
+    expect(onClick).toHaveBeenCalledTimes(200);
+  });
+
+  it('rerender 50 times preserves structure', () => {
+    const { container, rerender } = render(<BidHistoryBtn onClick={vi.fn()} />);
+    for (let i = 0; i < 50; i++) {
+      rerender(<BidHistoryBtn onClick={vi.fn()} />);
+      expect(container.textContent).toBe('View all bids');
+    }
+  });
+
+  it('handles 100 different onClick handlers', () => {
+    const handlers = Array.from({ length: 100 }, () => vi.fn());
+    const { container } = render(
+      <>
+        {handlers.map((h, i) => (
+          <BidHistoryBtn key={i} onClick={h} />
+        ))}
+      </>,
+    );
+    expect(container.children.length).toBe(100);
+  });
+
+  it('renders within deeply nested div', () => {
+    expect(() =>
+      render(
+        <div>
+          <div>
+            <div>
+              <BidHistoryBtn onClick={vi.fn()} />
+            </div>
+          </div>
+        </div>,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 240 で components 配下 4 file (AuctionActivityDateHeadline / AuctionActivityNijiTitle / ABIUpload / BidHistoryBtn) に edge case TC 追加。 5093 → 5113 (+20)。

Closes #811

## Test plan
- [x] vitest 全 pass (5113 TC)
- [x] lint pass