### PR TITLE
✅ test(niji-webapp): part 253 (components 4 file) で 5352 → 5372

### DIFF
--- a/packages/niji-webapp/src/components/ABIUpload/index.test.tsx
+++ b/packages/niji-webapp/src/components/ABIUpload/index.test.tsx
@@ -583,4 +583,72 @@ describe('ABIUpload Component', () => {
       ).not.toThrow();
     }
   });
+
+  it('renders 30 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <ABIUpload
+              key={i}
+              abiFileName={`file-${i}.json`}
+              isValid={false}
+              isInvalid={false}
+              onChange={vi.fn()}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    const { rerender } = render(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={false} onChange={vi.fn()} />,
+    );
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <ABIUpload
+            abiFileName={`file-${i}.json`}
+            isValid={i % 2 === 0}
+            isInvalid={i % 3 === 0}
+            onChange={vi.fn()}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles very long abiFileName (1000 char)', () => {
+    const long = `${'a'.repeat(995)}.json`;
+    expect(() =>
+      render(<ABIUpload abiFileName={long} isValid={false} isInvalid={false} onChange={vi.fn()} />),
+    ).not.toThrow();
+  });
+
+  it('handles unicode abiFileName', () => {
+    expect(() =>
+      render(
+        <ABIUpload
+          abiFileName="🎉日本語.json"
+          isValid={false}
+          isInvalid={false}
+          onChange={vi.fn()}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 50 onChange events fire handler', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <ABIUpload abiFileName="x.json" isValid={false} isInvalid={false} onChange={onChange} />,
+    );
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    for (let i = 0; i < 50; i++) {
+      fireEvent.change(input, { target: { files: [] } });
+    }
+    expect(onChange).toHaveBeenCalledTimes(50);
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -551,4 +551,63 @@ describe('AuctionActivity', () => {
       ),
     ).not.toThrow();
   });
+
+  it('renders 20 instances without crash', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <AuctionActivity key={i} {...defaults} auction={makeAuction() as never} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves wrapper', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { container, rerender } = wrap(
+      <AuctionActivity {...defaults} auction={makeAuction() as never} />,
+    );
+    for (let i = 0; i < 30; i++) {
+      rerender(
+        <MemoryRouter>
+          <AuctionActivity {...defaults} auction={makeAuction({ nounId: BigInt(i) }) as never} />
+        </MemoryRouter>,
+      );
+    }
+    expect(container.querySelector('[data-testid="wrapper"]')).not.toBeNull();
+  });
+
+  it('handles isFirstAuction=true variant', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <AuctionActivity {...defaults} isFirstAuction={true} auction={makeAuction() as never} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles displayGraphDepComps=false variant', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <AuctionActivity
+          {...defaults}
+          displayGraphDepComps={false}
+          auction={makeAuction() as never}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 1e9 nounId large bigint', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <AuctionActivity {...defaults} auction={makeAuction({ nounId: 1000000000n }) as never} />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -366,4 +366,46 @@ describe('AuctionActivityDateHeadline', () => {
     rerender(<AuctionActivityDateHeadline startTime={1735689600n} />);
     expect(container.querySelector('h4')).not.toBeNull();
   });
+
+  it('renders 100 instances without crash', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 100 }, (_, i) => (
+            <AuctionActivityDateHeadline key={i} startTime={BigInt(1700000000 + i)} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves h4', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container, rerender } = render(<AuctionActivityDateHeadline startTime={1700000000n} />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<AuctionActivityDateHeadline startTime={BigInt(1700000000 + i)} />);
+    }
+    expect(container.querySelector('h4')).not.toBeNull();
+  });
+
+  it('handles 0n startTime', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() => render(<AuctionActivityDateHeadline startTime={0n} />)).not.toThrow();
+  });
+
+  it('handles very large bigint startTime', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(<AuctionActivityDateHeadline startTime={9_007_199_254_740_991n} />),
+    ).not.toThrow();
+  });
+
+  it('rapid 50 isCool toggle without crash', () => {
+    const { rerender } = render(<AuctionActivityDateHeadline startTime={1700000000n} />);
+    for (let i = 0; i < 50; i++) {
+      useAtomValueMock.mockReturnValue(i % 2 === 0);
+      expect(() => rerender(<AuctionActivityDateHeadline startTime={1700000000n} />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -319,4 +319,52 @@ describe('AuctionActivityNijiTitle', () => {
       expect(container.querySelector('h1')?.textContent).toContain('Niji');
     }
   });
+
+  it('renders 100 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 100 }, (_, i) => (
+            <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves h1', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={0n} />);
+    for (let i = 0; i < 30; i++) {
+      rerender(<AuctionActivityNijiTitle nounId={BigInt(i)} />);
+    }
+    expect(container.querySelector('h1')?.textContent).toContain('29');
+  });
+
+  it('all 100 h1 contains Niji prefix', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} />
+        ))}
+      </>,
+    );
+    const h1s = container.querySelectorAll('h1');
+    h1s.forEach(h1 => {
+      expect(h1.textContent).toContain('Niji');
+    });
+  });
+
+  it('handles MAX_SAFE_INTEGER bigint', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={9_007_199_254_740_991n} />);
+    expect(container.querySelector('h1')?.textContent).toContain('9007199254740991');
+  });
+
+  it('rapid isCool toggle 50 times', () => {
+    const { rerender } = render(<AuctionActivityNijiTitle nounId={1n} />);
+    for (let i = 0; i < 50; i++) {
+      expect(() =>
+        rerender(<AuctionActivityNijiTitle nounId={1n} isCool={i % 2 === 0} />),
+      ).not.toThrow();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 253 で components 配下 4 file (AuctionActivity / AuctionActivityDateHeadline / AuctionActivityNijiTitle / ABIUpload) に edge case TC 追加。 5352 → 5372 (+20)。

Closes #837

## Test plan
- [x] vitest 全 pass (5372 TC)
- [x] lint pass