### PR TITLE
🐛 fix(niji-contracts): NijiSeeder entropy salt test の偶発衝突 flaky を 12 trait 全比較で堅牢化

### DIFF
--- a/packages/niji-contracts/test/niji/NijiSeeder.test.ts
+++ b/packages/niji-contracts/test/niji/NijiSeeder.test.ts
@@ -278,8 +278,20 @@ describe('NijiSeeder', () => {
         await ethers.provider.send('evm_mine', []);
         const seedAtSample = await seeder.generateSeed(0, await art.getAddress());
 
-        expect(seedAtAlt.special !== seedAtSample.special || seedAtAlt.hair !== seedAtSample.hair)
-          .to.be.true;
+        const anyTraitChanged =
+          seedAtAlt.special !== seedAtSample.special ||
+          seedAtAlt.choker !== seedAtSample.choker ||
+          seedAtAlt.headphone !== seedAtSample.headphone ||
+          seedAtAlt.leftHand !== seedAtSample.leftHand ||
+          seedAtAlt.hat !== seedAtSample.hat ||
+          seedAtAlt.clothing !== seedAtSample.clothing ||
+          seedAtAlt.ear !== seedAtSample.ear ||
+          seedAtAlt.back !== seedAtSample.back ||
+          seedAtAlt.backDecoration !== seedAtSample.backDecoration ||
+          seedAtAlt.background !== seedAtSample.background ||
+          seedAtAlt.solidBackground !== seedAtSample.solidBackground ||
+          seedAtAlt.hair !== seedAtSample.hair;
+        expect(anyTraitChanged).to.be.true;
       } finally {
         await ethers.provider.send('evm_setAutomine', [true]);
       }


### PR DESCRIPTION
## Summary

`NijiSeeder.test.ts:282` の entropy salt 検証が special / hair の 2 trait のみ比較する設計のため、 SAMPLE_SALT (0xab repeat) / ALT_SALT (0xcd repeat) の組合せで両 trait が偶発衝突 (1/65536 確率) し master CI 上で flaky fail していた。 12 全 trait のいずれか変化を条件にする論理 OR に変更し、 衝突確率を (1/65536)^12 = 実質 0 まで下げる。

PR #2996 (turbo --concurrency=1) で OOM 解消後、 これまで OOM kill で隠れていた本 flaky が master CI Test (22.x) の唯一の残存 fail として露呈したため修正する。

## 検証

- local `pnpm hardhat test --grep "entropy salt"` ... 8 件全 pass
- local `pnpm hardhat test` (全件) ... 326 件全 pass / 17 秒

## Test plan

- [x] entropy salt 8 件 local pass
- [x] contracts test 326 件全 pass
- [ ] CI `Test (22.x)` green を merge 前確認

## 関連

- PR #2996 (#2995 / turbo --concurrency=1、 OOM 解消で本 flaky 露呈)
- PR #2994 (#2993 / sdk test 修復)

🤖 Generated with [Claude Code](https://claude.com/claude-code)