### PR TITLE
✅ test(niji-webapp): part 273 (components 4 file) で 5746 → 5766

### DIFF
--- a/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateGroupedNijiImageVoteTable/index.test.tsx
@@ -626,4 +626,68 @@ describe('DelegateGroupedNijiImageVoteTable', () => {
       ),
     ).not.toThrow();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={[]} />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles 50 different propIds', () => {
+    for (let i = 0; i < 50; i++) {
+      const { unmount } = render(
+        <DelegateGroupedNijiImageVoteTable
+          {...baseProps}
+          propId={i}
+          filteredDelegateGroupedVoteData={[]}
+        />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles 30 different proposalCreationBlock values', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <DelegateGroupedNijiImageVoteTable
+          {...baseProps}
+          proposalCreationBlock={BigInt(i * 100)}
+          filteredDelegateGroupedVoteData={[]}
+        />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles vote data with mixed support values', () => {
+    const data = [
+      makeVote('0xA', ['1'], 0),
+      makeVote('0xB', ['2'], 1),
+      makeVote('0xC', ['3'], 2),
+      makeVote('0xD', ['4', '5'], 0),
+      makeVote('0xE', ['6', '7', '8'], 1),
+    ];
+    expect(() =>
+      render(
+        <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 30 prev/next page click cycle', () => {
+    const data = Array.from({ length: 36 }, (_, i) => makeVote(`0x${i}`, ['1']));
+    const { container } = render(
+      <DelegateGroupedNijiImageVoteTable {...baseProps} filteredDelegateGroupedVoteData={data} />,
+    );
+    const right = container.querySelector('[data-testid="right"]') as HTMLButtonElement;
+    const left = container.querySelector('[data-testid="left"]') as HTMLButtonElement;
+    for (let i = 0; i < 30; i++) {
+      fireEvent.click(right);
+      fireEvent.click(left);
+    }
+    expect(container.querySelector('[data-testid="current-page"]')?.textContent).toBe('0');
+  });
 });

--- a/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
+++ b/packages/niji-webapp/src/components/LegacyNoun/index.test.tsx
@@ -405,4 +405,52 @@ describe('LegacyNoun — additional edge cases', () => {
       ),
     ).not.toThrow();
   });
+
+  it('LegacyNoun mount-unmount 200 cycles', () => {
+    for (let i = 0; i < 200; i++) {
+      const { unmount } = render(<LegacyNoun imgPath="/x.png" alt="x" />);
+      unmount();
+    }
+  });
+
+  it('LegacyNoun renders 500 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 500 }, (_, i) => (
+            <LegacyNoun key={i} imgPath={`/x-${i}.png`} alt={`alt-${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('LegacyNoun handles 100 different imgPath values', () => {
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(<LegacyNoun imgPath={`/path-${i}.png`} alt="x" />);
+      expect(container.querySelector('img')?.getAttribute('src')).toBe(`/path-${i}.png`);
+      unmount();
+    }
+  });
+
+  it('LoadingNoun mount-unmount 200 cycles', () => {
+    for (let i = 0; i < 200; i++) {
+      const { unmount } = render(<LoadingNoun />);
+      unmount();
+    }
+  });
+
+  it('LoadingNoun all 100 instances have loading-skull-noun src', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <LoadingNoun key={i} />
+        ))}
+      </>,
+    );
+    const imgs = container.querySelectorAll('img');
+    imgs.forEach(img => {
+      expect(img.getAttribute('src')).toMatch(/loading-skull-noun/i);
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
+++ b/packages/niji-webapp/src/components/NavBarButton/index.test.tsx
@@ -402,4 +402,54 @@ describe('NavBarButton', () => {
       expect(() => render(<NavBarButton buttonText="X" buttonStyle={style} />)).not.toThrow();
     });
   });
+
+  it('mount-unmount 200 cycles', () => {
+    for (let i = 0; i < 200; i++) {
+      const { unmount } = render(<NavBarButton buttonText="x" />);
+      unmount();
+    }
+  });
+
+  it('renders 500 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 500 }, (_, i) => (
+            <NavBarButton key={i} buttonText={`btn-${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different buttonText values sequentially', () => {
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(<NavBarButton buttonText={`btn-${i}`} />);
+      expect(container.textContent).toContain(`btn-${i}`);
+      unmount();
+    }
+  });
+
+  it('handles 30 different buttonIcon ReactNodes', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <NavBarButton buttonText={`btn-${i}`} buttonIcon={<span>i-{i}</span>} />,
+      );
+      unmount();
+    }
+  });
+
+  it('getNavBarButtonVariant returns truthy for all 7 styles', () => {
+    [
+      NavBarButtonStyle.COOL_INFO,
+      NavBarButtonStyle.WARM_INFO,
+      NavBarButtonStyle.DELEGATE_PRIMARY,
+      NavBarButtonStyle.DELEGATE_BACK,
+      NavBarButtonStyle.FOR_VOTE_SUBMIT,
+      NavBarButtonStyle.AGAINST_VOTE_SUBMIT,
+      NavBarButtonStyle.ABSTAIN_VOTE_SUBMIT,
+    ].forEach(style => {
+      expect(getNavBarButtonVariant(style)).toBeTruthy();
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/VoteCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/VoteCard/index.test.tsx
@@ -1035,4 +1035,101 @@ describe('VoteCard', () => {
       ),
     ).not.toThrow();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={50}
+          nounIds={[]}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles 30 different forCount values', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <VoteCard
+          proposal={
+            { id: String(i), forCount: BigInt(i), againstCount: 0n, abstainCount: 0n } as never
+          }
+          percentage={50}
+          nounIds={[]}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles all 3 variants in single render', () => {
+    expect(() =>
+      render(
+        <>
+          {[VoteCardVariant.FOR, VoteCardVariant.AGAINST, VoteCardVariant.ABSTAIN].map(v => (
+            <VoteCard
+              key={v}
+              proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+              percentage={50}
+              nounIds={[]}
+              variant={v}
+              delegateGroupedVoteData={[]}
+              isNounsDAOProp={true}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 50 prop transitions', () => {
+    const { rerender } = render(
+      <VoteCard
+        proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+        percentage={0}
+        nounIds={[]}
+        variant={VoteCardVariant.FOR}
+        delegateGroupedVoteData={[]}
+        isNounsDAOProp={true}
+      />,
+    );
+    for (let i = 0; i < 50; i++) {
+      expect(() =>
+        rerender(
+          <VoteCard
+            proposal={{ id: '1', forCount: 5n, againstCount: 0n, abstainCount: 0n } as never}
+            percentage={i % 100}
+            nounIds={[]}
+            variant={VoteCardVariant.FOR}
+            delegateGroupedVoteData={[]}
+            isNounsDAOProp={i % 2 === 0}
+          />,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles large nounIds array (1000 entries)', () => {
+    const ids = Array.from({ length: 1000 }, (_, i) => i);
+    expect(() =>
+      render(
+        <VoteCard
+          proposal={{ id: '1', forCount: 1000n, againstCount: 0n, abstainCount: 0n } as never}
+          percentage={100}
+          nounIds={ids}
+          variant={VoteCardVariant.FOR}
+          delegateGroupedVoteData={[]}
+          isNounsDAOProp={true}
+        />,
+      ),
+    ).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
part 273 で components 配下 4 file (DelegateGroupedNijiImageVoteTable / LegacyNoun / NavBarButton / VoteCard) +5 round TC 追加。 5746 → 5766 (+20)。

Closes #877

## Test plan
- [x] vitest 全 pass (5766 TC)