### PR TITLE
✅ test(niji-webapp): part 275 (components 4 file) で 5786 → 5806

### DIFF
--- a/packages/niji-webapp/src/components/Auction/index.test.tsx
+++ b/packages/niji-webapp/src/components/Auction/index.test.tsx
@@ -486,4 +486,53 @@ describe('Auction', () => {
     useAtomValueMock.mockReturnValue(10n);
     expect(() => wrap(<Auction />)).not.toThrow();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = wrap(<Auction auction={makeAuction(BigInt(i)) as never} />);
+      unmount();
+    }
+  });
+
+  it('renders 30 instances all with mixed auctions', () => {
+    useAtomValueMock.mockReturnValue(100n);
+    isNounderMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <Auction key={i} auction={makeAuction(BigInt(i)) as never} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('rapid 30 isNounder toggle', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    for (let i = 0; i < 30; i++) {
+      isNounderMock.mockReturnValue(i % 2 === 0);
+      const { unmount } = wrap(<Auction auction={makeAuction(BigInt(i)) as never} />);
+      unmount();
+    }
+    isNounderMock.mockReturnValue(false);
+  });
+
+  it('handles auction with bidder=0x edge case', () => {
+    useAtomValueMock.mockReturnValue(10n);
+    isNounderMock.mockReturnValue(false);
+    const auction = { ...makeAuction(5n), bidder: '0x' };
+    expect(() => wrap(<Auction auction={auction as never} />)).not.toThrow();
+  });
+
+  it('handles 30 different bigint nounIds', () => {
+    useAtomValueMock.mockReturnValue(100n);
+    isNounderMock.mockReturnValue(false);
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = wrap(<Auction auction={makeAuction(BigInt(i * 10)) as never} />);
+      unmount();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityWrapper/index.test.tsx
@@ -461,4 +461,59 @@ describe('AuctionActivityWrapper', () => {
     );
     expect(container.querySelectorAll('div').length).toBe(300);
   });
+
+  it('mount-unmount 500 cycles', () => {
+    for (let i = 0; i < 500; i++) {
+      const { unmount } = render(<AuctionActivityWrapper>x</AuctionActivityWrapper>);
+      unmount();
+    }
+  });
+
+  it('renders 1000 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 1000 }, (_, i) => (
+            <AuctionActivityWrapper key={i}>{i}</AuctionActivityWrapper>
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 30 different ReactNode children', () => {
+    for (let i = 0; i < 30; i++) {
+      const { container, unmount } = render(
+        <AuctionActivityWrapper>
+          <span data-testid={`child-${i}`}>{i}</span>
+        </AuctionActivityWrapper>,
+      );
+      expect(container.querySelector(`[data-testid="child-${i}"]`)).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it('handles 50 different string children', () => {
+    for (let i = 0; i < 50; i++) {
+      const { container, unmount } = render(
+        <AuctionActivityWrapper>str-{i}</AuctionActivityWrapper>,
+      );
+      expect(container.querySelector('div')?.textContent).toContain(`str-${i}`);
+      unmount();
+    }
+  });
+
+  it('all 100 wrappers contain unique children content', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <AuctionActivityWrapper key={i}>content-{i}</AuctionActivityWrapper>
+        ))}
+      </>,
+    );
+    const divs = container.querySelectorAll('div');
+    divs.forEach((div, i) => {
+      expect(div.textContent).toContain(`content-${i}`);
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/ByLineHoverCard/index.test.tsx
@@ -606,4 +606,67 @@ describe('ByLineHoverCard', () => {
     const long = '0x' + 'a'.repeat(200);
     expect(() => render(<ByLineHoverCard proposerAddress={long} />)).not.toThrow();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(<ByLineHoverCard proposerAddress="0xA" />);
+      unmount();
+    }
+  });
+
+  it('renders 30 instances all in loading state', () => {
+    useSubgraphQueryMock.mockReturnValue({ data: undefined, loading: true, error: undefined });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <ByLineHoverCard key={i} proposerAddress={`0xADDR${i}`} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 30 different proposer addresses with data', () => {
+    for (let i = 0; i < 30; i++) {
+      useSubgraphQueryMock.mockReturnValue({
+        data: { delegates: [{ id: `0xD${i}`, nijiRepresented: [{ id: '1' }] }] },
+        loading: false,
+        error: undefined,
+      });
+      const { unmount } = render(<ByLineHoverCard proposerAddress={`0xP${i}`} />);
+      unmount();
+    }
+  });
+
+  it('handles all 3 query state combinations', () => {
+    [
+      { loading: true, error: undefined, data: undefined },
+      { loading: false, error: new Error('e'), data: undefined },
+      {
+        loading: false,
+        error: undefined,
+        data: { delegates: [{ id: '0xA', nijiRepresented: [{ id: '1' }] }] },
+      },
+    ].forEach(state => {
+      useSubgraphQueryMock.mockReturnValue(state);
+      const { unmount } = render(<ByLineHoverCard proposerAddress="0xA" />);
+      unmount();
+    });
+  });
+
+  it('handles 30 different niji counts in stacked', () => {
+    for (let i = 1; i <= 30; i++) {
+      const niji = Array.from({ length: i }, (_, j) => ({ id: String(j) }));
+      useSubgraphQueryMock.mockReturnValue({
+        data: { delegates: [{ id: '0xA', nijiRepresented: niji }] },
+        loading: false,
+        error: undefined,
+      });
+      const { container, unmount } = render(<ByLineHoverCard proposerAddress="0xA" />);
+      expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe(`stack-${i}`);
+      unmount();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
+++ b/packages/niji-webapp/src/components/DelegateHoverCard/index.test.tsx
@@ -809,4 +809,85 @@ describe('DelegateHoverCard', () => {
       render(<DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={0n} />),
     ).not.toThrow();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+      );
+      unmount();
+    }
+  });
+
+  it('handles 30 different delegates with full data', () => {
+    for (let i = 0; i < 30; i++) {
+      useDelegateNounsAtBlockQueryMock.mockReturnValue({
+        data: {
+          delegates: [{ id: `0xD${i}`, nijiRepresented: [{ id: String(i) }] }],
+        },
+        loading: false,
+        error: undefined,
+      });
+      const { unmount } = render(
+        <DelegateHoverCard delegateId={`delegate-0xD${i}`} proposalCreationBlock={1n} />,
+      );
+      unmount();
+    }
+  });
+
+  it('renders 30 instances all in loading state', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 30 }, (_, i) => (
+            <DelegateHoverCard
+              key={i}
+              delegateId={`delegate-0xX${i}`}
+              proposalCreationBlock={BigInt(i)}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 30 different niji counts in stacked', () => {
+    for (let i = 1; i <= 30; i++) {
+      const niji = Array.from({ length: i }, (_, j) => ({ id: String(j) }));
+      useDelegateNounsAtBlockQueryMock.mockReturnValue({
+        data: { delegates: [{ id: '0xA', nijiRepresented: niji }] },
+        loading: false,
+        error: undefined,
+      });
+      const { container, unmount } = render(
+        <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={1n} />,
+      );
+      expect(container.querySelector('[data-testid="stacked"]')?.textContent).toBe(`stack-${i}`);
+      unmount();
+    }
+  });
+
+  it('handles 30 different proposalCreationBlock values', () => {
+    useDelegateNounsAtBlockQueryMock.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(
+        <DelegateHoverCard delegateId="delegate-0xA" proposalCreationBlock={BigInt(i * 100)} />,
+      );
+      unmount();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
part 275 で components 配下 4 file (Auction / AuctionActivityWrapper / ByLineHoverCard / DelegateHoverCard) +5 round TC 追加。 5786 → 5806 (+20)。

Closes #881

## Test plan
- [x] vitest 全 pass (5806 TC)