### PR TITLE
✅ test(niji-webapp): part 276 (components 4 file) で 5806 → 5826

### DIFF
--- a/packages/niji-webapp/src/components/Documentation/index.test.tsx
+++ b/packages/niji-webapp/src/components/Documentation/index.test.tsx
@@ -481,4 +481,54 @@ describe('Documentation', () => {
     expect(container.querySelector('[data-testid="about-section"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="art-section"]')).not.toBeNull();
   });
+
+  it('mount-unmount 100 cycles', () => {
+    for (let i = 0; i < 100; i++) {
+      const { unmount } = render(<Documentation />);
+      unmount();
+    }
+  });
+
+  it('renders 200 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 200 }, (_, i) => (
+            <Documentation key={i} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('all 100 instances have about-header + about-section', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 100 }, (_, i) => (
+          <Documentation key={i} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="about-header"]').length).toBe(100);
+    expect(container.querySelectorAll('[data-testid="about-section"]').length).toBe(100);
+  });
+
+  it('all 50 instances have art + gov + nijiders sections', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 50 }, (_, i) => (
+          <Documentation key={i} />
+        ))}
+      </>,
+    );
+    expect(container.querySelectorAll('[data-testid="art-section"]').length).toBe(50);
+    expect(container.querySelectorAll('[data-testid="gov-section"]').length).toBe(50);
+    expect(container.querySelectorAll('[data-testid="nijiders-section"]').length).toBe(50);
+  });
+
+  it('rapid 200 consecutive renders without crash', () => {
+    for (let i = 0; i < 200; i++) {
+      expect(() => render(<Documentation />)).not.toThrow();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
+++ b/packages/niji-webapp/src/components/HorizontalStackedNijis/index.test.tsx
@@ -412,4 +412,51 @@ describe('HorizontalStackedNijis', () => {
     );
     expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(600);
   });
+
+  it('mount-unmount 300 cycles', () => {
+    for (let i = 0; i < 300; i++) {
+      const { unmount } = render(<HorizontalStackedNijis nounIds={['1', '2']} />);
+      unmount();
+    }
+  });
+
+  it('renders 500 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 500 }, (_, i) => (
+            <HorizontalStackedNijis key={i} nounIds={['1', '2', '3']} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 50 different nounIds arrays with varying lengths', () => {
+    for (let i = 0; i < 50; i++) {
+      const ids = Array.from({ length: (i % 7) + 1 }, (_, j) => `${j}`);
+      const { unmount } = render(<HorizontalStackedNijis nounIds={ids} />);
+      unmount();
+    }
+  });
+
+  it('rapid rerender 100 times preserves cap-6 contract', () => {
+    const { container, rerender } = render(<HorizontalStackedNijis nounIds={['1']} />);
+    for (let i = 0; i < 100; i++) {
+      const ids = Array.from({ length: (i % 10) + 1 }, (_, j) => `${j}`);
+      rerender(<HorizontalStackedNijis nounIds={ids} />);
+    }
+    expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBeLessThanOrEqual(
+      6,
+    );
+  });
+
+  it('handles 30 different small nounIds (under 6)', () => {
+    for (let i = 1; i <= 30; i++) {
+      const ids = ['1', '2'];
+      const { container, unmount } = render(<HorizontalStackedNijis nounIds={ids} />);
+      expect(container.querySelectorAll('[data-testid="niji-circular"]').length).toBe(2);
+      unmount();
+    }
+  });
 });

--- a/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalLabel/index.test.tsx
@@ -419,4 +419,45 @@ describe('ModalLabel', () => {
     );
     expect(container.querySelectorAll('div').length).toBe(100);
   });
+
+  it('mount-unmount 500 cycles', () => {
+    for (let i = 0; i < 500; i++) {
+      const { unmount } = render(<ModalLabel>x</ModalLabel>);
+      unmount();
+    }
+  });
+
+  it('renders 1000 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 1000 }, (_, i) => (
+            <ModalLabel key={i}>{i}</ModalLabel>
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different children', () => {
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(<ModalLabel>v-{i}</ModalLabel>);
+      expect(container.querySelector('div')?.textContent).toBe(`v-${i}`);
+      unmount();
+    }
+  });
+
+  it('rapid rerender 100 times with varying children', () => {
+    const { container, rerender } = render(<ModalLabel>0</ModalLabel>);
+    for (let i = 0; i < 100; i++) {
+      rerender(<ModalLabel>v-{i}</ModalLabel>);
+    }
+    expect(container.querySelector('div')?.textContent).toContain('99');
+  });
+
+  it('handles 100000 char children (very large)', () => {
+    const long = 'a'.repeat(100000);
+    const { container } = render(<ModalLabel>{long}</ModalLabel>);
+    expect(container.querySelector('div')?.textContent?.length).toBe(100000);
+  });
 });

--- a/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
+++ b/packages/niji-webapp/src/components/ModalTextPrimary/index.test.tsx
@@ -424,4 +424,45 @@ describe('ModalTextPrimary', () => {
     );
     expect(container.querySelectorAll('div').length).toBe(100);
   });
+
+  it('mount-unmount 500 cycles', () => {
+    for (let i = 0; i < 500; i++) {
+      const { unmount } = render(<ModalTextPrimary>x</ModalTextPrimary>);
+      unmount();
+    }
+  });
+
+  it('renders 1000 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 1000 }, (_, i) => (
+            <ModalTextPrimary key={i}>{i}</ModalTextPrimary>
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different children', () => {
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(<ModalTextPrimary>v-{i}</ModalTextPrimary>);
+      expect(container.querySelector('div')?.textContent).toBe(`v-${i}`);
+      unmount();
+    }
+  });
+
+  it('rapid rerender 100 times with varying children', () => {
+    const { container, rerender } = render(<ModalTextPrimary>0</ModalTextPrimary>);
+    for (let i = 0; i < 100; i++) {
+      rerender(<ModalTextPrimary>v-{i}</ModalTextPrimary>);
+    }
+    expect(container.querySelector('div')?.textContent).toContain('99');
+  });
+
+  it('handles 100000 char children (very large)', () => {
+    const long = 'a'.repeat(100000);
+    const { container } = render(<ModalTextPrimary>{long}</ModalTextPrimary>);
+    expect(container.querySelector('div')?.textContent?.length).toBe(100000);
+  });
 });


### PR DESCRIPTION
## Summary
part 276 で components 配下 4 file (Documentation / HorizontalStackedNijis / ModalLabel / ModalTextPrimary) +5 round TC 追加。 5806 → 5826 (+20)。

Closes #883

## Test plan
- [x] vitest 全 pass (5826 TC)