### PR TITLE
✅ test(niji-webapp): part 248 (components 4 file) で 5252 → 5272

### DIFF
--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
@@ -493,4 +493,76 @@ describe('DelegateGroupedNijiImageVoteTable', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders 10 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <DelegateGroupedNijiImageVoteTable
+              key={i}
+              {...baseProps}
+              filteredDelegateGroupedVoteData={[]}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    const { rerender } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={[]} />,
+    );
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <DelegateGroupedNijiImageVoteTable
+            {...baseProps}
+            propId={i}
+            filteredDelegateGroupedVoteData={[]}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles 500 vote entries', () => {
+    const data = Array.from({ length: 500 }, (_, i) => makeVote(`0xDEL${i}`, [String(i)], 1));
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles very large proposalCreationBlock', () => {
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable
+          propId={1}
+          proposalCreationBlock={9_007_199_254_740_991n}
+          filteredDelegateGroupedVoteData={[]}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles rapid prop change 50 times', () => {
+    const { rerender } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={[]} />,
+    );
+    for (let i = 0; i < 50; i++) {
+      expect(() =>
+        rerender(
+          <DelegateGroupedNijiImageVoteTable
+            {...baseProps}
+            propId={i + 100}
+            proposalCreationBlock={BigInt(100 + i)}
+            filteredDelegateGroupedVoteData={[]}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
+++ b/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
@@ -315,4 +315,47 @@ describe('LegacyNoun — additional edge cases', () => {
     const { container } = render(<LegacyNoun imgPath="/x.png" alt="日本語ALT文字列" />);
     expect(container.querySelector('img')?.getAttribute('alt')).toBe('日本語ALT文字列');
   });
+
+  it('LegacyNoun renders 100 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 100 }, (_, i) => (
+            <LegacyNoun key={i} imgPath={`/img-${i}.png`} alt={`alt-${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('LegacyNoun rerender 30 times preserves img', () => {
+    const { container, rerender } = render(<LegacyNoun imgPath="/x.png" alt="x" />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<LegacyNoun imgPath={`/x-${i}.png`} alt={`x-${i}`} />);
+    }
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('/x-29.png');
+  });
+
+  it('LegacyNoun handles very long imgPath (1000 char)', () => {
+    const long = '/x'.repeat(500);
+    const { container } = render(<LegacyNoun imgPath={long} alt="x" />);
+    expect(container.querySelector('img')?.getAttribute('src')?.length).toBe(long.length);
+  });
+
+  it('LegacyNoun handles whitespace-only alt', () => {
+    const { container } = render(<LegacyNoun imgPath="/x.png" alt="   " />);
+    expect(container.querySelector('img')?.getAttribute('alt')).toBe('   ');
+  });
+
+  it('LoadingNoun renders 50 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <LoadingNoun key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
@@ -315,4 +315,43 @@ describe('NavBarButton', () => {
       expect(() => render(<NavBarButton buttonText="X" buttonStyle={style} />)).not.toThrow();
     });
   });
+
+  it('renders 100 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 100 }, (_, i) => (
+            <NavBarButton key={i} buttonText={`btn-${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves button text', () => {
+    const { container, rerender } = render(<NavBarButton buttonText="x" />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<NavBarButton buttonText={`btn-${i}`} />);
+    }
+    expect(container.textContent).toContain('btn-29');
+  });
+
+  it('rapid 100 onClick events fire handler 100 times', () => {
+    const onClick = vi.fn();
+    const { container } = render(<NavBarButton buttonText="x" onClick={onClick} />);
+    const target = container.firstElementChild as HTMLElement;
+    for (let i = 0; i < 100; i++) fireEvent.click(target);
+    expect(onClick).toHaveBeenCalledTimes(100);
+  });
+
+  it('handles unicode buttonText', () => {
+    const { container } = render(<NavBarButton buttonText="🎉 ボタン" />);
+    expect(container.textContent).toContain('🎉 ボタン');
+  });
+
+  it('handles very long buttonText (1000 char)', () => {
+    const long = 'a'.repeat(1000);
+    const { container } = render(<NavBarButton buttonText={long} />);
+    expect(container.textContent?.length).toBeGreaterThanOrEqual(1000);
+  });
 });

--- a/packages/niji-webapp/src/components/VoteCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCard/index.test.tsx
@@ -844,4 +844,104 @@ describe('VoteCard', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders 10 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <VoteCard
+              key={i}
+              proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+              percentage={50}
+              nounIds={[]}
+              variant={VoteCardVariant.FOR}
+              delegateGroupedVoteData={[]}
+              isNounsDAOProp={true}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    const { rerender } = render(
+      <VoteCard
+        proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+        percentage={50}
+        nounIds={[]}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={[]}
+        isNounsDAOProp={true}
+      />,
+    );
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <VoteCard
+            proposal={
+              {
+                id: String(i),
+                forCount: BigInt(i),
+                againstCount: 0n,
+                abstainCount: 0n,
+              } as never
+            }
+            percentage={i % 100}
+            nounIds={[]}
+            variant={VoteCardVariant.FOR}
+            delegateGroupedVoteData={[]}
+            isNounsDAOProp={true}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles 500 nounIds', () => {
+    const ids = Array.from({ length: 500 }, (_, i) => i);
+    expect(() =>
+      render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 500n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={100}
+          nounIds={ids}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles negative percentage edge case', () => {
+    expect(() =>
+      render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 0n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={-10}
+          nounIds={[]}
+          variant={VoteCardVariant.ABSTAIN}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles percentage > 100', () => {
+    expect(() =>
+      render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 0n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={150}
+          nounIds={[]}
+          variant={VoteCardVariant.AGAINST}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 248 で components 配下 4 file (DelegateGroupedNijiImageVoteTable / LegacyNoun / NavBarButton / VoteCard) に edge case TC 追加。 5252 → 5272 (+20)。

Closes #827

## Test plan
- [x] vitest 全 pass (5272 TC)
- [x] lint pass