### PR TITLE
✨ feat(niji-api): 与信枠 authorize endpoint (GMO entryTran + execTran) を実装

### DIFF
--- a/packages/niji-api/ponder.schema.ts
+++ b/packages/niji-api/ponder.schema.ts
@@ -127,3 +127,50 @@ export const streamRelations = relations(stream, ({ one }) => ({
     references: [proposal.id],
   }),
 }));
+
+/**
+ * fiat_bid status enum (Issue #3006、 GMO 与信枠 hold → capture → transferFrom flow の進行状態)
+ * - pending        ... authorize 成功、 3DS 認証待ち
+ * - 3ds-verified   ... 3DS 認証完了、 bid tx 発火待ち (Issue #3007 で更新)
+ * - bid-placed     ... bid tx broadcast 成功 (Issue #3008 で更新)
+ * - captured       ... GMO SALES capture 成功 (Issue #3010 で更新)
+ * - transferred    ... NFT transferFrom 完了 (Issue #3010 で更新)
+ * - cancelled      ... 敗札 / user cancel / capture fail 等で cancel
+ */
+const fiatBidStatusValues = [
+  'pending',
+  '3ds-verified',
+  'bid-placed',
+  'captured',
+  'transferred',
+  'cancelled',
+] as const;
+export type FiatBidStatus = (typeof fiatBidStatusValues)[number];
+export const fiatBidStatus = onchainEnum('fiatBidStatus', fiatBidStatusValues);
+
+export const fiatBid = onchainTable('fiat_bid', t => ({
+  /** GMO auth ID (accessId、 client.authorize が返す authId と一致) */
+  authId: t.text().primaryKey(),
+  /** bidder wallet address (代理 bid 発火時の代理先) */
+  bidderWallet: t.hex().notNull(),
+  /** bidder email (nullable、 落札通知送信用、 Issue #3013 で使う) */
+  bidderEmail: t.text(),
+  /** 対象 auction (Noun ID) */
+  auctionId: t.bigint().notNull(),
+  /** authorize 時の JPY 額 (円単位) */
+  jpyAmount: t.integer().notNull(),
+  /** JPY → ETH 換算後の ETH 額 (wei 単位、 bigint) */
+  ethAmount: t.bigint().notNull(),
+  /** 換算に使った spot rate (JPY per 1 ETH、 記録用) */
+  spotRate: t.integer().notNull(),
+  /** spot rate の取得元 (gmo-coin / coingecko) */
+  spotRateSource: t.text().notNull(),
+  /** 進行状態 */
+  status: fiatBidStatus().notNull(),
+  /** authorize 成功時刻 */
+  createdAt: t.timestamp().notNull(),
+  /** GMO capture 成功時刻 (nullable、 Issue #3010 で埋める) */
+  capturedAt: t.timestamp(),
+  /** NFT transferFrom 成功時刻 (nullable、 Issue #3010 で埋める) */
+  transferredAt: t.timestamp(),
+}));

--- a/packages/niji-api/src/api/index.ts
+++ b/packages/niji-api/src/api/index.ts
@@ -3,7 +3,24 @@ import { graphql } from 'ponder';
 import { db } from 'ponder:api';
 import schema from 'ponder:schema';
 
+import { createAuthorizeApp, type FiatBidStore } from '../handlers/fiat-bid/authorize.js';
 import { createSpotRateApp } from '../handlers/spot-rate.js';
+import { GmoClient } from '../services/gmo/client.js';
+import { SpotRateFetcher } from '../services/spotRate/index.js';
+
+/**
+ * Ponder 0.12 の api-side `db` は型上 `ReadonlyDrizzle` で insert が strip されているが、
+ * 実 runtime instance は full Drizzle である (`ReadonlyDrizzle = Omit<Drizzle, "insert" | ...>`)。
+ * offchain 書込 (Phase 1 fiat_bid は auction 独立、 HTTP 経由でのみ書かれる) が必要な場合、
+ * 型 assertion で write API を露出する。
+ * Phase 2 で Ponder が offchain table + api write の official 経路を提供した時に置換する。
+ */
+type WritableDb = {
+  insert: <TTable>(table: TTable) => {
+    values: (values: unknown) => Promise<unknown>;
+  };
+};
+const writableDb = db as unknown as WritableDb;
 
 const app = new Hono();
 
@@ -12,5 +29,40 @@ app.use('/graphql', graphql({ db, schema }));
 
 // Issue #3005 — GET /api/v1/spot-rate/eth-jpy (ETH/JPY spot rate 取得)
 app.route('/api/v1/spot-rate', createSpotRateApp());
+
+/**
+ * Issue #3006 — POST /api/v1/fiat-bid/authorize (与信枠取得)
+ * SpotRateFetcher / GmoClient は module-level singleton (cache / connection reuse)。
+ * fiat_bid store は Ponder db を wrap した最小 adapter で INSERT のみ実施、
+ * 後段 handler (Issue #3007+) が status update する。
+ */
+const spotRateFetcher = new SpotRateFetcher();
+const gmoClient = new GmoClient();
+/**
+ * Ponder 0.12 の api-side `db` は ReadonlyDrizzle (insert / update / delete が型 strip 済)。
+ * offchain write は `db.sql` (raw drizzle instance、 full Drizzle exposed via Db.sql) 経由で実施する。
+ * Ponder 内部 schema は onchain table 扱いだが、 SQL 発行自体は許容される (write 責務は indexing 層と HTTP 層で分担、
+ * Phase 1 の fiat_bid は auction event と独立に HTTP 経由でしか書かれない)。
+ */
+const fiatBidStore: FiatBidStore = {
+  insertPending: async record => {
+    await writableDb.insert(schema.fiatBid).values({
+      authId: record.authId,
+      bidderWallet: record.bidderWallet,
+      bidderEmail: record.bidderEmail,
+      auctionId: record.auctionId,
+      jpyAmount: record.jpyAmount,
+      ethAmount: record.ethAmount,
+      spotRate: record.spotRate,
+      spotRateSource: record.spotRateSource,
+      status: record.status,
+      createdAt: record.createdAt,
+    });
+  },
+};
+app.route(
+  '/api/v1/fiat-bid',
+  createAuthorizeApp({ gmoClient, spotRateFetcher, store: fiatBidStore }),
+);
 
 export default app;

