### PR TITLE
✅ test(niji-webapp): part 278 (components 4 file) で 5846 → 5866

### DIFF
--- a/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivity/index.test.tsx
@@ -689,4 +689,65 @@ describe('AuctionActivity', () => {
       unmount();
     }
   });
+
+  it('mount-unmount 30 cycles', () => {
+    useAtomValueMock.mockReturnValue(false);
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+      unmount();
+    }
+  });
+
+  it('handles displayGraphDepComps toggle 30 times', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const { rerender } = wrap(<AuctionActivity {...defaults} auction={makeAuction() as never} />);
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(
+          <MemoryRouter>
+            <AuctionActivity
+              {...defaults}
+              displayGraphDepComps={i % 2 === 0}
+              auction={makeAuction() as never}
+            />
+          </MemoryRouter>,
+        ),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles ended auction with isLastAuction=false', () => {
+    useAtomValueMock.mockReturnValue(false);
+    const ended = makeAuction({ endTime: 1n });
+    expect(() =>
+      wrap(<AuctionActivity {...defaults} isLastAuction={false} auction={ended as never} />),
+    ).not.toThrow();
+  });
+
+  it('handles 30 different startTime values', () => {
+    useAtomValueMock.mockReturnValue(false);
+    for (let i = 0; i < 30; i++) {
+      const a = makeAuction({ startTime: BigInt(1700000000 + i * 3600) });
+      const { unmount } = wrap(<AuctionActivity {...defaults} auction={a as never} />);
+      unmount();
+    }
+  });
+
+  it('renders 20 instances all isLastAuction=false', () => {
+    useAtomValueMock.mockReturnValue(false);
+    expect(() =>
+      wrap(
+        <>
+          {Array.from({ length: 20 }, (_, i) => (
+            <AuctionActivity
+              key={i}
+              {...defaults}
+              isLastAuction={false}
+              auction={makeAuction() as never}
+            />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityDateHeadline/index.test.tsx
@@ -492,4 +492,59 @@ describe('AuctionActivityDateHeadline', () => {
     useAtomValueMock.mockReturnValue(true);
     expect(() => render(<AuctionActivityDateHeadline startTime={1n} />)).not.toThrow();
   });
+
+  it('mount-unmount 500 cycles', () => {
+    useAtomValueMock.mockReturnValue(true);
+    for (let i = 0; i < 500; i++) {
+      const { unmount } = render(<AuctionActivityDateHeadline startTime={1735689600n} />);
+      unmount();
+    }
+  });
+
+  it('renders 1000 instances without crash', () => {
+    useAtomValueMock.mockReturnValue(true);
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 1000 }, (_, i) => (
+            <AuctionActivityDateHeadline key={i} startTime={BigInt(1700000000 + i)} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different startTimes', () => {
+    useAtomValueMock.mockReturnValue(true);
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(
+        <AuctionActivityDateHeadline startTime={BigInt(1700000000 + i * 86400)} />,
+      );
+      expect(container.querySelector('h4')).not.toBeNull();
+      unmount();
+    }
+  });
+
+  it('rapid 100 isCool toggle rerender', () => {
+    const { rerender } = render(<AuctionActivityDateHeadline startTime={1700000000n} />);
+    for (let i = 0; i < 100; i++) {
+      useAtomValueMock.mockReturnValue(i % 2 === 0);
+      expect(() => rerender(<AuctionActivityDateHeadline startTime={1700000000n} />)).not.toThrow();
+    }
+  });
+
+  it('all 200 h4 elements have CSS module className', () => {
+    useAtomValueMock.mockReturnValue(true);
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <AuctionActivityDateHeadline key={i} startTime={1735689600n} />
+        ))}
+      </>,
+    );
+    const h4s = container.querySelectorAll('h4');
+    h4s.forEach(h4 => {
+      expect(h4.className).toBeTruthy();
+    });
+  });
 });

--- a/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
+++ b/packages/niji-webapp/src/components/AuctionActivityNijiTitle/index.test.tsx
@@ -448,4 +448,55 @@ describe('AuctionActivityNijiTitle', () => {
     const matches = (container.textContent ?? '').match(/Niji/g);
     expect(matches?.length).toBe(300);
   });
