### PR TITLE
✅ test(niji-webapp): part 264 (components 4 file) で 5566 → 5586

### DIFF
--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
@@ -565,4 +565,65 @@ describe('DelegateGroupedNijiImageVoteTable', () => {
       ).not.toThrow();
     }
   });
+
+  it('mount-unmount 30 cycles', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={[]} />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles all 3 supportDetailed variants', () => {
+    [0, 1, 2].forEach(s => {
+      const data = [makeVote('0xA', ['1'], s as 0 | 1 | 2)];
+      expect(() =>
+        render(
+          <DelegateGroupedNijiImageVoteTable
+            {...baseProps}
+            filteredDelegateGroupedVoteData={data}
+          />,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  it('renders 5 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 5 }, (_, i) => (
+            <DelegateGroupedNijiImageVoteTable
+              key={i}
+              {...baseProps}
+              propId={i}
+              filteredDelegateGroupedVoteData={[]}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 1000 vote entries', () => {
+    const data = Array.from({ length: 1000 }, (_, i) => makeVote(`0xDEL${i}`, [String(i)], 1));
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 0n proposalCreationBlock edge case', () => {
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable
+          propId={1}
+          proposalCreationBlock={0n}
+          filteredDelegateGroupedVoteData={[]}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
+++ b/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
@@ -358,4 +358,51 @@ describe('LegacyNoun — additional edge cases', () => {
       ),
     ).not.toThrow();
   });
+
+  it('LegacyNoun mount-unmount 100 cycles', () => {
+    for (let i = 0; i < 100; i++) {
+      const { unmount } = render(<LegacyNoun imgPath={`/x-${i}.png`} alt="x" />);
+      unmount();
+    }
+  });
+
+  it('LegacyNoun renders 300 instances', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 300 }, (_, i) => (
+            <LegacyNoun key={i} imgPath={`/img-${i}.png`} alt={`alt-${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('LegacyNoun handles 50 different alts', () => {
+    for (let i = 0; i < 50; i++) {
+      const { container, unmount } = render(<LegacyNoun imgPath="/x.png" alt={`alt-${i}`} />);
+      expect(container.querySelector('img')?.getAttribute('alt')).toBe(`alt-${i}`);
+      unmount();
+    }
+  });
+
+  it('LegacyNoun handles className + wrapperClassName combined', () => {
+    const { container } = render(
+      <LegacyNoun imgPath="/x.png" alt="x" className="img-cls" wrapperClassName="wrap-cls" />,
+    );
+    expect(container.querySelector('img')?.className).toContain('img-cls');
+    expect(container.querySelector('div')?.className).toContain('wrap-cls');
+  });
+
+  it('LoadingNoun renders 200 instances', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 200 }, (_, i) => (
+            <LoadingNoun key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
@@ -354,4 +354,52 @@ describe('NavBarButton', () => {
     const { container } = render(<NavBarButton buttonText={long} />);
     expect(container.textContent?.length).toBeGreaterThanOrEqual(1000);
   });
+
+  it('mount-unmount 100 cycles', () => {
+    for (let i = 0; i < 100; i++) {
+      const { unmount } = render(<NavBarButton buttonText="x" />);
+      unmount();
+    }
+  });
+
+  it('renders 200 instances', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 200 }, (_, i) => (
+            <NavBarButton key={i} buttonText={`btn-${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 50 different buttonText sequentially', () => {
+    for (let i = 0; i < 50; i++) {
+      const { container, unmount } = render(<NavBarButton buttonText={`btn-${i}`} />);
+      expect(container.textContent).toContain(`btn-${i}`);
+      unmount();
+    }
+  });
+
+  it('renders with JSX buttonText', () => {
+    const { container } = render(
+      <NavBarButton buttonText={<strong data-testid="jsx-text">Bold</strong>} />,
+    );
+    expect(container.querySelector('[data-testid="jsx-text"]')?.textContent).toBe('Bold');
+  });
+
+  it('handles all 7 NavBarButtonStyle variants', () => {
+    [
+      NavBarButtonStyle.COOL_INFO,
+      NavBarButtonStyle.WARM_INFO,
+      NavBarButtonStyle.DELEGATE_PRIMARY,
+      NavBarButtonStyle.DELEGATE_BACK,
+      NavBarButtonStyle.FOR_VOTE_SUBMIT,
+      NavBarButtonStyle.AGAINST_VOTE_SUBMIT,
+      NavBarButtonStyle.ABSTAIN_VOTE_SUBMIT,
+    ].forEach(style => {
+      expect(() => render(<NavBarButton buttonText="X" buttonStyle={style} />)).not.toThrow();
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/VoteCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCard/index.test.tsx
@@ -944,4 +944,95 @@ describe('VoteCard', () => {
       ),
     ).not.toThrow();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={50}
+          nounIds={[]}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles all 3 variants', () => {
+    [VoteCardVariant.FOR, VoteCardVariant.AGAINST, VoteCardVariant.ABSTAIN].forEach(v => {
+      expect(() =>
+        render(
+          <VoteCard
+            proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+            percentage={50}
+            nounIds={[]}
+            variant={v}
+            delegateGroupedVoteData={[]}
+            isNounsDAOProp={true}
+          />,
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  it('rapid 50 percentage changes', () => {
+    const { rerender } = render(
+      <VoteCard
+        proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+        percentage={0}
+        nounIds={[]}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={[]}
+        isNounsDAOProp={true}
+      />,
+    );
+    for (let i = 0; i < 50; i++) {
+      expect(() =>
+        rerender(
+          <VoteCard
+            proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+            percentage={i * 2}
+            nounIds={[]}
+            variant={VoteCardVariant.FOR}
+            delegateGroupedVoteData={[]}
+            isNounsDAOProp={true}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles isNounsDAOProp=false branch', () => {
+    expect(() =>
+      render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={50}
+          nounIds={[]}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={false}
+        />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 nounIds', () => {
+    const ids = Array.from({ length: 100 }, (_, i) => i);
+    expect(() =>
+      render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 100n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={100}
+          nounIds={ids}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 264 で components 配下 4 file (DelegateGroupedNijiImageVoteTable / LegacyNoun / NavBarButton / VoteCard) +5 round TC 追加。 5566 → 5586 (+20)。

Closes #859

## Test plan
- [x] vitest 全 pass (5586 TC)