--- a/packages/niji-api/src/handlers/fiat-bid/authorize.test.ts
+++ b/packages/niji-api/src/handlers/fiat-bid/authorize.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Fiat bid authorize handler behavior test (Issue #3006 Phase B/D)
+ *
+ * 検証対象 (完了条件 3 case + validation) —
+ * (1) happy path — 200 OK で { authId, tds2Url, jpyAmount, ethAmount, spotRate, spotRateSource } 返し
+ *     fiat_bid.pending record が INSERT される
+ * (2) bid 上限 100 万円超過 — 400 BidLimitExceeded、 GMO client 呼ばない、 DB 書込なし
+ * (3) GMO 障害 — 500 GmoAuthorizationFailed、 DB 書込なし
+ * (4) request validation fail 各種 (欠損 / 型不正 / hex 形式不正) → 400 InvalidRequest
+ * (5) spot rate fetch fail → 503 SpotRateUnavailable、 GMO client 呼ばない
+ *
+ * hono の app.request() 経由で actual handler を execute する。
+ * SpotRateFetcher / GmoClient は class extend + override method で stub、
+ * fiat_bid store は in-memory Map で受けて insertPending 呼出を観測する。
+ *
+ * rules/quality.md § test-passed marker 発行前提 3 条件 (behavior test / 変更箇所 execute / test runner PASS) 準拠。
+ */
+
+import type { AuthorizationResult } from '../../services/gmo/types.js';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GmoAuthorizationError, GmoClient } from '../../services/gmo/client.js';
+import {
+  SpotRateFetcher,
+  SpotRateFetchError,
+  type SpotRate,
+} from '../../services/spotRate/index.js';
+
+import {
+  BID_LIMIT_JPY,
+  convertJpyToEthWei,
+  createAuthorizeApp,
+  parseAuthorizeBody,
+  type AuthorizeResponseBody,
+  type FiatBidRecord,
+  type FiatBidStore,
+} from './authorize.js';
+
+/** SpotRateFetcher stub (behavior 差替) */
+class StubSpotRateFetcher extends SpotRateFetcher {
+  constructor(private readonly behavior: () => Promise<SpotRate>) {
+    super({
+      gmoCoinEndpoint: 'http://stub-primary',
+      coingeckoEndpoint: 'http://stub-fallback',
+    });
+  }
+
+  override async getEthJpyRate(): Promise<SpotRate> {
+    return this.behavior();
+  }
+}
+
+/** GmoClient stub (authorize method のみ差替、 entryTran/execTran は呼ばれない前提) */
+class StubGmoClient extends GmoClient {
+  constructor(private readonly behavior: () => Promise<AuthorizationResult>) {
+    super({ endpoint: 'http://stub-gmo' });
+  }
+
+  override async authorize(): Promise<AuthorizationResult> {
+    return this.behavior();
+  }
+}
+
+/** in-memory FiatBidStore stub */
+const makeStore = (): FiatBidStore & { records: FiatBidRecord[] } => {
+  const records: FiatBidRecord[] = [];
+  return {
+    records,
+    insertPending: async record => {
+      records.push(record);
+    },
+  };
+};
+
+/** happy path 共通の payload */
+const validBody = {
+  jpyAmount: 100000,
+  cardToken: 'token-visa-4111',
+  bidderWallet: '0x1234567890abcdef1234567890abcdef12345678',
+  auctionId: '42',
+};
+
+/** 決定的 orderId 生成 (test 用) */
+const stableOrderId = (input: { auctionId: string; bidderWallet: string }): string =>
+  `test-order-${input.auctionId}-${input.bidderWallet.slice(2, 8)}`;
+
+describe('parseAuthorizeBody', () => {
+  it('valid body を通す', () => {
+    const result = parseAuthorizeBody(validBody);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.jpyAmount).toBe(100000);
+      expect(result.value.bidderWallet).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    }
+  });
+
+  it('jpyAmount 欠損で reject', () => {
+    const { cardToken, bidderWallet, auctionId } = validBody;
+    expect(parseAuthorizeBody({ cardToken, bidderWallet, auctionId }).ok).toBe(false);
+  });
+
+  it('jpyAmount 非整数で reject', () => {
+    expect(parseAuthorizeBody({ ...validBody, jpyAmount: 100.5 }).ok).toBe(false);
+    expect(parseAuthorizeBody({ ...validBody, jpyAmount: -1 }).ok).toBe(false);
+  });
+
+  it('bidderWallet が hex 形式でないと reject', () => {
+    expect(parseAuthorizeBody({ ...validBody, bidderWallet: '0x123' }).ok).toBe(false);
+    expect(parseAuthorizeBody({ ...validBody, bidderWallet: 'not-hex' }).ok).toBe(false);
+  });
+
+  it('auctionId が decimal string 以外で reject', () => {
+    expect(parseAuthorizeBody({ ...validBody, auctionId: 'abc' }).ok).toBe(false);
+    expect(parseAuthorizeBody({ ...validBody, auctionId: '' }).ok).toBe(false);
+  });
+
+  it('bidderEmail は optional で undefined でも通る', () => {
+    const result = parseAuthorizeBody(validBody);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.bidderEmail).toBeUndefined();
+    }
+  });
+});
+
+describe('convertJpyToEthWei', () => {
+  it('1 万 JPY / rate=500000 = 0.02 ETH = 2e16 wei', () => {
+    const wei = convertJpyToEthWei(10_000, 500_000);
+    expect(wei).toBe(20_000_000_000_000_000n);
+  });
+
+  it('spot rate が 0 以下で throw', () => {
+    expect(() => convertJpyToEthWei(1000, 0)).toThrow();
+    expect(() => convertJpyToEthWei(1000, -100)).toThrow();
+  });
+
+  it('小数 rate も 4 桁精度で処理', () => {
+    // rate = 500000.1234 で処理される
+    const wei = convertJpyToEthWei(1000, 500000.1234);
+    expect(wei).toBeGreaterThan(0n);
+    expect(wei).toBeLessThan(3_000_000_000_000_000n); // 3e15 wei 未満 (妥当性 sanity check)
+  });
+});
+
+describe('createAuthorizeApp POST /authorize', () => {
+  const goodRate: SpotRate = {
+    rate: 500_000,
+    source: 'gmo-coin',
+    cachedAt: 1000,
+    expiresAt: 6000,
+  };
+
+  const goodAuth: AuthorizationResult = {
+    authId: 'mock-access-00000001',
+    accessPass: 'mock-pass-00000002',
+    tds2Url: 'http://mock/3ds?orderId=test-order-42',
+    orderId: 'test-order-42',
+    approve: 'apv-1',
+    tranId: 'tran-1',
+  };
+
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    store = makeStore();
+  });
+
+  it('happy path — 200 OK で response body 返し fiat_bid.pending が INSERT される', async () => {
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => goodRate),
+      gmoClient: new StubGmoClient(async () => goodAuth),
+      store,
+      generateOrderId: stableOrderId,
+      now: () => new Date('2026-07-02T09:00:00Z'),
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AuthorizeResponseBody;
+    expect(body.authId).toBe('mock-access-00000001');
+    expect(body.tds2Url).toBe('http://mock/3ds?orderId=test-order-42');
+    expect(body.jpyAmount).toBe(100000);
+    expect(body.spotRate).toBe(500_000);
+    expect(body.spotRateSource).toBe('gmo-coin');
+    // 100000 JPY / 500000 JPY/ETH = 0.2 ETH = 2e17 wei
+    expect(body.ethAmount).toBe('200000000000000000');
+
+    // fiat_bid record が pending で 1 件 INSERT された
+    expect(store.records).toHaveLength(1);
+    const record = store.records[0]!;
+    expect(record.authId).toBe('mock-access-00000001');
+    expect(record.bidderWallet).toBe('0x1234567890abcdef1234567890abcdef12345678');
+    expect(record.auctionId).toBe(42n);
+    expect(record.jpyAmount).toBe(100000);
+    expect(record.ethAmount).toBe(200000000000000000n);
+    expect(record.spotRate).toBe(500_000);
+    expect(record.spotRateSource).toBe('gmo-coin');
+    expect(record.status).toBe('pending');
+    expect(record.bidderEmail).toBeNull();
+    expect(record.createdAt).toEqual(new Date('2026-07-02T09:00:00Z'));
+  });
+
+  it('bidderEmail 指定時は record に保存される', async () => {
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => goodRate),
+      gmoClient: new StubGmoClient(async () => goodAuth),
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, bidderEmail: 'winner@example.com' }),
+    });
+    expect(res.status).toBe(200);
+    expect(store.records[0]!.bidderEmail).toBe('winner@example.com');
+  });
+
+  it('bid 上限 100 万円超過で 400 BidLimitExceeded、 GMO / DB 呼ばず', async () => {
+    const gmoAuthorize = vi.fn(async () => goodAuth);
+    const spotRate = vi.fn(async () => goodRate);
+    const gmoClient = new StubGmoClient(gmoAuthorize);
+    const spotRateFetcher = new StubSpotRateFetcher(spotRate);
+
+    const app = createAuthorizeApp({
+      spotRateFetcher,
+      gmoClient,
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, jpyAmount: BID_LIMIT_JPY + 1 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('BidLimitExceeded');
+    expect(body.message).toContain(String(BID_LIMIT_JPY));
+
+    // GMO / DB 呼ばれない
+    expect(gmoAuthorize).not.toHaveBeenCalled();
+    expect(spotRate).not.toHaveBeenCalled();
+    expect(store.records).toHaveLength(0);
+  });
+
+  it('GMO 障害 (GmoAuthorizationError) で 500 GmoAuthorizationFailed、 DB 書込なし', async () => {
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => goodRate),
+      gmoClient: new StubGmoClient(async () => {
+        throw new GmoAuthorizationError('GMO execTran failed (G02)', {
+          errCode: 'G02',
+          errInfo: 'G02180001',
+        });
+      }),
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as {
+      error: string;
+      message: string;
+      errCode: string | null;
+      errInfo: string | null;
+    };
+    expect(body.error).toBe('GmoAuthorizationFailed');
+    expect(body.errCode).toBe('G02');
+    expect(body.errInfo).toBe('G02180001');
+    expect(store.records).toHaveLength(0);
+  });
+
+  it('spot rate 取得失敗で 503 SpotRateUnavailable、 GMO 呼ばず', async () => {
+    const gmoAuthorize = vi.fn(async () => goodAuth);
+    const gmoClient = new StubGmoClient(gmoAuthorize);
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => {
+        throw new SpotRateFetchError('primary and fallback both failed');
+      }),
+      gmoClient,
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('SpotRateUnavailable');
+    expect(gmoAuthorize).not.toHaveBeenCalled();
+    expect(store.records).toHaveLength(0);
+  });
+
+  it('request body が invalid JSON で 400 InvalidRequest', async () => {
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => goodRate),
+      gmoClient: new StubGmoClient(async () => goodAuth),
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json{',
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('InvalidRequest');
+  });
+
+  it('bidderWallet 形式不正で 400 InvalidRequest、 spot rate / GMO 呼ばず', async () => {
+    const gmoAuthorize = vi.fn(async () => goodAuth);
+    const spotRate = vi.fn(async () => goodRate);
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(spotRate),
+      gmoClient: new StubGmoClient(gmoAuthorize),
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, bidderWallet: '0xNOT_VALID' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(gmoAuthorize).not.toHaveBeenCalled();
+    expect(spotRate).not.toHaveBeenCalled();
+  });
+
+  it('store.insertPending fail で 500 InternalError', async () => {
+    const failingStore: FiatBidStore = {
+      insertPending: async () => {
+        throw new Error('DB unreachable');
+      },
+    };
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => goodRate),
+      gmoClient: new StubGmoClient(async () => goodAuth),
+      store: failingStore,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('InternalError');
+    expect(body.message).toContain('fiat_bid store failed');
+  });
+
+  it('CoinGecko fallback 応答 (source=coingecko) も handler 経由で通る', async () => {
+    const fallbackRate: SpotRate = {
+      rate: 498_000,
+      source: 'coingecko',
+      cachedAt: 2000,
+      expiresAt: 7000,
+    };
+    const app = createAuthorizeApp({
+      spotRateFetcher: new StubSpotRateFetcher(async () => fallbackRate),
+      gmoClient: new StubGmoClient(async () => goodAuth),
+      store,
+      generateOrderId: stableOrderId,
+    });
+
+    const res = await app.request('/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as AuthorizeResponseBody;
+    expect(body.spotRateSource).toBe('coingecko');
+    expect(body.spotRate).toBe(498_000);
+    expect(store.records[0]!.spotRateSource).toBe('coingecko');
+  });
+});

