### PR TITLE
🔧 fix(niji-webapp): ja-JP / zh-CN の i18n missing 7 件を翻訳追加で lingui compile --strict pass (#2990)

### DIFF
--- a/packages/niji-webapp/src/locales/en-US.po
+++ b/packages/niji-webapp/src/locales/en-US.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
 msgstr "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
 
@@ -49,8 +49,8 @@ msgstr "Objection period triggered"
 msgid "Update proposal"
 msgstr "Update proposal"
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Nijis voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 msgstr "Nijis voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 
@@ -95,7 +95,7 @@ msgstr "Playground"
 msgid "You've already delegated to this address"
 msgstr "You've already delegated to this address"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Daily Auctions"
 msgstr "Daily Auctions"
 
@@ -148,7 +148,7 @@ msgstr "Required % of Nijis to Pass"
 msgid "Winner"
 msgstr "Winner"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
 msgstr "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
 
@@ -184,7 +184,7 @@ msgstr "Version History"
 msgid "Compound Governance"
 msgstr "Compound Governance"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
 msgstr "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
 
@@ -192,7 +192,7 @@ msgstr "attempt to alter Niji auction cadence for the purpose of maintaining or 
 msgid "Delegate {availableVotes} Votes"
 msgstr "Delegate {availableVotes} Votes"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more about the DUNA"
 msgstr "Learn more about the DUNA"
 
@@ -201,8 +201,8 @@ msgid "Streamed so far"
 msgstr "Streamed so far"
 
 #: src/components/Footer.tsx
-msgid "Map"
-msgstr "Map"
+#~ msgid "Map"
+#~ msgstr "Map"
 
 #: src/components/CandidateSponsors/OriginalSignature.tsx
 msgid "Awaiting signature"
@@ -243,7 +243,7 @@ msgstr "<0>Proposed by: </0><1>{proposer}</1><2>{transactionLink}</2>"
 msgid "3.5 artists, 6.5 technologists"
 msgstr "3.5 artists, 6.5 technologists"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "bribe voters to facilitate withdraws of the treasury for personal gain"
 msgstr "bribe voters to facilitate withdraws of the treasury for personal gain"
 
@@ -261,14 +261,14 @@ msgid "Download All"
 msgstr "Download All"
 
 #: src/components/Banner/index.tsx
-msgid "FOREVER."
-msgstr "FOREVER."
+#~ msgid "FOREVER."
+#~ msgstr "FOREVER."
 
 #: src/pages/Forks/index.tsx
 msgid "There are no active forks."
 msgstr "There are no active forks."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 
@@ -284,7 +284,7 @@ msgstr "Go to playground"
 msgid "or more"
 msgstr "or more"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
 msgstr "Niji artwork is in the {publicDomainLink}."
 
@@ -319,11 +319,15 @@ msgstr "You've successfully withdrawn {withdrawAmount} {unitForDisplay} to your 
 msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nijis voters, it can be promoted to a proposal. "
 msgstr "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nijis voters, it can be promoted to a proposal. "
 
-#: src/components/Documentation/index.tsx
+#: src/pages/CrystalBall/index.tsx
+msgid "現在オークション中"
+msgstr "現在オークション中"
+
+#: src/components/Documentation/AboutSection.tsx
 msgid "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
 msgstr "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Add your feedback"
 msgstr "Add your feedback"
 
@@ -347,7 +351,7 @@ msgstr "Candidate updated!"
 msgid "You <0>MUST</0> maintain enough voting power to meet the proposal threshold until your proposal is executed. If you fail to do so, anyone can cancel your proposal."
 msgstr "You <0>MUST</0> maintain enough voting power to meet the proposal threshold until your proposal is executed. If you fail to do so, anyone can cancel your proposal."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "There are unfortunately no algorithmic solutions for making these determinations in advance (if there were, the veto would not be required), and proposals must be considered on a case by case basis."
 msgstr "There are unfortunately no algorithmic solutions for making these determinations in advance (if there were, the veto would not be required), and proposals must be considered on a case by case basis."
 
@@ -363,7 +367,7 @@ msgstr "Calendar"
 msgid "Settle manually"
 msgstr "Settle manually"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Artwork is generative and stored directly on-chain (not IPFS)."
 msgstr "Artwork is generative and stored directly on-chain (not IPFS)."
 
@@ -395,7 +399,7 @@ msgstr "CryptoPunks"
 msgid "Available to withdraw"
 msgstr "Available to withdraw"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "You can experiment with off-chain Niji generation at the {playgroundLink}."
 msgstr "You can experiment with off-chain Niji generation at the {playgroundLink}."
 
@@ -433,8 +437,8 @@ msgid "You can settle manually in {0} minutes"
 msgstr "You can settle manually in {0} minutes"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Nijispot"
-msgstr "Nijispot"
+#~ msgid "Nijispot"
+#~ msgstr "Nijispot"
 
 #: src/pages/Candidate/index.tsx
 msgid "<0>Note: </0>This proposal candidate has been proposed onchain."
@@ -449,7 +453,7 @@ msgstr "Reason (Optional)"
 msgid "Update Delegate"
 msgstr "Update Delegate"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Settlement of one auction kicks off the next."
 msgstr "Settlement of one auction kicks off the next."
 
@@ -480,8 +484,8 @@ msgid "Delegate Update Failed"
 msgstr "Delegate Update Failed"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
-msgstr "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
+#~ msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
+#~ msgstr "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
 
 #: src/components/Footer.tsx
 #: src/pages/Forks/index.tsx
@@ -493,11 +497,11 @@ msgstr "Governance"
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsList.tsx
 msgid "Sponsoring a proposal requires at least one Niji vote"
 msgstr "Sponsoring a proposal requires at least one Niji vote"
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Signature request"
 msgstr "Signature request"
 
@@ -505,7 +509,7 @@ msgstr "Signature request"
 msgid "<0>Delegated Nijis: </0>"
 msgstr "<0>Delegated Nijis: </0>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
 msgstr "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
 
@@ -517,11 +521,11 @@ msgstr "The playground was built using the {nijiProtocolLink}. Niji's traits are
 msgid "Address"
 msgstr "Address"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Governance ‘Slow Start’"
 msgstr "Governance ‘Slow Start’"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Summary"
 msgstr "Summary"
 
@@ -547,7 +551,7 @@ msgstr "Remove sponsorship"
 msgid "Only Nijis you owned or were delegated to you before {0} are eligible to vote."
 msgstr "Only Nijis you owned or were delegated to you before {0} are eligible to vote."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
 msgstr "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
 
@@ -600,7 +604,7 @@ msgstr "Edit"
 msgid "Review Action Details"
 msgstr "Review Action Details"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
 msgstr "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
 
@@ -608,13 +612,13 @@ msgstr "Each time an auction is settled, the settlement transaction will also ca
 msgid "Candidate Created!"
 msgstr "Candidate Created!"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 #: src/components/NijiContent/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Niji DAO"
 msgstr "Niji DAO"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider's Reward"
 msgstr "Nijider's Reward"
 
@@ -631,7 +635,7 @@ msgstr "Proposal Created!"
 msgid "Active"
 msgstr "Active"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO uses a fork of {compoundGovLink}."
 msgstr "Niji DAO uses a fork of {compoundGovLink}."
 
@@ -693,7 +697,7 @@ msgstr "More than {0} Nijis ({1}% of the DAO) are required to pass the threshold
 msgid "Please try again."
 msgstr "Please try again."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
 msgstr "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
 
@@ -726,9 +730,9 @@ msgstr "Create proposal candidate"
 msgid "Already has"
 msgstr "Already has"
 
-#. placeholder {0}: userVoteSupport && supportText[userVoteSupport.supportDetailed].toLowerCase()
-#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport?.createdTimestamp * 1000).fromNow()
-#: src/components/VoteSignals/VoteSignals.tsx
+#. placeholder {0}: userVoteSupport && SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()
+#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport.createdTimestamp * 1000).fromNow()
+#: src/components/VoteSignals/VoteSignalsUserFeedback.tsx
 msgid "You provided <0>{0}</0> feedback {1}"
 msgstr "You provided <0>{0}</0> feedback {1}"
 
@@ -738,7 +742,7 @@ msgstr "For this reason, we, the project's founders (‘Nijiders’) have chosen
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Against"
 msgstr "Against"
 
@@ -776,7 +780,7 @@ msgstr "You don't have enough votes to submit a proposal"
 msgid "Failed to fetch"
 msgstr "Failed to fetch"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr "unequally withdraw the treasury for personal gain"
 
@@ -793,8 +797,8 @@ msgid "Candidates submitted by community members will appear here."
 msgstr "Candidates submitted by community members will appear here."
 
 #: src/components/Banner/index.tsx
-msgid "ONE NOUN,"
-msgstr "ONE NOUN,"
+#~ msgid "ONE NOUN,"
+#~ msgstr "ONE NOUN,"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "<0/><1>Guidelines</1><2/>• Do <3>NOT</3> request ETH to trade into USDC. Instead, request USDC directly.<4/>• Do <5>NOT</5> transfer funds externally to create an ETH or USDC stream. Instead, use the \"Stream Funds\" action.<6/><7>Supported Action Types</7><8/><9>• Transfer Funds: </9>Send USDC, ETH, or stETH.<10/><11>• Stream Funds: </11>Stream USDC or WETH over time.<12/><13>• Function Call: </13>Call a contract function."
@@ -814,7 +818,7 @@ msgstr "Fork"
 msgid "Stream"
 msgstr "Stream"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Submit"
 msgstr "Submit"
 
@@ -822,7 +826,7 @@ msgstr "Submit"
 msgid "Auction"
 msgstr "Auction"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Update proposal candidates must be re-signed by the original signers."
 msgstr "Update proposal candidates must be re-signed by the original signers."
 
@@ -855,6 +859,10 @@ msgstr "Back"
 #: src/pages/Governance/index.tsx
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
+
+#: src/pages/CrystalBall/index.tsx
+msgid "※ Niji Seeder の seed 生成は keccak256(blockhash + tokenId + timestamp + prevrandao) をシードに使うため、 実際に mint される block の hash で seed が確定します。 ここでの予測は現時点 (latest block) で chain に問い合わせた view 結果なので、 実際の auction 開始 block と異なれば絵柄も変わります。"
+msgstr "※ Niji Seeder の seed 生成は keccak256(blockhash + tokenId + timestamp + prevrandao) をシードに使うため、 実際に mint される block の hash で seed が確定します。 ここでの予測は現時点 (latest block) で chain に問い合わせた view 結果なので、 実際の auction 開始 block と異なれば絵柄も変わります。"
 
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
@@ -935,7 +943,7 @@ msgstr "All Niji auction proceeds are sent to the Niji DAO. For this reason, we,
 msgid "Deploy Fork"
 msgstr "Deploy Fork"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
 msgstr "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
 
@@ -943,7 +951,7 @@ msgstr "The Niji Foundation considers the veto an emergency power that should no
 msgid "View the candidate"
 msgstr "View the candidate"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "No sponsored votes needed"
 msgstr "No sponsored votes needed"
 
@@ -977,7 +985,7 @@ msgstr "Note"
 msgid "<0>Delegated Niji: </0>"
 msgstr "<0>Delegated Niji: </0>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "All Nijis are members of Niji DAO."
 msgstr "All Nijis are members of Niji DAO."
 
@@ -986,14 +994,14 @@ msgid "Now has"
 msgstr "Now has"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Build With Niji. Get Funded."
-msgstr "Build With Niji. Get Funded."
+#~ msgid "Build With Niji. Get Funded."
+#~ msgstr "Build With Niji. Get Funded."
 
 #: src/components/Winner/index.tsx
 msgid "You"
 msgstr "You"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-proposal feedback"
 msgstr "Pre-proposal feedback"
 
@@ -1016,7 +1024,7 @@ msgstr "Updatable"
 msgid "Auction ended"
 msgstr "Auction ended"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposal candidates must meet the required Nijis vote threshold."
 msgstr "Proposal candidates must meet the required Nijis vote threshold."
 
@@ -1034,11 +1042,11 @@ msgstr "Submit Proposal"
 msgid "Submit Vote"
 msgstr "Submit Vote"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Traits"
 msgstr "Niji Traits"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 
@@ -1046,7 +1054,7 @@ msgstr "Nijis are generated randomly based Ethereum block hashes. There are no '
 msgid "Your <0>{availableVotes}</0> votes are being delegated to a new account."
 msgstr "Your <0>{availableVotes}</0> votes are being delegated to a new account."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
 msgstr "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
 
@@ -1063,7 +1071,7 @@ msgstr "Bid history"
 msgid "This proposal can be edited for "
 msgstr "This proposal can be edited for "
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Adding your feedback"
 msgstr "Adding your feedback"
 
@@ -1073,8 +1081,8 @@ msgid "Any token holder can signal to fork (exit) in response to a governance pr
 msgstr "Any token holder can signal to fork (exit) in response to a governance proposal. If a {0}quorum of tokens signal to exit, the fork will succeed."
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
-msgstr "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
+#~ msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
+#~ msgstr "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
 
 #: src/components/LanguageSelectionModal/index.tsx
 msgid "Select Language"
@@ -1088,6 +1096,11 @@ msgstr "Please place a bid higher than or equal to the minimum bid amount of {0}
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploying Niji fork and beginning the forking period"
 msgstr "Deploying Niji fork and beginning the forking period"
+
+#: src/components/Footer.tsx
+#: src/components/NavBar/index.tsx
+msgid "Crystal Ball"
+msgstr "Crystal Ball"
 
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
@@ -1105,7 +1118,7 @@ msgstr "Creating ZIP..."
 msgid "Proposed Transactions"
 msgstr "Proposed Transactions"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
 msgstr "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
 
@@ -1113,7 +1126,7 @@ msgstr "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts
 msgid "Review Function Call Action"
 msgstr "Review Function Call Action"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 
@@ -1131,7 +1144,7 @@ msgstr "Proposals cannot be executed during a forking period"
 msgid "Vote on Prop {0}"
 msgstr "Vote on Prop {0}"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
 msgstr "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
 
@@ -1139,7 +1152,7 @@ msgstr "Nijis are stored directly on Ethereum and do not utilize pointers to oth
 msgid "Bids"
 msgstr "Bids"
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Submit signature"
 msgstr "Submit signature"
 
@@ -1154,7 +1167,7 @@ msgstr "Etherscan"
 msgid "Description"
 msgstr "Description"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
 msgstr "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
 
@@ -1162,7 +1175,7 @@ msgstr "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing 
 msgid "Change"
 msgstr "Change"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The compressed parts are efficiently converted into a single base64 encoded SVG image on-chain. To accomplish this, each part is decoded into an intermediate format before being converted into a series of SVG rects using batched, on-chain string concatenation. Once the entire SVG has been generated, it is base64 encoded."
 msgstr "The compressed parts are efficiently converted into a single base64 encoded SVG image on-chain. To accomplish this, each part is decoded into an intermediate format before being converted into a series of SVG rects using batched, on-chain string concatenation. Once the entire SVG has been generated, it is base64 encoded."
 
@@ -1211,7 +1224,7 @@ msgstr "Current Threshold"
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
 msgstr "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
 
@@ -1225,6 +1238,7 @@ msgstr "No arguments required "
 msgid "Add Streaming Payment Action"
 msgstr "Add Streaming Payment Action"
 
+#: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "LP"
@@ -1235,7 +1249,9 @@ msgstr "LP"
 msgid "Niji DAO Fork{0}"
 msgstr "Niji DAO Fork{0}"
 
-#. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
+#. placeholder {0}: i18n.number(Number(currentQuorum ?? 0))
+#. placeholder {0}: proposal.quorumVotes
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr "{0} votes"
@@ -1244,11 +1260,11 @@ msgstr "{0} votes"
 msgid "Withdraw from Stream <0/>"
 msgstr "Withdraw from Stream <0/>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "WTF?"
 msgstr "WTF?"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
 msgstr "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
 
@@ -1288,6 +1304,10 @@ msgstr "Proposal"
 msgid "Voted with<0>{numVotesForProp}</0>Nijis"
 msgstr "Voted with<0>{numVotesForProp}</0>Nijis"
 
+#: src/pages/CrystalBall/index.tsx
+msgid "次に登場する Niji をブロックチェーン上の seed 生成ロジックで先取り。 現在オークション中の Niji の次から 5 体先までを予測表示します。"
+msgstr "次に登場する Niji をブロックチェーン上の seed 生成ロジックで先取り。 現在オークション中の Niji の次から 5 体先までを予測表示します。"
+
 #: src/components/VoteModal/index.tsx
 msgid "Gas spent on voting will be refunded to you."
 msgstr "Gas spent on voting will be refunded to you."
@@ -1300,7 +1320,7 @@ msgstr "Will have"
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
 msgstr "Voted with<0>{numVotesForProp}</0>Niji"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-voting feedback"
 msgstr "Pre-voting feedback"
 
@@ -1309,7 +1329,7 @@ msgstr "Pre-voting feedback"
 msgid "Starts {0}"
 msgstr "Starts {0}"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 
@@ -1331,7 +1351,7 @@ msgstr "Delegate Updated!"
 msgid "You've generated {0} years worth of Nijis"
 msgstr "You've generated {0} years worth of Nijis"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
 msgstr "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
 
@@ -1389,7 +1409,7 @@ msgstr "Tip"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Abstain"
 msgstr "Abstain"
 
@@ -1416,13 +1436,13 @@ msgstr "Starting on"
 msgid "Colored Noggles"
 msgstr "Colored Noggles"
 
-#. placeholder {0}: props.candidate.proposerVotes
-#. placeholder {1}: props.candidate.proposerVotes > 1 ? 's' : ''
-#: src/components/CandidateSponsors/index.tsx
+#. placeholder {0}: candidate.proposerVotes
+#. placeholder {1}: candidate.proposerVotes > 1 ? 's' : ''
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposer has {0} vote{1}"
 msgstr "Proposer has {0} vote{1}"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "On-Chain Artwork"
 msgstr "On-Chain Artwork"
 
@@ -1435,10 +1455,10 @@ msgid "You can settle manually in 1 minute"
 msgstr "You can settle manually in 1 minute"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Niji is a global community."
-msgstr "Niji is a global community."
+#~ msgid "Niji is a global community."
+#~ msgstr "Niji is a global community."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
 msgstr "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
 
@@ -1463,6 +1483,10 @@ msgstr "Add one or more proposal actions and describe your proposal for the comm
 msgid "Forking"
 msgstr "Forking"
 
+#: src/pages/CrystalBall/index.tsx
+msgid "計算中…"
+msgstr "計算中…"
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.tsx
 msgid "Add Stream Date Details"
 msgstr "Add Stream Date Details"
@@ -1479,7 +1503,7 @@ msgstr "The Threshold (minimum number of For votes required to pass a proposal) 
 msgid "Explore traits"
 msgstr "Explore traits"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
 msgstr "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
 
@@ -1499,11 +1523,11 @@ msgstr "Ends on"
 msgid "Token"
 msgstr "Token"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The treasury is controlled exclusively by Nijis via governance."
 msgstr "The treasury is controlled exclusively by Nijis via governance."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is trustlessly auctioned every 24 hours, forever."
 msgstr "One Niji is trustlessly auctioned every 24 hours, forever."
 
@@ -1558,7 +1582,7 @@ msgstr "Go to auction"
 msgid "Submissions are free for Nijis voters. Non-voters can submit for a {0} ETH fee."
 msgstr "Submissions are free for Nijis voters. Non-voters can submit for a {0} ETH fee."
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "This candidate has met the required threshold, but Nijis voters can still add support until it’s put onchain."
 msgstr "This candidate has met the required threshold, but Nijis voters can still add support until it’s put onchain."
 
@@ -1590,7 +1614,7 @@ msgstr "More details on how the dynamic threshold works can be found <0>here</0>
 msgid "Review and Add"
 msgstr "Review and Add"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "100% of Niji auction proceeds are trustlessly sent to the treasury."
 msgstr "100% of Niji auction proceeds are trustlessly sent to the treasury."
 
@@ -1601,6 +1625,10 @@ msgstr "<0>Proposed by: </0><1>{proposerLink}</1>{transactionLink}"
 #: src/components/NavLocaleSwitcher/index.tsx
 msgid "Language"
 msgstr "Language"
+
+#: src/pages/CrystalBall/index.tsx
+msgid "Niji Crystal Ball"
+msgstr "Niji Crystal Ball"
 
 #: src/pages/Vote/index.tsx
 msgid "Starts"
@@ -1654,7 +1682,7 @@ msgstr "This candidate currently has {0} signatures."
 msgid "Delegate"
 msgstr "Delegate"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA"
 msgstr "Niji DUNA"
 
@@ -1675,7 +1703,7 @@ msgstr "{0} ETH fee upon submission"
 msgid "Nijiders' Reward"
 msgstr "Nijiders' Reward"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is equal to one vote."
 msgstr "One Niji is equal to one vote."
 
@@ -1683,7 +1711,7 @@ msgstr "One Niji is equal to one vote."
 msgid "Proposal Candidate"
 msgstr "Proposal Candidate"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "make upgrades to critical smart contracts without undergoing an audit"
 msgstr "make upgrades to critical smart contracts without undergoing an audit"
 
@@ -1695,7 +1723,7 @@ msgstr "Streams start and end at 00:00 UTC on selected dates."
 msgid "You have no Votes."
 msgstr "You have no Votes."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
 msgstr "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
 
@@ -1703,13 +1731,13 @@ msgstr "Trait generation is not truly random. Traits can be predicted when minti
 msgid "There was an error withdrawing to your wallet."
 msgstr "There was an error withdrawing to your wallet."
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Seeder Contract"
 msgstr "Niji Seeder Contract"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "For"
 msgstr "For"
 
@@ -1718,8 +1746,8 @@ msgid "Help mint the next Niji"
 msgstr "Help mint the next Niji"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "One Niji, Every Day, Forever."
-msgstr "One Niji, Every Day, Forever."
+#~ msgid "One Niji, Every Day, Forever."
+#~ msgstr "One Niji, Every Day, Forever."
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Function"
@@ -1735,7 +1763,7 @@ msgstr "Download the individual traits that compose Nijis"
 
 #. placeholder {0}: humanizeTraitKey(traitKey)
 #. placeholder {1}: NijiImageData.images[traitKey].length
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "{0} ({1})"
 msgstr "{0} ({1})"
 
@@ -1784,12 +1812,12 @@ msgid "Proposer functions"
 msgstr "Proposer functions"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
-msgstr "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
+#~ msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
+#~ msgstr "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
 
 #: src/components/Banner/index.tsx
-msgid "EVERY DAY,"
-msgstr "EVERY DAY,"
+#~ msgid "EVERY DAY,"
+#~ msgstr "EVERY DAY,"
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"

--- a/packages/niji-webapp/src/locales/ja-JP.po
+++ b/packages/niji-webapp/src/locales/ja-JP.po
@@ -18,7 +18,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "Last-Translator: \n"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
 msgstr "Niji DUNA は、Niji DAO の分散型の特性に整合する堅牢な法的枠組みを提供するため、<0/> を通じてワイオミング州で設立された、法的に認められた分散型非法人非営利協会です。この構造により、Niji DAO は分散型ガバナンスの理念を損なうことなく、有限責任保護と法的明確性を保ちながら運営できます。"
 
@@ -54,8 +54,8 @@ msgstr "異議申し立て期間が開始されました"
 msgid "Update proposal"
 msgstr "提案を更新"
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Nijis voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 msgstr "Nijisの投票者は、保留中の提案の提案者に対して、どのように投票するつもりかのアイデアを提供し、提案の変更に関する有益なガイダンスを提供するために投票シグナルを送ることができます。"
 
@@ -100,7 +100,7 @@ msgstr "遊び場"
 msgid "You've already delegated to this address"
 msgstr "あなたはすでにこのアドレスに委任しています"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Daily Auctions"
 msgstr "デイリーオークション"
 
@@ -153,7 +153,7 @@ msgstr "可決に必要な Niji の割合 (%)"
 msgid "Winner"
 msgstr "落札者"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
 msgstr "Niji はオンチェーンアバターコミュニティの形成を改善するための実験的な試みです。{cryptopunksLink} のようなプロジェクトがデジタルコミュニティとアイデンティティのブートストラップを試みた一方で、Niji はアイデンティティ、コミュニティ、ガバナンス、およびコミュニティが利用できるトレジャリーのブートストラップを試みます。"
 
@@ -189,7 +189,7 @@ msgstr "バージョン履歴"
 msgid "Compound Governance"
 msgstr "コンパウンドガバナンス"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
 msgstr "投票の過半数を維持または獲得する目的で Niji オークションの頻度を変更しようとする"
 
@@ -197,7 +197,7 @@ msgstr "投票の過半数を維持または獲得する目的で Niji オーク
 msgid "Delegate {availableVotes} Votes"
 msgstr "{availableVotes}票を委任する"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more about the DUNA"
 msgstr "DUNAについて詳しく学ぶ"
 
@@ -206,8 +206,8 @@ msgid "Streamed so far"
 msgstr "これまでにストリーミングされた"
 
 #: src/components/Footer.tsx
-msgid "Map"
-msgstr "地図"
+#~ msgid "Map"
+#~ msgstr "地図"
 
 #: src/components/CandidateSponsors/OriginalSignature.tsx
 msgid "Awaiting signature"
@@ -248,7 +248,7 @@ msgstr "<0>提案者: </0><1>{proposer}</1><2>{transactionLink}</2>"
 msgid "3.5 artists, 6.5 technologists"
 msgstr "3.5アーティスト、6.5技術者"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "bribe voters to facilitate withdraws of the treasury for personal gain"
 msgstr "個人的な利益のために財務省からの引き出しを容易にするために有権者を買収する"
 
@@ -266,14 +266,14 @@ msgid "Download All"
 msgstr "すべてダウンロード"
 
 #: src/components/Banner/index.tsx
-msgid "FOREVER."
-msgstr "永遠に。"
+#~ msgid "FOREVER."
+#~ msgstr "永遠に。"
 
 #: src/pages/Forks/index.tsx
 msgid "There are no active forks."
 msgstr "アクティブなフォークはありません。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr "その結果、Niji Foundation は Niji DAO が代替案を実装する準備が整うまで、拒否権の管理者となることを想定しており、したがってこの権限を行使する条件を明確にしたいと考えています。"
 
@@ -289,7 +289,7 @@ msgstr "プレイグラウンドに行く"
 msgid "or more"
 msgstr "かそれ以上"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
 msgstr "Niji のアートワークは {publicDomainLink} にあります。"
 
@@ -324,11 +324,15 @@ msgstr "{withdrawAmount} {unitForDisplay}をウォレットに正常に引き出
 msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nijis voters, it can be promoted to a proposal. "
 msgstr "提案候補は誰でも作成できます。候補がNijisの投票者から十分な署名を受け取ると、提案に昇格することができます。"
 
-#: src/components/Documentation/index.tsx
+#: src/pages/CrystalBall/index.tsx
+msgid "現在オークション中"
+msgstr "現在オークション中"
+
+#: src/components/Documentation/AboutSection.tsx
 msgid "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
 msgstr "DUNA モデルを採用することで、Niji DAO は分散型の自律性と法的確実性のバランスを求める DAO の先駆的な事例を示し、分散型ガバナンス革新の最前線における地位をさらに確固たるものにします。"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Add your feedback"
 msgstr "フィードバックを追加"
 
@@ -352,7 +356,7 @@ msgstr "候補が更新されました！"
 msgid "You <0>MUST</0> maintain enough voting power to meet the proposal threshold until your proposal is executed. If you fail to do so, anyone can cancel your proposal."
 msgstr "あなたは<0>必ず</0>提案が実行されるまで、提案のしきい値を満たすのに十分な投票力を維持しなければなりません。そうしない場合、誰でもあなたの提案をキャンセルすることができます。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "There are unfortunately no algorithmic solutions for making these determinations in advance (if there were, the veto would not be required), and proposals must be considered on a case by case basis."
 msgstr "残念ながら、これらの決定を事前に行うためのアルゴリズム的な解決策はありません（もしあれば、拒否権は必要ありません）、提案はケースバイケースで考慮する必要があります。"
 
@@ -368,7 +372,7 @@ msgstr "カレンダー"
 msgid "Settle manually"
 msgstr "手動で決済する"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Artwork is generative and stored directly on-chain (not IPFS)."
 msgstr "生成されたアートワークは直接オンチェーンに保存されます(IPFSではありません)。"
 
@@ -400,7 +404,7 @@ msgstr "クリプトパンクス"
 msgid "Available to withdraw"
 msgstr "引き出し可能"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "You can experiment with off-chain Niji generation at the {playgroundLink}."
 msgstr "{playgroundLink} でオフチェーンの Niji 生成を試すことができます。"
 
@@ -438,8 +442,8 @@ msgid "You can settle manually in {0} minutes"
 msgstr "{0} 分で手動で決済できます"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Nijispot"
-msgstr "Nijispot"
+#~ msgid "Nijispot"
+#~ msgstr "Nijispot"
 
 #: src/pages/Candidate/index.tsx
 msgid "<0>Note: </0>This proposal candidate has been proposed onchain."
@@ -454,7 +458,7 @@ msgstr "理由\"(任意)\""
 msgid "Update Delegate"
 msgstr "デリゲートを更新"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Settlement of one auction kicks off the next."
 msgstr "オークションの決済が１つ終わる度に次が始まります。"
 
@@ -485,8 +489,8 @@ msgid "Delegate Update Failed"
 msgstr "委任された更新に失敗しました"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
-msgstr "Niji には誰もが関わる方法があります。カエルに名前を付けるような気まぐれな取り組みから、ローズパレード用の巨大な山車を作るような野心的なプロジェクト、さらには Prop House のようなクリプトインフラまで。Niji はあらゆる規模と領域のプロジェクトに資金を提供します。"
+#~ msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
+#~ msgstr "Niji には誰もが関わる方法があります。カエルに名前を付けるような気まぐれな取り組みから、ローズパレード用の巨大な山車を作るような野心的なプロジェクト、さらには Prop House のようなクリプトインフラまで。Niji はあらゆる規模と領域のプロジェクトに資金を提供します。"
 
 #: src/components/Footer.tsx
 #: src/pages/Forks/index.tsx
@@ -498,11 +502,11 @@ msgstr "ガバナンス"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsList.tsx
 msgid "Sponsoring a proposal requires at least one Niji vote"
 msgstr "提案をスポンサーするには、少なくとも1つのNijiの投票が必要です"
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Signature request"
 msgstr "署名リクエスト"
 
@@ -510,7 +514,7 @@ msgstr "署名リクエスト"
 msgid "<0>Delegated Nijis: </0>"
 msgstr "委任Niji: "
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
 msgstr "Niji オークションコントラクトは、24 時間ごとに 1 つの Niji を永遠にオークションする、自己完結型の Niji 生成と配布のメカニズムとして機能します。オークション収益 (ETH) の 100% は自動的に Niji DAO トレジャリーに預けられ、Niji 所有者によって管理されます。"
 
@@ -522,11 +526,11 @@ msgstr "遊び場は {nijiProtocolLink} を使用して構築されました。N
 msgid "Address"
 msgstr "アドレス"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Governance ‘Slow Start’"
 msgstr "ガバナンス「スロースタート」"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Summary"
 msgstr "まとめ"
 
@@ -552,7 +556,7 @@ msgstr "スポンサーシップを削除"
 msgid "Only Nijis you owned or were delegated to you before {0} are eligible to vote."
 msgstr "投票できるのは {0} 以前に所有していた、または委任されたNijisのみです。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
 msgstr "Nijider への配布は 24 時間オークションの頻度を妨げません。Niji は Nijider のマルチシグに直接送られ、オークションは次に利用可能な Niji ID で予定どおり継続されます。"
 
@@ -605,7 +609,7 @@ msgstr "編集"
 msgid "Review Action Details"
 msgstr "アクション詳細の確認"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
 msgstr "オークションが決済されるたびに、決済トランザクションは新しい Niji のミントと新しい 24 時間オークションの開始を引き起こします。"
 
@@ -613,13 +617,13 @@ msgstr "オークションが決済されるたびに、決済トランザクシ
 msgid "Candidate Created!"
 msgstr "候補が作成されました！"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 #: src/components/NijiContent/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Niji DAO"
 msgstr "Niji DAO"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider's Reward"
 msgstr "Nijiderへの報酬"
 
@@ -636,7 +640,7 @@ msgstr "提案が作成されました！"
 msgid "Active"
 msgstr "実行されました"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO uses a fork of {compoundGovLink}."
 msgstr "Niji DAO は {compoundGovLink} のフォークを使用しています。"
 
@@ -698,7 +702,7 @@ msgstr "閾値を通過するには、{0}以上のNijis（DAOの{1}%）が必要
 msgid "Please try again."
 msgstr "もう一度やり直してください。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
 msgstr "属性の希少性に関する明示的なルールは存在しません。すべての Niji は等しくレアです。"
 
@@ -731,9 +735,9 @@ msgstr "提案候補を作成"
 msgid "Already has"
 msgstr "すでに持っています"
 
-#. placeholder {0}: userVoteSupport && supportText[userVoteSupport.supportDetailed].toLowerCase()
-#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport?.createdTimestamp * 1000).fromNow()
-#: src/components/VoteSignals/VoteSignals.tsx
+#. placeholder {0}: userVoteSupport && SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()
+#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport.createdTimestamp * 1000).fromNow()
+#: src/components/VoteSignals/VoteSignalsUserFeedback.tsx
 msgid "You provided <0>{0}</0> feedback {1}"
 msgstr "<0>{0}</0>のフィードバックを提供しました {1}"
 
@@ -743,7 +747,7 @@ msgstr "そのため、 プロジェクト創設メンバー (‘Nijiders’) �
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Against"
 msgstr "反対"
 
@@ -781,7 +785,7 @@ msgstr "提案を提出するのに十分な投票がありません"
 msgid "Failed to fetch"
 msgstr "取得できませんでした"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr "個人的な利益のために不平等に財務省を引き出す"
 
@@ -798,8 +802,8 @@ msgid "Candidates submitted by community members will appear here."
 msgstr "コミュニティメンバーによって提出された候補者はここに表示されます。"
 
 #: src/components/Banner/index.tsx
-msgid "ONE NOUN,"
-msgstr "1つのNOUNを"
+#~ msgid "ONE NOUN,"
+#~ msgstr "1つのNOUNを"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "<0/><1>Guidelines</1><2/>• Do <3>NOT</3> request ETH to trade into USDC. Instead, request USDC directly.<4/>• Do <5>NOT</5> transfer funds externally to create an ETH or USDC stream. Instead, use the \"Stream Funds\" action.<6/><7>Supported Action Types</7><8/><9>• Transfer Funds: </9>Send USDC, ETH, or stETH.<10/><11>• Stream Funds: </11>Stream USDC or WETH over time.<12/><13>• Function Call: </13>Call a contract function."
@@ -819,7 +823,7 @@ msgstr "フォーク"
 msgid "Stream"
 msgstr "ストリーム"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Submit"
 msgstr "送信"
 
@@ -827,7 +831,7 @@ msgstr "送信"
 msgid "Auction"
 msgstr "オークション"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Update proposal candidates must be re-signed by the original signers."
 msgstr "提案候補の更新は、元の署名者によって再署名される必要があります。"
 
@@ -860,6 +864,10 @@ msgstr "戻る"
 #: src/pages/Governance/index.tsx
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr "Niji は <0>Niji DAO</0> を統治します。Niji は提案に投票することも、票を第三者に委任することもできます。提案を提出するには最低 <1>{0}</1> が必要です。"
+
+#: src/pages/CrystalBall/index.tsx
+msgid "※ Niji Seeder の seed 生成は keccak256(blockhash + tokenId + timestamp + prevrandao) をシードに使うため、 実際に mint される block の hash で seed が確定します。 ここでの予測は現時点 (latest block) で chain に問い合わせた view 結果なので、 実際の auction 開始 block と異なれば絵柄も変わります。"
+msgstr "※ Niji Seeder の seed 生成は keccak256(blockhash + tokenId + timestamp + prevrandao) をシードに使うため、 実際に mint される block の hash で seed が確定します。 ここでの予測は現時点 (latest block) で chain に問い合わせた view 結果なので、 実際の auction 開始 block と異なれば絵柄も変わります。"
 
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
@@ -940,7 +948,7 @@ msgstr "Niji オークション収益はすべて Niji DAO に送られます。
 msgid "Deploy Fork"
 msgstr "フォークをデプロイ"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
 msgstr "Niji Foundation は拒否権を、通常の業務遂行の中では行使すべきでない緊急権限であると考えています。Niji Foundation は、Niji DAO または Niji Foundation に重大な法的または存続上のリスクをもたらす提案に対して拒否権を行使します。これには (これらに限定されませんが) 以下のような提案が含まれます。"
 
@@ -948,7 +956,7 @@ msgstr "Niji Foundation は拒否権を、通常の業務遂行の中では行�
 msgid "View the candidate"
 msgstr "候補者を表示"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "No sponsored votes needed"
 msgstr "スポンサー付き投票は不要"
 
@@ -982,7 +990,7 @@ msgstr "注"
 msgid "<0>Delegated Niji: </0>"
 msgstr "委任Niji: "
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "All Nijis are members of Niji DAO."
 msgstr "すべての Niji は Niji DAO のメンバーです。"
 
@@ -991,14 +999,14 @@ msgid "Now has"
 msgstr "今持っています"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Build With Niji. Get Funded."
-msgstr "Niji と共に作ろう。資金を得よう。"
+#~ msgid "Build With Niji. Get Funded."
+#~ msgstr "Niji と共に作ろう。資金を得よう。"
 
 #: src/components/Winner/index.tsx
 msgid "You"
 msgstr "あなた"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-proposal feedback"
 msgstr "提案前のフィードバック"
 
@@ -1021,7 +1029,7 @@ msgstr "更新可能"
 msgid "Auction ended"
 msgstr "オークションが終了しました"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposal candidates must meet the required Nijis vote threshold."
 msgstr "提案候補は、必要なNijisの投票閾値を満たす必要があります。"
 
@@ -1039,11 +1047,11 @@ msgstr "提案を提出"
 msgid "Submit Vote"
 msgstr "投票を提出"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Traits"
 msgstr "Niji トレイト"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr "Niji は Ethereum のブロックハッシュに基づいてランダムに生成されます。Niji トレイトの希少性を支配する 'if' 文やその他のルールは存在せず、すべての Niji が等しくレアです。執筆時点では、Niji は以下で構成されています。"
 
@@ -1051,7 +1059,7 @@ msgstr "Niji は Ethereum のブロックハッシュに基づいてランダム
 msgid "Your <0>{availableVotes}</0> votes are being delegated to a new account."
 msgstr "あなたは<0>{availableVotes}</0>アカウントに委任されています"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
 msgstr "Niji コミュニティは提案拒否権の代替案 ('rage quit' など) の予備的検討を行いましたが、満足のいく解決策を実装するためには、さらに多くの研究、開発、テストを必要とする難しい問題であることが今や明らかです。"
 
@@ -1068,7 +1076,7 @@ msgstr "入札履歴"
 msgid "This proposal can be edited for "
 msgstr "この提案は編集可能です "
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Adding your feedback"
 msgstr "フィードバックを追加"
 
@@ -1078,8 +1086,8 @@ msgid "Any token holder can signal to fork (exit) in response to a governance pr
 msgstr "トークン保有者は、ガバナンス提案に応じてフォーク（退出）を示すことができます。{0}のクォーラムのトークンが退出を示した場合、フォークは成功します。"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
-msgstr "ウガンダの学校から LA のコーヒーショップまで、サンパウロのクリプトハブからメルボルンのデリまで、Niji は創造的な人々がアイデアを実現する場所どこにでも存在します。<0/> で nounish な人、場所、物を探索してみよう。"
+#~ msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
+#~ msgstr "ウガンダの学校から LA のコーヒーショップまで、サンパウロのクリプトハブからメルボルンのデリまで、Niji は創造的な人々がアイデアを実現する場所どこにでも存在します。<0/> で nounish な人、場所、物を探索してみよう。"
 
 #: src/components/LanguageSelectionModal/index.tsx
 msgid "Select Language"
@@ -1093,6 +1101,11 @@ msgstr "最低入札額の {0} ETHと同じかそれ以上の入札額を設定�
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploying Niji fork and beginning the forking period"
 msgstr "Niji フォークをデプロイしてフォーク期間を開始"
+
+#: src/components/Footer.tsx
+#: src/components/NavBar/index.tsx
+msgid "Crystal Ball"
+msgstr "Crystal Ball"
 
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
@@ -1110,7 +1123,7 @@ msgstr "ZIPを作成中..."
 msgid "Proposed Transactions"
 msgstr "提案中のトランザクション"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
 msgstr "ワイオミング州の DUNA 法の下で、Niji DAO は自らの名義で資産を保有し、契約を締結し、法的措置に参加できます。ガバナンスは完全に分散化されたままで、決定は Niji 保有者によるオンチェーン投票によってのみ制御されます。これにより Niji DAO は持続的にプロジェクトに資金を提供し、トレジャリーを管理し、デジタルと物理の世界の両方で自信を持って交流できます。"
 
@@ -1118,7 +1131,7 @@ msgstr "ワイオミング州の DUNA 法の下で、Niji DAO は自らの名義
 msgid "Review Function Call Action"
 msgstr "関数呼び出しアクションのレビュー"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "Niji Seeder コントラクトは、ミントプロセス中に Niji のトレイトを決定するために使用されます。Seeder コントラクトは、将来のトレイト生成アルゴリズムのアップグレードを可能にするために置き換え可能です。さらに、Niji DAO によってロックして、将来の更新を防ぐこともできます。現在、Niji トレイトは疑似乱数生成を使用して決定されます。"
 
@@ -1136,7 +1149,7 @@ msgstr "フォーク期間中は提案を実行できません"
 msgid "Vote on Prop {0}"
 msgstr "提案 {0} に投票"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
 msgstr "Niji は Ethereum 上に直接保存され、IPFS のような他のネットワークへのポインタを使用しません。これは Niji のパーツがカスタムの run-length encoding (RLE) という可逆圧縮の形式を使用して圧縮され、オンチェーンに保存されているために可能です。"
 
@@ -1144,7 +1157,7 @@ msgstr "Niji は Ethereum 上に直接保存され、IPFS のような他のネ�
 msgid "Bids"
 msgstr "入札"
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Submit signature"
 msgstr "署名を提出"
 
@@ -1159,7 +1172,7 @@ msgstr "Etherscan"
 msgid "Description"
 msgstr "説明"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
 msgstr "Niji DAO は {compoundGovLink} のフォークを利用し、Niji エコシステムの主要なガバナンス機関です。Niji DAO トレジャリーは、毎日の Niji オークションからの ETH 収益の 100% を受け取ります。各 Niji は Niji DAO の取り消し不能なメンバーであり、すべてのガバナンス事項において 1 票の権利を持ちます。Niji の票は譲渡不能 (Niji を売却すると票も一緒に移ります) ですが委任可能で、Niji を所有している限り票を他の誰かに割り当てることができます。"
 
@@ -1167,7 +1180,7 @@ msgstr "Niji DAO は {compoundGovLink} のフォークを利用し、Niji エコ
 msgid "Change"
 msgstr "代理人を変更する"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The compressed parts are efficiently converted into a single base64 encoded SVG image on-chain. To accomplish this, each part is decoded into an intermediate format before being converted into a series of SVG rects using batched, on-chain string concatenation. Once the entire SVG has been generated, it is base64 encoded."
 msgstr "圧縮されたパーツは、オンチェインで効率よく1つのbase64エンコードされたSVG画像に変換されます。そのために、各パーツは中間フォーマットにデコードされた後、オンチェーンでの文字列連結により一連のSVG rectsに変換されます。SVG全体が生成されると、それはbase64でエンコードされます。"
 
@@ -1216,7 +1229,7 @@ msgstr "現在の閾値"
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr "すべての特性は<0>CC0</0>（クリエイティブ・コモンズ・ゼロ）であり、パブリックドメインに属し、制限なくあらゆる目的で自由に使用できます。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
 msgstr "詳細は以下をご覧ください。または {playgroundLink} を使ってオフチェーンで Niji の作成を開始しましょう。"
 
@@ -1230,6 +1243,7 @@ msgstr "引数は不要"
 msgid "Add Streaming Payment Action"
 msgstr "ストリーミング支払いアクションを追加"
 
+#: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "LP"
@@ -1240,7 +1254,9 @@ msgstr "LP"
 msgid "Niji DAO Fork{0}"
 msgstr "Niji DAO Fork{0}"
 
-#. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
+#. placeholder {0}: i18n.number(Number(currentQuorum ?? 0))
+#. placeholder {0}: proposal.quorumVotes
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr "{0} 票"
@@ -1249,11 +1265,11 @@ msgstr "{0} 票"
 msgid "Withdraw from Stream <0/>"
 msgstr "ストリームから引き出す<0/>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "WTF?"
 msgstr "WTF?"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
 msgstr "Nijider は Niji という形で報酬を受け取ります (最初の 5 年間は供給量の 10%)。"
 
@@ -1293,6 +1309,10 @@ msgstr "提案"
 msgid "Voted with<0>{numVotesForProp}</0>Nijis"
 msgstr "<0>{numVotesForProp}</0>のNijiで投票"
 
+#: src/pages/CrystalBall/index.tsx
+msgid "次に登場する Niji をブロックチェーン上の seed 生成ロジックで先取り。 現在オークション中の Niji の次から 5 体先までを予測表示します。"
+msgstr "次に登場する Niji をブロックチェーン上の seed 生成ロジックで先取り。 現在オークション中の Niji の次から 5 体先までを予測表示します。"
+
 #: src/components/VoteModal/index.tsx
 msgid "Gas spent on voting will be refunded to you."
 msgstr "投票に使ったガスは返金されます。"
@@ -1305,7 +1325,7 @@ msgstr "票になります"
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
 msgstr "<0>{numVotesForProp}</0> Niji で投票"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-voting feedback"
 msgstr "投票前のフィードバック"
 
@@ -1314,7 +1334,7 @@ msgstr "投票前のフィードバック"
 msgid "Starts {0}"
 msgstr "あと{0}で始まります"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "提案拒否権は当初、Niji DAO トレジャリーに対する '51% 攻撃' 問題への一時的な解決策として構想されました。Nijider は当初、Niji の健全な配布が DAO の保護として十分であると考えていましたが、インセンティブとリスクのより完全な理解により、権利が削除される前により堅牢なゲーム理論的解決策を実装すべきという一般的な合意が Nijider、Niji Foundation、より広いコミュニティ内で形成されました。"
 
@@ -1336,7 +1356,7 @@ msgstr "デリゲートが更新されました"
 msgid "You've generated {0} years worth of Nijis"
 msgstr "{0} 年分の Niji を生成しました"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
 msgstr "Niji オークション収益の 100% が Niji DAO に送られるため、Nijider は自身に Niji で報酬を与えることを選びました。プロジェクト最初の 5 年間、10 個ごとの Niji (Niji id #0、#10、#20、#30 など) は自動的に Nijider のマルチシグに送られ、ベスティングされ、プロジェクトの創設メンバー間で共有されます。"
 
@@ -1382,7 +1402,7 @@ msgstr "あなたの<0>{availableVotes}</0>票が新しいアカウントに委�
 
 #: src/pages/Playground/index.tsx
 #~ msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
-#~ msgstr ""
+#~ msgstr "プレイグラウンドは {nounsProtocolLink} を使用して構築されました。Niji のトレイトは Niji Seed によって決定されます。シードは {nounsAssetsLink} を使用して生成され、{nounsSDKLink} を使用してレンダリングされました。"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
@@ -1394,7 +1414,7 @@ msgstr "ヒント"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Abstain"
 msgstr "棄権"
 
@@ -1421,13 +1441,13 @@ msgstr "開始日"
 msgid "Colored Noggles"
 msgstr "カラーノグル"
 
-#. placeholder {0}: props.candidate.proposerVotes
-#. placeholder {1}: props.candidate.proposerVotes > 1 ? 's' : ''
-#: src/components/CandidateSponsors/index.tsx
+#. placeholder {0}: candidate.proposerVotes
+#. placeholder {1}: candidate.proposerVotes > 1 ? 's' : ''
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposer has {0} vote{1}"
 msgstr "提案者は{0}票を持っています{1}"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "On-Chain Artwork"
 msgstr "オンチェーンアートワーク"
 
@@ -1440,10 +1460,10 @@ msgid "You can settle manually in 1 minute"
 msgstr "1分で手動で決済できます"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Niji is a global community."
-msgstr "Niji はグローバルなコミュニティです。"
+#~ msgid "Niji is a global community."
+#~ msgstr "Niji はグローバルなコミュニティです。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
 msgstr "決済は落札者にとって最も強くインセンティブが与えられますが、誰でもトリガーできます。これにより Ethereum が稼働しており興味のある入札者がいる限り、システムは Niji をトラストレスにオークションすることができます。"
 
@@ -1468,6 +1488,10 @@ msgstr "1つ以上の提案アクションを追加し、コミュニティの�
 msgid "Forking"
 msgstr "フォーキング"
 
+#: src/pages/CrystalBall/index.tsx
+msgid "計算中…"
+msgstr "計算中…"
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.tsx
 msgid "Add Stream Date Details"
 msgstr "ストリーム日付の詳細を追加"
@@ -1484,7 +1508,7 @@ msgstr "閾値（提案を通過させるために必要な賛成票の最小数
 msgid "Explore traits"
 msgstr "特性を探索"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
 msgstr "'Nijider' は Niji を立ち上げた 10 人のビルダーのグループです。Nijider は以下のとおりです。"
 
@@ -1504,11 +1528,11 @@ msgstr "終了日時"
 msgid "Token"
 msgstr "トークン"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The treasury is controlled exclusively by Nijis via governance."
 msgstr "トレジャリーはガバナンスを通じて Niji によってのみ制御されます。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is trustlessly auctioned every 24 hours, forever."
 msgstr "1 つの Niji が 24 時間ごとに、永遠にトラストレスにオークションされます。"
 
@@ -1563,7 +1587,7 @@ msgstr "オークションに行く"
 msgid "Submissions are free for Nijis voters. Non-voters can submit for a {0} ETH fee."
 msgstr "Nijisの投票者は提出が無料です。非投票者は{0} ETHの手数料で提出できます。"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "This candidate has met the required threshold, but Nijis voters can still add support until it’s put onchain."
 msgstr "この候補者は必要な閾値を満たしていますが、Nijisの投票者はオンチェーンに載るまでサポートを追加できます。"
 
@@ -1595,7 +1619,7 @@ msgstr "動的閾値の動作についての詳細は<0>こちら</0>で確認�
 msgid "Review and Add"
 msgstr "レビューして追加"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "100% of Niji auction proceeds are trustlessly sent to the treasury."
 msgstr "Niji オークション収益の 100% はトラストレスにトレジャリーに送られます。"
 
@@ -1606,6 +1630,10 @@ msgstr "<0>提案者：</0><1>{proposerLink}</1>{transactionLink}"
 #: src/components/NavLocaleSwitcher/index.tsx
 msgid "Language"
 msgstr "言語"
+
+#: src/pages/CrystalBall/index.tsx
+msgid "Niji Crystal Ball"
+msgstr "Niji Crystal Ball"
 
 #: src/pages/Vote/index.tsx
 msgid "Starts"
@@ -1659,7 +1687,7 @@ msgstr "この候補者は現在{0}の署名を持っています。"
 msgid "Delegate"
 msgstr "投票を委任する"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA"
 msgstr "Niji DUNA"
 
@@ -1680,7 +1708,7 @@ msgstr "提出時に{0} ETHの手数料"
 msgid "Nijiders' Reward"
 msgstr "Nijiderへの報酬"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is equal to one vote."
 msgstr "1 Niji は 1 票に等しい。"
 
@@ -1688,7 +1716,7 @@ msgstr "1 Niji は 1 票に等しい。"
 msgid "Proposal Candidate"
 msgstr "提案候補"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "make upgrades to critical smart contracts without undergoing an audit"
 msgstr "監査を受けずに重要なスマートコントラクトをアップグレードする"
 
@@ -1700,7 +1728,7 @@ msgstr "ストリームは選択した日付の00:00 UTCに開始および終了
 msgid "You have no Votes."
 msgstr "投票がありません。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
 msgstr "トレイトの生成は真にランダムではありません。ペンディングブロックで Niji をミントする際にトレイトを予測できます。"
 
@@ -1708,13 +1736,13 @@ msgstr "トレイトの生成は真にランダムではありません。ペン
 msgid "There was an error withdrawing to your wallet."
 msgstr "ウォレットへの引き出し中にエラーが発生しました。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Seeder Contract"
 msgstr "Niji Seeder コントラクト"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "For"
 msgstr "賛成"
 
@@ -1723,8 +1751,8 @@ msgid "Help mint the next Niji"
 msgstr "次の Niji のミントを支援"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "One Niji, Every Day, Forever."
-msgstr "毎日 1 つの Niji を、永遠に。"
+#~ msgid "One Niji, Every Day, Forever."
+#~ msgstr "毎日 1 つの Niji を、永遠に。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Function"
@@ -1740,7 +1768,7 @@ msgstr "Niji を構成する個別のトレイトをダウンロード"
 
 #. placeholder {0}: humanizeTraitKey(traitKey)
 #. placeholder {1}: NijiImageData.images[traitKey].length
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "{0} ({1})"
 msgstr "{0} ({1})"
 
@@ -1789,12 +1817,12 @@ msgid "Proposer functions"
 msgstr "提案者の機能"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
-msgstr "無限のアート作品をご覧ください！Niji はアイデアに資金を提供し、コラボレーションを育むことでポジティブな影響をもたらす、コミュニティ所有のブランドです。コレクターや技術者から、非営利団体やブランドまで、Niji はすべての人のためのものです。"
+#~ msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
+#~ msgstr "無限のアート作品をご覧ください！Niji はアイデアに資金を提供し、コラボレーションを育むことでポジティブな影響をもたらす、コミュニティ所有のブランドです。コレクターや技術者から、非営利団体やブランドまで、Niji はすべての人のためのものです。"
 
 #: src/components/Banner/index.tsx
-msgid "EVERY DAY,"
-msgstr "毎日"
+#~ msgid "EVERY DAY,"
+#~ msgstr "毎日"
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"

--- a/packages/niji-webapp/src/locales/pseudo.po
+++ b/packages/niji-webapp/src/locales/pseudo.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
 msgstr ""
 
@@ -49,8 +49,8 @@ msgstr ""
 msgid "Update proposal"
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Nijis voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 msgstr ""
 
@@ -99,7 +99,7 @@ msgstr ""
 msgid "You've already delegated to this address"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Daily Auctions"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "Winner"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
 msgstr ""
 
@@ -196,7 +196,7 @@ msgstr ""
 msgid "Compound Governance"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Delegate {availableVotes} Votes"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more about the DUNA"
 msgstr ""
 
@@ -213,8 +213,8 @@ msgid "Streamed so far"
 msgstr ""
 
 #: src/components/Footer.tsx
-msgid "Map"
-msgstr ""
+#~ msgid "Map"
+#~ msgstr ""
 
 #: src/components/CandidateSponsors/OriginalSignature.tsx
 msgid "Awaiting signature"
@@ -259,7 +259,7 @@ msgstr ""
 msgid "3.5 artists, 6.5 technologists"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "bribe voters to facilitate withdraws of the treasury for personal gain"
 msgstr ""
 
@@ -277,14 +277,14 @@ msgid "Download All"
 msgstr ""
 
 #: src/components/Banner/index.tsx
-msgid "FOREVER."
-msgstr ""
+#~ msgid "FOREVER."
+#~ msgstr ""
 
 #: src/pages/Forks/index.tsx
 msgid "There are no active forks."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr ""
 
@@ -312,7 +312,7 @@ msgstr ""
 #~ msgid "Nouns Protocol"
 #~ msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
 msgstr ""
 
@@ -351,11 +351,15 @@ msgstr ""
 msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nijis voters, it can be promoted to a proposal. "
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/pages/CrystalBall/index.tsx
+msgid "現在オークション中"
+msgstr ""
+
+#: src/components/Documentation/AboutSection.tsx
 msgid "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Add your feedback"
 msgstr ""
 
@@ -379,7 +383,7 @@ msgstr ""
 msgid "You <0>MUST</0> maintain enough voting power to meet the proposal threshold until your proposal is executed. If you fail to do so, anyone can cancel your proposal."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "There are unfortunately no algorithmic solutions for making these determinations in advance (if there were, the veto would not be required), and proposals must be considered on a case by case basis."
 msgstr ""
 
@@ -395,7 +399,7 @@ msgstr ""
 msgid "Settle manually"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Artwork is generative and stored directly on-chain (not IPFS)."
 msgstr ""
 
@@ -427,7 +431,7 @@ msgstr ""
 msgid "Available to withdraw"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "You can experiment with off-chain Niji generation at the {playgroundLink}."
 msgstr ""
 
@@ -470,8 +474,8 @@ msgid "You can settle manually in {0} minutes"
 msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Nijispot"
-msgstr ""
+#~ msgid "Nijispot"
+#~ msgstr ""
 
 #: src/pages/Candidate/index.tsx
 msgid "<0>Note: </0>This proposal candidate has been proposed onchain."
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Update Delegate"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Settlement of one auction kicks off the next."
 msgstr ""
 
@@ -521,8 +525,8 @@ msgid "Delegate Update Failed"
 msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
-msgstr ""
+#~ msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
+#~ msgstr ""
 
 #: src/components/Footer.tsx
 #: src/pages/Forks/index.tsx
@@ -534,11 +538,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsList.tsx
 msgid "Sponsoring a proposal requires at least one Niji vote"
 msgstr ""
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Signature request"
 msgstr ""
 
@@ -550,7 +554,7 @@ msgstr ""
 #~ msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nouns voters, it can be promoted to a proposal."
 #~ msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
 msgstr ""
 
@@ -562,11 +566,11 @@ msgstr ""
 msgid "Address"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Governance ‘Slow Start’"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Summary"
 msgstr ""
 
@@ -592,7 +596,7 @@ msgstr ""
 msgid "Only Nijis you owned or were delegated to you before {0} are eligible to vote."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
 msgstr ""
 
@@ -649,7 +653,7 @@ msgstr ""
 msgid "Review Action Details"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
 msgstr ""
 
@@ -657,13 +661,13 @@ msgstr ""
 msgid "Candidate Created!"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 #: src/components/NijiContent/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Niji DAO"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider's Reward"
 msgstr ""
 
@@ -680,7 +684,7 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO uses a fork of {compoundGovLink}."
 msgstr ""
 
@@ -746,7 +750,7 @@ msgstr ""
 msgid "Please try again."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
 msgstr ""
 
@@ -779,9 +783,9 @@ msgstr ""
 msgid "Already has"
 msgstr ""
 
-#. placeholder {0}: userVoteSupport && supportText[userVoteSupport.supportDetailed].toLowerCase()
-#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport?.createdTimestamp * 1000).fromNow()
-#: src/components/VoteSignals/VoteSignals.tsx
+#. placeholder {0}: userVoteSupport && SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()
+#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport.createdTimestamp * 1000).fromNow()
+#: src/components/VoteSignals/VoteSignalsUserFeedback.tsx
 msgid "You provided <0>{0}</0> feedback {1}"
 msgstr ""
 
@@ -791,7 +795,7 @@ msgstr ""
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Against"
 msgstr ""
 
@@ -833,7 +837,7 @@ msgstr ""
 msgid "Failed to fetch"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr ""
 
@@ -850,8 +854,8 @@ msgid "Candidates submitted by community members will appear here."
 msgstr ""
 
 #: src/components/Banner/index.tsx
-msgid "ONE NOUN,"
-msgstr ""
+#~ msgid "ONE NOUN,"
+#~ msgstr ""
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "<0/><1>Guidelines</1><2/>• Do <3>NOT</3> request ETH to trade into USDC. Instead, request USDC directly.<4/>• Do <5>NOT</5> transfer funds externally to create an ETH or USDC stream. Instead, use the \"Stream Funds\" action.<6/><7>Supported Action Types</7><8/><9>• Transfer Funds: </9>Send USDC, ETH, or stETH.<10/><11>• Stream Funds: </11>Stream USDC or WETH over time.<12/><13>• Function Call: </13>Call a contract function."
@@ -875,7 +879,7 @@ msgstr ""
 msgid "Stream"
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Submit"
 msgstr ""
 
@@ -883,7 +887,7 @@ msgstr ""
 msgid "Auction"
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Update proposal candidates must be re-signed by the original signers."
 msgstr ""
 
@@ -915,6 +919,10 @@ msgstr ""
 #. placeholder {0}: nijisRequired !== undefined ? ( <> {nijisRequired} {threshold === 0 ? nijiSingular : nijiPlural} </> ) : ( '...' )
 #: src/pages/Governance/index.tsx
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
+msgstr ""
+
+#: src/pages/CrystalBall/index.tsx
+msgid "※ Niji Seeder の seed 生成は keccak256(blockhash + tokenId + timestamp + prevrandao) をシードに使うため、 実際に mint される block の hash で seed が確定します。 ここでの予測は現時点 (latest block) で chain に問い合わせた view 結果なので、 実際の auction 開始 block と異なれば絵柄も変わります。"
 msgstr ""
 
 #: src/components/ByLineHoverCard/index.tsx
@@ -1000,7 +1008,7 @@ msgstr ""
 msgid "Deploy Fork"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
 msgstr ""
 
@@ -1008,7 +1016,7 @@ msgstr ""
 msgid "View the candidate"
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "No sponsored votes needed"
 msgstr ""
 
@@ -1042,7 +1050,7 @@ msgstr ""
 msgid "<0>Delegated Niji: </0>"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "All Nijis are members of Niji DAO."
 msgstr ""
 
@@ -1051,14 +1059,14 @@ msgid "Now has"
 msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Build With Niji. Get Funded."
-msgstr ""
+#~ msgid "Build With Niji. Get Funded."
+#~ msgstr ""
 
 #: src/components/Winner/index.tsx
 msgid "You"
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-proposal feedback"
 msgstr ""
 
@@ -1085,7 +1093,7 @@ msgstr ""
 msgid "Auction ended"
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposal candidates must meet the required Nijis vote threshold."
 msgstr ""
 
@@ -1103,11 +1111,11 @@ msgstr ""
 msgid "Submit Vote"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Traits"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr ""
 
@@ -1119,7 +1127,7 @@ msgstr ""
 #~ msgid "Nounspot"
 #~ msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
 msgstr ""
 
@@ -1136,7 +1144,7 @@ msgstr ""
 msgid "This proposal can be edited for "
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Adding your feedback"
 msgstr ""
 
@@ -1146,8 +1154,8 @@ msgid "Any token holder can signal to fork (exit) in response to a governance pr
 msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
-msgstr ""
+#~ msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
+#~ msgstr ""
 
 #: src/components/LanguageSelectionModal/index.tsx
 msgid "Select Language"
@@ -1160,6 +1168,11 @@ msgstr ""
 
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploying Niji fork and beginning the forking period"
+msgstr ""
+
+#: src/components/Footer.tsx
+#: src/components/NavBar/index.tsx
+msgid "Crystal Ball"
 msgstr ""
 
 #: src/components/NavBar/index.tsx
@@ -1178,7 +1191,7 @@ msgstr ""
 msgid "Proposed Transactions"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
 msgstr ""
 
@@ -1186,7 +1199,7 @@ msgstr ""
 msgid "Review Function Call Action"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr ""
 
@@ -1208,7 +1221,7 @@ msgstr ""
 msgid "Vote on Prop {0}"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
 msgstr ""
 
@@ -1216,7 +1229,7 @@ msgstr ""
 msgid "Bids"
 msgstr ""
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Submit signature"
 msgstr ""
 
@@ -1231,7 +1244,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
 msgstr ""
 
@@ -1239,7 +1252,7 @@ msgstr ""
 msgid "Change"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The compressed parts are efficiently converted into a single base64 encoded SVG image on-chain. To accomplish this, each part is decoded into an intermediate format before being converted into a series of SVG rects using batched, on-chain string concatenation. Once the entire SVG has been generated, it is base64 encoded."
 msgstr ""
 
@@ -1296,7 +1309,7 @@ msgstr ""
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
 msgstr ""
 
@@ -1314,6 +1327,7 @@ msgstr ""
 #~ msgid "This candidate has met the required threshold, but Nouns voters can still add support until it’s put onchain."
 #~ msgstr ""
 
+#: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "LP"
@@ -1324,7 +1338,9 @@ msgstr ""
 msgid "Niji DAO Fork{0}"
 msgstr ""
 
-#. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
+#. placeholder {0}: i18n.number(Number(currentQuorum ?? 0))
+#. placeholder {0}: proposal.quorumVotes
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr ""
@@ -1333,11 +1349,11 @@ msgstr ""
 msgid "Withdraw from Stream <0/>"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "WTF?"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
 msgstr ""
 
@@ -1377,6 +1393,10 @@ msgstr ""
 msgid "Voted with<0>{numVotesForProp}</0>Nijis"
 msgstr ""
 
+#: src/pages/CrystalBall/index.tsx
+msgid "次に登場する Niji をブロックチェーン上の seed 生成ロジックで先取り。 現在オークション中の Niji の次から 5 体先までを予測表示します。"
+msgstr ""
+
 #: src/components/Documentation/index.tsx
 #~ msgid "Nounder distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nounder's Multisig, and auctions continue on schedule with the next available Niji ID."
 #~ msgstr ""
@@ -1393,7 +1413,7 @@ msgstr ""
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
 msgstr ""
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-voting feedback"
 msgstr ""
 
@@ -1402,7 +1422,7 @@ msgstr ""
 msgid "Starts {0}"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr ""
 
@@ -1424,7 +1444,7 @@ msgstr ""
 msgid "You've generated {0} years worth of Nijis"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
 msgstr ""
 
@@ -1486,7 +1506,7 @@ msgstr ""
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Abstain"
 msgstr ""
 
@@ -1517,13 +1537,13 @@ msgstr ""
 msgid "Colored Noggles"
 msgstr ""
 
-#. placeholder {0}: props.candidate.proposerVotes
-#. placeholder {1}: props.candidate.proposerVotes > 1 ? 's' : ''
-#: src/components/CandidateSponsors/index.tsx
+#. placeholder {0}: candidate.proposerVotes
+#. placeholder {1}: candidate.proposerVotes > 1 ? 's' : ''
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposer has {0} vote{1}"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "On-Chain Artwork"
 msgstr ""
 
@@ -1540,10 +1560,10 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Niji is a global community."
-msgstr ""
+#~ msgid "Niji is a global community."
+#~ msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
 msgstr ""
 
@@ -1572,6 +1592,10 @@ msgstr ""
 msgid "Forking"
 msgstr ""
 
+#: src/pages/CrystalBall/index.tsx
+msgid "計算中…"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.tsx
 msgid "Add Stream Date Details"
 msgstr ""
@@ -1592,7 +1616,7 @@ msgstr ""
 msgid "Explore traits"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
 msgstr ""
 
@@ -1612,11 +1636,11 @@ msgstr ""
 msgid "Token"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The treasury is controlled exclusively by Nijis via governance."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is trustlessly auctioned every 24 hours, forever."
 msgstr ""
 
@@ -1671,7 +1695,7 @@ msgstr ""
 msgid "Submissions are free for Nijis voters. Non-voters can submit for a {0} ETH fee."
 msgstr ""
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "This candidate has met the required threshold, but Nijis voters can still add support until it’s put onchain."
 msgstr ""
 
@@ -1707,7 +1731,7 @@ msgstr ""
 msgid "Review and Add"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "100% of Niji auction proceeds are trustlessly sent to the treasury."
 msgstr ""
 
@@ -1717,6 +1741,10 @@ msgstr ""
 
 #: src/components/NavLocaleSwitcher/index.tsx
 msgid "Language"
+msgstr ""
+
+#: src/pages/CrystalBall/index.tsx
+msgid "Niji Crystal Ball"
 msgstr ""
 
 #: src/pages/Vote/index.tsx
@@ -1775,7 +1803,7 @@ msgstr ""
 msgid "Delegate"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA"
 msgstr ""
 
@@ -1796,7 +1824,7 @@ msgstr ""
 msgid "Nijiders' Reward"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is equal to one vote."
 msgstr ""
 
@@ -1804,7 +1832,7 @@ msgstr ""
 msgid "Proposal Candidate"
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "make upgrades to critical smart contracts without undergoing an audit"
 msgstr ""
 
@@ -1816,7 +1844,7 @@ msgstr ""
 msgid "You have no Votes."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
 msgstr ""
 
@@ -1824,13 +1852,13 @@ msgstr ""
 msgid "There was an error withdrawing to your wallet."
 msgstr ""
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Seeder Contract"
 msgstr ""
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "For"
 msgstr ""
 
@@ -1839,8 +1867,8 @@ msgid "Help mint the next Niji"
 msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "One Niji, Every Day, Forever."
-msgstr ""
+#~ msgid "One Niji, Every Day, Forever."
+#~ msgstr ""
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Function"
@@ -1856,7 +1884,7 @@ msgstr ""
 
 #. placeholder {0}: humanizeTraitKey(traitKey)
 #. placeholder {1}: NijiImageData.images[traitKey].length
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "{0} ({1})"
 msgstr ""
 
@@ -1905,12 +1933,12 @@ msgid "Proposer functions"
 msgstr ""
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
-msgstr ""
+#~ msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
+#~ msgstr ""
 
 #: src/components/Banner/index.tsx
-msgid "EVERY DAY,"
-msgstr ""
+#~ msgid "EVERY DAY,"
+#~ msgstr ""
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"

--- a/packages/niji-webapp/src/locales/zh-CN.po
+++ b/packages/niji-webapp/src/locales/zh-CN.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA is a legally recognized Decentralized Unincorporated Nonprofit Association established in Wyoming via <0/> designed to provide a robust legal framework that aligns with the decentralized nature of Niji DAO. This structure allows Niji DAO to operate with limited liability protection and legal clarity without compromising its decentralized governance ethos."
 msgstr "Niji DUNA 是一个通过 <0/> 在怀俄明州设立的、法律上认可的去中心化非法人非营利协会,旨在提供与 Niji DAO 去中心化特性相一致的强大法律框架。该结构使 Niji DAO 能够在不损害其去中心化治理精神的情况下运营,享有有限责任保护和法律明确性。"
 
@@ -49,8 +49,8 @@ msgstr "异议期已触发"
 msgid "Update proposal"
 msgstr "更新提案"
 
-#: src/components/VoteSignals/VoteSignals.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Nijis voters can cast voting signals to give proposers of pending proposals an idea of how they intend to vote and helpful guidance on proposal changes to change their vote."
 msgstr "Nijis 投票者可以发出投票信号，这既能让待定提案的提出者预估到他们的投票倾向，也能为提案修改提供宝贵指引，以争取（或引导）投票者转变其最终投票。"
 
@@ -95,7 +95,7 @@ msgstr "游乐场"
 msgid "You've already delegated to this address"
 msgstr "您已将投票委托给此地址"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Daily Auctions"
 msgstr "每日拍卖"
 
@@ -148,7 +148,7 @@ msgstr "通过所需的 Niji 百分比"
 msgid "Winner"
 msgstr "获胜者"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijis are an experimental attempt to improve the formation of on-chain avatar communities. While projects such as {cryptopunksLink} have attempted to bootstrap digital community and identity, Nijis attempt to bootstrap identity, community, governance, and a treasury that can be used by the community."
 msgstr "Niji 是改进链上头像社区形成的实验性尝试。虽然 {cryptopunksLink} 等项目曾尝试引导数字社区和身份,但 Niji 尝试引导身份、社区、治理以及可供社区使用的金库。"
 
@@ -184,7 +184,7 @@ msgstr "版本历史"
 msgid "Compound Governance"
 msgstr "Compound 治理"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "attempt to alter Niji auction cadence for the purpose of maintaining or acquiring a voting majority"
 msgstr "为了维持或获得投票多数而试图改变 Niji 拍卖节奏"
 
@@ -192,7 +192,7 @@ msgstr "为了维持或获得投票多数而试图改变 Niji 拍卖节奏"
 msgid "Delegate {availableVotes} Votes"
 msgstr "委托 {availableVotes} 票"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more about the DUNA"
 msgstr "了解更多关于DUNA的信息"
 
@@ -201,8 +201,8 @@ msgid "Streamed so far"
 msgstr "已流转金额"
 
 #: src/components/Footer.tsx
-msgid "Map"
-msgstr "地图"
+#~ msgid "Map"
+#~ msgstr "地图"
 
 #: src/components/CandidateSponsors/OriginalSignature.tsx
 msgid "Awaiting signature"
@@ -243,7 +243,7 @@ msgstr "<0>提案者：</0><1>{proposer}</1><2>{transactionLink}</2>"
 msgid "3.5 artists, 6.5 technologists"
 msgstr "3.5 位艺术家，6.5 位技术专家"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "bribe voters to facilitate withdraws of the treasury for personal gain"
 msgstr "贿赂选民以便从国库中提取资金以谋取个人利益"
 
@@ -261,14 +261,14 @@ msgid "Download All"
 msgstr "下载全部"
 
 #: src/components/Banner/index.tsx
-msgid "FOREVER."
-msgstr "永远。"
+#~ msgid "FOREVER."
+#~ msgstr "永远。"
 
 #: src/pages/Forks/index.tsx
 msgid "There are no active forks."
 msgstr "当前无正在进行的分叉。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr "因此,Niji 基金会预计将担任否决权的管理者,直到 Niji DAO 准备好实施替代方案,因此希望明确行使此权力的条件。"
 
@@ -284,7 +284,7 @@ msgstr "前往游乐场"
 msgid "or more"
 msgstr "或以上"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
 msgstr "Niji 艺术作品位于 {publicDomainLink}。"
 
@@ -319,11 +319,15 @@ msgstr "您已成功提取 {withdrawAmount} {unitForDisplay} 到您的钱包"
 msgid "Proposal candidates can be created by anyone. If a candidate receives enough signatures by Nijis voters, it can be promoted to a proposal. "
 msgstr "任何人都可创建提案候选。若候选人获得足够的 Niji 投票签名，即可升级为正式提案。"
 
-#: src/components/Documentation/index.tsx
+#: src/pages/CrystalBall/index.tsx
+msgid "現在オークション中"
+msgstr "当前拍卖中"
+
+#: src/components/Documentation/AboutSection.tsx
 msgid "By adopting the DUNA model, Niji DAO sets a pioneering example for DAOs seeking to balance decentralized autonomy with legal certainty, further solidifying its position at the forefront of decentralized governance innovation."
 msgstr "通过采用 DUNA 模式,Niji DAO 为寻求平衡去中心化自治与法律确定性的 DAO 树立了开创性的榜样,进一步巩固了其在去中心化治理创新前沿的地位。"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Add your feedback"
 msgstr "添加您的反馈"
 
@@ -347,7 +351,7 @@ msgstr "候选已更新！"
 msgid "You <0>MUST</0> maintain enough voting power to meet the proposal threshold until your proposal is executed. If you fail to do so, anyone can cancel your proposal."
 msgstr "您<0>必须</0>保持足够的投票权以达到提案门槛，直到您的提案被执行。如果未能做到这一点，任何人都可以取消您的提案。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "There are unfortunately no algorithmic solutions for making these determinations in advance (if there were, the veto would not be required), and proposals must be considered on a case by case basis."
 msgstr "很遗憾，没有算法可在事前做出这些判定（即使有，也正因如此仍需保留否决权），提案需逐案审议。"
 
@@ -363,7 +367,7 @@ msgstr "日历"
 msgid "Settle manually"
 msgstr "手动结算"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Artwork is generative and stored directly on-chain (not IPFS)."
 msgstr "艺术作品是生成式的并直接存储在链上（非 IPFS）。"
 
@@ -395,7 +399,7 @@ msgstr "CryptoPunks"
 msgid "Available to withdraw"
 msgstr "可提取"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "You can experiment with off-chain Niji generation at the {playgroundLink}."
 msgstr "你可以在 {playgroundLink} 试验链下 Niji 生成。"
 
@@ -433,8 +437,8 @@ msgid "You can settle manually in {0} minutes"
 msgstr "您可在 {0} 分钟内手动结算"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Nijispot"
-msgstr "Nijispot"
+#~ msgid "Nijispot"
+#~ msgstr "Nijispot"
 
 #: src/pages/Candidate/index.tsx
 msgid "<0>Note: </0>This proposal candidate has been proposed onchain."
@@ -449,7 +453,7 @@ msgstr "理由（可选）"
 msgid "Update Delegate"
 msgstr "更新委托"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Settlement of one auction kicks off the next."
 msgstr "一次拍卖结算后，下一次拍卖随即开始。"
 
@@ -480,8 +484,8 @@ msgid "Delegate Update Failed"
 msgstr "委托更新失败"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
-msgstr "每个人都有方法参与 Niji。从给青蛙起名这样的奇思妙想,到为玫瑰花车游行建造巨型花车的雄心勃勃的项目,甚至像 Prop House 这样的加密基础设施。Niji 资助各种规模和领域的项目。"
+#~ msgid "There's a way for everyone to get involved with Niji. From whimsical endeavors like naming a frog, to ambitious projects like constructing a giant float for the Rose Parade, or even crypto infrastructure like Prop House. Niji funds projects of all sizes and domains."
+#~ msgstr "每个人都有方法参与 Niji。从给青蛙起名这样的奇思妙想,到为玫瑰花车游行建造巨型花车的雄心勃勃的项目,甚至像 Prop House 这样的加密基础设施。Niji 资助各种规模和领域的项目。"
 
 #: src/components/Footer.tsx
 #: src/pages/Forks/index.tsx
@@ -493,11 +497,11 @@ msgstr "治理"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsList.tsx
 msgid "Sponsoring a proposal requires at least one Niji vote"
 msgstr "赞助提案至少需要一个 Niji 投票"
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Signature request"
 msgstr "签名请求"
 
@@ -505,7 +509,7 @@ msgstr "签名请求"
 msgid "<0>Delegated Nijis: </0>"
 msgstr "<0>委托的 Nijis：</0>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The Niji Auction Contract will act as a self-sufficient Niji generation and distribution mechanism, auctioning one Niji every 24 hours, forever. 100% of auction proceeds (ETH) are automatically deposited in the Niji DAO treasury, where they are governed by Niji owners."
 msgstr "Niji 拍卖合约将作为一个自给自足的 Niji 生成和分发机制,每 24 小时拍卖一个 Niji,永远持续。100% 的拍卖收益 (ETH) 自动存入 Niji DAO 金库,由 Niji 所有者治理。"
 
@@ -517,11 +521,11 @@ msgstr "游乐场使用 {nijiProtocolLink} 构建。Niji 的特征由 Niji Seed 
 msgid "Address"
 msgstr "地址"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "Governance ‘Slow Start’"
 msgstr "治理“缓启动”"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Summary"
 msgstr "摘要"
 
@@ -547,7 +551,7 @@ msgstr "移除支持"
 msgid "Only Nijis you owned or were delegated to you before {0} are eligible to vote."
 msgstr "只有您在 {0} 之前拥有或被委托的 Nijis 才可投票。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider distributions don't interfere with the cadence of 24 hour auctions. Nijis are sent directly to the Nijider's Multisig, and auctions continue on schedule with the next available Niji ID."
 msgstr "Nijider 分发不会干扰 24 小时拍卖的节奏。Niji 直接发送到 Nijider 的多重签名,拍卖按计划继续进行,使用下一个可用的 Niji ID。"
 
@@ -600,7 +604,7 @@ msgstr "编辑"
 msgid "Review Action Details"
 msgstr "审核操作详情"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Each time an auction is settled, the settlement transaction will also cause a new Niji to be minted and a new 24 hour auction to begin. "
 msgstr "每次拍卖结算时,结算交易也会导致铸造一个新的 Niji 并开始一个新的 24 小时拍卖。"
 
@@ -608,13 +612,13 @@ msgstr "每次拍卖结算时,结算交易也会导致铸造一个新的 Niji �
 msgid "Candidate Created!"
 msgstr "候选已创建！"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 #: src/components/NijiContent/index.tsx
 #: src/pages/Governance/index.tsx
 msgid "Niji DAO"
 msgstr "Niji DAO"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Nijider's Reward"
 msgstr "Nijiders 奖励"
 
@@ -631,7 +635,7 @@ msgstr "提案已创建！"
 msgid "Active"
 msgstr "活跃"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO uses a fork of {compoundGovLink}."
 msgstr "Niji DAO 使用 {compoundGovLink} 的分叉。"
 
@@ -693,7 +697,7 @@ msgstr "需要超过 {0} 个 Niji（占 DAO 的 {1}%）才能通过门槛"
 msgid "Please try again."
 msgstr "请再试一次。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "No explicit rules exist for attribute scarcity; all Nijis are equally rare."
 msgstr "不存在关于属性稀缺性的明确规则;所有 Niji 同样稀有。"
 
@@ -726,9 +730,9 @@ msgstr "创建提案候选"
 msgid "Already has"
 msgstr "已拥有"
 
-#. placeholder {0}: userVoteSupport && supportText[userVoteSupport.supportDetailed].toLowerCase()
-#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport?.createdTimestamp * 1000).fromNow()
-#: src/components/VoteSignals/VoteSignals.tsx
+#. placeholder {0}: userVoteSupport && SUPPORT_TEXT[userVoteSupport.supportDetailed].toLowerCase()
+#. placeholder {1}: userVoteSupport?.createdTimestamp && dayjs(userVoteSupport.createdTimestamp * 1000).fromNow()
+#: src/components/VoteSignals/VoteSignalsUserFeedback.tsx
 msgid "You provided <0>{0}</0> feedback {1}"
 msgstr "您已提供 <0>{0}</0> 条反馈 {1}"
 
@@ -738,7 +742,7 @@ msgstr "因此,我们这些项目创始人 ('Nijider') 选择以 Niji 作为自�
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Against"
 msgstr "反对"
 
@@ -776,7 +780,7 @@ msgstr "您的票数不足，无法提交提案"
 msgid "Failed to fetch"
 msgstr "获取失败"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr "不平等地从国库中提取资金以谋取个人利益"
 
@@ -793,8 +797,8 @@ msgid "Candidates submitted by community members will appear here."
 msgstr "社区成员提交的候选将在此显示。"
 
 #: src/components/Banner/index.tsx
-msgid "ONE NOUN,"
-msgstr "一个 NOUN，"
+#~ msgid "ONE NOUN,"
+#~ msgstr "一个 NOUN，"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "<0/><1>Guidelines</1><2/>• Do <3>NOT</3> request ETH to trade into USDC. Instead, request USDC directly.<4/>• Do <5>NOT</5> transfer funds externally to create an ETH or USDC stream. Instead, use the \"Stream Funds\" action.<6/><7>Supported Action Types</7><8/><9>• Transfer Funds: </9>Send USDC, ETH, or stETH.<10/><11>• Stream Funds: </11>Stream USDC or WETH over time.<12/><13>• Function Call: </13>Call a contract function."
@@ -814,7 +818,7 @@ msgstr "分叉"
 msgid "Stream"
 msgstr "流支付"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Submit"
 msgstr "提交"
 
@@ -822,7 +826,7 @@ msgstr "提交"
 msgid "Auction"
 msgstr "拍卖"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Update proposal candidates must be re-signed by the original signers."
 msgstr "更新提案候选必须由原始签名者重新签名。"
 
@@ -855,6 +859,10 @@ msgstr "返回"
 #: src/pages/Governance/index.tsx
 msgid "Nijis govern <0>Niji DAO</0>. Nijis can vote on proposals or delegate their vote to a third party. A minimum of <1>{0}</1> is required to submit proposals."
 msgstr "Niji 治理 <0>Niji DAO</0>。Niji 可以对提案投票或将其投票委托给第三方。提交提案至少需要 <1>{0}</1>。"
+
+#: src/pages/CrystalBall/index.tsx
+msgid "※ Niji Seeder の seed 生成は keccak256(blockhash + tokenId + timestamp + prevrandao) をシードに使うため、 実際に mint される block の hash で seed が確定します。 ここでの予測は現時点 (latest block) で chain に問い合わせた view 結果なので、 実際の auction 開始 block と異なれば絵柄も変わります。"
+msgstr "※ Niji Seeder 的 seed 生成使用 keccak256(blockhash + tokenId + timestamp + prevrandao) 作为种子，因此 seed 由实际 mint 时的 block hash 确定。此处的预测是基于当前 (latest block) 时刻向 chain 查询的 view 结果，因此若实际 auction 开始的 block 不同，图像也会变化。"
 
 #: src/components/EditProposalButton/index.tsx
 msgid "Update Proposal Candidate"
@@ -935,7 +943,7 @@ msgstr "所有 Niji 拍卖收益都被发送到 Niji DAO。因此,我们这些�
 msgid "Deploy Fork"
 msgstr "部署分叉"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji Foundation considers the veto an emergency power that should not be exercised in the normal course of business. The Niji Foundation will veto proposals that introduce non-trivial legal or existential risks to the Niji DAO or the Niji Foundation, including (but not necessarily limited to) proposals that:"
 msgstr "Niji 基金会认为否决权是一种紧急权力,在正常业务过程中不应行使。Niji 基金会将否决会给 Niji DAO 或 Niji 基金会带来重大法律或存续风险的提案,包括 (但不限于) 以下提案:"
 
@@ -943,7 +951,7 @@ msgstr "Niji 基金会认为否决权是一种紧急权力,在正常业务过程
 msgid "View the candidate"
 msgstr "查看候选人"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "No sponsored votes needed"
 msgstr "不需要赞助票"
 
@@ -977,7 +985,7 @@ msgstr "注意"
 msgid "<0>Delegated Niji: </0>"
 msgstr "<0>已委托 Niji：</0>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "All Nijis are members of Niji DAO."
 msgstr "所有 Niji 都是 Niji DAO 的成员。"
 
@@ -986,14 +994,14 @@ msgid "Now has"
 msgstr "现在拥有"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Build With Niji. Get Funded."
-msgstr "与 Niji 共同建设。获得资助。"
+#~ msgid "Build With Niji. Get Funded."
+#~ msgstr "与 Niji 共同建设。获得资助。"
 
 #: src/components/Winner/index.tsx
 msgid "You"
 msgstr "您"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-proposal feedback"
 msgstr "提案前反馈"
 
@@ -1016,7 +1024,7 @@ msgstr "可更新"
 msgid "Auction ended"
 msgstr "拍卖已结束"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposal candidates must meet the required Nijis vote threshold."
 msgstr "候选提案必须达到所需的 Niji 投票门槛。"
 
@@ -1034,11 +1042,11 @@ msgstr "提交提案"
 msgid "Submit Vote"
 msgstr "提交投票"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Traits"
 msgstr "Niji 特征"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr "Niji 基于以太坊区块哈希随机生成。没有 'if' 语句或其他规则来管理 Niji 特征的稀缺性,这使得所有 Niji 同样稀有。截至撰写本文时,Niji 由以下组成:"
 
@@ -1046,7 +1054,7 @@ msgstr "Niji 基于以太坊区块哈希随机生成。没有 'if' 语句或其�
 msgid "Your <0>{availableVotes}</0> votes are being delegated to a new account."
 msgstr "您的 <0>{availableVotes}</0> 票正在委托给新账户。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The Niji community has undertaken a preliminary exploration of proposal veto alternatives (‘rage quit’ etc.), but it is now clear that this is a difficult problem that will require significantly more research, development and testing before a satisfactory solution can be implemented."
 msgstr "Niji 社区已经对提案否决权的替代方案 ('rage quit' 等) 进行了初步探索,但现在很清楚这是一个困难的问题,在实施令人满意的解决方案之前需要更多的研究、开发和测试。"
 
@@ -1063,7 +1071,7 @@ msgstr "出价历史"
 msgid "This proposal can be edited for "
 msgstr "此提案可编辑时间为 "
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Adding your feedback"
 msgstr "正在添加您的反馈"
 
@@ -1073,8 +1081,8 @@ msgid "Any token holder can signal to fork (exit) in response to a governance pr
 msgstr "任何代币持有者均可针对某项治理提案，发出分叉（即选择退出）的信号。一旦发出退出信号的代币数量达到 {0}的法定门槛，分叉便会成功。"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
-msgstr "从乌干达的学校到洛杉矶的咖啡店,从圣保罗的加密中心到墨尔本的熟食店,Niji 生活在富有创造力的人们将想法付诸实践的地方。通过 <0/> 探索 nounish 的人、地点和事物。"
+#~ msgid "From a school in Uganda to a coffee shop in LA, from a crypto hub in São Paulo to a deli in Melbourne, Niji lives wherever creative people bring ideas to life. Explore nounish people, places, and things with <0/>."
+#~ msgstr "从乌干达的学校到洛杉矶的咖啡店,从圣保罗的加密中心到墨尔本的熟食店,Niji 生活在富有创造力的人们将想法付诸实践的地方。通过 <0/> 探索 nounish 的人、地点和事物。"
 
 #: src/components/LanguageSelectionModal/index.tsx
 msgid "Select Language"
@@ -1088,6 +1096,11 @@ msgstr "请出价大于或等于最低竞标金额 {0} ETH"
 #: src/pages/Fork/DeployForkButton.tsx
 msgid "Deploying Niji fork and beginning the forking period"
 msgstr "部署 Niji 分叉并开始分叉期"
+
+#: src/components/Footer.tsx
+#: src/components/NavBar/index.tsx
+msgid "Crystal Ball"
+msgstr "水晶球"
 
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
@@ -1105,7 +1118,7 @@ msgstr "正在创建ZIP..."
 msgid "Proposed Transactions"
 msgstr "提议的交易"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Under Wyoming's DUNA Act, Niji DAO can hold assets, enter into contracts, and participate in legal actions in its own name. Governance remains fully decentralized, with decisions controlled exclusively by Niji holders via on-chain voting. This enables Niji DAO to sustainably fund projects, manage its treasury, and interact confidently within both the digital and physical worlds."
 msgstr "根据怀俄明州的 DUNA 法案,Niji DAO 可以以自己的名义持有资产、签订合同并参与法律行动。治理保持完全去中心化,决策完全由 Niji 持有者通过链上投票控制。这使 Niji DAO 能够可持续地资助项目、管理其金库,并在数字和物理世界中自信地互动。"
 
@@ -1113,7 +1126,7 @@ msgstr "根据怀俄明州的 DUNA 法案,Niji DAO 可以以自己的名义持�
 msgid "Review Function Call Action"
 msgstr "审核函数调用操作"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "Niji Seeder 合约用于在铸造过程中确定 Niji 特征。Seeder 合约可以被替换以允许未来的特征生成算法升级。此外,它可以被 Niji DAO 锁定以防止任何未来的更新。目前,Niji 特征使用伪随机数生成确定:"
 
@@ -1131,7 +1144,7 @@ msgstr "在分叉期间无法执行提案"
 msgid "Vote on Prop {0}"
 msgstr "在提案 {0} 上投票"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are stored directly on Ethereum and do not utilize pointers to other networks such as IPFS. This is possible because Niji parts are compressed and stored on-chain using a custom run-length encoding (RLE), which is a form of lossless compression."
 msgstr "Niji 直接存储在以太坊上,不使用指向 IPFS 等其他网络的指针。这是可能的,因为 Niji 部件使用自定义的 run-length encoding (RLE) 压缩并存储在链上,这是一种无损压缩形式。"
 
@@ -1139,7 +1152,7 @@ msgstr "Niji 直接存储在以太坊上,不使用指向 IPFS 等其他网络的
 msgid "Bids"
 msgstr "出价"
 
-#: src/components/CandidateSponsors/SignatureForm.tsx
+#: src/components/CandidateSponsors/signature/SignatureStatusOverlay.tsx
 msgid "Submit signature"
 msgstr "提交签名"
 
@@ -1154,7 +1167,7 @@ msgstr "Etherscan"
 msgid "Description"
 msgstr "描述"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DAO utilizes a fork of {compoundGovLink} and is the main governing body of the Niji ecosystem. The Niji DAO treasury receives 100% of ETH proceeds from daily Niji auctions. Each Niji is an irrevocable member of Niji DAO and entitled to one vote in all governance matters. Niji votes are non-transferable (if you sell your Niji the vote goes with it) but delegatable, which means you can assign your vote to someone else as long as you own your Niji."
 msgstr "Niji DAO 使用 {compoundGovLink} 的分叉,是 Niji 生态系统的主要治理机构。Niji DAO 金库接收来自每日 Niji 拍卖的 100% ETH 收益。每个 Niji 都是 Niji DAO 的不可撤销成员,在所有治理事项中有权获得一票。Niji 投票不可转让 (如果你出售你的 Niji,投票权也会随之转移),但可以委托,这意味着只要你拥有 Niji,你就可以将你的投票分配给其他人。"
 
@@ -1162,7 +1175,7 @@ msgstr "Niji DAO 使用 {compoundGovLink} 的分叉,是 Niji 生态系统的主�
 msgid "Change"
 msgstr "更改"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "The compressed parts are efficiently converted into a single base64 encoded SVG image on-chain. To accomplish this, each part is decoded into an intermediate format before being converted into a series of SVG rects using batched, on-chain string concatenation. Once the entire SVG has been generated, it is base64 encoded."
 msgstr "压缩的部件在链上高效地转换为单个 base64 编码的 SVG 图像。为实现此目的，先将每个部件解码为中间格式，然后通过批量链上字符串连接将其转换为一系列 SVG 矩形。生成整个 SVG 后，将其进行 base64 编码。"
 
@@ -1211,7 +1224,7 @@ msgstr "当前门槛"
 msgid "All traits are <0>CC0</0> (Creative Commons Zero), meaning they are in the public domain and free to use for any purpose without restriction."
 msgstr "所有特征均为<0>CC0</0>（知识共享零协议），这意味着它们属于公共领域，可以自由用于任何目的，无需限制。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Learn more below, or start creating Nijis off-chain using the {playgroundLink}."
 msgstr "在下面了解更多信息,或使用 {playgroundLink} 开始链下创建 Niji。"
 
@@ -1225,6 +1238,7 @@ msgstr "无需参数 "
 msgid "Add Streaming Payment Action"
 msgstr "添加流支付操作"
 
+#: src/components/Footer.tsx
 #: src/components/NavBar/index.tsx
 #: src/components/NavBar/index.tsx
 msgid "LP"
@@ -1235,7 +1249,9 @@ msgstr "LP"
 msgid "Niji DAO Fork{0}"
 msgstr "Niji DAO 分叉{0}"
 
-#. placeholder {0}: isV2Prop ? i18n.number(Number(currentQuorum ?? 0)) : proposal.quorumVotes
+#. placeholder {0}: i18n.number(Number(currentQuorum ?? 0))
+#. placeholder {0}: proposal.quorumVotes
+#: src/pages/Vote/index.tsx
 #: src/pages/Vote/index.tsx
 msgid "{0} votes"
 msgstr "{0} 票"
@@ -1244,11 +1260,11 @@ msgstr "{0} 票"
 msgid "Withdraw from Stream <0/>"
 msgstr "从流中提取 <0/>"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "WTF?"
 msgstr "什么情况？"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Nijiders receive rewards in the form of Nijis (10% of supply for first 5 years)."
 msgstr "Nijider 以 Niji 的形式获得奖励 (前 5 年供应量的 10%)。"
 
@@ -1288,6 +1304,10 @@ msgstr "提案"
 msgid "Voted with<0>{numVotesForProp}</0>Nijis"
 msgstr "使用<0>{numVotesForProp}</0>个 Nijis 进行投票"
 
+#: src/pages/CrystalBall/index.tsx
+msgid "次に登場する Niji をブロックチェーン上の seed 生成ロジックで先取り。 現在オークション中の Niji の次から 5 体先までを予測表示します。"
+msgstr "通过区块链上的 seed 生成逻辑提前预览下一个登场的 Niji。从当前拍卖中的 Niji 开始，预测显示之后 5 个 Niji。"
+
 #: src/components/VoteModal/index.tsx
 msgid "Gas spent on voting will be refunded to you."
 msgstr "投票所花费的燃料费将退还给您。"
@@ -1300,7 +1320,7 @@ msgstr "将拥有"
 msgid "Voted with<0>{numVotesForProp}</0>Niji"
 msgstr "以 <0>{numVotesForProp}</0> Niji 投票"
 
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsHeader.tsx
 msgid "Pre-voting feedback"
 msgstr "投票前反馈"
 
@@ -1309,7 +1329,7 @@ msgstr "投票前反馈"
 msgid "Starts {0}"
 msgstr "{0}开始"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "提案否决权最初被设想为对 Niji DAO 金库 '51% 攻击' 问题的临时解决方案。虽然 Nijider 最初认为 Niji 的健康分配将为 DAO 提供足够的保护,但对激励和风险的更完整理解使 Nijider、Niji 基金会和更广泛的社区内达成了普遍共识,即在删除该权利之前应实施更强大的博弈论解决方案。"
 
@@ -1331,7 +1351,7 @@ msgstr "委托已更新！"
 msgid "You've generated {0} years worth of Nijis"
 msgstr "你已经生成了 {0} 年的 Niji"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "Because 100% of Niji auction proceeds are sent to Niji DAO, Nijiders have chosen to compensate themselves with Nijis. Every 10th Niji for the first 5 years of the project (Niji ids #0, #10, #20, #30 and so on) will be automatically sent to the Nijider's multisig to be vested and shared among the founding members of the project."
 msgstr "因为 100% 的 Niji 拍卖收益都被发送到 Niji DAO,所以 Nijider 选择以 Niji 作为自己的报酬。在项目的前 5 年里,每第 10 个 Niji (Niji id #0、#10、#20、#30 等) 将自动发送到 Nijider 的多重签名以进行归属并在项目的创始成员之间共享。"
 
@@ -1377,7 +1397,7 @@ msgstr "您的 <0>{availableVotes}</0> 票已委托给一个新账户。"
 
 #: src/pages/Playground/index.tsx
 #~ msgid "The playground was built using the {nounsProtocolLink}. Niji's traits are determined by the Niji Seed. The seed was generated using {nounsAssetsLink} and rendered using the {nounsSDKLink}."
-#~ msgstr ""
+#~ msgstr "Playground 使用 {nounsProtocolLink} 构建。Niji 的特征由 Niji Seed 决定。Seed 使用 {nounsAssetsLink} 生成，并使用 {nounsSDKLink} 渲染。"
 
 #: src/components/DynamicQuorumInfoModal/index.tsx
 msgid "% of Nijis Currently Against"
@@ -1389,7 +1409,7 @@ msgstr "提示"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "Abstain"
 msgstr "弃权"
 
@@ -1416,13 +1436,13 @@ msgstr "开始于"
 msgid "Colored Noggles"
 msgstr "彩色眼镜"
 
-#. placeholder {0}: props.candidate.proposerVotes
-#. placeholder {1}: props.candidate.proposerVotes > 1 ? 's' : ''
-#: src/components/CandidateSponsors/index.tsx
+#. placeholder {0}: candidate.proposerVotes
+#. placeholder {1}: candidate.proposerVotes > 1 ? 's' : ''
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "Proposer has {0} vote{1}"
 msgstr "提案者拥有 {0} 票{1}"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "On-Chain Artwork"
 msgstr "链上艺术品"
 
@@ -1435,10 +1455,10 @@ msgid "You can settle manually in 1 minute"
 msgstr "您可以在 1 分钟内手动结算"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Niji is a global community."
-msgstr "Niji 是一个全球社区。"
+#~ msgid "Niji is a global community."
+#~ msgstr "Niji 是一个全球社区。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "While settlement is most heavily incentivized for the winning bidder, it can be triggered by anyone, allowing the system to trustlessly auction Nijis as long as Ethereum is operational and there are interested bidders."
 msgstr "虽然结算对中标者激励最强,但任何人都可以触发,这使得系统在以太坊运行且有感兴趣的投标者的情况下能够无信任地拍卖 Niji。"
 
@@ -1463,6 +1483,10 @@ msgstr "添加一个或多个提案操作，并为社区描述您的提案。提
 msgid "Forking"
 msgstr "分叉中"
 
+#: src/pages/CrystalBall/index.tsx
+msgid "計算中…"
+msgstr "计算中…"
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsPaymentDetailsStep/index.tsx
 msgid "Add Stream Date Details"
 msgstr "添加流支付日期详情"
@@ -1479,7 +1503,7 @@ msgstr "门槛（通过提案所需的最少支持票数）取决于提案的反
 msgid "Explore traits"
 msgstr "探索特征"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/NijidersRewardSection.tsx
 msgid "'Nijiders' are the group of ten builders that initiated Niji. Here are the Nijiders:"
 msgstr "'Nijider' 是发起 Niji 的十名建造者群体。Nijider 如下:"
 
@@ -1499,11 +1523,11 @@ msgstr "结束于"
 msgid "Token"
 msgstr "令牌"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "The treasury is controlled exclusively by Nijis via governance."
 msgstr "金库通过治理完全由 Niji 控制。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is trustlessly auctioned every 24 hours, forever."
 msgstr "每 24 小时无信任地拍卖一个 Niji,永远持续。"
 
@@ -1558,7 +1582,7 @@ msgstr "前往拍卖"
 msgid "Submissions are free for Nijis voters. Non-voters can submit for a {0} ETH fee."
 msgstr "Nijis 投票者提交是免费的。非投票者可以支付 {0} ETH 的费用提交。"
 
-#: src/components/CandidateSponsors/index.tsx
+#: src/components/CandidateSponsors/SponsorsHeader.tsx
 msgid "This candidate has met the required threshold, but Nijis voters can still add support until it’s put onchain."
 msgstr "此候选（方案/提案）已满足了必要的支持门槛，但在其最终被部署到链上之前，Nijis 的投票者们依然有机会为其追加支持"
 
@@ -1590,7 +1614,7 @@ msgstr "想了解此动态门槛的具体运作方式，请点击<0>这里</0>�
 msgid "Review and Add"
 msgstr "审核并添加"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "100% of Niji auction proceeds are trustlessly sent to the treasury."
 msgstr "100% 的 Niji 拍卖收益无信任地发送到金库。"
 
@@ -1601,6 +1625,10 @@ msgstr "<0>提议者：</0><1>{proposerLink}</1>{transactionLink}"
 #: src/components/NavLocaleSwitcher/index.tsx
 msgid "Language"
 msgstr "语言"
+
+#: src/pages/CrystalBall/index.tsx
+msgid "Niji Crystal Ball"
+msgstr "Niji 水晶球"
 
 #: src/pages/Vote/index.tsx
 msgid "Starts"
@@ -1654,7 +1682,7 @@ msgstr "该候选人目前有 {0} 个签名。"
 msgid "Delegate"
 msgstr "委托"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "Niji DUNA"
 msgstr "Niji DUNA"
 
@@ -1675,7 +1703,7 @@ msgstr "提交时需支付 {0} ETH 费用"
 msgid "Nijiders' Reward"
 msgstr "Nijiders 奖励"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/AboutSection.tsx
 msgid "One Niji is equal to one vote."
 msgstr "一个 Niji 等于一票。"
 
@@ -1683,7 +1711,7 @@ msgstr "一个 Niji 等于一票。"
 msgid "Proposal Candidate"
 msgstr "提案候选"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/GovernanceSection.tsx
 msgid "make upgrades to critical smart contracts without undergoing an audit"
 msgstr "在未经审计的情况下对关键智能合约进行升级"
 
@@ -1695,7 +1723,7 @@ msgstr "流支付在所选日期的 00:00 UTC 开始和结束。"
 msgid "You have no Votes."
 msgstr "您没有投票。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Trait generation is not truly random. Traits can be predicted when minting a Niji on the pending block."
 msgstr "特征生成并非真正随机。在 pending 区块上铸造 Niji 时可以预测特征。"
 
@@ -1703,13 +1731,13 @@ msgstr "特征生成并非真正随机。在 pending 区块上铸造 Niji 时可
 msgid "There was an error withdrawing to your wallet."
 msgstr "提取到您的钱包时出错。"
 
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Niji Seeder Contract"
 msgstr "Niji Seeder 合约"
 
 #: src/components/VoteCard/index.tsx
 #: src/components/VoteModal/index.tsx
-#: src/components/VoteSignals/VoteSignals.tsx
+#: src/components/VoteSignals/VoteSignalsForm.tsx
 msgid "For"
 msgstr "支持"
 
@@ -1718,8 +1746,8 @@ msgid "Help mint the next Niji"
 msgstr "帮助铸造下一个 Niji"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "One Niji, Every Day, Forever."
-msgstr "每天一个 Niji,永远持续。"
+#~ msgid "One Niji, Every Day, Forever."
+#~ msgstr "每天一个 Niji,永远持续。"
 
 #: src/components/ProposalActionsModal/steps/FunctionCallReviewStep/index.tsx
 msgid "Function"
@@ -1735,7 +1763,7 @@ msgstr "下载组成 Niji 的各个特征"
 
 #. placeholder {0}: humanizeTraitKey(traitKey)
 #. placeholder {1}: NijiImageData.images[traitKey].length
-#: src/components/Documentation/index.tsx
+#: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "{0} ({1})"
 msgstr "{0} ({1})"
 
@@ -1784,12 +1812,12 @@ msgid "Proposer functions"
 msgstr "提案者功能"
 
 #: src/components/NijisIntroSection/index.tsx
-msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
-msgstr "看哪,一件无限的艺术作品!Niji 是一个社区所有的品牌,通过资助创意和促进合作产生积极影响。从收藏家和技术人员到非营利组织和品牌,Niji 适合每个人。"
+#~ msgid "Behold, an infinite work of art! Niji is a community-owned brand that makes a positive impact by funding ideas and fostering collaboration. From collectors and technologists, to non-profits and brands, Niji is for everyone."
+#~ msgstr "看哪,一件无限的艺术作品!Niji 是一个社区所有的品牌,通过资助创意和促进合作产生积极影响。从收藏家和技术人员到非营利组织和品牌,Niji 适合每个人。"
 
 #: src/components/Banner/index.tsx
-msgid "EVERY DAY,"
-msgstr "每一天，"
+#~ msgid "EVERY DAY,"
+#~ msgstr "每一天，"
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"


### PR DESCRIPTION
## Summary

- `Check for missing translations` CI job の fail 解消 (ja-JP / zh-CN 共に missing 7 件 → 0 件)
- CrystalBall page + Footer/NavBar の 6 active entries + Playground 旧版 1 obsolete entry に翻訳追加
- `pnpm i18n:extract` auto-update で en-US/pseudo の source 参照 path 更新 + 削除 msgid を `#~` obsolete 化 (機能変更なし)

## 変更内訳

| file | 変更内容 | 行数 |
|---|---|---|
| `packages/niji-webapp/src/locales/ja-JP.po` | 7 件翻訳追加 (msgstr 埋め) + lingui extract auto-update | +111 / -85 |
| `packages/niji-webapp/src/locales/zh-CN.po` | 7 件簡体字翻訳追加 + lingui extract auto-update | +111 / -85 |
| `packages/niji-webapp/src/locales/en-US.po` | lingui extract auto-update (source path 更新 + 削除 msgid を obsolete 化) | +138 / -108 |
| `packages/niji-webapp/src/locales/pseudo.po` | 同上 | +138 / -108 |

### 7 件の内訳

| msgid | ja-JP msgstr | zh-CN msgstr |
|---|---|---|
| `現在オークション中` | `現在オークション中` | `当前拍卖中` |
| `Crystal Ball` | `Crystal Ball` | `水晶球` |
| `計算中…` | `計算中…` | `计算中…` |
| `Niji Crystal Ball` | `Niji Crystal Ball` | `Niji 水晶球` |
| `次に登場する Niji を ...` (CrystalBall 説明文) | 日本語そのまま | 簡体字翻訳 |
| `※ Niji Seeder の seed 生成は keccak256(...) ...` (CrystalBall 注釈) | 日本語そのまま | 簡体字翻訳 |
| `The playground was built using the {nounsProtocolLink}...` (obsolete) | 日本語翻訳 | 簡体字翻訳 |

source msgid が既に日本語のものは ja-JP msgstr に同じ日本語を入れる方針 (lingui の挙動上、 msgstr 空は missing 扱い、 msgid と同じでも明示的に埋める必要)。

### lingui の挙動

- `lingui compile --strict` は `#~ msgid` (obsolete entry) でも msgstr 空を missing としてカウントするため、 obsolete 1 件にも翻訳追加が必要だった
- `--clean` で obsolete 一括削除する選択肢もあったが、 他 11 件の翻訳資産が失われる副作用があるため避けた

## Test plan

- [x] `pnpm i18n:compile --strict` exit 0 (local 確認済、 missing 0 件)
- [x] `pnpm i18n:extract` で catalog statistics ja-JP/zh-CN 共に missing=0 確認
- [ ] CI `Check for missing translations` job green
- [ ] master merge 後の post-merge CI 全 green

## 関連

- Closes #2990
- Pre-existing 問題 (PR #2988 起因ではない、 同 PR で発見されたのみ)
- 失敗 run = https://github.com/Niji-DAO/niji-monorepo/actions/runs/28426187254/job/84230673613
- `[fallback] direct-gh-chain` (Linear free limit 到達のため Linear mirror 起票なし、 `/ship` skill § GitHub Issue 経路 fallback 規約)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgdKhYSgYfHh3H4PLLQMjW