### PR TITLE
✅ test(niji-webapp): part 270 (components 4 file) で 5686 → 5706

### DIFF
--- a/packages/niji-webapp/src/components/CandidateSponsors/index.test.tsx
+++ b/packages/niji-webapp/src/components/CandidateSponsors/index.test.tsx
@@ -547,4 +547,60 @@ describe('CandidateSponsors', () => {
     expect(() => render(<CandidateSponsors {...baseProps} />)).not.toThrow();
     hookState.userVotes = 5;
   });
+
+  it('mount-unmount 30 cycles', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(<CandidateSponsors {...baseProps} />);
+      unmount();
+    }
+  });
+
+  it('handles 100 different blockNumber values', () => {
+    for (let i = 0; i < 100; i++) {
+      const { unmount } = render(<CandidateSponsors {...baseProps} blockNumber={BigInt(i)} />);
+      unmount();
+    }
+  });
+
+  it('renders 30 instances independently', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <CandidateSponsors key={i} {...baseProps} blockNumber={BigInt(i)} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 30 different userVotes values', () => {
+    const orig = hookState.userVotes;
+    for (let i = 0; i < 30; i++) {
+      hookState.userVotes = i;
+      const { unmount } = render(<CandidateSponsors {...baseProps} />);
+      unmount();
+    }
+    hookState.userVotes = orig;
+  });
+
+  it('handles all 8 state combinations', () => {
+    const origState = {
+      isThresholdMet: hookState.isThresholdMet,
+      isAccountSigner: hookState.isAccountSigner,
+      isOriginalSigner: hookState.isOriginalSigner,
+    };
+    [true, false].forEach(t => {
+      [true, false].forEach(s => {
+        [true, false].forEach(o => {
+          hookState.isThresholdMet = t;
+          hookState.isAccountSigner = s;
+          hookState.isOriginalSigner = o;
+          const { unmount } = render(<CandidateSponsors {...baseProps} />);
+          unmount();
+        });
+      });
+    });
+    Object.assign(hookState, origState);
+  });
 });

--- a/packages/niji-webapp/src/components/DelegationCandidateVoteCountInfo/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegationCandidateVoteCountInfo/index.test.tsx
@@ -498,4 +498,63 @@ describe('DelegationCandidateVoteCountInfo', () => {
     );
     expect(container.querySelector('[data-testid="text-jsx"]')?.textContent).toBe('Hello');
   });
+
+  it('mount-unmount 200 cycles', () => {
+    for (let i = 0; i < 200; i++) {
+      const { unmount } = render(
+        <DelegationCandidateVoteCountInfo text="x" voteCount={1} isLoading={false} />,
+      );
+      unmount();
+    }
+  });
+
+  it('renders 300 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 300 }, (_, i) => (
+            <DelegationCandidateVoteCountInfo
+              key={i}
+              text={`t-${i}`}
+              voteCount={i}
+              isLoading={false}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different voteCounts', () => {
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(
+        <DelegationCandidateVoteCountInfo text="x" voteCount={i} isLoading={false} />,
+      );
+      expect(container.textContent).toContain(String(i));
+      unmount();
+    }
+  });
+
+  it('rapid isLoading toggle 100 times', () => {
+    const { rerender } = render(
+      <DelegationCandidateVoteCountInfo text="x" voteCount={5} isLoading={false} />,
+    );
+    for (let i = 0; i < 100; i++) {
+      expect(() =>
+        rerender(
+          <DelegationCandidateVoteCountInfo text="x" voteCount={5} isLoading={i % 2 === 0} />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles 50 different text values', () => {
+    for (let i = 0; i < 50; i++) {
+      const { container, unmount } = render(
+        <DelegationCandidateVoteCountInfo text={`t-${i}`} voteCount={1} isLoading={false} />,
+      );
+      expect(container.textContent).toContain(`t-${i}`);
+      unmount();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
+++ b/packages/niji-webapp/src/components/EnsOrLongAddress/index.test.tsx
@@ -474,4 +474,54 @@ describe('EnsOrLongAddress', () => {
     const { container } = render(<EnsOrLongAddress address={ADDR} />);
     expect(container.textContent).toBe(ADDR);
   });
+
+  it('mount-unmount 200 cycles', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    for (let i = 0; i < 200; i++) {
+      const { unmount } = render(<EnsOrLongAddress address={ADDR} />);
+      unmount();
+    }
+  });
+
+  it('renders 300 instances without crash', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 300 }, (_, i) => (
+            <EnsOrLongAddress key={i} address={ADDR} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different addresses', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue(undefined);
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    for (let i = 0; i < 100; i++) {
+      const addr = ('0x' + i.toString(16).padStart(40, '0')) as `0x${string}`;
+      const { unmount } = render(<EnsOrLongAddress address={addr} />);
+      unmount();
+    }
+  });
+
+  it('handles 30 different ENS names with blocked check', () => {
+    for (let i = 0; i < 30; i++) {
+      vi.mocked(useReverseENSLookUp).mockReturnValue(`ens-${i}.eth`);
+      vi.mocked(containsBlockedText).mockReturnValue(i % 5 === 0);
+      const { unmount } = render(<EnsOrLongAddress address={ADDR} />);
+      unmount();
+    }
+  });
+
+  it('rerender 100 times with stable ENS name', () => {
+    vi.mocked(useReverseENSLookUp).mockReturnValue('stable.eth');
+    vi.mocked(containsBlockedText).mockReturnValue(false);
+    const { container, rerender } = render(<EnsOrLongAddress address={ADDR} />);
+    for (let i = 0; i < 100; i++) {
+      rerender(<EnsOrLongAddress address={ADDR} />);
+    }
+    expect(container.textContent).toBe('stable.eth');
+  });
 });

--- a/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavDropdown/index.test.tsx
@@ -640,4 +640,62 @@ describe('NavDropDown', () => {
       ),
     ).not.toThrow();
   });
+
+  it('mount-unmount 100 cycles', () => {
+    for (let i = 0; i < 100; i++) {
+      const { unmount } = render(
+        <NavDropDown buttonText="Menu">
+          <span>x</span>
+        </NavDropDown>,
+      );
+      unmount();
+    }
+  });
+
+  it('renders 300 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 300 }, (_, i) => (
+            <NavDropDown key={i} buttonText={`Menu-${i}`}>
+              <span>x</span>
+            </NavDropDown>
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 50 different buttonText values sequentially', () => {
+    for (let i = 0; i < 50; i++) {
+      const { container, unmount } = render(
+        <NavDropDown buttonText={`Menu-${i}`}>
+          <span>x</span>
+        </NavDropDown>,
+      );
+      expect(container.querySelector('[data-testid="nav-button"]')?.textContent).toBe(`Menu-${i}`);
+      unmount();
+    }
+  });
+
+  it('handles 30 different children counts', () => {
+    for (let i = 1; i <= 30; i++) {
+      const children = Array.from({ length: i }, (_, j) => <span key={j}>item-{j}</span>);
+      const { unmount } = render(<NavDropDown buttonText="Menu">{children}</NavDropDown>);
+      unmount();
+    }
+  });
+
+  it('all 100 instances have exactly 1 nav-button each', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <NavDropDown key={i} buttonText="x">
+            <span>y</span>
+          </NavDropDown>
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="nav-button"]').length).toBe(100);
+  });
 });


### PR DESCRIPTION
## Summary
part 270 で components 配下 4 file (NavDropdown / EnsOrLongAddress / CandidateSponsors / DelegationCandidateVoteCountInfo) +5 round TC 追加。 5686 → 5706 (+20)。

Closes #871

## Test plan
- [x] vitest 全 pass (5706 TC)