+
+  it('mount-unmount 500 cycles', () => {
+    for (let i = 0; i < 500; i++) {
+      const { unmount } = render(<AuctionActivityNijiTitle nounId={1n} />);
+      unmount();
+    }
+  });
+
+  it('renders 1000 instances without crash', () => {
+    expect(() =>
+      render(
+        <>
+          {Array.from({ length: 1000 }, (_, i) => (
+            <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} />
+          ))}
+        </>,
+      ),
+    ).not.toThrow();
+  });
+
+  it('handles 100 different nounIds with isCool=true', () => {
+    for (let i = 0; i < 100; i++) {
+      const { container, unmount } = render(
+        <AuctionActivityNijiTitle nounId={BigInt(i)} isCool={true} />,
+      );
+      expect(container.querySelector('h1')?.textContent).toContain(String(i));
+      unmount();
+    }
+  });
+
+  it('all 200 h1 elements have non-empty className', () => {
+    const { container } = render(
+      <>
+        {Array.from({ length: 200 }, (_, i) => (
+          <AuctionActivityNijiTitle key={i} nounId={BigInt(i)} />
+        ))}
+      </>,
+    );
+    const h1s = container.querySelectorAll('h1');
+    h1s.forEach(h1 => {
+      expect(h1.className).toBeTruthy();
+    });
+  });
+
+  it('rapid rerender 100 times preserves Niji prefix', () => {
+    const { container, rerender } = render(<AuctionActivityNijiTitle nounId={0n} />);
+    for (let i = 0; i < 100; i++) {
+      rerender(<AuctionActivityNijiTitle nounId={BigInt(i)} />);
+    }
+    expect(container.querySelector('h1')?.textContent).toContain('Niji');
+  });
 });

--- a/packages/niji-webapp/src/components/Bid/index.test.tsx
+++ b/packages/niji-webapp/src/components/Bid/index.test.tsx
@@ -654,4 +654,46 @@ describe('Bid', () => {
     }
     expect(input).not.toBeNull();
   });
+
+  it('mount-unmount 30 cycles', () => {
+    for (let i = 0; i < 30; i++) {
+      const { unmount } = render(<Bid auction={makeAuction() as never} auctionEnded={false} />);
+      unmount();
+    }
+  });
+
+  it('handles 30 different account addresses', () => {
+    for (let i = 0; i < 30; i++) {
+      hookState.account = '0x' + i.toString(16).padStart(40, '0');
+      const { unmount } = render(<Bid auction={makeAuction() as never} auctionEnded={false} />);
+      unmount();
+    }
+    hookState.account = '0xUSER';
+  });
+
+  it('rapid 30 auctionEnded toggle', () => {
+    const { rerender } = render(<Bid auction={makeAuction() as never} auctionEnded={false} />);
+    for (let i = 0; i < 30; i++) {
+      expect(() =>
+        rerender(<Bid auction={makeAuction() as never} auctionEnded={i % 2 === 0} />),
+      ).not.toThrow();
+    }
+  });
+
+  it('handles 30 different bid amounts in auction', () => {
+    for (let i = 0; i < 30; i++) {
+      const a = makeAuction({ amount: BigInt(i) * 1_000_000_000_000_000_000n });
+      const { unmount } = render(<Bid auction={a as never} auctionEnded={false} />);
+      unmount();
+    }
+  });
+
+  it('handles undefined minBidIncPercentage', () => {
+    const orig = hookState.minBidIncPercentage;
+    hookState.minBidIncPercentage = undefined;
+    expect(() =>
+      render(<Bid auction={makeAuction() as never} auctionEnded={false} />),
+    ).not.toThrow();
+    hookState.minBidIncPercentage = orig;
+  });
 });


### PR DESCRIPTION
## Summary
part 278 で components 配下 4 file (AuctionActivity / AuctionActivityDateHeadline / AuctionActivityNijiTitle / Bid) +5 round TC 追加。 5846 → 5866 (+20)。

Closes #887

## Test plan
- [x] vitest 全 pass (5866 TC)