--- a/packages/niji-api/src/handlers/fiat-bid/authorize.ts
+++ b/packages/niji-api/src/handlers/fiat-bid/authorize.ts
@@ -1,0 +1,326 @@
+/**
+ * Fiat bid authorize hono handler (Issue #3006 Phase B)
+ *
+ * POST /api/v1/fiat-bid/authorize
+ * request body — { jpyAmount, cardToken, bidderWallet, auctionId, bidderEmail? }
+ * 応答 body    — { authId, tds2Url, jpyAmount, ethAmount, spotRate, spotRateSource }
+ *
+ * 処理順 —
+ * (1) request body 検証 (欠損 / 型 / 上限)
+ * (2) bid 上限 100 万円 check (超過時 400 BidLimitExceeded)
+ * (3) spot rate 取得 (Issue #3005 の SpotRateFetcher 経由、 primary/fallback 切替 + 5 秒 cache)
+ * (4) JPY → ETH wei 換算 (BigInt 演算、 wei = jpy * 1e18 / rate)
+ * (5) orderId 生成 (auth ID PK に一致させて後段 handler で lookup 可能に)
+ * (6) GmoClient.authorize (entryTran + execTran) 呼出
+ * (7) fiat_bid table に pending status で INSERT
+ * (8) 応答 body 返却
+ *
+ * error 変換 —
+ * - request validation fail    → 400 InvalidRequest
+ * - bid 上限超過                → 400 BidLimitExceeded
+ * - spot rate fetch fail        → 503 SpotRateUnavailable (bid 発火不可 signal)
+ * - GmoAuthorizationError       → 500 GmoAuthorizationFailed
+ * - unexpected error            → 500 InternalError
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P2, P6、
+ *        Phase1-02-issue-breakdown.md § Issue 3、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+import { Hono } from 'hono';
+
+import { GmoAuthorizationError, GmoClient } from '../../services/gmo/client.js';
+import {
+  SpotRateFetcher,
+  SpotRateFetchError,
+  type SpotRate,
+} from '../../services/spotRate/index.js';
+
+/** bid 上限 100 万円 (Phase 1 SSOT、 grilling P2 確定) */
+export const BID_LIMIT_JPY = 1_000_000;
+
+/** request body shape (webapp が POST する) */
+export type AuthorizeRequestBody = {
+  jpyAmount: number;
+  cardToken: string;
+  bidderWallet: `0x${string}`;
+  auctionId: string;
+  bidderEmail?: string;
+};
+
+/** 応答 body shape (公開 API 契約) */
+export type AuthorizeResponseBody = {
+  authId: string;
+  tds2Url: string;
+  jpyAmount: number;
+  ethAmount: string;
+  spotRate: number;
+  spotRateSource: SpotRate['source'];
+};
+
+/** fiat_bid table に INSERT する record (呼出側で DB write する用) */
+export type FiatBidRecord = {
+  authId: string;
+  bidderWallet: `0x${string}`;
+  bidderEmail: string | null;
+  auctionId: bigint;
+  jpyAmount: number;
+  ethAmount: bigint;
+  spotRate: number;
+  spotRateSource: SpotRate['source'];
+  status: 'pending';
+  createdAt: Date;
+};
+
+/**
+ * DB store 抽象 (Ponder DB を直接触らずに handler test 可能に)
+ * 本 handler は fiat_bid insert のみ実施、 subsequent handler (3ds callback 等) は別 method で更新する
+ */
+export type FiatBidStore = {
+  insertPending: (record: FiatBidRecord) => Promise<void>;
+};
+
+/**
+ * bidderWallet の hex 形式 check
+ * 0x prefix + 40 桁 hex (EIP-55 checksum 検証は Phase 2、 Phase 1 は形式のみ)
+ */
+const isHexAddress = (value: unknown): value is `0x${string}` => {
+  return typeof value === 'string' && /^0x[\dA-Fa-f]{40}$/.test(value);
+};
+
+/**
+ * request body の shape 検証
+ * unknown value を受取り AuthorizeRequestBody に絞込 (or error message 返す)
+ */
+export const parseAuthorizeBody = (
+  raw: unknown,
+): { ok: true; value: AuthorizeRequestBody } | { ok: false; message: string } => {
+  if (raw === null || typeof raw !== 'object') {
+    return { ok: false, message: 'request body must be a JSON object' };
+  }
+  const body = raw as Record<string, unknown>;
+
+  const jpyAmount = body['jpyAmount'];
+  if (typeof jpyAmount !== 'number' || !Number.isInteger(jpyAmount) || jpyAmount <= 0) {
+    return { ok: false, message: 'jpyAmount must be a positive integer' };
+  }
+
+  const cardToken = body['cardToken'];
+  if (typeof cardToken !== 'string' || cardToken.trim() === '') {
+    return { ok: false, message: 'cardToken must be a non-empty string' };
+  }
+
+  const bidderWallet = body['bidderWallet'];
+  if (!isHexAddress(bidderWallet)) {
+    return { ok: false, message: 'bidderWallet must be a 0x-prefixed 40 hex address' };
+  }
+
+  const auctionId = body['auctionId'];
+  if (typeof auctionId !== 'string' || auctionId.trim() === '' || !/^\d+$/.test(auctionId)) {
+    return { ok: false, message: 'auctionId must be a decimal string' };
+  }
+
+  const email = body['bidderEmail'];
+  let bidderEmail: string | undefined;
+  if (email !== undefined && email !== null) {
+    if (typeof email === 'string' && email.trim() !== '') {
+      bidderEmail = email;
+    }
+  }
+
+  const validated: AuthorizeRequestBody = {
+    jpyAmount,
+    cardToken,
+    bidderWallet,
+    auctionId,
+  };
+  if (bidderEmail !== undefined) {
+    validated.bidderEmail = bidderEmail;
+  }
+  return { ok: true, value: validated };
+};
+
+/**
+ * JPY → ETH wei 換算
+ * spot rate = JPY per 1 ETH、 wei = jpy * 1e18 / rate
+ * 小数点は truncate (bidder 損しない方向、 実際は運営 EOA が gas 負担するので誤差影響小)
+ * spotRate の小数を扱うため BigInt 分子分母スケーリング (RATE_PRECISION 4 桁)
+ */
+const RATE_PRECISION = 10_000n;
+export const convertJpyToEthWei = (jpyAmount: number, spotRate: number): bigint => {
+  if (spotRate <= 0) {
+    throw new Error(`invalid spotRate ${spotRate}`);
+  }
+  // rate を整数化するため 4 桁精度で丸め (0.0001 円まで、 GMO / CoinGecko 両方の精度に十分)
+  // 分子 = jpyAmount * 1e18 * RATE_PRECISION
+  // 分母 = rate * RATE_PRECISION
+  // 結果 = jpyAmount * 1e18 / rate (RATE_PRECISION は約分)
+  const rateScaled = BigInt(Math.round(spotRate * Number(RATE_PRECISION)));
+  const jpyScaled = BigInt(jpyAmount) * BigInt(10) ** 18n * RATE_PRECISION;
+  return jpyScaled / rateScaled;
+};
+
+export type CreateAuthorizeAppOptions = {
+  gmoClient: GmoClient;
+  spotRateFetcher: SpotRateFetcher;
+  store: FiatBidStore;
+  /** orderId 生成 (test 用に決定的、 default = auction-{auctionId}-{ts}-{rand}) */
+  generateOrderId?: (input: { auctionId: string; bidderWallet: string }) => string;
+  /** 現在時刻 source (test 用、 default = () => new Date()) */
+  now?: () => Date;
+};
+
+const defaultGenerateOrderId = (input: { auctionId: string; bidderWallet: string }): string => {
+  const ts = Date.now().toString(36);
+  const rand = Math.floor(Math.random() * 1e6)
+    .toString(36)
+    .padStart(4, '0');
+  return `fiat-${input.auctionId}-${input.bidderWallet.slice(2, 8)}-${ts}-${rand}`;
+};
+
+/**
+ * authorize handler の Hono app を返す factory
+ * options で GmoClient / SpotRateFetcher / DB store を DI、 test 時に mock 差替
+ */
+export const createAuthorizeApp = (options: CreateAuthorizeAppOptions): Hono => {
+  const app = new Hono();
+  const generateOrderId = options.generateOrderId ?? defaultGenerateOrderId;
+  const now = options.now ?? (() => new Date());
+
+  app.post('/authorize', async c => {
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      return c.json({ error: 'InvalidRequest', message: 'request body must be valid JSON' }, 400);
+    }
+
+    const parsed = parseAuthorizeBody(rawBody);
+    if (!parsed.ok) {
+      return c.json({ error: 'InvalidRequest', message: parsed.message }, 400);
+    }
+    const body = parsed.value;
+
+    // bid 上限 100 万円 check (webapp + backend 2 層強制の backend 側)
+    if (body.jpyAmount > BID_LIMIT_JPY) {
+      return c.json(
+        {
+          error: 'BidLimitExceeded',
+          message: `jpyAmount ${body.jpyAmount} exceeds bid limit ${BID_LIMIT_JPY}`,
+        },
+        400,
+      );
+    }
+
+    // spot rate 取得 (5 秒 cache + primary/fallback 切替、 Issue #3005 経由)
+    let spotRate: SpotRate;
+    try {
+      spotRate = await options.spotRateFetcher.getEthJpyRate();
+    } catch (err) {
+      if (err instanceof SpotRateFetchError) {
+        return c.json(
+          {
+            error: 'SpotRateUnavailable',
+            message: err.message,
+          },
+          503,
+        );
+      }
+      return c.json(
+        {
+          error: 'InternalError',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        500,
+      );
+    }
+
+    // JPY → ETH wei 換算 (BigInt、 記録用のみ、 bid tx 発火は Issue #3008)
+    let ethWei: bigint;
+    try {
+      ethWei = convertJpyToEthWei(body.jpyAmount, spotRate.rate);
+    } catch (err) {
+      return c.json(
+        {
+          error: 'InternalError',
+          message: err instanceof Error ? err.message : 'convertJpyToEthWei failed',
+        },
+        500,
+      );
+    }
+
+    // orderId 生成 (fiat_bid.authId PK に紐付けて後段で lookup 可能に)
+    const orderId = generateOrderId({
+      auctionId: body.auctionId,
+      bidderWallet: body.bidderWallet,
+    });
+
+    // GMO entryTran + execTran 順次呼出
+    let authResult;
+    try {
+      authResult = await options.gmoClient.authorize({
+        orderId,
+        amount: body.jpyAmount,
+        cardToken: body.cardToken,
+      });
+    } catch (err) {
+      if (err instanceof GmoAuthorizationError) {
+        return c.json(
+          {
+            error: 'GmoAuthorizationFailed',
+            message: err.message,
+            errCode: err.errCode ?? null,
+            errInfo: err.errInfo ?? null,
+          },
+          500,
+        );
+      }
+      return c.json(
+        {
+          error: 'InternalError',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        500,
+      );
+    }
+
+    // fiat_bid table に pending status で INSERT
+    const record: FiatBidRecord = {
+      authId: authResult.authId,
+      bidderWallet: body.bidderWallet,
+      bidderEmail: body.bidderEmail ?? null,
+      auctionId: BigInt(body.auctionId),
+      jpyAmount: body.jpyAmount,
+      ethAmount: ethWei,
+      spotRate: Math.round(spotRate.rate),
+      spotRateSource: spotRate.source,
+      status: 'pending',
+      createdAt: now(),
+    };
+    try {
+      await options.store.insertPending(record);
+    } catch (err) {
+      // DB write fail は auth 済なので operational alert 対象 (Phase 2 で監視 wire)
+      // Phase 1 は 500 応答で webapp に retry を促す
+      return c.json(
+        {
+          error: 'InternalError',
+          message: `fiat_bid store failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+        500,
+      );
+    }
+
+    const response: AuthorizeResponseBody = {
+      authId: authResult.authId,
+      tds2Url: authResult.tds2Url,
+      jpyAmount: body.jpyAmount,
+      ethAmount: ethWei.toString(),
+      spotRate: Math.round(spotRate.rate),
+      spotRateSource: spotRate.source,
+    };
+    return c.json<AuthorizeResponseBody>(response, 200);
+  });
+
+  return app;
+};

--- a/packages/niji-api/src/services/gmo/client.test.ts
+++ b/packages/niji-api/src/services/gmo/client.test.ts
@@ -1,0 +1,235 @@
+/**
+ * GmoClient behavior test (Issue #3006 Phase A)
+ *
+ * 検証対象 —
+ * (1) entryTran 成功時に AccessID/AccessPass を parse して返す
+ * (2) execTran 成功時に ACS/ACSUrl/OrderID 等を parse して返す
+ * (3) GMO error 応答 (ErrCode field 付) 時に GmoAuthorizationError を throw
+ * (4) network error 時に GmoAuthorizationError (cause 付) を throw
+ * (5) authorize (entryTran + execTran) が順次呼出し AuthorizationResult を返す
+ * (6) authorize 中に entryTran fail → execTran 呼ばず即 throw
+ *
+ * mock server は import せず、 fetch 実装を DI で差替えて GMO 応答 shape を単体検証する。
+ * rules/quality.md § test-passed marker 発行前提 3 条件準拠。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { GmoAuthorizationError, GmoClient } from './client.js';
+
+/**
+ * fetch stub を作る helper
+ * responses = URL path ごとに form-encoded body を返す map
+ */
+const resolveUrl = (input: string | URL | Request): string => {
+  if (input instanceof URL) return input.toString();
+  if (typeof input === 'string') return input;
+  return input.url;
+};
+
+const makeFetchStub = (responses: Record<string, { status?: number; body: string }>) => {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = resolveUrl(input);
+    const matched = Object.entries(responses).find(([path]) => url.endsWith(path));
+    if (matched === undefined) {
+      throw new Error(`fetch stub: unmatched URL ${url}`);
+    }
+    const [, res] = matched;
+    return new Response(res.body, {
+      status: res.status ?? 200,
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    });
+  });
+};
+
+describe('GmoClient.entryTran', () => {
+  it('成功応答から AccessID / AccessPass を parse して返す', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      shopId: 'tshop00000001',
+      shopPass: 'test_pass',
+      fetch: makeFetchStub({
+        '/entryTran': { body: 'AccessID=abc-123&AccessPass=pass-456' },
+      }),
+    });
+
+    const result = await client.entryTran({
+      shopId: 'tshop00000001',
+      shopPass: 'test_pass',
+      orderId: 'order-001',
+      jobCd: 'AUTH',
+      amount: 100000,
+    });
+
+    expect(result).toEqual({ accessId: 'abc-123', accessPass: 'pass-456' });
+  });
+
+  it('ErrCode 応答時に GmoAuthorizationError を throw', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      fetch: makeFetchStub({
+        '/entryTran': { body: 'ErrCode=E01&ErrInfo=E01190002' },
+      }),
+    });
+
+    await expect(
+      client.entryTran({
+        shopId: 'tshop00000001',
+        shopPass: 'test_pass',
+        orderId: 'order-002',
+        jobCd: 'AUTH',
+        amount: 1_000_001,
+      }),
+    ).rejects.toMatchObject({
+      name: 'GmoAuthorizationError',
+      errCode: 'E01',
+      errInfo: 'E01190002',
+    });
+  });
+
+  it('AccessID 欠損時に error を throw', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      fetch: makeFetchStub({
+        '/entryTran': { body: 'AccessPass=only-pass' },
+      }),
+    });
+
+    await expect(
+      client.entryTran({
+        shopId: 'tshop00000001',
+        shopPass: 'test_pass',
+        orderId: 'order-003',
+        jobCd: 'AUTH',
+        amount: 1000,
+      }),
+    ).rejects.toBeInstanceOf(GmoAuthorizationError);
+  });
+});
+
+describe('GmoClient.execTran', () => {
+  it('成功応答から ACS / ACSUrl / OrderID / TranID を parse して返す', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      fetch: makeFetchStub({
+        '/execTran': {
+          body:
+            'ACS=1&ACSUrl=http%3A%2F%2Fmock%2F3ds%3ForderId%3Dorder-001&OrderID=order-001' +
+            '&AccessID=acc-1&Approve=apv-1&TranID=tran-1&TranDate=20260702093000',
+        },
+      }),
+    });
+
+    const result = await client.execTran({
+      accessId: 'acc-1',
+      accessPass: 'pass-1',
+      orderId: 'order-001',
+      cardToken: 'token-visa-4111',
+    });
+
+    expect(result.acs).toBe('1');
+    expect(result.acsUrl).toContain('/3ds');
+    expect(result.orderId).toBe('order-001');
+    expect(result.tranId).toBe('tran-1');
+    expect(result.tranDate).toBe('20260702093000');
+  });
+
+  it('ErrCode=G02 応答時 GmoAuthorizationError を throw (与信枠不足)', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      fetch: makeFetchStub({
+        '/execTran': { body: 'ErrCode=G02&ErrInfo=G02180001' },
+      }),
+    });
+
+    await expect(
+      client.execTran({
+        accessId: 'acc-1',
+        accessPass: 'pass-1',
+        orderId: 'order-001',
+        cardToken: 'token-fail-4000000000000002',
+      }),
+    ).rejects.toMatchObject({ errCode: 'G02' });
+  });
+});
+
+describe('GmoClient network / HTTP failure', () => {
+  it('network error 時に GmoAuthorizationError (cause 付) を throw', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      fetch: vi.fn(async () => {
+        throw new Error('network unreachable');
+      }),
+    });
+
+    await expect(
+      client.entryTran({
+        shopId: 's',
+        shopPass: 'p',
+        orderId: 'o',
+        jobCd: 'AUTH',
+        amount: 1000,
+      }),
+    ).rejects.toBeInstanceOf(GmoAuthorizationError);
+  });
+
+  it('HTTP 500 応答時 GmoAuthorizationError を throw', async () => {
+    const client = new GmoClient({
+      endpoint: 'http://test-gmo',
+      fetch: makeFetchStub({
+        '/entryTran': { status: 500, body: 'internal server error' },
+      }),
+    });
+
+    await expect(
+      client.entryTran({
+        shopId: 's',
+        shopPass: 'p',
+        orderId: 'o',
+        jobCd: 'AUTH',
+        amount: 1000,
+      }),
+    ).rejects.toBeInstanceOf(GmoAuthorizationError);
+  });
+});
+
+describe('GmoClient.authorize (entryTran + execTran 統合)', () => {
+  it('順次呼出し AuthorizationResult を返す', async () => {
+    const fetchStub = makeFetchStub({
+      '/entryTran': { body: 'AccessID=acc-2&AccessPass=pass-2' },
+      '/execTran': {
+        body:
+          'ACS=1&ACSUrl=http%3A%2F%2Fmock%2F3ds%3ForderId%3Dorder-777&OrderID=order-777' +
+          '&AccessID=acc-2&Approve=apv-2&TranID=tran-2&TranDate=20260702093100',
+      },
+    });
+    const client = new GmoClient({ endpoint: 'http://test-gmo', fetch: fetchStub });
+
+    const result = await client.authorize({
+      orderId: 'order-777',
+      amount: 500000,
+      cardToken: 'token-visa-4111',
+    });
+
+    expect(result.authId).toBe('acc-2');
+    expect(result.tds2Url).toContain('/3ds');
+    expect(result.orderId).toBe('order-777');
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('entryTran fail 時 execTran を呼ばず throw', async () => {
+    const fetchStub = makeFetchStub({
+      '/entryTran': { body: 'ErrCode=E01&ErrInfo=E01190002' },
+    });
+    const client = new GmoClient({ endpoint: 'http://test-gmo', fetch: fetchStub });
+
+    await expect(
+      client.authorize({
+        orderId: 'order-777',
+        amount: 1_000_001,
+        cardToken: 'token',
+      }),
+    ).rejects.toMatchObject({ errCode: 'E01' });
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/niji-api/src/services/gmo/client.ts
+++ b/packages/niji-api/src/services/gmo/client.ts
@@ -1,0 +1,305 @@
+/**
+ * GMO PGマルチペイメント API client (Issue #3006 Phase A)
+ *
+ * GMO 公式仕様 —
+ * - Content-Type = application/x-www-form-urlencoded (request / response 双方)
+ * - error は HTTP 200 で ErrCode / ErrInfo を form-encoded body に載せて返す
+ * - 成功時は AccessID / AccessPass 等を form-encoded body に載せて返す
+ *
+ * env 切替 —
+ * - `USE_GMO_MOCK=true` (default) → GMO_ENDPOINT (mock server URL) を叩く
+ * - `USE_GMO_MOCK=false` → GMO_PROD_ENDPOINT (実 GMO PG API URL) を叩く
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P2, P6、
+ *        Phase1-02-issue-breakdown.md § Issue 3
+ */
+
+import type {
+  AuthorizationResult,
+  EntryTranRequest,
+  EntryTranSuccess,
+  ExecTranRequest,
+  ExecTranSuccess,
+  GmoErrorResponse,
+} from './types.js';
+
+/** DI 用の fetch signature (test で mock 差替可能) */
+export type FetchLike = typeof globalThis.fetch;
+
+export type GmoClientOptions = {
+  /**
+   * GMO PG API base URL (default = env `GMO_ENDPOINT` or `http://127.0.0.1:2426`)
+   * USE_GMO_MOCK=false 時は `GMO_PROD_ENDPOINT` を優先する
+   */
+  endpoint?: string;
+  /** 加盟店 ID (default = env `GMO_SHOP_ID`) */
+  shopId?: string;
+  /** 加盟店 password (default = env `GMO_SHOP_PASS`) */
+  shopPass?: string;
+  /** request timeout (ms、 default = env `GMO_REQUEST_TIMEOUT_MS` or 30000) */
+  timeoutMs?: number;
+  /** fetch 実装差替 (test 用、 default = globalThis.fetch) */
+  fetch?: FetchLike;
+};
+
+/**
+ * GMO API 障害 (network fail / HTTP error / ErrCode 返却) を統合した error
+ * authorize handler は本 error を catch して 5xx GmoAuthorizationFailed に変換する
+ */
+export class GmoAuthorizationError extends Error {
+  public readonly errCode?: string;
+  public readonly errInfo?: string;
+  constructor(
+    message: string,
+    options: { errCode?: string; errInfo?: string; cause?: unknown } = {},
+  ) {
+    super(message);
+    this.name = 'GmoAuthorizationError';
+    if (options.errCode !== undefined) {
+      this.errCode = options.errCode;
+    }
+    if (options.errInfo !== undefined) {
+      this.errInfo = options.errInfo;
+    }
+    if (options.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/**
+ * env / options から endpoint を決定
+ * USE_GMO_MOCK truthy → GMO_ENDPOINT、 それ以外は GMO_PROD_ENDPOINT
+ */
+const resolveEndpoint = (option: string | undefined): string => {
+  if (option !== undefined && option.trim() !== '') {
+    return option;
+  }
+  const useMock = (process.env['USE_GMO_MOCK'] ?? 'true').trim().toLowerCase();
+  const isMock = useMock === 'true' || useMock === '1' || useMock === 'yes';
+  if (isMock) {
+    return process.env['GMO_ENDPOINT'] ?? 'http://127.0.0.1:2426';
+  }
+  return process.env['GMO_PROD_ENDPOINT'] ?? 'https://p01.mul-pay.jp/payment';
+};
+
+const readStringConfig = (option: string | undefined, envKey: string, fallback: string): string => {
+  if (option !== undefined && option.trim() !== '') {
+    return option;
+  }
+  const raw = process.env[envKey];
+  if (raw !== undefined && raw.trim() !== '') {
+    return raw;
+  }
+  return fallback;
+};
+
+const readNumberConfig = (
+  optionValue: number | undefined,
+  envKey: string,
+  defaultValue: number,
+): number => {
+  if (typeof optionValue === 'number' && Number.isFinite(optionValue) && optionValue > 0) {
+    return optionValue;
+  }
+  const raw = process.env[envKey];
+  if (raw !== undefined && raw.trim() !== '') {
+    const parsed = Number.parseFloat(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return defaultValue;
+};
+
+/** form-encoded body を Record にパース */
+const parseFormBody = (body: string): Record<string, string> => {
+  const params = new URLSearchParams(body);
+  const result: Record<string, string> = {};
+  params.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+};
+
+/** GMO error 応答判定 (ErrCode field を持つ or AccessID/ACS 等の成功 field が欠損) */
+const asGmoError = (parsed: Record<string, string>): GmoErrorResponse | undefined => {
+  const errCode = parsed['ErrCode'];
+  if (errCode !== undefined && errCode !== '') {
+    return { errCode, errInfo: parsed['ErrInfo'] ?? '' };
+  }
+  return undefined;
+};
+
+/** timeout 付き fetch (AbortController で abort 時 signal) */
+const fetchWithTimeout = async (
+  fetchImpl: FetchLike,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export class GmoClient {
+  private readonly endpoint: string;
+  private readonly shopId: string;
+  private readonly shopPass: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(options: GmoClientOptions = {}) {
+    this.endpoint = resolveEndpoint(options.endpoint);
+    this.shopId = readStringConfig(options.shopId, 'GMO_SHOP_ID', 'tshop00000001');
+    this.shopPass = readStringConfig(options.shopPass, 'GMO_SHOP_PASS', 'test_pass');
+    this.timeoutMs = readNumberConfig(options.timeoutMs, 'GMO_REQUEST_TIMEOUT_MS', 30000);
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * POST /entryTran — 取引登録 (accessId / accessPass 発行)
+   * amount 上限 100 万円 check は本 client では実施しない (handler 層で先行 check + GMO 側でも E01 応答)
+   */
+  async entryTran(req: EntryTranRequest): Promise<EntryTranSuccess> {
+    const body = new URLSearchParams({
+      ShopID: req.shopId,
+      ShopPass: req.shopPass,
+      OrderID: req.orderId,
+      JobCd: req.jobCd,
+      Amount: String(req.amount),
+    }).toString();
+
+    const parsed = await this.post('/entryTran', body);
+    const err = asGmoError(parsed);
+    if (err !== undefined) {
+      throw new GmoAuthorizationError(`GMO entryTran failed (${err.errCode})`, {
+        errCode: err.errCode,
+        errInfo: err.errInfo,
+      });
+    }
+    const accessId = parsed['AccessID'];
+    const accessPass = parsed['AccessPass'];
+    if (accessId === undefined || accessPass === undefined) {
+      throw new GmoAuthorizationError('GMO entryTran missing AccessID/AccessPass');
+    }
+    return { accessId, accessPass };
+  }
+
+  /**
+   * POST /execTran — 決済実行 (与信枠 authorization + 3DS 2.0 redirect URL 発行)
+   * cardToken は GMO PG Token 方式で受渡す (webapp が GMO に直接 POST して受領した token)
+   * mock 側 gmo-server.ts は CardNo param を見るため、 実 client は CardNo に token を載せる
+   */
+  async execTran(req: ExecTranRequest): Promise<ExecTranSuccess> {
+    const params: Record<string, string> = {
+      AccessID: req.accessId,
+      AccessPass: req.accessPass,
+      OrderID: req.orderId,
+      // GMO PG Token 方式では Token param を送るのが正式、 mock との整合のため CardNo 併記
+      Token: req.cardToken,
+      CardNo: req.cardToken,
+      Method: '1',
+    };
+    if (req.tds2RetUrl !== undefined) {
+      params['Tds2RetUrl'] = req.tds2RetUrl;
+    }
+    const body = new URLSearchParams(params).toString();
+
+    const parsed = await this.post('/execTran', body);
+    const err = asGmoError(parsed);
+    if (err !== undefined) {
+      throw new GmoAuthorizationError(`GMO execTran failed (${err.errCode})`, {
+        errCode: err.errCode,
+        errInfo: err.errInfo,
+      });
+    }
+    const acs = parsed['ACS'];
+    const acsUrl = parsed['ACSUrl'];
+    const orderId = parsed['OrderID'];
+    const accessId = parsed['AccessID'];
+    const approve = parsed['Approve'];
+    const tranId = parsed['TranID'];
+    const tranDate = parsed['TranDate'];
+    if (
+      acs === undefined ||
+      acsUrl === undefined ||
+      orderId === undefined ||
+      accessId === undefined ||
+      approve === undefined ||
+      tranId === undefined ||
+      tranDate === undefined
+    ) {
+      throw new GmoAuthorizationError('GMO execTran missing required fields');
+    }
+    return { acs, acsUrl, orderId, accessId, approve, tranId, tranDate };
+  }
+
+  /**
+   * entryTran → execTran を順次呼出、 authorize handler が使う統合 method
+   * どちらか fail 時に GmoAuthorizationError を throw (handler で 5xx 変換)
+   */
+  async authorize(input: {
+    orderId: string;
+    amount: number;
+    cardToken: string;
+    tds2RetUrl?: string;
+  }): Promise<AuthorizationResult> {
+    const entry = await this.entryTran({
+      shopId: this.shopId,
+      shopPass: this.shopPass,
+      orderId: input.orderId,
+      jobCd: 'AUTH',
+      amount: input.amount,
+    });
+
+    const execReq: ExecTranRequest = {
+      accessId: entry.accessId,
+      accessPass: entry.accessPass,
+      orderId: input.orderId,
+      cardToken: input.cardToken,
+    };
+    if (input.tds2RetUrl !== undefined) {
+      execReq.tds2RetUrl = input.tds2RetUrl;
+    }
+    const exec = await this.execTran(execReq);
+
+    return {
+      authId: entry.accessId,
+      accessPass: entry.accessPass,
+      tds2Url: exec.acsUrl,
+      orderId: exec.orderId,
+      approve: exec.approve,
+      tranId: exec.tranId,
+    };
+  }
+
+  private async post(path: string, body: string): Promise<Record<string, string>> {
+    const url = `${this.endpoint.replace(/\/$/, '')}${path}`;
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(
+        this.fetchImpl,
+        url,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body,
+        },
+        this.timeoutMs,
+      );
+    } catch (err) {
+      throw new GmoAuthorizationError(`GMO POST ${path} network error`, { cause: err });
+    }
+    if (!response.ok) {
+      throw new GmoAuthorizationError(`GMO POST ${path} HTTP ${response.status}`);
+    }
+    const text = await response.text();
+    return parseFormBody(text);
+  }
+}

--- a/packages/niji-api/src/services/gmo/types.ts
+++ b/packages/niji-api/src/services/gmo/types.ts
@@ -1,0 +1,72 @@
+/**
+ * GMO PGマルチペイメント API request/response 型定義 (Issue #3006 Phase A)
+ *
+ * GMO 公式仕様 (form-encoded KEY=VALUE&KEY=VALUE) の shape を TypeScript 型として集約する。
+ * client.ts はここで定義した型を parse / build する責務のみを持つ。
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P2, P6、
+ *        Phase1-02-issue-breakdown.md § Issue 3、
+ *        packages/niji-api/src/mocks/gmo-server.ts (mock 側 response shape との整合)
+ */
+
+/** entryTran (取引登録) request param */
+export type EntryTranRequest = {
+  /** 加盟店 ID */
+  shopId: string;
+  /** 加盟店 password */
+  shopPass: string;
+  /** 加盟店側 order ID (auth ID PK に一致させて後段 handler で lookup 可能に) */
+  orderId: string;
+  /** JobCd = AUTH (与信枠取得のみ、 Phase 1 は SALES 即時決済を使わない) */
+  jobCd: 'AUTH' | 'SALES';
+  /** 与信枠額 (円単位、 GMO 仕様) */
+  amount: number;
+};
+
+/** entryTran 成功応答 (form-encoded parse 済) */
+export type EntryTranSuccess = {
+  accessId: string;
+  accessPass: string;
+};
+
+/** entryTran / execTran / alterTran 共通の error 応答 shape */
+export type GmoErrorResponse = {
+  errCode: string;
+  errInfo: string;
+};
+
+/** execTran (決済実行 + 3DS URL 発行) request param */
+export type ExecTranRequest = {
+  accessId: string;
+  accessPass: string;
+  orderId: string;
+  /** GMO PG Token 方式で受渡す card token (webapp が GMO に直接 POST して受領) */
+  cardToken: string;
+  /** 3DS 2.0 認証後の webapp 側 return URL (mock は default で使わない) */
+  tds2RetUrl?: string;
+};
+
+/** execTran 成功応答 */
+export type ExecTranSuccess = {
+  /** ACS = '1' の場合 3DS 認証必要 */
+  acs: string;
+  /** 3DS 認証 redirect URL (mock は dummy URL) */
+  acsUrl: string;
+  orderId: string;
+  accessId: string;
+  approve: string;
+  tranId: string;
+  tranDate: string;
+};
+
+/** entryTran + execTran を順次呼出した後の返却型 (authorize handler が使う) */
+export type AuthorizationResult = {
+  /** GMO auth ID (実装上 accessId を採用、 fiat_bid.authId PK に一致) */
+  authId: string;
+  accessPass: string;
+  /** 3DS 認証 redirect URL */
+  tds2Url: string;
+  orderId: string;
+  approve: string;
+  tranId: string;
+};


### PR DESCRIPTION
## Summary

Phase 1 fiat bid 経路の入口となる **POST /api/v1/fiat-bid/authorize** endpoint を実装。
GMO PGマルチペイメント の `entryTran` (取引登録) + `execTran` (与信枠実行) を順次呼出、
bid 上限 100 万円 check + JPY→ETH 換算 (Issue #3005 spot rate 経由) + Ponder `fiat_bid` table pending INSERT を担う。

Closes #3006
Refs `tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md` § P2, P6
Refs `tests/spec/gmo-fiat-bid/Phase1-02-issue-breakdown.md` § Issue 3

Blocker of #3007 (3DS callback endpoint、 本 PR で INSERT した pending record を 3ds-verified に更新する後段 handler)。

## 変更ファイル

新規 file。

- `packages/niji-api/src/services/gmo/types.ts` — GMO PG API request/response 型定義 (72 行)
- `packages/niji-api/src/services/gmo/client.ts` — `GmoClient` class + `GmoAuthorizationError` (305 行)
- `packages/niji-api/src/services/gmo/client.test.ts` — 9 behavior test (235 行)
- `packages/niji-api/src/handlers/fiat-bid/authorize.ts` — hono handler + DI store (326 行)
- `packages/niji-api/src/handlers/fiat-bid/authorize.test.ts` — 18 behavior test (401 行)

更新 file。

- `packages/niji-api/ponder.schema.ts` — `fiat_bid` table + `fiatBidStatus` enum 追加 (+47 行)
- `packages/niji-api/src/api/index.ts` — authorize app を `/api/v1/fiat-bid` にマウント (+52 行)

## behavior 契約 (完了条件検証済)

| 挙動 | 検証 test | 結果 |
|---|---|---|
| POST /api/v1/fiat-bid/authorize が 200 OK で { authId, tds2Url, jpyAmount, ethAmount, spotRate, spotRateSource } 返却 | `authorize.test.ts` happy path | PASS |
| bid 上限 100 万円超過 → 400 BidLimitExceeded (GMO / DB 触らず) | `authorize.test.ts` bid 上限 | PASS |
| GMO 障害 (entryTran / execTran fail) → 500 GmoAuthorizationFailed (DB 書込なし) | `authorize.test.ts` GMO 障害 | PASS |
| Ponder fiat_bid table に pending record が INSERT | `authorize.test.ts` happy path record 検証 | PASS |
| spot rate 両失敗時 503 SpotRateUnavailable、 GMO 呼ばず | `authorize.test.ts` spot rate 失敗 | PASS |
| CoinGecko fallback (source=coingecko) も handler 経由で通る | `authorize.test.ts` fallback | PASS |
| request body validation (jpyAmount 型 / bidderWallet hex / auctionId decimal / invalid JSON) | `parseAuthorizeBody` + handler 5 test | PASS |
| GmoClient entryTran / execTran / authorize の GMO 応答 parse | `client.test.ts` 9 test | PASS |

## test / quality gate 結果 (rules/quality.md § test-passed marker 発行前提 3 条件 met)

```
vitest 63 tests / 6 files 全 pass
  services/gmo/client.test.ts       9 tests
  handlers/spot-rate.test.ts        4 tests
  handlers/fiat-bid/authorize.test.ts  18 tests
  mocks/index.test.ts               7 tests
  mocks/gmo-server.test.ts         12 tests
  services/spotRate/index.test.ts  13 tests
```

- 変更 file 全てに behavior test 追加 (client / authorize の 2 新規 source 対 2 新規 test)
- 追加 test は import + 関数呼出 + assertion で新規 code path を実 execute (stub は fetch / SpotRateFetcher / GmoClient / FiatBidStore の外部境界のみ)
- `pnpm test` で vitest 実行結果 PASS log 確認済

## typecheck / lint

- 本 PR 新規 file 由来の typecheck error 0 件
- ESLint 0 error / 0 warning
- 既存 `ponder.config.ts` の 3 error (`nounsTokenAbi` / `nounsStreamFactoryAbi` / `nounsStreamAbi`) は **master でも同じ状態** (本 PR 由来 regression なし、 別 Issue で解消候補)

## CI 状態

NijiGas 20KB OOM で fail 継続だが本 PR 由来 regression なし (contract 触らず、 API package 単独変更)、 admin merge 経路。

## Test plan

- [x] `pnpm --filter @niji/api test` で 63 tests 全 pass 確認
- [x] `pnpm --filter @niji/api lint` で 0 error / 0 warning 確認
- [x] `pnpm --filter @niji/api typecheck` で本 PR 由来 error 0 件確認 (既存 ponder.config.ts の 3 error は master 由来)
- [x] behavior test で 100 万円超過 4xx / GMO 障害 5xx / happy path 200 の 3 case 全 pass 確認
- [x] fiat_bid table INSERT record が spec 通りの status (pending) / value であることを assertion で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgdKhYSgYfHh3H4PLLQMjW