### PR TITLE
✅ test(niji-webapp): part 249 (components 4 file) で 5272 → 5292

### DIFF
--- a/packages/niji-webapp/src/components/BrandSpinner/index.test.tsx
+++ b/packages/niji-webapp/src/components/BrandSpinner/index.test.tsx
@@ -334,4 +334,57 @@ describe('BrandSpinner', () => {
       expect(container.querySelector('svg')?.getAttribute('width')).toBe(w);
     }
   });
+
+  it('renders 200 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 200 }, (_, i) => (
+            <BrandSpinner key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 50 times preserves svg + path + circle', () => {
+    const { container, rerender } = render(<BrandSpinner />);
+    for (let i = 0; i < 50; i++) {
+      rerender(<BrandSpinner />);
+    }
+    expect(container.querySelector('svg path')).not.toBeNull();
+    expect(container.querySelector('svg circle')).not.toBeNull();
+  });
+
+  it('all 200 instances have width=25 attribute', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <BrandSpinner key={i} />
+        ))}
+      </>,
+    );
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBe(200);
+    svgs.forEach(svg => {
+      expect(svg.getAttribute('width')).toBe('25');
+    });
+  });
+
+  it('all 50 instances have circle element', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <BrandSpinner key={i} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('svg circle').length).toBe(50);
+  });
+
+  it('rapid consecutive renders 100 times without crash', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(() => render(<BrandSpinner />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
+++ b/packages/niji-webapp/src/components/GrayCircle/index.test.tsx
@@ -337,4 +337,55 @@ describe('GrayCircle', () => {
     );
     expect(container.querySelectorAll('img').length).toBe(3);
   });
+
+  it('renders 200 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 200 }, (_, i) => (
+            <GrayCircle key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 50 times preserves img', () => {
+    const { container, rerender } = render(<GrayCircle />);
+    for (let i = 0; i < 50; i++) {
+      rerender(<GrayCircle isDelegateView={i % 2 === 0} />);
+    }
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('all 100 instances render with delegate=true', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <GrayCircle key={i} isDelegateView={true} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(100);
+  });
+
+  it('all imgs have decorative empty alt', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <GrayCircle key={i} />
+        ))}
+      </>,
+    );
+    const imgs = container.querySelectorAll('img');
+    imgs.forEach(img => {
+      expect(img.getAttribute('alt')).toBe('');
+    });
+  });
+
+  it('rapid consecutive renders 100 times without crash', () => {
+    for (let i = 0; i < 100; i++) {
+      expect(() => render(<GrayCircle />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/MinBid/index.test.tsx
+++ b/packages/niji-webapp/src/components/MinBid/index.test.tsx
@@ -329,4 +329,48 @@ describe('MinBid', () => {
       expect(container.querySelectorAll('img').length).toBe(1);
     }
   });
+
+  it('renders 100 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 100 }, (_, i) => (
+            <MinBid key={i} minBid={parseEther(`${i + 1}`)} onClick={() => {}} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 100 onClick events fire handler', () => {
+    const onClick = vi.fn();
+    const { container } = render(<MinBid minBid={parseEther('1')} onClick={onClick} />);
+    const wrapper = container.querySelector('div')!;
+    for (let i = 0; i < 100; i++) fireEvent.click(wrapper);
+    expect(onClick).toHaveBeenCalledTimes(100);
+  });
+
+  it('rerender 30 times preserves img', () => {
+    const { container, rerender } = render(<MinBid minBid={parseEther('1')} onClick={() => {}} />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<MinBid minBid={parseEther(`${i + 1}.5`)} onClick={() => {}} />);
+    }
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('handles 1 wei minBid (very small amount)', () => {
+    const { container } = render(<MinBid minBid={1n} onClick={() => {}} />);
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  it('handles all 100 imgs in single mount', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <MinBid key={i} minBid={parseEther(`${i + 1}`)} onClick={() => {}} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('img').length).toBe(100);
+  });
 });

--- a/packages/niji-webapp/src/components/VoteCardPager/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCardPager/index.test.tsx
@@ -349,4 +349,41 @@ describe('VoteCardPager', () => {
       expect(container.querySelectorAll('span').length).toBe(i);
     }
   });
+
+  it('renders 50 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <VoteCardPager key={i} {...defaults} currentPage={i % 3} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 100 right arrow clicks fire handler', () => {
+    const onRight = vi.fn();
+    const { container } = render(<VoteCardPager {...defaults} onRightArrowClick={onRight} />);
+    const right = container.querySelectorAll('button')[1] as HTMLElement;
+    for (let i = 0; i < 100; i++) fireEvent.click(right);
+    expect(onRight).toHaveBeenCalledTimes(100);
+  });
+
+  it('rapid 100 left arrow clicks fire handler', () => {
+    const onLeft = vi.fn();
+    const { container } = render(<VoteCardPager {...defaults} onLeftArrowClick={onLeft} />);
+    const left = container.querySelectorAll('button')[0] as HTMLElement;
+    for (let i = 0; i < 100; i++) fireEvent.click(left);
+    expect(onLeft).toHaveBeenCalledTimes(100);
+  });
+
+  it('handles very large numPages (100)', () => {
+    const { container } = render(<VoteCardPager {...defaults} numPages={100} currentPage={50} />);
+    expect(container.querySelectorAll('span').length).toBe(100);
+  });
+
+  it('handles negative currentPage edge case', () => {
+    expect(() => render(<VoteCardPager {...defaults} currentPage={-1} />)).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 249 で components 配下 4 file (VoteCardPager / BrandSpinner / GrayCircle / MinBid) に edge case TC 追加。 5272 → 5292 (+20)。

Closes #829

## Test plan
- [x] vitest 全 pass (5292 TC)
- [x] lint pass