### PR TITLE
🔧 fix(ci): turbo run test に --concurrency=1 追加で OOM kill (137) 構造的解消 (#2995)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "NODE_OPTIONS=--max_old_space_size=16384 prettier --write 'packages/**/*.{ts(x)?,sol,md,css,json}' '!**/typechain/**'",
     "lint": "eslint --cache --cache-location .cache/.eslintcache",
     "prepare": "husky",
-    "test": "turbo run test"
+    "test": "turbo run test --concurrency=1"
   },
   "devDependencies": {
     "@eslint-react/eslint-plugin": "^2.13.0",
@@ -66,13 +66,13 @@
       "unix-dgram"
     ],
     "overrides": {
-      "@typescript-eslint/utils": ">=8.56.0",
       "@babel/traverse": ">=7.23.2",
       "@openzeppelin/contracts": "4.4.0",
       "@openzeppelin/contracts-upgradeable": "4.4.0",
       "@openzeppelin/hardhat-upgrades": ">=3.9.1",
       "@openzeppelin/upgrades-core": ">=1.42.0",
       "@types/node": "catalog:",
+      "@typescript-eslint/utils": ">=8.56.0",
       "async": ">=2.6.4",
       "axios": ">=0.30.0",
       "braces": ">=3.0.3",


### PR DESCRIPTION
## 概要

PR #2994 (sdk test 修復) merge 後の master CI `Test (22.x)` job で `@niji/subgraph#test` が **OOM kill (exit 137)** で fail。
turbo の test task を逐次実行 (`--concurrency=1`) に変更し、 ubuntu-latest 7GB RAM の peak memory を 1-3GB に収めて構造的解消する。

## 変更内容

- `package.json` line 14 ... `"turbo run test"` → `"turbo run test --concurrency=1"`
- formatter (prettier-plugin-packagejson) により `overrides` 内の `@typescript-eslint/utils` が alphabetical 位置に再配置 (副次的変更、 semantic 同値)

## CI 全面禁止規約遵守

`rules/git-workflow.md` § CI 全面禁止 により `.github/workflows/*.yaml` は触らない。
直近 fix(ci) 系 5 PR と同じ「CI workflow 外で構造的解消」 方針。

- #2985 (CAR-301) ... subgraph devDependencies で turbo 順序強制
- #2987 (#2986) ... hardhat-abi-exporter runOnCompile: true
- #2992 (#2989) ... turbo.json contracts#build outputs 追加
- 本 PR (#2995) ... root package.json test script `--concurrency=1`

## 効果

- contracts (1-2GB) + subgraph (1-3GB) + sdk (500MB-1GB) + webapp (1-2GB) の並列実行を逐次化、 peak 4-8GB → 1-3GB
- build time +1-2 分の引き換えに OOM 構造的解消
- billing 増加なし (runner upgrade 不要)
- `build` / `dev` は並列維持 (turbo run build / dev 無変更)

## 仕組み

```mermaid
graph LR
    A[turbo run test 並列<br/>peak 4-8GB] -->|137 kill| B[OOM fail]
    C[turbo run test --concurrency=1<br/>peak 1-3GB] -->|逐次実行| D[OOM 回避]
```

## Test plan

- [ ] PR push 後 CI `Test (22.x)` green 確認
- [ ] OOM kill 137 が再発しない
- [ ] build time 増加 +2 分以内

Closes #2995

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgdKhYSgYfHh3H4PLLQMjW