### PR TITLE
✅ test(niji-webapp): part 256 (components 4 file) で 5412 → 5426

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -610,4 +610,34 @@ describe('AuctionActivity', () => {
       ),
     ).not.toThrow();
   });
+
+  it('handles isLastAuction=false variant', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <AuctionActivity {...defaults} isLastAuction={false} auction={makeAuction() as never} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid useAtomValue toggle 30 times', () => {
+    const { rerender } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    for (let i = 0; i < 30; i++) {
+      useAtomValueMock.mockReturnValue(i % 2 === 0);
+      expect(() =>
+        rerender(
+          <MemoryRouter>
+            <AuctionActivity {...defaults} auction={makeAuction() as never} />
+          </MemoryRouter>,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles 0n nounId edge case', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(<AuctionActivity {...defaults} auction={makeAuction({ nounId: 0n }) as never} />),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -408,4 +408,36 @@ describe('AuctionActivityDateHeadline', () => {
       expect(() => rerender(<AuctionActivityDateHeadline startTime={1700000000n} />)).not.toThrow();
     }
   });
+
+  it('handles 1n startTime (very small)', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() => render(<AuctionActivityDateHeadline startTime={1n} />)).not.toThrow();
+  });
+
+  it('renders 200 instances', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={BigInt(1700000000 + i)} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h4').length).toBe(200);
+  });
+
+  it('all 100 instances have warm style when isCool=false', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={BigInt(1700000000 + i)} />
+        ))}
+      </>,
+    );
+    const h4s = container.querySelectorAll('h4');
+    h4s.forEach(h4 => {
+      expect(h4.getAttribute('style')).toContain('warm');
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -367,4 +367,34 @@ describe('AuctionActivityNijiTitle', () => {
       ).not.toThrow();
     }
   });
+
+  it('renders 200 instances', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('h1').length).toBe(200);
+  });
+
+  it('handles 1000000000n (1e9) nounId', () => {
+    const { container } = render(<AuctionActivityNijiTitle nounId={1000000000n} />);
+    expect(container.querySelector('h1')?.textContent).toContain('1000000000');
+  });
+
+  it('all 50 instances with isCool=true have cool style', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} isCool={true} />
+        ))}
+      </>,
+    );
+    const h1s = container.querySelectorAll('h1');
+    h1s.forEach(h1 => {
+      expect(h1.getAttribute('style')).toContain('cool');
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/Bid/index.test.tsx
+++ b/packages/niji-webapp/src/components/Bid/index.test.tsx
@@ -537,4 +537,63 @@ describe('Bid', () => {
       ).not.toThrow();
     }
   });
+
+  it('renders 20 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <Bid
+              key={i}
+              auction={makeAuction({ nounId: BigInt(i) }) as never}
+              auctionEnded={false}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rerender 30 times preserves component', () => {
+    const { rerender } = render(<Bid auction={makeAuction() as never} auctionEnded={false} />);
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <Bid auction={makeAuction({ nounId: BigInt(i) }) as never} auctionEnded={false} />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles MAX_SAFE_INTEGER bigint nounId', () => {
+    expect(() =>
+      render(
+        <Bid
+          auction={makeAuction({ nounId: 9_007_199_254_740_991n }) as never}
+          auctionEnded={false}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles auctionEnded=true variant', () => {
+    expect(() =>
+      render(<Bid auction={makeAuction() as never} auctionEnded={true} />),
+    ).not.toThrow();
+  });
+
+  it('handles all hookState placeBid combinations', () => {
+    const orig = { ...hookState.placeBid };
+    [
+      { isPending: true, isError: false, isSuccess: false },
+      { isPending: false, isError: true, isSuccess: false },
+      { isPending: false, isError: false, isSuccess: true },
+    ].forEach(s => {
+      hookState.placeBid = s;
+      expect(() =>
+        render(<Bid auction={makeAuction() as never} auctionEnded={false} />),
+      ).not.toThrow();
+    });
+    hookState.placeBid = orig;
+  });
 });


### PR DESCRIPTION
## Summary
part 256 で components 配下 4 file (Bid / AuctionActivity / AuctionActivityDateHeadline / AuctionActivityNijiTitle) に edge case TC 追加。 5412 → 5426 (+14)。

Closes #843

## Test plan
- [x] vitest 全 pass (5426 TC)
- [x] lint pass