### PR TITLE
✅ test(niji-webapp): part 250 (components 4 file) で 5292 → 5312

### DIFF
--- a/packages/niji-webapp/src/components/Auction/index.test.tsx
+++ b/packages/niji-webapp/src/components/Auction/index.test.tsx
@@ -395,4 +395,56 @@ describe('Auction', () => {
   it('renders for id 0n (boundary repeat)', () => {
     expect(() => wrap(<Auction auction={makeAuction(0n)} />)).not.toThrow();
   });
+
+  it('renders 10 instances without crash', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 10 }, (_, i) => (
+            <Auction key={i} auction={makeAuction(BigInt(i))} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    const { rerender } = wrap(<Auction auction={makeAuction(0n)} />);
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <MemoryRouter>
+            <Auction auction={makeAuction(BigInt(i))} />
+          </MemoryRouter>,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles very large bigint nounId (MAX_SAFE_INTEGER)', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    expect(() => wrap(<Auction auction={makeAuction(9_007_199_254_740_991n)} />)).not.toThrow();
+  });
+
+  it('rapid 100 renders with id=5n without crash', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    for (let i = 0; i < 100; i++) {
+      expect(() => wrap(<Auction auction={makeAuction(5n)} />)).not.toThrow();
+    }
+  });
+
+  it('renders all 50 different bid amounts', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <Auction key={i} auction={{ ...makeAuction(BigInt(i)), amount: BigInt(i * 1000) }} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
@@ -352,4 +352,56 @@ describe('AuctionActivityWrapper', () => {
     const { container } = render(<AuctionActivityWrapper>{'<>&"\''}</AuctionActivityWrapper>);
     expect(container.querySelector('div')?.textContent).toBe('<>&"\'');
   });
+
+  it('renders 200 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 200 }, (_, i) => (
+            <AuctionActivityWrapper key={i}>{i}</AuctionActivityWrapper>
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 50 times preserves div', () => {
+    const { container, rerender } = render(<AuctionActivityWrapper>x</AuctionActivityWrapper>);
+    for (let i = 0; i < 50; i++) {
+      rerender(<AuctionActivityWrapper>val-{i}</AuctionActivityWrapper>);
+    }
+    expect(container.querySelector('div')?.textContent).toContain('49');
+  });
+
+  it('handles 10000 char children', () => {
+    const long = 'a'.repeat(10000);
+    const { container } = render(<AuctionActivityWrapper>{long}</AuctionActivityWrapper>);
+    expect(container.querySelector('div')?.textContent?.length).toBe(10000);
+  });
+
+  it('handles array of 100 children', () => {
+    const items = Array.from({ length: 100 }, (_, i) => i);
+    const { container } = render(
+      <AuctionActivityWrapper>
+        {items.map(n => (
+          <span key={n}>{n}</span>
+        ))}
+      </AuctionActivityWrapper>,
+    );
+    expect(container.querySelectorAll('span').length).toBe(100);
+  });
+
+  it('all 200 instances have max-lg:mx-4 class', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <AuctionActivityWrapper key={i}>x</AuctionActivityWrapper>
+        ))}
+      </>,
+    );
+    const divs = container.querySelectorAll('div');
+    divs.forEach(div => {
+      expect(div.className).toContain('max-lg:mx-4');
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
@@ -519,4 +519,47 @@ describe('ByLineHoverCard', () => {
       render(<ByLineHoverCard proposerAddress={'0x' + 'a'.repeat(200)} />),
     ).not.toThrow();
   });
+
+  it('renders 50 instances without crash', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <ByLineHoverCard key={i} proposerAddress={`0xADDR${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    const { rerender } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    for (let i = 0; i < 30; i++) {
+      expect(() => rerender(<ByLineHoverCard proposerAddress={`0xA${i}`} />)).not.toThrow();
+    }
+  });
+
+  it('handles rapid loading state transitions 50 times', () => {
+    const { rerender } = render(<ByLineHoverCard proposerAddress="0xA" />);
+    for (let i = 0; i < 50; i++) {
+      useSubgraphQueryMock.mockReturnValue({
+        data: undefined,
+        loading: i % 2 === 0,
+        error: undefined,
+      });
+      expect(() => rerender(<ByLineHoverCard proposerAddress="0xA" />)).not.toThrow();
+    }
+  });
+
+  it('handles empty string proposer address', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    expect(() => render(<ByLineHoverCard proposerAddress="" />)).not.toThrow();
+  });
+
+  it('handles unicode proposer address', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    expect(() => render(<ByLineHoverCard proposerAddress="🚀0xJP" />)).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -646,4 +646,89 @@ describe('DelegateHoverCard', () => {
       ).not.toThrow();
     }
   });
+
+  it('renders 50 instances without crash', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 50 }, (_, i) => (
+            <DelegateHoverCard
+              key={i}
+              delegateId={`delegate-0xX${i}`}
+              proposalCreationBlock={BigInt(i)}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    const { rerender } = render(
+      <DelegateHoverCard delegateId="delegate-0x0" proposalCreationBlock={1n} />,
+    );
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <DelegateHoverCard
+            delegateId={`delegate-0x${i}`}
+            proposalCreationBlock={BigInt(i + 100)}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles very large proposalCreationBlock', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <DelegateHoverCard
+          delegateId="delegate-0xA"
+          proposalCreationBlock={9_007_199_254_740_991n}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles unicode delegateId', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(<DelegateHoverCard delegateId="delegate-🚀日本" proposalCreationBlock={1n} />),
+    ).not.toThrow();
+  });
+
+  it('handles rapid loading state transitions 50 times', () => {
+    const { rerender } = render(
+      <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+    );
+    for (let i = 0; i < 50; i++) {
+      useDelegateNounsAtBlockQueryMock.mockReturnValue({
+        data: undefined,
+        loading: i % 2 === 0,
+        error: undefined,
+      });
+      expect(() =>
+        rerender(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />),
+      ).not.toThrow();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 250 で components 配下 4 file (Auction / AuctionActivityWrapper / ByLineHoverCard / DelegateHoverCard) に edge case TC 追加。 5292 → 5312 (+20)。

Closes #831

## Test plan
- [x] vitest 全 pass (5312 TC)
- [x] lint pass