### PR TITLE
✨ feat(niji-api): 運営 EOA 代理 bid tx 発火 endpoint を viem で実装 (#3008)

### DIFF
--- a/packages/niji-api/.env.example
+++ b/packages/niji-api/.env.example
@@ -72,3 +72,22 @@ SPOT_RATE_CACHE_TTL_MS=5000
 # rate 乖離許容幅 (%)
 # 2% 超で user 再確認 modal 表示 (AC 4)、 BTC/ETH 日中 volatility 実測から算出
 SPOT_RATE_TOLERANCE_PERCENT=2
+
+# ------------------------------------------------------------------
+# BidRelay (Issue #3008) — 運営 EOA 代理 bid tx 発火
+# Base Sepolia で NijiAuctionHouseV3.createBid tx を運営 EOA から broadcast
+# ------------------------------------------------------------------
+
+# 運営 EOA 秘密鍵 (0x-prefixed 64 hex chars)、 Phase 1 = env 直、 Phase 3 = AWS KMS 移行
+# 本番切替時は env 直書き禁止、 KMS / 1Password / hardware wallet 経由で管理
+# .env.local (git 管理外) に実値、 本 .env.example は placeholder のみ
+OPERATOR_EOA_PRIVATE_KEY=0x0000000000000000000000000000000000000000000000000000000000000000
+
+# Base Sepolia RPC endpoint (chain id = 84532)
+# default = 公式 public RPC (rate limit 前提、 本格運用時は Alchemy / Infura 契約)
+BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+
+# NijiAuctionHouseV3 contract address (Base Sepolia)
+# sdk 側 nijiAuctionHouseAddress[84532] の placeholder を override する場合のみ設定
+# 未設定時は sdk の default (0x0 placeholder) を使う、 実 deploy 後の address 差替経路
+# NIJI_AUCTION_HOUSE_ADDRESS=0x...

--- a/packages/niji-api/src/api/index.ts
+++ b/packages/niji-api/src/api/index.ts
@@ -1,3 +1,4 @@
+import { nijiAuctionHouseAddress } from '@niji/sdk/actions';
 import { eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { graphql } from 'ponder';
@@ -9,7 +10,13 @@ import {
   type ThreeDsCallbackStore,
 } from '../handlers/fiat-bid/3ds-callback.js';
 import { createAuthorizeApp, type FiatBidStore } from '../handlers/fiat-bid/authorize.js';
+import { createPlaceBidApp, type PlaceBidStore } from '../handlers/fiat-bid/place-bid.js';
 import { createSpotRateApp } from '../handlers/spot-rate.js';
+import {
+  BidRelay,
+  createBaseSepoliaPublicClient,
+  createEnvSigner,
+} from '../services/bidRelay/index.js';
 import { GmoClient } from '../services/gmo/client.js';
 import { SpotRateFetcher } from '../services/spotRate/index.js';
 
@@ -117,5 +124,90 @@ const threeDsCallbackStore: ThreeDsCallbackStore = {
   },
 };
 app.route('/api/v1/fiat-bid', createThreeDsCallbackApp({ gmoClient, store: threeDsCallbackStore }));
+
+/**
+ * Issue #3008 — POST /api/v1/fiat-bid/place-bid (運営 EOA 代理 bid tx 発火)
+ *
+ * fiat_bid.status = "3ds-verified" record を lookup → NijiAuctionHouseV3.createBid tx broadcast →
+ * fiat_bid.status = "bid-placed" UPDATE + txHash 返却。
+ *
+ * revert (BidTooLow / AuctionEnded / gas 高騰 / RPC 障害) 時は GMO alterTran cancel + fiat_bid.status = "cancelled"。
+ *
+ * 秘密鍵管理 = Phase 1 は env OPERATOR_EOA_PRIVATE_KEY 直、 SignerProvider interface で抽象化 (Phase 3 KMS 移行想定)。
+ *
+ * NijiAuctionHouseV3 address = Base Sepolia (chainId=84532) は sdk 側 nijiAuctionHouseAddress で 0x0 placeholder、
+ * 実 deploy 後は env NIJI_AUCTION_HOUSE_ADDRESS で override 可能。
+ */
+const operatorPrivateKeyRaw = process.env['OPERATOR_EOA_PRIVATE_KEY'] ?? '';
+const baseSepoliaRpcUrl =
+  process.env['BASE_SEPOLIA_RPC_URL'] ??
+  process.env['PONDER_RPC_URL_84532'] ??
+  'https://sepolia.base.org';
+const nijiAuctionHouseAddressOverride = process.env['NIJI_AUCTION_HOUSE_ADDRESS'];
+const auctionHouseAddress = (nijiAuctionHouseAddressOverride ??
+  nijiAuctionHouseAddress[84532]) as `0x${string}`;
+
+/**
+ * BidRelay singleton は operatorPrivateKey が env に設定されている時のみ生成する。
+ * env 未設定時は place-bid endpoint は 500 応答するが、 module load 時 crash を避ける
+ * (test / codegen / typecheck 時に env 不要の設計)。
+ */
+let placeBidStore: PlaceBidStore | null = null;
+let bidRelay: BidRelay | null = null;
+const isValidOperatorKey =
+  operatorPrivateKeyRaw.length === 66 && operatorPrivateKeyRaw.startsWith('0x');
+if (
+  isValidOperatorKey &&
+  (auctionHouseAddress as string) !== '0x0000000000000000000000000000000000000000'
+) {
+  const operatorPrivateKey = operatorPrivateKeyRaw as `0x${string}`;
+  const signer = createEnvSigner({
+    privateKey: operatorPrivateKey,
+    rpcUrl: baseSepoliaRpcUrl,
+  });
+  const publicClient = createBaseSepoliaPublicClient(baseSepoliaRpcUrl);
+  bidRelay = new BidRelay({
+    signer,
+    publicClient,
+    auctionHouseAddress,
+  });
+
+  placeBidStore = {
+    findVerified: async authId => {
+      const rows = await (db
+        .select()
+        .from(schema.fiatBid)
+        .where(eq(schema.fiatBid.authId, authId)) as unknown as Promise<
+        Array<{
+          authId: string;
+          status: string;
+          ethAmount: bigint;
+        }>
+      >);
+      const row = rows[0];
+      if (!row) return null;
+      // Phase 1 mock 環境の accessPass 派生 (3ds-callback と同一 logic、 実 GMO 切替時に schema field 追加で置換)
+      const accessPass = authId.startsWith('mock-access-')
+        ? `mock-pass-${(Number(authId.replace('mock-access-', '')) + 1).toString().padStart(8, '0')}`
+        : `${authId}-pass`;
+      return {
+        authId: row.authId,
+        status: row.status,
+        ethAmount: row.ethAmount,
+        accessPass,
+      };
+    },
+    updateStatus: async input => {
+      const update: Record<string, unknown> = { status: input.status };
+      // txHash 保存 field は Phase 1 schema に無い、 Phase 2 で fiat_bid.bidTxHash 追加時に配線
+      // (現状は log / operational trace のみで管理)
+      await writableDb
+        .update(schema.fiatBid)
+        .set(update)
+        .where(eq(schema.fiatBid.authId, input.authId));
+    },
+  };
+  app.route('/api/v1/fiat-bid', createPlaceBidApp({ bidRelay, gmoClient, store: placeBidStore }));
+}
 
 export default app;

--- a/packages/niji-api/src/handlers/fiat-bid/place-bid.test.ts
+++ b/packages/niji-api/src/handlers/fiat-bid/place-bid.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Fiat bid place-bid handler behavior test (Issue #3008 Phase B/D)
+ *
+ * 検証対象 (完了条件 5 case + validation + error 分岐) —
+ * (1) happy path — 200 OK で { status: "bid-placed", txHash }、
+ *     BidRelay.placeBid 呼出 + store.updateStatus("bid-placed") 呼出
+ * (2) revert 分岐 (BidTooLow) — 200 OK で { status: "cancelled", txHash: null, message }、
+ *     store.updateStatus("cancelled") + GmoClient.cancelAuthorization 呼出
+ * (3) status ≠ 3ds-verified で 409 Conflict、 BidRelay 呼ばず
+ * (4) authId 該当なしで 404 NotFound、 BidRelay / GMO 呼ばず
+ * (5) GMO cancel 失敗 (revert 経路後) → 500 GmoCancelFailed、 fiat_bid.status は cancelled UPDATE 済
+ * (6) request validation fail (authId 欠損 / 型不正) → 400 InvalidRequest
+ * (7) request body invalid JSON → 400 InvalidRequest
+ *
+ * hono の app.request() 経由で actual handler を execute する。
+ * BidRelay / GmoClient は class stub、 PlaceBidStore は in-memory Map で受けて呼出を観測する。
+ *
+ * rules/quality.md § test-passed marker 発行前提 3 条件準拠 (behavior test / 変更箇所 execute / test runner PASS)。
+ */
+
+import type { AlterTranSuccess, SecureTran2Success } from '../../services/gmo/types.js';
+import type { Hash } from 'viem';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BidRelay, BidRelayError, type SignerProvider } from '../../services/bidRelay/index.js';
+import { GmoAuthorizationError, GmoClient } from '../../services/gmo/client.js';
+
+import {
+  createPlaceBidApp,
+  messageForRevertReason,
+  parsePlaceBidBody,
+  type PlaceBidResponseBody,
+  type PlaceBidStore,
+} from './place-bid.js';
+
+/** GmoClient stub (verifyTds2 / cancelAuthorization method のみ差替) */
+class StubGmoClient extends GmoClient {
+  constructor(
+    private readonly behavior: {
+      verifyTds2?: () => Promise<SecureTran2Success>;
+      cancelAuthorization?: () => Promise<AlterTranSuccess>;
+    } = {},
+  ) {
+    super({ endpoint: 'http://stub-gmo' });
+  }
+  override async verifyTds2(): Promise<SecureTran2Success> {
+    if (this.behavior.verifyTds2 === undefined) {
+      throw new Error('StubGmoClient.verifyTds2 behavior not set');
+    }
+    return this.behavior.verifyTds2();
+  }
+  override async cancelAuthorization(): Promise<AlterTranSuccess> {
+    if (this.behavior.cancelAuthorization === undefined) {
+      throw new Error('StubGmoClient.cancelAuthorization behavior not set');
+    }
+    return this.behavior.cancelAuthorization();
+  }
+}
+
+/** BidRelay stub (placeBid のみ差替、 constructor は minimal signer / publicClient で満たす) */
+class StubBidRelay extends BidRelay {
+  constructor(
+    private readonly placeBidBehavior:
+      | { kind: 'success'; txHash: Hash; auctionId: bigint; ethAmount: bigint }
+      | { kind: 'error'; error: BidRelayError },
+  ) {
+    const dummySigner: SignerProvider = {
+      address: '0x0000000000000000000000000000000000000000',
+      getWalletClient: () => {
+        throw new Error('StubBidRelay: getWalletClient should not be called');
+      },
+    };
+    super({
+      signer: dummySigner,
+      publicClient: {
+        readContract: async () => ({}),
+      } as unknown as import('viem').PublicClient,
+      auctionHouseAddress: '0x0000000000000000000000000000000000000000',
+    });
+  }
+
+  override async placeBid(input: { ethAmount: bigint }) {
+    if (this.placeBidBehavior.kind === 'error') {
+      throw this.placeBidBehavior.error;
+    }
+    return {
+      txHash: this.placeBidBehavior.txHash,
+      auctionId: this.placeBidBehavior.auctionId,
+      ethAmount: input.ethAmount,
+    };
+  }
+}
+
+/** in-memory PlaceBidStore stub */
+type StubRecord = {
+  authId: string;
+  status: string;
+  ethAmount: bigint;
+  accessPass: string;
+};
+
+const makeStore = (
+  seed: StubRecord | null = null,
+): PlaceBidStore & {
+  updates: Array<{ authId: string; status: string; txHash?: string }>;
+  lookups: string[];
+} => {
+  const updates: Array<{ authId: string; status: string; txHash?: string }> = [];
+  const lookups: string[] = [];
+  const records = new Map<string, StubRecord>();
+  if (seed) records.set(seed.authId, seed);
+  return {
+    updates,
+    lookups,
+    findVerified: async authId => {
+      lookups.push(authId);
+      return records.get(authId) ?? null;
+    },
+    updateStatus: async input => {
+      updates.push(input);
+      const existing = records.get(input.authId);
+      if (existing) records.set(input.authId, { ...existing, status: input.status });
+    },
+  };
+};
+
+const validBody = { authId: 'mock-access-00000001' };
+
+const seededVerifiedRecord: StubRecord = {
+  authId: 'mock-access-00000001',
+  status: '3ds-verified',
+  ethAmount: 250_000_000_000_000_000n, // 0.25 ETH wei
+  accessPass: 'mock-pass-00000002',
+};
+
+const stubTxHash = '0xdeadbeef000000000000000000000000000000000000000000000000000000ff' as Hash;
+const goodCancel: AlterTranSuccess = {
+  accessId: 'mock-access-00000001',
+  accessPass: 'mock-pass-00000002',
+  status: 'VOID',
+};
+
+describe('parsePlaceBidBody', () => {
+  it('valid body を通す', () => {
+    const result = parsePlaceBidBody(validBody);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.value.authId).toBe('mock-access-00000001');
+  });
+
+  it('authId 欠損で reject', () => {
+    expect(parsePlaceBidBody({}).ok).toBe(false);
+  });
+
+  it('authId が空文字で reject', () => {
+    expect(parsePlaceBidBody({ authId: '' }).ok).toBe(false);
+    expect(parsePlaceBidBody({ authId: '   ' }).ok).toBe(false);
+  });
+
+  it('null / 非 object で reject', () => {
+    expect(parsePlaceBidBody(null).ok).toBe(false);
+    expect(parsePlaceBidBody('string').ok).toBe(false);
+    expect(parsePlaceBidBody(42).ok).toBe(false);
+  });
+});
+
+describe('messageForRevertReason', () => {
+  it('各 reason に対して user 通知 msg を返す', () => {
+    expect(messageForRevertReason('BidTooLow')).toContain('上乗せ');
+    expect(messageForRevertReason('AuctionEnded')).toContain('終了');
+    expect(messageForRevertReason('GasPriceHigh')).toContain('混雑');
+    expect(messageForRevertReason('RpcError')).toContain('network');
+    expect(messageForRevertReason('Unknown')).toContain('broadcast');
+  });
+});
+
+describe('createPlaceBidApp POST /place-bid', () => {
+  let store: ReturnType<typeof makeStore>;
+
+  beforeEach(() => {
+    store = makeStore(seededVerifiedRecord);
+  });
+
+  it('happy path — bid tx broadcast → status="bid-placed" UPDATE で 200 OK', async () => {
+    const cancelStub = vi.fn(async () => goodCancel);
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient({ cancelAuthorization: cancelStub }),
+      store,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PlaceBidResponseBody;
+    expect(body.authId).toBe('mock-access-00000001');
+    expect(body.status).toBe('bid-placed');
+    expect(body.txHash).toBe(stubTxHash);
+
+    // status update は bid-placed で 1 回、 txHash 含む
+    expect(store.updates).toHaveLength(1);
+    expect(store.updates[0]).toEqual({
+      authId: 'mock-access-00000001',
+      status: 'bid-placed',
+      txHash: stubTxHash,
+    });
+
+    // GMO cancel は呼ばれない
+    expect(cancelStub).not.toHaveBeenCalled();
+  });
+
+  it('revert (BidTooLow) — GMO cancel + status="cancelled" UPDATE で 200 OK', async () => {
+    const cancelStub = vi.fn(async () => goodCancel);
+    const bidRelay = new StubBidRelay({
+      kind: 'error',
+      error: new BidRelayError('execution reverted: BidTooLow()', { reason: 'BidTooLow' }),
+    });
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient({ cancelAuthorization: cancelStub }),
+      store,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PlaceBidResponseBody;
+    expect(body.authId).toBe('mock-access-00000001');
+    expect(body.status).toBe('cancelled');
+    expect(body.txHash).toBe(null);
+    expect(body.message).toContain('上乗せ');
+
+    // status update は cancelled で 1 回、 GMO cancel が呼ばれる
+    expect(store.updates).toHaveLength(1);
+    expect(store.updates[0]).toEqual({
+      authId: 'mock-access-00000001',
+      status: 'cancelled',
+    });
+    expect(cancelStub).toHaveBeenCalledTimes(1);
+  });
+
+  it('revert (AuctionEnded) — user 通知 msg に「終了」 が含まれる', async () => {
+    const cancelStub = vi.fn(async () => goodCancel);
+    const bidRelay = new StubBidRelay({
+      kind: 'error',
+      error: new BidRelayError('AuctionEnded()', { reason: 'AuctionEnded' }),
+    });
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient({ cancelAuthorization: cancelStub }),
+      store,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as PlaceBidResponseBody;
+    expect(body.status).toBe('cancelled');
+    expect(body.message).toContain('終了');
+  });
+
+  it('status ≠ 3ds-verified — 409 Conflict、 BidRelay / GMO 呼ばず', async () => {
+    const cancelStub = vi.fn(async () => goodCancel);
+    const placeBidStub = vi.fn();
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    // 上書きで spy
+    bidRelay.placeBid = placeBidStub;
+
+    const pendingStore = makeStore({
+      ...seededVerifiedRecord,
+      status: 'pending',
+    });
+
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient({ cancelAuthorization: cancelStub }),
+      store: pendingStore,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; actualStatus: string };
+    expect(body.error).toBe('Conflict');
+    expect(body.actualStatus).toBe('pending');
+
+    // BidRelay / GMO cancel / status update は呼ばれない
+    expect(placeBidStub).not.toHaveBeenCalled();
+    expect(cancelStub).not.toHaveBeenCalled();
+    expect(pendingStore.updates).toHaveLength(0);
+  });
+
+  it('authId 該当なし — 404 NotFound、 BidRelay / GMO 呼ばず', async () => {
+    const cancelStub = vi.fn(async () => goodCancel);
+    const placeBidStub = vi.fn();
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    bidRelay.placeBid = placeBidStub;
+
+    const emptyStore = makeStore(null);
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient({ cancelAuthorization: cancelStub }),
+      store: emptyStore,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('NotFound');
+
+    expect(placeBidStub).not.toHaveBeenCalled();
+    expect(cancelStub).not.toHaveBeenCalled();
+    expect(emptyStore.updates).toHaveLength(0);
+    expect(emptyStore.lookups).toContain('mock-access-00000001');
+  });
+
+  it('revert 後 GMO cancel 失敗 → 500 GmoCancelFailed、 status=cancelled は UPDATE 済', async () => {
+    const bidRelay = new StubBidRelay({
+      kind: 'error',
+      error: new BidRelayError('AuctionEnded()', { reason: 'AuctionEnded' }),
+    });
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient({
+        cancelAuthorization: async () => {
+          throw new GmoAuthorizationError('GMO alterTran failed (G05)', {
+            errCode: 'G05',
+            errInfo: 'G05180001',
+          });
+        },
+      }),
+      store,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; errCode: string; revertReason: string };
+    expect(body.error).toBe('GmoCancelFailed');
+    expect(body.errCode).toBe('G05');
+    expect(body.revertReason).toBe('AuctionEnded');
+
+    // status update は先行 UPDATE 済 (cancelled)
+    expect(store.updates).toHaveLength(1);
+    expect(store.updates[0]).toEqual({
+      authId: 'mock-access-00000001',
+      status: 'cancelled',
+    });
+  });
+
+  it('request body が invalid JSON で 400 InvalidRequest', async () => {
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient(),
+      store,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json{',
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('InvalidRequest');
+  });
+
+  it('authId 欠損で 400 InvalidRequest、 BidRelay 呼ばず', async () => {
+    const placeBidStub = vi.fn();
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    bidRelay.placeBid = placeBidStub;
+
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient(),
+      store,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(placeBidStub).not.toHaveBeenCalled();
+    expect(store.updates).toHaveLength(0);
+  });
+
+  it('store.findVerified fail で 500 InternalError', async () => {
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    const failingStore: PlaceBidStore = {
+      findVerified: async () => {
+        throw new Error('DB unreachable');
+      },
+      updateStatus: async () => {
+        // no-op
+      },
+    };
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient(),
+      store: failingStore,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('InternalError');
+    expect(body.message).toContain('fiat_bid lookup failed');
+  });
+
+  it('success 後 status update fail で 500 InternalError (txHash は保持)', async () => {
+    const bidRelay = new StubBidRelay({
+      kind: 'success',
+      txHash: stubTxHash,
+      auctionId: 42n,
+      ethAmount: seededVerifiedRecord.ethAmount,
+    });
+    const failingStore: PlaceBidStore = {
+      findVerified: async () => ({
+        authId: 'mock-access-00000001',
+        status: '3ds-verified',
+        ethAmount: seededVerifiedRecord.ethAmount,
+        accessPass: seededVerifiedRecord.accessPass,
+      }),
+      updateStatus: async () => {
+        throw new Error('DB unreachable during update');
+      },
+    };
+    const app = createPlaceBidApp({
+      bidRelay,
+      gmoClient: new StubGmoClient(),
+      store: failingStore,
+    });
+
+    const res = await app.request('/place-bid', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; txHash: string };
+    expect(body.error).toBe('InternalError');
+    expect(body.txHash).toBe(stubTxHash);
+  });
+});

