### PR TITLE
🔧 fix(ci): subgraph devDeps に @niji/contracts 追加で turbo 順序強制 (CAR-301)

### DIFF
--- a/packages/niji-subgraph/package.json
+++ b/packages/niji-subgraph/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.97.1",
     "@graphprotocol/graph-ts": "0.38.1",
+    "@niji/contracts": "workspace:*",
     "assemblyscript": "^0.19.23",
     "matchstick-as": "0.6.0",
     "mustache": "4.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -435,7 +435,7 @@ importers:
         version: 2.3.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
+        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
       dotenv:
         specifier: 'catalog:'
         version: 16.5.0
@@ -481,6 +481,9 @@ importers:
       '@graphprotocol/graph-ts':
         specifier: 0.38.1
         version: 0.38.1
+      '@niji/contracts':
+        specifier: workspace:*
+        version: link:../niji-contracts
       assemblyscript:
         specifier: ^0.19.23
         version: 0.19.23
@@ -546,7 +549,7 @@ importers:
         version: 6.6.3
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
+        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
       bad-words:
         specifier: ^3.0.4
         version: 3.0.4


### PR DESCRIPTION
## Summary

- `packages/niji-subgraph/package.json` の `devDependencies` に `"@niji/contracts": "workspace:*"` を追加
- turbo は package.json 依存宣言から `^build` 順序を解決するため、 これで `@niji/contracts#build` → `@niji/subgraph#build` 順序を強制
- master CI が `subgraph.yaml` の `../niji-contracts/abi/...` 参照を解決できず連続 fail していた根本原因の修正

## Test plan

- [x] `pnpm install` で lockfile 更新 (workspace link 追加のみ)
- [x] `pnpm turbo run build --dry-run=json` で `@niji/subgraph#build deps: ['@niji/contracts#build']` 確認
- [x] `pnpm turbo run build --filter='@niji/subgraph' --filter='@niji/contracts'` 全 4 task green
- [ ] CI `Build (22.x)` で contracts → subgraph 順序になり subgraph が pass する

## Out of scope

webapp の TypeScript test 型 error (`usdcUtils.test.ts` / `subgraph.test.ts` / `nijiStream.test.ts`) は pre-existing で本 PR 対象外。 別 Issue で対応する。

Refs CAR-301
Closes CAR-301