### PR TITLE
🔧 fix(ci): turbo.json で @niji/contracts#build の outputs に abi/artifacts/typechain/cache 追加 (#2989)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,10 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", "build/**", ".next/**", "!.next/cache/**"]
     },
+    "@niji/contracts#build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "abi/**", "artifacts/**", "typechain/**", "cache/**"]
+    },
     "test": {
       "dependsOn": ["build"],
       "outputs": [],


### PR DESCRIPTION
## Summary

- CI `Test (22.x)` job の真因 = turbo cache hit 時に `hardhat compile` の outputs (`abi/` / `artifacts/` / `typechain/`) が復元されず、 subgraph の `graph test` で subgraph.yaml の abi file 参照が `File does not exist` で fail
- `@niji/contracts#build` task を override して generated assets を outputs に追加することで、 turbo cache hit 経路でも全 generated assets が復元される
- local 再現検証完了 (削除 → cache hit 復元 → subgraph test 全 34 件 pass)

Closes #2989

## 真因の特定

CI 失敗 run (28427664938) の log 抜粋。

```
@niji/subgraph:test cache miss, executing 26b3c0d10d0369c3
> graph test
- Load subgraph from subgraph.yaml
✖ Failed to load subgraph from subgraph.yaml: Error in subgraph.yaml:
  Path: dataSources > 0 > mapping > abis > 0 > file
  File does not exist: ../niji-contracts/abi/contracts/NijiAuctionHouse.sol/NijiAuctionHouse.json
```

直前の log で `@niji/contracts:build cache hit, replaying logs f1e8c1e72380f305` = cache hit で `hardhat compile` 実行 skip → `abi/` 生成されない。

turbo.json 旧 build task outputs は `["dist/**", "build/**", ".next/**", "!.next/cache/**"]` のみで、 niji-contracts の hardhat compile が生成する `abi/` / `artifacts/` / `typechain/` は cache 対象外だった。

Issue #2989 で挙げられた仮説 (Polly fixture 不足、 CI が turbo 経路通っていない) は当初の調査時点で全て偽 ... CI は `turbo run test` 経由で subgraph build dependency も解決されており、 Polly error は別文脈の noise (削除済 test 残骸 mock missing) で本 fail とは無関係。

## 修正内容

`turbo.json` に `@niji/contracts#build` task を追加。

```json
"@niji/contracts#build": {
  "dependsOn": ["^build"],
  "outputs": ["dist/**", "abi/**", "artifacts/**", "typechain/**", "cache/**"]
}
```

- `dependsOn: ["^build"]` ... default build task と同じ依存 (継承漏れ防止のため明示)
- `outputs` に `abi/` `artifacts/` `typechain/` `cache/` 追加 (hardhat compile 生成物全て)
- `cache/**` は hardhat incremental compile cache (turbo restore 時の整合性確保)

汎用 `build` task に追加せず package 別 override する理由 = `abi/` ディレクトリ名は他 package と衝突する可能性があり、 contracts 専用 override で scope 局所化。

## Test plan

- [x] local で abi/artifacts/typechain/cache 削除 → `pnpm turbo run build --filter=@niji/contracts` (cache hit) → 全 generated assets 復元確認 (`FULL TURBO` 表示)
- [x] cache hit 後に `pnpm --filter @niji/subgraph test` 全 34 件 pass 確認
- [x] 修正前は local でも abi 削除すると同じ error 再現 (CI fail と一致)
- [x] turbo.json JSON 構文 valid 確認

[fallback] direct-gh-chain (Linear mirror 起票は workspace free limit 超で skip、 GH Issue 直接 chain 経路)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgdKhYSgYfHh3H4PLLQMjW