--- a/packages/niji-api/src/handlers/fiat-bid/place-bid.ts
+++ b/packages/niji-api/src/handlers/fiat-bid/place-bid.ts
@@ -1,0 +1,264 @@
+/**
+ * Fiat bid place-bid hono handler (Issue #3008 Phase B)
+ *
+ * POST /api/v1/fiat-bid/place-bid
+ * request body — { authId }
+ * 応答 body    — { authId, txHash, status: "bid-placed" | "cancelled", message }
+ *
+ * 処理順 —
+ * (1) request body 検証 (authId)
+ * (2) fiat_bid record を authId で lookup、 status = "3ds-verified" verify
+ * (3) BidRelay.placeBid で bid tx broadcast (chain 上 auction ID 取得 + createBid 発火)
+ * (4) 成功時 fiat_bid.status = "bid-placed" UPDATE + txHash 返却
+ * (5) tx broadcast fail (BidRelayError) 時 GMO alterTran cancel + fiat_bid.status = "cancelled" UPDATE + user 通知 msg 返却
+ *
+ * error 変換 —
+ * - request validation fail    → 400 InvalidRequest
+ * - fiat_bid not found         → 404 NotFound
+ * - fiat_bid.status ≠ 3ds-verified → 409 Conflict (idempotency 保護、 already bid-placed / cancelled 状態を弾く)
+ * - BidRelayError (revert / RPC) → 200 OK で { status: "cancelled", message } (顧客不利防止で 200 応答 + GMO cancel 済)
+ * - GMO cancel fail            → 500 GmoCancelFailed (与信枠残る、 operational alert 対象)
+ * - unexpected error            → 500 InternalError
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P3-c, P6、
+ *        Phase1-02-issue-breakdown.md § Issue 5、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+import { Hono } from 'hono';
+
+import { BidRelay, BidRelayError, type BidRevertReason } from '../../services/bidRelay/index.js';
+import { GmoAuthorizationError, GmoClient } from '../../services/gmo/client.js';
+
+/** request body shape (webapp が POST する) */
+export type PlaceBidRequestBody = {
+  authId: string;
+};
+
+/** 応答 body shape (公開 API 契約) */
+export type PlaceBidResponseBody = {
+  authId: string;
+  status: 'bid-placed' | 'cancelled';
+  txHash: string | null;
+  message: string;
+};
+
+/** DB store 抽象 (Ponder DB を直接触らずに handler test 可能に) */
+export type PlaceBidStore = {
+  /**
+   * fiat_bid record を authId で lookup、 無ければ null
+   * status / ethAmount / accessPass を返す (bid 発火判定 + GMO cancel 用)
+   */
+  findVerified: (authId: string) => Promise<{
+    authId: string;
+    status: string;
+    ethAmount: bigint;
+    accessPass: string;
+  } | null>;
+  /**
+   * status を "bid-placed" or "cancelled" に UPDATE
+   * 冪等性 = 同 authId + 同 status で 2 度呼ばれても状態遷移 valid
+   */
+  updateStatus: (input: {
+    authId: string;
+    status: 'bid-placed' | 'cancelled';
+    txHash?: string;
+  }) => Promise<void>;
+};
+
+/** revert reason から user 通知 msg を生成 (webapp 表示用) */
+export const messageForRevertReason = (reason: BidRevertReason): string => {
+  switch (reason) {
+    case 'BidTooLow':
+      return '他の入札者に上乗せされました。 再入札は個別に行ってください。';
+    case 'AuctionEnded':
+      return 'auction は既に終了しています。';
+    case 'GasPriceHigh':
+      return 'network が混雑しています。 しばらく待って再試行してください。';
+    case 'RpcError':
+      return 'network 障害が発生しました。 しばらく待って再試行してください。';
+    case 'Unknown':
+    default:
+      return 'bid tx の broadcast に失敗しました。 与信枠は自動的に cancel されました。';
+  }
+};
+
+/**
+ * request body の shape 検証
+ * unknown value を受取り PlaceBidRequestBody に絞込 (or error message 返す)
+ */
+export const parsePlaceBidBody = (
+  raw: unknown,
+): { ok: true; value: PlaceBidRequestBody } | { ok: false; message: string } => {
+  if (raw === null || typeof raw !== 'object') {
+    return { ok: false, message: 'request body must be a JSON object' };
+  }
+  const body = raw as Record<string, unknown>;
+  const authId = body['authId'];
+  if (typeof authId !== 'string' || authId.trim() === '') {
+    return { ok: false, message: 'authId must be a non-empty string' };
+  }
+  return { ok: true, value: { authId } };
+};
+
+export type CreatePlaceBidAppOptions = {
+  bidRelay: BidRelay;
+  gmoClient: GmoClient;
+  store: PlaceBidStore;
+};
+
+/**
+ * place-bid handler の Hono app を返す factory
+ * options で BidRelay / GmoClient / DB store を DI、 test 時に mock 差替
+ */
+export const createPlaceBidApp = (options: CreatePlaceBidAppOptions): Hono => {
+  const app = new Hono();
+
+  app.post('/place-bid', async c => {
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      return c.json({ error: 'InvalidRequest', message: 'request body must be valid JSON' }, 400);
+    }
+
+    const parsed = parsePlaceBidBody(rawBody);
+    if (!parsed.ok) {
+      return c.json({ error: 'InvalidRequest', message: parsed.message }, 400);
+    }
+    const body = parsed.value;
+
+    // fiat_bid record lookup、 無ければ 404
+    let record: Awaited<ReturnType<PlaceBidStore['findVerified']>>;
+    try {
+      record = await options.store.findVerified(body.authId);
+    } catch (err) {
+      return c.json(
+        {
+          error: 'InternalError',
+          message: `fiat_bid lookup failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+        500,
+      );
+    }
+    if (record === null) {
+      return c.json(
+        {
+          error: 'NotFound',
+          message: `fiat_bid record not found for authId=${body.authId}`,
+        },
+        404,
+      );
+    }
+
+    // status = "3ds-verified" 以外は 409 Conflict (idempotency 保護)
+    if (record.status !== '3ds-verified') {
+      return c.json(
+        {
+          error: 'Conflict',
+          message: `fiat_bid status must be "3ds-verified" (actual: "${record.status}")`,
+          actualStatus: record.status,
+        },
+        409,
+      );
+    }
+
+    // bid tx broadcast 試行
+    try {
+      const result = await options.bidRelay.placeBid({ ethAmount: record.ethAmount });
+
+      // 成功 — fiat_bid.status = "bid-placed" に UPDATE
+      try {
+        await options.store.updateStatus({
+          authId: body.authId,
+          status: 'bid-placed',
+          txHash: result.txHash,
+        });
+      } catch (err) {
+        // tx broadcast 済で DB write fail は operational alert 対象 (Phase 2 で監視 wire)
+        return c.json(
+          {
+            error: 'InternalError',
+            message: `fiat_bid status update failed after bid tx broadcast: ${err instanceof Error ? err.message : String(err)}`,
+            txHash: result.txHash,
+          },
+          500,
+        );
+      }
+
+      const response: PlaceBidResponseBody = {
+        authId: body.authId,
+        status: 'bid-placed',
+        txHash: result.txHash,
+        message: 'bid tx を broadcast しました。',
+      };
+      return c.json<PlaceBidResponseBody>(response, 200);
+    } catch (err) {
+      // bid tx broadcast fail — GMO cancel + fiat_bid.status = "cancelled" 遷移
+      if (!(err instanceof BidRelayError)) {
+        return c.json(
+          {
+            error: 'InternalError',
+            message: err instanceof Error ? err.message : String(err),
+          },
+          500,
+        );
+      }
+
+      const revertReason = err.reason;
+      const userMessage = messageForRevertReason(revertReason);
+
+      // 順序 — 先に DB 更新 (顧客保護、 fiat_bid は cancel 済で二度課金 / 二度 bid 発火防止)
+      try {
+        await options.store.updateStatus({ authId: body.authId, status: 'cancelled' });
+      } catch (dbErr) {
+        return c.json(
+          {
+            error: 'InternalError',
+            message: `fiat_bid status update failed: ${dbErr instanceof Error ? dbErr.message : String(dbErr)}`,
+          },
+          500,
+        );
+      }
+
+      // GMO alterTran cancel (与信枠解除)、 fail 時は 500 GmoCancelFailed で明示
+      try {
+        await options.gmoClient.cancelAuthorization({
+          accessId: body.authId,
+          accessPass: record.accessPass,
+        });
+      } catch (gmoErr) {
+        if (gmoErr instanceof GmoAuthorizationError) {
+          return c.json(
+            {
+              error: 'GmoCancelFailed',
+              message: gmoErr.message,
+              errCode: gmoErr.errCode ?? null,
+              errInfo: gmoErr.errInfo ?? null,
+              revertReason,
+            },
+            500,
+          );
+        }
+        return c.json(
+          {
+            error: 'InternalError',
+            message: gmoErr instanceof Error ? gmoErr.message : String(gmoErr),
+          },
+          500,
+        );
+      }
+
+      // cancelled 遷移完了、 200 OK で user 通知 msg を返却 (webapp が modal 表示)
+      const response: PlaceBidResponseBody = {
+        authId: body.authId,
+        status: 'cancelled',
+        txHash: null,
+        message: userMessage,
+      };
+      return c.json<PlaceBidResponseBody>(response, 200);
+    }
+  });
+
+  return app;
+};

--- a/packages/niji-api/src/services/bidRelay/index.test.ts
+++ b/packages/niji-api/src/services/bidRelay/index.test.ts
@@ -1,0 +1,265 @@
+/**
+ * BidRelay service behavior test (Issue #3008 Phase D)
+ *
+ * 検証対象 —
+ * (1) placeBid happy path — auction() view call → createBid writeContract → txHash 返却
+ * (2) placeBid revert — writeContract throw で BidRelayError.reason = 分類 reason
+ * (3) getCurrentAuctionId — auction() view call の nounId 抽出
+ * (4) classifyBidError — 各 revert 文言に対して正しい BidRevertReason を返す
+ *
+ * viem PublicClient / WalletClient は class 実装が公開されていないため、
+ * SignerProvider interface + PublicClient interface を stub object で差替える。
+ *
+ * rules/quality.md § test-passed marker 発行前提 3 条件準拠 (behavior test / 変更箇所 execute / test runner PASS)。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { BidRelay, BidRelayError, classifyBidError, type SignerProvider } from './index.js';
+
+/** viem PublicClient の必要 method のみ持つ stub 型 (readContract) */
+type PublicClientLike = {
+  readContract: ReturnType<typeof vi.fn>;
+};
+
+/** viem WalletClient の必要 method のみ持つ stub 型 (writeContract / account) */
+type WalletClientLike = {
+  account: { address: `0x${string}` };
+  writeContract: ReturnType<typeof vi.fn>;
+};
+
+const OPERATOR_ADDRESS: `0x${string}` = '0x1234567890123456789012345678901234567890';
+const AUCTION_HOUSE_ADDRESS: `0x${string}` = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+const makeSigner = (walletClient: WalletClientLike): SignerProvider => ({
+  address: OPERATOR_ADDRESS,
+  // viem WalletClient 型と厳密一致しないが、 本 test は writeContract / account のみ使う
+  getWalletClient: () => walletClient as unknown as ReturnType<SignerProvider['getWalletClient']>,
+});
+
+const mockAuctionResult = {
+  nounId: 42n,
+  amount: 100_000_000_000_000_000n,
+  startTime: 1720000000,
+  endTime: 1720086400,
+  bidder: '0x0000000000000000000000000000000000000000' as `0x${string}`,
+  settled: false,
+};
+
+describe('classifyBidError', () => {
+  it('BidTooLow 系文言を BidTooLow に分類', () => {
+    expect(classifyBidError(new Error('reverted: BidTooLow()'))).toBe('BidTooLow');
+    expect(classifyBidError(new Error('Must send more than reserve price'))).toBe('BidTooLow');
+  });
+
+  it('AuctionEnded 系文言を AuctionEnded に分類', () => {
+    expect(classifyBidError(new Error('AuctionEnded()'))).toBe('AuctionEnded');
+    expect(classifyBidError(new Error('Auction has ended'))).toBe('AuctionEnded');
+    expect(classifyBidError(new Error('Auction expired'))).toBe('AuctionEnded');
+  });
+
+  it('gas 高騰系文言を GasPriceHigh に分類', () => {
+    expect(classifyBidError(new Error('gas price too low'))).toBe('GasPriceHigh');
+    expect(classifyBidError(new Error('transaction underpriced'))).toBe('GasPriceHigh');
+    expect(classifyBidError(new Error('replacement transaction underpriced'))).toBe('GasPriceHigh');
+  });
+
+  it('RPC 系文言を RpcError に分類', () => {
+    expect(classifyBidError(new Error('fetch failed'))).toBe('RpcError');
+    expect(classifyBidError(new Error('ECONNREFUSED'))).toBe('RpcError');
+    expect(classifyBidError(new Error('request timeout'))).toBe('RpcError');
+    expect(classifyBidError(new Error('RPC error 500'))).toBe('RpcError');
+  });
+
+  it('未分類文言を Unknown に分類', () => {
+    expect(classifyBidError(new Error('something unexpected'))).toBe('Unknown');
+    expect(classifyBidError('bare string error')).toBe('Unknown');
+    expect(classifyBidError(null)).toBe('Unknown');
+  });
+});
+
+describe('BidRelay.getCurrentAuctionId', () => {
+  it('auction() view call の nounId を返す', async () => {
+    const readContract = vi.fn(async () => mockAuctionResult);
+    const publicClient: PublicClientLike = { readContract };
+    const walletClient: WalletClientLike = {
+      account: { address: OPERATOR_ADDRESS },
+      writeContract: vi.fn(),
+    };
+    const relay = new BidRelay({
+      signer: makeSigner(walletClient),
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    const auctionId = await relay.getCurrentAuctionId();
+    expect(auctionId).toBe(42n);
+
+    expect(readContract).toHaveBeenCalledTimes(1);
+    const calls = readContract.mock.calls as unknown as Array<
+      Array<{ address: string; functionName: string }>
+    >;
+    const call = calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call?.address).toBe(AUCTION_HOUSE_ADDRESS);
+    expect(call?.functionName).toBe('auction');
+  });
+});
+
+describe('BidRelay.placeBid', () => {
+  const bidAmount = 250_000_000_000_000_000n; // 0.25 ETH wei
+  const stubTxHash = '0xdeadbeef000000000000000000000000000000000000000000000000000000ff' as const;
+
+  it('happy path — auction ID 取得 → writeContract → txHash 返却', async () => {
+    const readContract = vi.fn(async () => mockAuctionResult);
+    const writeContract = vi.fn(async () => stubTxHash);
+    const publicClient: PublicClientLike = { readContract };
+    const walletClient: WalletClientLike = {
+      account: { address: OPERATOR_ADDRESS },
+      writeContract,
+    };
+    const relay = new BidRelay({
+      signer: makeSigner(walletClient),
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    const result = await relay.placeBid({ ethAmount: bidAmount });
+
+    expect(result.txHash).toBe(stubTxHash);
+    expect(result.auctionId).toBe(42n);
+    expect(result.ethAmount).toBe(bidAmount);
+
+    // readContract で auction() 取得、 writeContract で createBid broadcast
+    expect(readContract).toHaveBeenCalledTimes(1);
+    expect(writeContract).toHaveBeenCalledTimes(1);
+    const writeCalls = writeContract.mock.calls as unknown as Array<
+      Array<{
+        address: string;
+        functionName: string;
+        args: bigint[];
+        value: bigint;
+      }>
+    >;
+    const writeCall = writeCalls[0]?.[0];
+    expect(writeCall).toBeDefined();
+    expect(writeCall?.address).toBe(AUCTION_HOUSE_ADDRESS);
+    expect(writeCall?.functionName).toBe('createBid');
+    // 単一引数 = createBid(uint256) overload 選択、 args = [auctionId]
+    expect(writeCall?.args).toEqual([42n]);
+    expect(writeCall?.value).toBe(bidAmount);
+  });
+
+  it('writeContract throw で BidRelayError.reason=BidTooLow', async () => {
+    const readContract = vi.fn(async () => mockAuctionResult);
+    const writeContract = vi.fn(async () => {
+      throw new Error('execution reverted: BidTooLow()');
+    });
+    const publicClient: PublicClientLike = { readContract };
+    const walletClient: WalletClientLike = {
+      account: { address: OPERATOR_ADDRESS },
+      writeContract,
+    };
+    const relay = new BidRelay({
+      signer: makeSigner(walletClient),
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    await expect(relay.placeBid({ ethAmount: bidAmount })).rejects.toMatchObject({
+      name: 'BidRelayError',
+      reason: 'BidTooLow',
+    });
+  });
+
+  it('writeContract throw で BidRelayError.reason=AuctionEnded', async () => {
+    const readContract = vi.fn(async () => mockAuctionResult);
+    const writeContract = vi.fn(async () => {
+      throw new Error('execution reverted: AuctionEnded()');
+    });
+    const publicClient: PublicClientLike = { readContract };
+    const walletClient: WalletClientLike = {
+      account: { address: OPERATOR_ADDRESS },
+      writeContract,
+    };
+    const relay = new BidRelay({
+      signer: makeSigner(walletClient),
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    await expect(relay.placeBid({ ethAmount: bidAmount })).rejects.toMatchObject({
+      name: 'BidRelayError',
+      reason: 'AuctionEnded',
+    });
+  });
+
+  it('readContract fail で BidRelayError (auction id 取得 fail)', async () => {
+    const readContract = vi.fn(async () => {
+      throw new Error('RPC network error');
+    });
+    const writeContract = vi.fn();
+    const publicClient: PublicClientLike = { readContract };
+    const walletClient: WalletClientLike = {
+      account: { address: OPERATOR_ADDRESS },
+      writeContract,
+    };
+    const relay = new BidRelay({
+      signer: makeSigner(walletClient),
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    await expect(relay.placeBid({ ethAmount: bidAmount })).rejects.toMatchObject({
+      name: 'BidRelayError',
+      reason: 'RpcError',
+    });
+    // writeContract は呼ばれない
+    expect(writeContract).not.toHaveBeenCalled();
+  });
+
+  it('WalletClient.account 欠損で BidRelayError', async () => {
+    const readContract = vi.fn(async () => mockAuctionResult);
+    const writeContract = vi.fn();
+    const publicClient: PublicClientLike = { readContract };
+    // account なし WalletClient
+    const walletClient = {
+      account: undefined,
+      writeContract,
+    };
+    const relay = new BidRelay({
+      signer: {
+        address: OPERATOR_ADDRESS,
+        getWalletClient: () =>
+          walletClient as unknown as ReturnType<SignerProvider['getWalletClient']>,
+      },
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    await expect(relay.placeBid({ ethAmount: bidAmount })).rejects.toBeInstanceOf(BidRelayError);
+    expect(writeContract).not.toHaveBeenCalled();
+  });
+
+  it('unknown revert 文言で BidRelayError.reason=Unknown', async () => {
+    const readContract = vi.fn(async () => mockAuctionResult);
+    const writeContract = vi.fn(async () => {
+      throw new Error('mysterious internal error');
+    });
+    const publicClient: PublicClientLike = { readContract };
+    const walletClient: WalletClientLike = {
+      account: { address: OPERATOR_ADDRESS },
+      writeContract,
+    };
+    const relay = new BidRelay({
+      signer: makeSigner(walletClient),
+      publicClient: publicClient as unknown as import('viem').PublicClient,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    await expect(relay.placeBid({ ethAmount: bidAmount })).rejects.toMatchObject({
+      name: 'BidRelayError',
+      reason: 'Unknown',
+    });
+  });
+});

--- a/packages/niji-api/src/services/bidRelay/index.ts
+++ b/packages/niji-api/src/services/bidRelay/index.ts
@@ -1,0 +1,239 @@
+/**
+ * BidRelay service (Issue #3008 Phase A + B + C)
+ *
+ * 運営 EOA が代理で NijiAuctionHouseV3.createBid tx を発火する service。
+ *
+ * fiat bidder は 3DS 認証で fiat_bid.status = "3ds-verified" 状態、
+ * 本 service が chain 上で bid tx を broadcast、 tx hash 取得 + 1 block confirm で fiat_bid.status = "bid-placed"。
+ * tx revert (BidTooLow / AuctionEnded / gas 高騰 / RPC 障害) 時は GMO alterTran cancel + fiat_bid.status = "cancelled"。
+ *
+ * 秘密鍵管理 —
+ * Phase 1 = env 変数 (OPERATOR_EOA_PRIVATE_KEY) 直、 SignerProvider interface で抽象化。
+ * Phase 3 = KmsSigner (AWS KMS) に置換予定、 interface 定義で移行時 scope 最小化。
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P3-c, P6、
+ *        Phase1-02-issue-breakdown.md § Issue 5、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+import { nijiAuctionHouseAbi } from '@niji/sdk/actions';
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  type Address,
+  type Hash,
+  type Hex,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { baseSepolia } from 'viem/chains';
+
+/**
+ * Signer 抽象 (Phase 1 = EnvSigner env 直読、 Phase 3 = KmsSigner に置換)
+ * address 取得 + tx sign の 2 method で運営 EOA を代理する
+ */
+export type SignerProvider = {
+  readonly address: Address;
+  /** 現在の Signer instance を wrap した viem WalletClient を返す (実 broadcast 用) */
+  getWalletClient: () => WalletClient;
+};
+
+/**
+ * Phase 1 = env 変数直読の Signer 実装
+ * OPERATOR_EOA_PRIVATE_KEY を privateKeyToAccount に渡して WalletClient を生成
+ */
+export const createEnvSigner = (options: { privateKey: Hex; rpcUrl: string }): SignerProvider => {
+  const account = privateKeyToAccount(options.privateKey);
+  const walletClient = createWalletClient({
+    account,
+    chain: baseSepolia,
+    transport: http(options.rpcUrl),
+  });
+  return {
+    address: account.address,
+    getWalletClient: () => walletClient,
+  };
+};
+
+/**
+ * PublicClient factory (chain read + wait for receipt に使う)
+ * test では stub PublicClient を options で DI
+ * baseSepolia の chain-specific 型は generic PublicClient と unification できないため
+ * unknown as PublicClient で intentional widen (BidRelay 内で必要 method のみ使う)
+ */
+export const createBaseSepoliaPublicClient = (rpcUrl: string): PublicClient => {
+  const client = createPublicClient({
+    chain: baseSepolia,
+    transport: http(rpcUrl),
+  });
+  return client as unknown as PublicClient;
+};
+
+/** bid tx broadcast 結果 (fiat_bid.status = "bid-placed" 遷移用) */
+export type PlaceBidSuccess = {
+  txHash: Hash;
+  /** chain 上の auction ID (BidPlaced event verify で使う) */
+  auctionId: bigint;
+  /** bid 額 (wei、 記録用) */
+  ethAmount: bigint;
+};
+
+/** bid tx revert 理由の enum (GMO cancel + user 通知 msg を分岐) */
+export type BidRevertReason =
+  | 'BidTooLow'
+  | 'AuctionEnded'
+  | 'GasPriceHigh'
+  | 'RpcError'
+  | 'Unknown';
+
+/**
+ * bid tx broadcast fail を意味する error
+ * revert 理由 + 元 error を保持、 handler 層が GMO cancel + user 通知 msg 選択に使う
+ */
+export class BidRelayError extends Error {
+  public readonly reason: BidRevertReason;
+  constructor(
+    message: string,
+    options: { reason: BidRevertReason; cause?: unknown } = { reason: 'Unknown' },
+  ) {
+    super(message);
+    this.name = 'BidRelayError';
+    this.reason = options.reason;
+    if (options.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/** viem error message から revert 理由を推定 (Phase 1 = string match、 Phase 2 で custom error decode に強化) */
+export const classifyBidError = (err: unknown): BidRevertReason => {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/bidtoolow|must send more/i.test(message)) return 'BidTooLow';
+  if (/auctionended|auction expired|auction has ended/i.test(message)) return 'AuctionEnded';
+  if (/gas price|underpriced|replacement transaction/i.test(message)) return 'GasPriceHigh';
+  if (/network|fetch|econn|timeout|rpc/i.test(message)) return 'RpcError';
+  return 'Unknown';
+};
+
+export type BidRelayOptions = {
+  /** 運営 EOA (Phase 1 = createEnvSigner の返値、 test = stub) */
+  signer: SignerProvider;
+  /** chain read + wait receipt 用 (test = stub PublicClient) */
+  publicClient: PublicClient;
+  /** NijiAuctionHouseV3 contract address (Base Sepolia、 未 deploy 環境は 0x0 で env から後で差替) */
+  auctionHouseAddress: Address;
+};
+
+/**
+ * BidRelay service — 運営 EOA が代理で NijiAuctionHouseV3.createBid tx を発火する
+ *
+ * flow —
+ * (1) 現在の auction ID を chain から取得 (nijiAuctionHouseAbi.auction() view call)
+ * (2) createBid(nounId) を bid value = ethAmount で broadcast
+ * (3) tx hash を返却 (handler が fiat_bid.status = "bid-placed" UPDATE)
+ * (4) 別 method waitForBidConfirmation で 1 block confirm + BidPlaced event verify
+ *
+ * error handling —
+ * broadcast 失敗 or receipt status = "reverted" で BidRelayError throw、 handler が GMO cancel + user 通知
+ */
+export class BidRelay {
+  private readonly signer: SignerProvider;
+  private readonly publicClient: PublicClient;
+  private readonly auctionHouseAddress: Address;
+
+  constructor(options: BidRelayOptions) {
+    this.signer = options.signer;
+    this.publicClient = options.publicClient;
+    this.auctionHouseAddress = options.auctionHouseAddress;
+  }
+
+  /**
+   * 現在の auction を chain から取得
+   * NijiAuctionHouseV3.auction() は AuctionV2View struct を返す (nounId / amount / startTime / endTime / bidder / settled)
+   * 本 service では nounId のみ使う (createBid target)
+   */
+  async getCurrentAuctionId(): Promise<bigint> {
+    // readContract で auction() struct を取得、 nounId は uint96 だが JS bigint で受ける
+    const result = (await this.publicClient.readContract({
+      address: this.auctionHouseAddress,
+      abi: nijiAuctionHouseAbi,
+      functionName: 'auction',
+    })) as {
+      nounId: bigint;
+      amount: bigint;
+      startTime: number;
+      endTime: number;
+      bidder: Address;
+      settled: boolean;
+    };
+    return result.nounId;
+  }
+
+  /**
+   * bid tx を broadcast、 tx hash を返す
+   * revert / broadcast 失敗は BidRelayError throw
+   *
+   * @param input.ethAmount bid 額 (wei)
+   * @returns { txHash, auctionId, ethAmount }
+   */
+  async placeBid(input: { ethAmount: bigint }): Promise<PlaceBidSuccess> {
+    let auctionId: bigint;
+    try {
+      auctionId = await this.getCurrentAuctionId();
+    } catch (err) {
+      throw new BidRelayError('failed to read current auction id', {
+        reason: classifyBidError(err),
+        cause: err,
+      });
+    }
+
+    // createBid(nounId) を writeContract で broadcast、 value = ethAmount で運営 EOA から送信
+    // NijiAuctionHouseV3 は payable createBid、 msg.sender = 運営 EOA が chain 上 bidder として記録される
+    // (fiat bidder wallet ≠ chain 上 bidder、 settle 後の transferFrom で fiat bidder wallet に NFT 送る 2 段構成)
+    //
+    // NijiAuctionHouseV3 abi は createBid が 2 overload (uint256 / uint256,uint32) を持つが、
+    // writeContract は functionName + args 数で overload 解決するので明示 disambiguation 不要
+    // (single-arg 呼出 = createBid(uint256) が選択される)。
+    let txHash: Hash;
+    try {
+      const walletClient = this.signer.getWalletClient();
+      const account = walletClient.account;
+      if (account === undefined) {
+        throw new BidRelayError('signer WalletClient missing account', { reason: 'Unknown' });
+      }
+      txHash = await walletClient.writeContract({
+        account,
+        chain: baseSepolia,
+        address: this.auctionHouseAddress,
+        abi: nijiAuctionHouseAbi,
+        functionName: 'createBid',
+        args: [auctionId],
+        value: input.ethAmount,
+      });
+    } catch (err) {
+      if (err instanceof BidRelayError) throw err;
+      throw new BidRelayError('bid tx broadcast failed', {
+        reason: classifyBidError(err),
+        cause: err,
+      });
+    }
+
+    return {
+      txHash,
+      auctionId,
+      ethAmount: input.ethAmount,
+    };
+  }
+
+  /** publicClient (watchReceipt が使う) */
+  get client(): PublicClient {
+    return this.publicClient;
+  }
+
+  /** auctionHouse address (watchReceipt が event source として使う) */
+  get auctionHouse(): Address {
+    return this.auctionHouseAddress;
+  }
+}

--- a/packages/niji-api/src/services/bidRelay/watchReceipt.test.ts
+++ b/packages/niji-api/src/services/bidRelay/watchReceipt.test.ts
@@ -1,0 +1,235 @@
+/**
+ * BidRelay watchReceipt behavior test (Issue #3008 Phase C/D)
+ *
+ * 検証対象 —
+ * (1) receipt.status = "success" + AuctionBid event → BidConfirmation 返却
+ * (2) receipt.status = "reverted" → BidRelayError.reason = Unknown
+ * (3) AuctionBid event なし → BidRelayError ('AuctionBid event not emitted...')
+ * (4) waitForTransactionReceipt throw → BidRelayError.reason = RpcError
+ *
+ * viem PublicClient は必要 method (waitForTransactionReceipt) のみ持つ stub で差替。
+ * event log の encode は encodeEventTopics + encodeAbiParameters で正確に生成。
+ *
+ * rules/quality.md § test-passed marker 発行前提 3 条件準拠 (behavior test / 変更箇所 execute / test runner PASS)。
+ */
+
+import { nijiAuctionHouseAbi } from '@niji/sdk/actions';
+import {
+  encodeAbiParameters,
+  encodeEventTopics,
+  keccak256,
+  toHex,
+  type Address,
+  type Hash,
+  type PublicClient,
+} from 'viem';
+import { describe, expect, it, vi } from 'vitest';
+
+import { waitForBidConfirmation } from './watchReceipt.js';
+
+import { BidRelayError } from './index.js';
+
+const AUCTION_HOUSE_ADDRESS: Address = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const OPERATOR_ADDRESS: Address = '0x1234567890123456789012345678901234567890';
+const OTHER_CONTRACT: Address = '0x9999999999999999999999999999999999999999';
+const STUB_TX_HASH: Hash = '0xdeadbeef000000000000000000000000000000000000000000000000000000ff';
+
+/** AuctionBid event log を encode (nounId indexed / sender + value + extended non-indexed) */
+const encodeAuctionBidLog = (input: {
+  nounId: bigint;
+  sender: Address;
+  value: bigint;
+  extended: boolean;
+  contractAddress: Address;
+}) => {
+  const topics = encodeEventTopics({
+    abi: nijiAuctionHouseAbi,
+    eventName: 'AuctionBid',
+    args: {
+      nounId: input.nounId,
+    },
+  });
+  const data = encodeAbiParameters(
+    [
+      { name: 'sender', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'extended', type: 'bool' },
+    ],
+    [input.sender, input.value, input.extended],
+  );
+  return {
+    address: input.contractAddress,
+    topics,
+    data,
+    // receipt log 型に必要な他 field は test 内で使わないので dummy 埋め
+    blockNumber: 100n,
+    blockHash: keccak256(toHex('block')),
+    transactionHash: STUB_TX_HASH,
+    transactionIndex: 0,
+    logIndex: 0,
+    removed: false,
+  };
+};
+
+const makeReceiptStub = (input: {
+  status: 'success' | 'reverted';
+  logs?: Array<ReturnType<typeof encodeAuctionBidLog>>;
+}) => ({
+  status: input.status,
+  blockNumber: 100n,
+  blockHash: keccak256(toHex('block')),
+  transactionHash: STUB_TX_HASH,
+  transactionIndex: 0,
+  from: OPERATOR_ADDRESS,
+  to: AUCTION_HOUSE_ADDRESS,
+  contractAddress: null,
+  gasUsed: 200_000n,
+  cumulativeGasUsed: 200_000n,
+  effectiveGasPrice: 1_000_000_000n,
+  logsBloom: '0x' + '0'.repeat(512),
+  logs: input.logs ?? [],
+  type: 'eip1559' as const,
+});
+
+describe('waitForBidConfirmation', () => {
+  it('success + AuctionBid event で BidConfirmation を返す', async () => {
+    const bidValue = 250_000_000_000_000_000n;
+    const nounId = 42n;
+    const log = encodeAuctionBidLog({
+      nounId,
+      sender: OPERATOR_ADDRESS,
+      value: bidValue,
+      extended: false,
+      contractAddress: AUCTION_HOUSE_ADDRESS,
+    });
+    const receipt = makeReceiptStub({ status: 'success', logs: [log] });
+    const publicClient = {
+      waitForTransactionReceipt: vi.fn(async () => receipt),
+    } as unknown as PublicClient;
+
+    const result = await waitForBidConfirmation({
+      publicClient,
+      txHash: STUB_TX_HASH,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+    });
+
+    expect(result.txHash).toBe(STUB_TX_HASH);
+    expect(result.blockNumber).toBe(100n);
+    expect(result.nounId).toBe(nounId);
+    expect(result.amount).toBe(bidValue);
+    expect(result.sender.toLowerCase()).toBe(OPERATOR_ADDRESS.toLowerCase());
+  });
+
+  it('receipt.status = "reverted" で BidRelayError', async () => {
+    const receipt = makeReceiptStub({ status: 'reverted' });
+    const publicClient = {
+      waitForTransactionReceipt: vi.fn(async () => receipt),
+    } as unknown as PublicClient;
+
+    await expect(
+      waitForBidConfirmation({
+        publicClient,
+        txHash: STUB_TX_HASH,
+        auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+      }),
+    ).rejects.toBeInstanceOf(BidRelayError);
+  });
+
+  it('AuctionBid event なしで BidRelayError (auctionHouse log 0 件)', async () => {
+    const receipt = makeReceiptStub({ status: 'success', logs: [] });
+    const publicClient = {
+      waitForTransactionReceipt: vi.fn(async () => receipt),
+    } as unknown as PublicClient;
+
+    await expect(
+      waitForBidConfirmation({
+        publicClient,
+        txHash: STUB_TX_HASH,
+        auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+      }),
+    ).rejects.toMatchObject({
+      name: 'BidRelayError',
+      message: expect.stringContaining('AuctionBid event not emitted'),
+    });
+  });
+
+  it('他 contract の log は無視する (auction house log のみ verify)', async () => {
+    // 別 contract に emit された AuctionBid 相当 log は無視され、 event なし error
+    const bidValue = 250_000_000_000_000_000n;
+    const nonMatchingLog = encodeAuctionBidLog({
+      nounId: 42n,
+      sender: OPERATOR_ADDRESS,
+      value: bidValue,
+      extended: false,
+      contractAddress: OTHER_CONTRACT,
+    });
+    const receipt = makeReceiptStub({ status: 'success', logs: [nonMatchingLog] });
+    const publicClient = {
+      waitForTransactionReceipt: vi.fn(async () => receipt),
+    } as unknown as PublicClient;
+
+    await expect(
+      waitForBidConfirmation({
+        publicClient,
+        txHash: STUB_TX_HASH,
+        auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+      }),
+    ).rejects.toMatchObject({
+      name: 'BidRelayError',
+      message: expect.stringContaining('AuctionBid event not emitted'),
+    });
+  });
+
+  it('waitForTransactionReceipt throw で BidRelayError.reason = RpcError', async () => {
+    const publicClient = {
+      waitForTransactionReceipt: vi.fn(async () => {
+        throw new Error('RPC timeout');
+      }),
+    } as unknown as PublicClient;
+
+    await expect(
+      waitForBidConfirmation({
+        publicClient,
+        txHash: STUB_TX_HASH,
+        auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+      }),
+    ).rejects.toMatchObject({
+      name: 'BidRelayError',
+      reason: 'RpcError',
+    });
+  });
+
+  it('confirmations / timeoutMs 引数を publicClient に伝搬', async () => {
+    const bidValue = 250_000_000_000_000_000n;
+    const log = encodeAuctionBidLog({
+      nounId: 42n,
+      sender: OPERATOR_ADDRESS,
+      value: bidValue,
+      extended: false,
+      contractAddress: AUCTION_HOUSE_ADDRESS,
+    });
+    const receipt = makeReceiptStub({ status: 'success', logs: [log] });
+    const waitStub = vi.fn(async () => receipt);
+    const publicClient = {
+      waitForTransactionReceipt: waitStub,
+    } as unknown as PublicClient;
+
+    await waitForBidConfirmation({
+      publicClient,
+      txHash: STUB_TX_HASH,
+      auctionHouseAddress: AUCTION_HOUSE_ADDRESS,
+      confirmations: 3,
+      timeoutMs: 30_000,
+    });
+
+    expect(waitStub).toHaveBeenCalledTimes(1);
+    const calls = waitStub.mock.calls as unknown as Array<
+      Array<{ hash: string; confirmations: number; timeout: number }>
+    >;
+    const call = calls[0]?.[0];
+    expect(call).toBeDefined();
+    expect(call?.hash).toBe(STUB_TX_HASH);
+    expect(call?.confirmations).toBe(3);
+    expect(call?.timeout).toBe(30_000);
+  });
+});

--- a/packages/niji-api/src/services/bidRelay/watchReceipt.ts
+++ b/packages/niji-api/src/services/bidRelay/watchReceipt.ts
@@ -1,0 +1,115 @@
+/**
+ * BidRelay receipt watcher (Issue #3008 Phase C)
+ *
+ * bid tx broadcast 後の receipt 監視 + AuctionBid event verify を担う。
+ * NijiAuctionHouseV3 の event 名 = "AuctionBid" (Nouns V3 ABI 由来、 spec 上の "BidPlaced" 呼称は event 名ではなく状態遷移名)。
+ *
+ * flow —
+ * (1) publicClient.waitForTransactionReceipt で 1 block confirm 待ち
+ * (2) receipt.status === "success" なら AuctionBid event 抽出 + verify
+ * (3) receipt.status === "reverted" なら BidRelayError throw (revert reason は receipt から推定困難、 classifyBidError で string match)
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P6、
+ *        Phase1-02-issue-breakdown.md § Issue 5、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+import { nijiAuctionHouseAbi } from '@niji/sdk/actions';
+import { decodeEventLog, type Address, type Hash, type PublicClient } from 'viem';
+
+import { BidRelayError } from './index.js';
+
+/** receipt watch 成功時の返値 (fiat_bid.status = "bid-placed" 遷移確定に使う) */
+export type BidConfirmation = {
+  txHash: Hash;
+  blockNumber: bigint;
+  /** AuctionBid event に含まれる nounId (chain 記録の一致 verify) */
+  nounId: bigint;
+  /** AuctionBid event に含まれる bid 額 (wei、 broadcast 時 value と一致 verify) */
+  amount: bigint;
+  /** chain 上の bidder = 運営 EOA address (代理 bid 発火の実行者記録) */
+  sender: Address;
+};
+
+export type WaitForBidConfirmationOptions = {
+  publicClient: PublicClient;
+  txHash: Hash;
+  auctionHouseAddress: Address;
+  /** 1 block confirm 待ち (default = 1) */
+  confirmations?: number;
+  /** timeout (ms、 default = 60000 = 60 秒) */
+  timeoutMs?: number;
+};
+
+/**
+ * bid tx receipt watch + BidPlaced event verify
+ *
+ * receipt.status === "reverted" 時 BidRelayError('bid tx reverted', reason: 'Unknown') throw
+ * receipt に BidPlaced event が含まれない時 BidRelayError('BidPlaced event not emitted') throw
+ */
+export const waitForBidConfirmation = async (
+  options: WaitForBidConfirmationOptions,
+): Promise<BidConfirmation> => {
+  const confirmations = options.confirmations ?? 1;
+  const timeoutMs = options.timeoutMs ?? 60_000;
+
+  let receipt;
+  try {
+    receipt = await options.publicClient.waitForTransactionReceipt({
+      hash: options.txHash,
+      confirmations,
+      timeout: timeoutMs,
+    });
+  } catch (err) {
+    throw new BidRelayError('waitForTransactionReceipt failed', {
+      reason: 'RpcError',
+      cause: err,
+    });
+  }
+
+  if (receipt.status !== 'success') {
+    // revert = chain 上で他 bidder に上乗せされた or auction 終了直前 settle された 等、
+    // handler 層で GMO alterTran cancel + user 通知 msg 選択 (BidRelayError.reason = Unknown)
+    throw new BidRelayError('bid tx reverted', { reason: 'Unknown' });
+  }
+
+  // AuctionBid event を decode して nounId / amount / sender を抽出
+  // auctionHouse から emit された log のみ対象、 他 contract log は無視
+  const auctionHouseLogs = receipt.logs.filter(
+    log => log.address.toLowerCase() === options.auctionHouseAddress.toLowerCase(),
+  );
+
+  for (const log of auctionHouseLogs) {
+    try {
+      const decoded = decodeEventLog({
+        abi: nijiAuctionHouseAbi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === 'AuctionBid') {
+        // AuctionBid struct — nounId (indexed) / sender / value / extended (bool)
+        // gen.ts § AuctionBid event 定義参照
+        const args = decoded.args as unknown as {
+          sender: Address;
+          nounId: bigint;
+          value: bigint;
+          extended: boolean;
+        };
+        return {
+          txHash: options.txHash,
+          blockNumber: receipt.blockNumber,
+          nounId: args.nounId,
+          amount: args.value,
+          sender: args.sender,
+        };
+      }
+    } catch {
+      // decode 失敗した log は skip (他 event の混入 or ABI 不一致)
+      continue;
+    }
+  }
+
+  throw new BidRelayError('AuctionBid event not emitted in receipt logs', {
+    reason: 'Unknown',
+  });
+};


### PR DESCRIPTION
## Summary

Phase 1 MVP の fiat bidder 用 bid tx 代理発火 flow (`POST /api/v1/fiat-bid/place-bid`) を実装。

3DS 認証済 `fiat_bid` record を lookup、 `NijiAuctionHouseV3.createBid` tx を運営 EOA から Base Sepolia に broadcast、 tx hash を返却 + `fiat_bid.status = "bid-placed"` に UPDATE。 revert / broadcast fail 時は GMO `alterTran(VOID)` cancel + `fiat_bid.status = "cancelled"` + user 通知 msg (「他の入札者に上乗せされました」「auction は終了しています」等) を返却。

## 主要変更

- `packages/niji-api/src/services/bidRelay/index.ts` (新規)
  - `BidRelay` class + `SignerProvider` interface + `classifyBidError` (viem error → revert reason 分類)
  - `createEnvSigner` (Phase 1 env 直読 signer) + `createBaseSepoliaPublicClient`
- `packages/niji-api/src/services/bidRelay/watchReceipt.ts` (新規、 `waitForBidConfirmation` で 1 block confirm + `AuctionBid` event verify)
- `packages/niji-api/src/handlers/fiat-bid/place-bid.ts` (新規、 POST /api/v1/fiat-bid/place-bid hono handler)
- `packages/niji-api/src/api/index.ts` (place-bid route 登録 + `BidRelay` singleton 生成 + `placeBidStore` DB adapter)
- `packages/niji-api/.env.example` (`OPERATOR_EOA_PRIVATE_KEY` / `BASE_SEPOLIA_RPC_URL` / `NIJI_AUCTION_HOUSE_ADDRESS` 追加)
- 単体 test 3 file (`BidRelay` 12 case + `watchReceipt` 6 case + `place-bid` handler 15 case)

## 秘密鍵管理 (Phase 3 KMS 移行前提)

Phase 1 は env 変数直、 `SignerProvider` interface で抽象化 (Phase 3 で `KmsSigner` 置換時 scope 最小)。
`.env.example` に placeholder のみ、 実値は `.env.local` (git 管理外) に記述。

```ts
export type SignerProvider = {
  readonly address: Address;
  getWalletClient: () => WalletClient;
};
```

## tx revert 分類

`BidTooLow` / `AuctionEnded` / `GasPriceHigh` / `RpcError` / `Unknown` の 5 種を viem error message で string match 分類、 revert 理由に応じた user 通知 msg を返却。

| 分類 | trigger 文言 | user 通知 msg |
|---|---|---|
| BidTooLow | `BidTooLow` / `Must send more` | 他の入札者に上乗せされました。 |
| AuctionEnded | `AuctionEnded` / `Auction has ended` | auction は既に終了しています。 |
| GasPriceHigh | `gas price` / `underpriced` | network が混雑しています。 |
| RpcError | `network` / `fetch` / `ECONN` / `timeout` / `RPC` | network 障害が発生しました。 |
| Unknown | 上記以外 | bid tx の broadcast に失敗しました。 |

## test-passed marker 発行前提 (rules/quality.md § 3 条件)

| file | behavior test | 変更箇所 execute | test runner PASS |
|---|---|---|---|
| services/bidRelay/index.ts | ✅ 12 case (index.test.ts) | ✅ placeBid / getCurrentAuctionId / classifyBidError | ✅ vitest PASS |
| services/bidRelay/watchReceipt.ts | ✅ 6 case (watchReceipt.test.ts) | ✅ waitForBidConfirmation | ✅ vitest PASS |
| handlers/fiat-bid/place-bid.ts | ✅ 15 case (place-bid.test.ts) | ✅ createPlaceBidApp / parsePlaceBidBody / messageForRevertReason | ✅ vitest PASS |
| api/index.ts | ⚠️ existing integration path、 新規追加 route の behavior は place-bid.test.ts で担保 | ✅ createPlaceBidApp 経由の route wire | ✅ vitest PASS |

121 test pass (33 test 追加、 121 = 88 既存 + 33 new)、 lint clean、 typecheck は ponder.config.ts の pre-existing 3 error 以外 clean。 実 Base Sepolia RPC 経路は e2e (別 Issue) で担保、 単体 test は viem mock で完結。

## Test plan

- [x] `pnpm test` = 121 pass (33 new)
- [x] `pnpm lint` = clean
- [x] `pnpm typecheck` = pre-existing ponder.config.ts 3 error 以外 clean
- [x] behavior test で viem mock 経由 bid tx sign + broadcast + happy path + revert 分岐 verify
- [x] revert 時の GMO cancel API 呼出も test で verify (14 test case 目 `revert 後 GMO cancel 失敗 → 500 GmoCancelFailed`)
- [ ] 実 Base Sepolia RPC 経路の broadcast (Issue #3011 e2e で担保予定)

Closes #3008
Refs `tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md` § P3-c, P6
Refs `tests/spec/gmo-fiat-bid/Phase1-02-issue-breakdown.md` § Issue 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgdKhYSgYfHh3H4PLLQMjW