### PR TITLE
🔧 fix(ci): hardhat-abi-exporter に runOnCompile: true 追加で CI ABI 生成保証 (#2986)

### DIFF
--- a/packages/niji-contracts/hardhat.config.ts
+++ b/packages/niji-contracts/hardhat.config.ts
@@ -87,6 +87,7 @@ const config: HardhatUserConfig = {
   abiExporter: {
     path: './abi',
     clear: true,
+    runOnCompile: true,
   },
   typechain: {
     outDir: './typechain',


### PR DESCRIPTION
## Summary

- CI Build (22.x) で `@niji/contracts#build` が `abi/contracts/**.json` 不在で fail する根本原因 (`hardhat-abi-exporter` の `runOnCompile` default が `false`) を `packages/niji-contracts/hardhat.config.ts` の `abiExporter` に `runOnCompile: true` を 1 行追加して解消した
- `hardhat compile` 実行毎に ABI export が自動 hook され、 CI clone 直後 (abi/ 不在) でも tsup の `../abi/contracts/**.json` import が解決可能になり、 contracts + sdk + subgraph 連動 build が green になる
- local では過去の手動 `pnpm hardhat export-abi` 残存で気付かれずに進行していた silent fail 経路を構造的に止める

## 背景

run 28420263511 fail log で `Compiled 152 Solidity files successfully` 後の ABI export step が観測されないことから、 `hardhat-abi-exporter` v2.x docs (`runOnCompile: default false`) と突合して根本原因確定。

PR #2985 (CAR-301) の turbo 順序強制で subgraph build を contracts 完了後にしたが、 そもそも abi 自体が CI で生成されていなかったため continue failure。 本 PR は最終 piece として ABI 物理生成を保証する。

## 修正内容

```diff
   abiExporter: {
     path: './abi',
     clear: true,
+    runOnCompile: true,
   },
```

## 検証 (local clean build)

```bash
cd packages/niji-contracts
rm -rf abi typechain artifacts cache
pnpm build:sol  # abi/contracts/ 17 entry 再生成確認 (NijiToken / NijiAuctionHouse / NijiDescriptor / NijiSeeder / governance/*4 等)
pnpm build:ts   # ESM + CJS + DTS 全 success
```

連動 package。
- `pnpm -F @niji/sdk build` → ABI deduplication complete
- `pnpm -F @niji/subgraph build` → Build completed: build/subgraph.yaml

## 影響範囲

- `packages/niji-contracts/hardhat.config.ts` (1 行追加)
- CI build 時間 ... ABI export step は数百 ms (`Generating typings` 後段 step、 全体 build 時間に対して無視できる)
- `.gitignore` 変更なし、 abi/ は引き続き CI build artifact として untracked 維持

## Test plan

- [x] local で `pnpm -F @niji/contracts build` (clean) が green
- [x] local で `pnpm -F @niji/sdk build` が green (contracts 依存)
- [x] local で `pnpm -F @niji/subgraph build` が green (abi 依存)
- [ ] CI Build (22.x) で contracts + subgraph + sdk + webapp 全 green を確認 (PR 後 CI 実行)
- [ ] `@niji/contracts#build` が turbo cache miss でも安定 success

## 関連

- Closes #2986
- PR #2985 (CAR-301 / turbo subgraph→contracts 配線、 本 PR の前段)
- 失敗 run = https://github.com/Niji-DAO/niji-monorepo/actions/runs/28420263511
- [fallback] direct-gh-chain (Linear mirror 未起票、 niji-monorepo Project が Linear に存在しないため `Closes #2986` のみで GH Issue 自動 close を成立)

🤖 Generated with [Claude Code](https://claude.com/claude-code)