### PR TITLE
🐛 fix(make): anvil --block-time 1 追加で block 自動進行 (auto-settler 動作前提)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,18 +85,21 @@ $(LOG_DIR):
 
 # anvil を background 起動。 既存プロセスがあれば再利用。
 # --state で chain state を $(ANVIL_STATE) に dump/load (load + 終了時 dump + 5 秒間隔の定期 dump)。
+# --block-time 1 で 1 秒間隔の自動 block mining を有効化 (auto-settler が endTime 経過検知 →
+# settle tx 送信 → 次 auction 開始 chain が回るために必須、 default の on-demand mining では
+# block timestamp が進まず auction endTime に永遠到達しないため)。
 # state file が存在すれば deploy 済 contract をそのまま load、 不存在なら fresh chain で起動。
 anvil-bg: | $(LOG_DIR)
 	@if [ -f "$(ANVIL_PID)" ] && kill -0 $$(cat $(ANVIL_PID)) 2>/dev/null; then \
 		echo "🟢 anvil already running (PID $$(cat $(ANVIL_PID)))"; \
 	else \
 		if [ -f "$(ANVIL_STATE)" ]; then \
-			echo "🚀 starting anvil on :$(ANVIL_PORT) (chain 31337, state load from $(ANVIL_STATE))..."; \
+			echo "🚀 starting anvil on :$(ANVIL_PORT) (chain 31337, state load from $(ANVIL_STATE), block-time 1s)..."; \
 		else \
-			echo "🚀 starting anvil on :$(ANVIL_PORT) (chain 31337, fresh state)..."; \
+			echo "🚀 starting anvil on :$(ANVIL_PORT) (chain 31337, fresh state, block-time 1s)..."; \
 		fi; \
 		nohup anvil --port $(ANVIL_PORT) --chain-id 31337 --host 127.0.0.1 \
-			--state "$(ANVIL_STATE)" --state-interval 5 \
+			--state "$(ANVIL_STATE)" --state-interval 5 --block-time 1 \
 			> "$(ANVIL_LOG)" 2>&1 & \
 		echo $$! > "$(ANVIL_PID)"; \
 		sleep 1; \


### PR DESCRIPTION
## Summary

PR #2999 / PR #3000 で `make dev` chain (anvil --state + auto-settler) を整備したが、 anvil default の on-demand mining (tx 受信時のみ block 生成) では block timestamp が startTime のまま固定され、 auction endTime に永遠到達しない問題があった。 user が webapp で観察しても「次 auction 始まらない」 状態。

`--block-time 1` を追加し 1 秒間隔の自動 block mining を有効化することで、 block timestamp が自動進行 → auction endTime 経過 → auto-settler が settle 検知 → settle tx 送信 → 次 auction 開始の chain が物理的に回るようになる。

## 実証 (本 fix 前 local 環境)

```
[before fix]
cast block latest → number: 564, timestamp: 1782829428 (固定、 5 秒後も同じ)
auto-settler.log → start log のみ、 settle event なし
auction endTime=1782829488 vs now=1782829428 → 差 60 秒だが永遠到達せず

[after evm_setIntervalMining 1 (= 本 PR の --block-time 1 と等価)]
cast block latest → number: 567, timestamp: 1782831861 (3 秒で 2433 秒進む)
auto-settler.log → "Niji 0 endTime=1782829488 now=1782831859 → settle 送信"
auto-settler.log → "settled tx=0x2d0fa2... → 次 auction 開始"
```

## Test plan

- [x] local で evm_setIntervalMining 1 投入 → block 自動進行 + auto-settler が settle 送信 + 次 auction 開始確認
- [x] `make help` syntax 正常
- [ ] CI green を merge 前確認
- [ ] master merge 後 user が `make dev-stop && make dev` で恒久動作確認

## Trade-off

- block 自動生成で anvil メモリ消費がわずかに増加 (1 sec/block × 8h 連続稼働で 28800 block、 実害なし)
- state-interval 5 と整合 (5 秒に 1 回 5 block 分の state dump)

## 関連

- PR #2999 (anvil --state load + 1 cmd 起動)
- PR #3000 (auto-settler 統合、 本 PR で前提条件保証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)