### PR TITLE
✨ feat(niji-api): Ponder schema 拡張 + AuthCleanupQueue で bid 増額 base infra を整備 (#3022)

### DIFF
--- a/packages/niji-api/ponder.schema.ts
+++ b/packages/niji-api/ponder.schema.ts
@@ -173,4 +173,14 @@ export const fiatBid = onchainTable('fiat_bid', t => ({
   capturedAt: t.timestamp(),
   /** NFT transferFrom 成功時刻 (nullable、 Issue #3010 で埋める) */
   transferredAt: t.timestamp(),
+  /**
+   * 45 日超 fallback の再 authorization 回数 (Issue #3022 Phase 2 base infra)
+   * default 0、 Issue #3024 の ReauthorizationWorker が 45 日経過を検出するごとに +1 する
+   */
+  reauthorizationCount: t.integer().notNull().default(0),
+  /**
+   * 直近の再 authorization 実行時刻 (Issue #3022 Phase 2 base infra、 nullable)
+   * ReauthorizationWorker が再 authorization 成功時に UPDATE、 次回 45 日 window 計算の起点
+   */
+  lastReauthorizedAt: t.timestamp(),
 }));

--- a/packages/niji-api/src/services/authCleanup/index.test.ts
+++ b/packages/niji-api/src/services/authCleanup/index.test.ts
@@ -1,0 +1,147 @@
+/**
+ * AuthCleanupQueue behavior test (Issue #3022 Phase 2 base infra)
+ *
+ * 検証対象 —
+ * (1) enqueue → 5 秒 delay 経過後に GMO alterTran(JobCd=VOID) 実行
+ * (2) rate limit 1 req/sec = 2 auth 連続 enqueue で 2 件目の実行が 1 秒後にずれる
+ * (3) fail 時 3 回まで retry (exponential backoff 1s / 2s / 4s、 合計 4 回試行)
+ * (4) 3 回全 fail で運営 alert log 発火 + queue から drain
+ *
+ * fake timers (vi.useFakeTimers) で時間経過を simulate、
+ * cancelAuthorization spy で GMO 呼出回数と authId を verify する。
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md § P2, AC 4、
+ *        Phase2-02-issue-breakdown.md § Issue P2-1、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuthCleanupQueue, type AuthCleanupExecutor } from './index.js';
+
+/**
+ * cancelAuthorization spy を behavior で振る舞い分岐する factory
+ * `behavior` は authId ごとに resolve / reject を返す (sequence controlled)
+ */
+const makeExecutor = (
+  behavior: (authId: string, attempt: number) => Promise<void>,
+): { executor: AuthCleanupExecutor; spy: ReturnType<typeof vi.fn> } => {
+  const attempts = new Map<string, number>();
+  const spy = vi.fn(async (authId: string) => {
+    const next = (attempts.get(authId) ?? 0) + 1;
+    attempts.set(authId, next);
+    return behavior(authId, next);
+  });
+  const executor: AuthCleanupExecutor = {
+    cancelAuthorization: async (authId: string) => spy(authId),
+  };
+  return { executor, spy };
+};
+
+describe('AuthCleanupQueue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('enqueue → 5 秒 delay 経過後に cancelAuthorization が呼ばれる', async () => {
+    const { executor, spy } = makeExecutor(async () => undefined);
+    const queue = new AuthCleanupQueue({ executor });
+
+    queue.enqueue('auth-1');
+
+    // 5 秒経過前は呼ばれない
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(spy).not.toHaveBeenCalled();
+
+    // 5 秒経過で 1 回目 tick、 executor が呼ばれる
+    await vi.advanceTimersByTimeAsync(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith('auth-1');
+  });
+
+  it('rate limit 1 req/sec = 2 auth 連続 enqueue で 2 件目の実行が 1 秒後にずれる', async () => {
+    const { executor, spy } = makeExecutor(async () => undefined);
+    const queue = new AuthCleanupQueue({ executor });
+
+    queue.enqueue('auth-1');
+    queue.enqueue('auth-2');
+
+    // delay 5 秒経過で 1 件目のみ実行 (rate limit 未経過)
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenNthCalledWith(1, 'auth-1');
+
+    // 1 秒後に 2 件目実行 (rate limit 1 req/sec)
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy).toHaveBeenNthCalledWith(2, 'auth-2');
+  });
+
+  it('fail 時 3 回 retry (exponential backoff 1s / 2s / 4s) で成功時は alert 出さず', async () => {
+    // 1-3 回目 fail、 4 回目 (= retry 3 回目) 成功
+    const { executor, spy } = makeExecutor(async (_authId, attempt) => {
+      if (attempt < 4) throw new Error(`attempt ${attempt} failed`);
+      return undefined;
+    });
+    const alertSpy = vi.fn();
+    const queue = new AuthCleanupQueue({ executor, onAlert: alertSpy });
+
+    queue.enqueue('auth-1');
+
+    // 5 秒 delay で 1 回目実行 (fail)
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // exponential backoff 1s で 2 回目実行 (fail)
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // exponential backoff 2s で 3 回目実行 (fail)
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    // exponential backoff 4s で 4 回目実行 (成功)
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(spy).toHaveBeenCalledTimes(4);
+
+    // 成功したので alert 呼ばれない
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  it('3 回全 retry fail で運営 alert log 発火 + queue から drain', async () => {
+    // 常に fail
+    const { executor, spy } = makeExecutor(async () => {
+      throw new Error('permanent failure');
+    });
+    const alertSpy = vi.fn();
+    const queue = new AuthCleanupQueue({ executor, onAlert: alertSpy });
+
+    queue.enqueue('auth-1');
+
+    // 5s delay → 1 回目 fail
+    await vi.advanceTimersByTimeAsync(5000);
+    // 1s backoff → 2 回目 fail
+    await vi.advanceTimersByTimeAsync(1000);
+    // 2s backoff → 3 回目 fail
+    await vi.advanceTimersByTimeAsync(2000);
+    // 4s backoff → 4 回目 fail (最終 retry)
+    await vi.advanceTimersByTimeAsync(4000);
+
+    expect(spy).toHaveBeenCalledTimes(4);
+    // 4 回 fail 後 alert 発火
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    expect(alertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authId: 'auth-1',
+        attempts: 4,
+      }),
+    );
+
+    // queue が drain したので、 次の 1 秒経過でも新規呼出なし
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
+});

--- a/packages/niji-api/src/services/authCleanup/index.ts
+++ b/packages/niji-api/src/services/authCleanup/index.ts
@@ -1,0 +1,178 @@
+/**
+ * AuthCleanupQueue service (Issue #3022 Phase 2 base infra)
+ *
+ * 責務 —
+ * Phase 2 の bid 増額 5 phase sequential で、 増額 bid 成功後に旧 authorization を GMO alterTran(JobCd=VOID)
+ * で cancel する非同期 queue。 chain tx confirm 後に enqueue、 5 秒後に処理開始、 rate limit 1 req/sec で順次実行、
+ * fail 時 exponential backoff (1s / 2s / 4s) で 3 回まで retry、 4 回全 fail で運営 alert log 発火する。
+ *
+ * 設計判断 (grilling P3-b A 案) —
+ * (a) chain tx 発火の critical path から旧 auth cleanup を切り離し、 増額 bid の user 待機時間を短縮する
+ * (b) 5 秒 delay で chain tx confirm 前の tx revert catch (BidTooLow 等) 時に cleanup をキャンセルできる余地を残す
+ * (c) 1 req/sec rate limit で GMO API の rate limit 抵触を回避 (実 GMO は 10 req/sec だが余裕を持たせる)
+ * (d) 3 回 retry でも fail した case は運営手動対応 (orphan 検出は Issue #3024 側 Phase 4 に外出し)
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md § P2, AC 4、
+ *        Phase2-02-issue-breakdown.md § Issue P2-1、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+/** cancelAuthorization = GmoClient.cancelAuthorization の抽象 (test 差替可能) */
+export type AuthCleanupExecutor = {
+  /** 与信枠 cancel を発火、 fail 時は throw (retry 判断は queue 側) */
+  cancelAuthorization: (authId: string) => Promise<void>;
+};
+
+/** 3 回全 fail 時の alert payload、 運営 log + 監視 (Phase 4) 経路で使う */
+export type AuthCleanupAlert = {
+  authId: string;
+  attempts: number;
+  lastError: string;
+};
+
+export type AuthCleanupQueueOptions = {
+  executor: AuthCleanupExecutor;
+  /** 3 回 fail 時の alert callback (default = console.error) */
+  onAlert?: (alert: AuthCleanupAlert) => void;
+  /**
+   * enqueue → 1 回目実行までの delay (ms、 default 5000)
+   * test で短縮可能、 5 秒は grilling P3-b で確定した値
+   */
+  initialDelayMs?: number;
+  /**
+   * rate limit interval (ms、 default 1000 = 1 req/sec)
+   * 2 件目以降の enqueue で 1 件目の実行時刻 + interval 以降にずらす
+   */
+  rateLimitIntervalMs?: number;
+  /**
+   * exponential backoff の base (ms、 default 1000)
+   * retry k 回目の delay = base * 2^(k-1)、 k=1 で 1s、 k=2 で 2s、 k=3 で 4s
+   */
+  backoffBaseMs?: number;
+  /**
+   * 最大 retry 回数 (default 3、 initial 1 回 + retry 3 回 = 4 attempts)
+   */
+  maxRetries?: number;
+};
+
+/** 内部 job state (queue の 1 件分) */
+type Job = {
+  authId: string;
+  /** 現在 attempt (初回 = 1、 retry n 回目 = n+1) */
+  attempt: number;
+};
+
+/**
+ * AuthCleanupQueue —
+ *
+ * enqueue(authId) で 1 件受付、 delay + rate limit + retry を setTimeout で管理する in-memory queue。
+ * Phase 2 = 1 instance (Ponder サーバ内)、 Phase 4 で cross-instance (SQS / Redis) に移行時は本 class の
+ * public shape (enqueue / drain) を維持したまま内部 setTimeout を差替える。
+ *
+ * 実装 note —
+ * - setTimeout の callback は async、 await で完了を待たず fire-and-forget (queue 側で attempt++ 管理)
+ * - rate limit は「次の実行可能時刻 = 前回実行時刻 + interval」 を保持、 enqueue 時に max(now+delay, nextSlot) を選ぶ
+ * - test は fake timers (vi.useFakeTimers + advanceTimersByTimeAsync) で時間経過を simulate
+ */
+export class AuthCleanupQueue {
+  private readonly executor: AuthCleanupExecutor;
+  private readonly onAlert: (alert: AuthCleanupAlert) => void;
+  private readonly initialDelayMs: number;
+  private readonly rateLimitIntervalMs: number;
+  private readonly backoffBaseMs: number;
+  private readonly maxRetries: number;
+  /** 次に rate limit slot が空く時刻 (ms、 Date.now() 基準) */
+  private nextAvailableSlotAt: number;
+  /** in-flight job 数 (test での drain 確認用、 現状は使わないが将来 metric 用に予約) */
+  private inflight: number;
+
+  constructor(options: AuthCleanupQueueOptions) {
+    this.executor = options.executor;
+    this.onAlert =
+      options.onAlert ??
+      ((alert): void => {
+        console.error('[AuthCleanupQueue] alert', alert);
+      });
+    this.initialDelayMs = options.initialDelayMs ?? 5000;
+    this.rateLimitIntervalMs = options.rateLimitIntervalMs ?? 1000;
+    this.backoffBaseMs = options.backoffBaseMs ?? 1000;
+    this.maxRetries = options.maxRetries ?? 3;
+    this.nextAvailableSlotAt = 0;
+    this.inflight = 0;
+  }
+
+  /**
+   * enqueue —
+   *
+   * 受付時に「delay 経過後」 と「rate limit slot が空く時刻」 の遅い方に scheduling。
+   * 同期返却 (setTimeout 登録のみ)、 実行完了を await しない fire-and-forget。
+   */
+  enqueue(authId: string): void {
+    const now = Date.now();
+    const earliestExecuteAt = now + this.initialDelayMs;
+    const scheduledAt = Math.max(earliestExecuteAt, this.nextAvailableSlotAt);
+    // rate limit slot を更新 (次の enqueue はこれ以降に scheduling)
+    this.nextAvailableSlotAt = scheduledAt + this.rateLimitIntervalMs;
+
+    const job: Job = { authId, attempt: 1 };
+    this.scheduleJob(job, scheduledAt - now);
+  }
+
+  /**
+   * scheduleJob —
+   *
+   * setTimeout で delayMs 後に executeJob を呼ぶ。
+   * 呼出後の retry は本 method を再帰的に呼び直す (attempt++ + backoff)。
+   */
+  private scheduleJob(job: Job, delayMs: number): void {
+    setTimeout(
+      () => {
+        void this.executeJob(job);
+      },
+      Math.max(0, delayMs),
+    );
+  }
+
+  /**
+   * executeJob —
+   *
+   * cancelAuthorization を呼び、 fail 時は attempt < maxRetries なら exponential backoff で再 schedule、
+   * attempt == maxRetries (= 初回 + retry 3 回 = 4 回目) fail で onAlert 発火 + queue から drop。
+   *
+   * 成功時は完了 (何も返さない、 fire-and-forget)。
+   */
+  private async executeJob(job: Job): Promise<void> {
+    this.inflight += 1;
+    try {
+      await this.executor.cancelAuthorization(job.authId);
+      // 成功、 queue から drain (何もしない)
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+      // attempt=1 (初回) fail → retry 1、 attempt=2 fail → retry 2、 attempt=3 fail → retry 3、
+      // attempt=4 fail → 最終 fail (retry 3 回すべて fail 済)
+      if (job.attempt <= this.maxRetries) {
+        // exponential backoff = base * 2^(attempt-1)、 attempt=1 → 1s、 attempt=2 → 2s、 attempt=3 → 4s
+        const backoffMs = this.backoffBaseMs * Math.pow(2, job.attempt - 1);
+        const nextJob: Job = {
+          authId: job.authId,
+          attempt: job.attempt + 1,
+        };
+        this.scheduleJob(nextJob, backoffMs);
+      } else {
+        // 初回 + retry 3 回 = 4 回 fail、 alert 発火して drain
+        this.onAlert({
+          authId: job.authId,
+          attempts: job.attempt,
+          lastError: errMessage,
+        });
+      }
+    } finally {
+      this.inflight -= 1;
+    }
+  }
+
+  /** in-flight job 数 (test の drain 確認用、 現状は observability のみ) */
+  get inflightCount(): number {
+    return this.inflight;
+  }
+}

--- a/tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md
+++ b/tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md
@@ -1,0 +1,94 @@
+# Phase 2 Master Spec — bid 増額 + 45 日超 fallback
+
+## タスクサマリ
+
+Phase 1 で確立した fiat bid end-to-end 経路 (1 発 bid のみ) を拡張し、 fiat bidder が同 auction 内で bid 増額できる 5 phase sequential 経路と、 auction 期間が 45 日を超えた場合の GMO 与信枠再 authorization fallback を実装する。
+Phase 1 と同じ Base Sepolia + GMO mock server 環境で e2e 検証、 subgraph 側の fiat 別 track は Phase 3 に外出し。
+
+## 前提設計 (grilling P3-a + P3-b + Phase 2 判断確定 SSOT)
+
+- bid 増額 = grilling P3-b A 案 (5 phase sequential + 非同期 cleanup) を Phase 2 で実装
+- 5 phase = frontend「増額 bid」 button → backend pre-flight で GMO 新 auth 取得 → chain bid tx 発火 (viem writeContract) → tx confirm 後 status 更新 → async cleanup queue で旧 auth alterTran VOID
+- 45 日超 fallback = grilling P3-a A 案 (24h auction + 45 日超で再 authorization fallback) を Phase 2 で実装
+- backend cron worker で fiat_bid.createdAt から経過日数計算、 45 日超で再 authorization 発火
+- subgraph 別 track = **Phase 2 では実装しない**、 Phase 3 本番切替時に subgraph 改修と同時実施 (backend DB fiat_bid table で observability 担保済)
+- bid 上限 = Phase 1 の 100 万円 / bid を維持、 増額後の合計額も 100 万円上限で強制
+
+## 受入条件 (AC、 YES/NO 検証可能)
+
+- AC 1 — Base Sepolia 上で fiat bidder が同 auction 内で 2 回目 bid (増額) を実行、 GMO 新 authorization + chain bid tx 発火 + 旧 authorization async cleanup の 5 phase が sequential 完走する
+- AC 2 — 増額 bid で JPY 額が Phase 1 bid 額を下回る場合、 client-side + backend validation の 2 層で「増額のみ受付」 エラー表示 + bid 不可
+- AC 3 — 増額 bid 合計額 (Phase 1 + 増額差分) が 100 万円超過時に validation エラー表示 + bid 不可
+- AC 4 — 旧 authorization の async cleanup queue が 5 秒 delay + 1 req/sec rate limit + 3 回 retry で GMO alterTran VOID を実行、 fail 時運営 log 通知
+- AC 5 — fiat_bid.createdAt から 45 日経過した pending record を backend cron が 1h ごとに検出、 GMO 再 authorization API 発火 + reauthorizationCount + lastReauthorizedAt UPDATE
+- AC 6 — 45 日超 fallback で新 authorization 失敗時、 fiat_bid.status = cancelled + 運営 alert log + user 通知 email
+- AC 7 — 増額 bid Playwright e2e test で「Phase 1 bid → 他 bidder 上乗せ → 増額 bid → 落札 → capture → transferFrom」 の golden path が Base Sepolia + GMO mock で 1 spec pass
+
+## スコープ境界
+
+### in (本 Phase で対応)
+
+- bid 増額 5 phase sequential 実装 (webapp button + backend pre-flight + BidRelay 再利用 + async cleanup queue)
+- 増額 bid client-side + backend validation (JPY 増額のみ / 100 万円上限)
+- 45 日超 fallback backend cron worker + 再 authorization API
+- fiat_bid schema 拡張 (reauthorizationCount / lastReauthorizedAt 追加)
+- 増額 bid Playwright e2e golden path 1 spec
+- operations runbook 追記 (bid 増額 flow + 45 日超対応手順)
+
+### out (本 Phase で対応しない、 Phase 3 以降)
+
+- subgraph fiat 別 track → Phase 3 (Base Mainnet 切替と同時)
+- Base Mainnet 切替 (env + contract address + subgraph endpoint) → Phase 3
+- GMO 本番環境切替 (3DS 本番認証 / PCI DSS 監査) → Phase 3
+- retry queue 自動化 (transfer fail / capture fail) → Phase 4
+- 監視 dashboard + 運営 alert 自動化 → Phase 4
+- Stripe fallback provider → Phase 4 (or GMO revoke 時のみ)
+- bidder 側独自 KYC (対応しない、 Terms 宣誓 + 3DS 2.0 で代替、 Phase 1 と同じ)
+
+## 反例ケース
+
+- 反例 1 — 3 回目 bid (2 回目増額) → Phase 2 では対応、 5 phase sequential は N 回反復可能な設計 (旧 auth cleanup queue が回数分 enqueue)
+- 反例 2 — 同時 bid 増額 (2 fiat bidder が同時に増額) → auction contract 側の BidTooLow revert で 1 名のみ成功、 revert 側は fiat_bid.status = cancelled + user 通知 (Phase 1 の revert 経路踏襲)
+- 反例 3 — 45 日超 fallback 実行中に auction settle → 再 authorization は skip、 settlement 経路が優先 (fiat_bid.status = 3ds-verified または bid-placed のみ再 auth 対象)
+- 反例 4 — Base Mainnet 環境での動作保証 → Phase 3 で env 変更、 Phase 2 は Sepolia 前提 hardcode 継続
+- 反例 5 — subgraph 側の fiat 落札可視化 → Phase 3、 Phase 2 は backend DB のみで観測
+
+## 影響範囲 (touched file 候補)
+
+### packages/niji-webapp
+
+- `src/components/FiatBidModal/index.tsx` — 「増額 bid」 branch 追加 (既存 bid record 存在時の UI 差分)
+- `src/hooks/useFiatBid.ts` — 増額 bid endpoint 呼出 + 5 phase state 管理
+- `src/state/atoms/auctionAtom.ts` — 増額 bid state 追加
+- `tests/e2e/fiat-bid-topup.spec.ts` — 新規、 Playwright 増額 bid golden path
+
+### packages/niji-api
+
+- `src/handlers/fiat-bid/topup.ts` — 新規、 POST /api/v1/fiat-bid/topup で増額 bid pre-flight
+- `src/handlers/fiat-bid/topup.test.ts` — 新規、 behavior test 3 case
+- `src/services/bidRelay/index.ts` — 拡張、 増額 bid の tx 発火再利用
+- `src/services/authCleanup/index.ts` — 新規、 async cleanup queue (5 秒 delay + rate limit + retry)
+- `src/services/authCleanup/index.test.ts` — 新規
+- `src/services/reauthorization/index.ts` — 新規、 45 日超 fallback cron worker
+- `src/services/reauthorization/index.test.ts` — 新規
+- `src/api/index.ts` — topup route + cron worker 起動
+- `ponder.schema.ts` — fiat_bid table に reauthorizationCount / lastReauthorizedAt 追加
+
+### packages/niji-contracts
+
+- 完全無改修 (Phase 1 と同じ、 NijiAuctionHouseV3 未変更)
+
+### packages/niji-subgraph
+
+- 完全無改修 (fiat 別 track は Phase 3)
+
+### docs
+
+- `docs/operations/gmo-fiat-bid.md` — 拡張、 bid 増額 flow + 45 日超対応手順 追記
+
+## 既知のリスク・前提
+
+- Ponder framework の cron worker 実装経路は Ponder 0.12 の scheduler API を活用、 未提供機能なら別 service (node-cron) 分離
+- GMO 再 authorization API の実 endpoint 仕様は Phase 3 本番切替時に GMO デモ環境再取得で確定 (Phase 2 mock は entryTran 再呼出で simulate)
+- 45 日超 fallback で auction 期間が 60 日超えた場合の cascading failure は Phase 4 で監視 dashboard 追加
+- 増額 bid の async cleanup queue が backend crash で消えた場合の rebuild 経路は Phase 4 で orphan auth 検出 API 追加

--- a/tests/spec/gmo-fiat-bid/Phase2-02-issue-breakdown.md
+++ b/tests/spec/gmo-fiat-bid/Phase2-02-issue-breakdown.md
@@ -1,0 +1,63 @@
+# Phase 2 Issue Breakdown — 5 Issue 分割案
+
+## 分割方針
+
+rules/dev-flow.md § Issue 粒度 (1 Issue = 1 PR = 1 branch、 1 PR 300 行目安) に整合させるため、 Phase 2 全体 (推定 1000-1500 行) を 5 Issue に分割。 各 Issue は独立実装可能 + 依存関係を明示。
+
+## Issue 一覧
+
+### Issue P2-1 — Ponder schema 拡張 + async cleanup queue (backend)
+
+- スコープ — packages/niji-api の ponder.schema.ts に reauthorizationCount / lastReauthorizedAt を fiat_bid table に追加、 src/services/authCleanup/index.ts に AuthCleanupQueue class を Write (5 秒 delay + 1 req/sec rate limit + 3 回 retry で GMO alterTran VOID)
+- AC — pending 状態の旧 authorization を 5 秒後 queue enqueue → 1 req/sec 順次実行 → 3 回 retry で fail 通知
+- 依存 — なし (Phase 2 base infra)
+- 推定 — 200-300 行、 8-10 時間
+
+### Issue P2-2 — bid 増額 topup endpoint (backend)
+
+- スコープ — packages/niji-api/src/handlers/fiat-bid/topup.ts に hono handler + POST /api/v1/fiat-bid/topup、 pre-flight で GMO 新 auth + AuthCleanupQueue enqueue + BidRelay 再利用で chain tx 発火
+- AC — 増額 bid 額を受付、 pre-flight 新 auth + tx broadcast + 旧 auth cleanup enqueue まで完走
+- 依存 — Issue P2-1 (AuthCleanupQueue)
+- 推定 — 250-350 行、 10-14 時間
+
+### Issue P2-3 — 45 日超 fallback cron worker (backend)
+
+- スコープ — packages/niji-api/src/services/reauthorization/index.ts に ReauthorizationWorker class、 1h 周期で fiat_bid.createdAt から 45 日超の pending/3ds-verified/bid-placed record を検出 → GMO 再 authorization API 発火 + reauthorizationCount + lastReauthorizedAt UPDATE
+- AC — 45 日超 record を 1h ごと検出 + 再 authorization 発火、 失敗時 fiat_bid.status = cancelled + user 通知 email
+- 依存 — Issue P2-1 (schema 拡張)
+- 推定 — 200-250 行、 8-10 時間
+
+### Issue P2-4 — 増額 bid UI (webapp)
+
+- スコープ — packages/niji-webapp/src/components/FiatBidModal/index.tsx に「増額 bid」 branch 追加 (既存 bid record 存在時の UI 差分)、 useFiatBid hook で topup endpoint 呼出 + 5 phase state 管理、 client-side validation (増額のみ / 100 万円上限)
+- AC — 増額 bid button 表示条件 + modal 開閉 + 5 phase stepper + validation エラー表示
+- 依存 — Issue P2-2 (topup endpoint)
+- 推定 — 200-300 行、 8-12 時間
+
+### Issue P2-5 — Playwright e2e + operations runbook 更新
+
+- スコープ — packages/niji-webapp/tests/e2e/fiat-bid-topup.spec.ts に増額 bid golden path spec、 docs/operations/gmo-fiat-bid.md に bid 増額 flow + 45 日超対応手順 追記
+- AC — e2e で「Phase 1 bid → 他 bidder 上乗せ → 増額 bid → 落札 → capture → transferFrom」 golden path 1 spec pass、 runbook に 2 手順追加
+- 依存 — Issue P2-3, P2-4
+- 推定 — 150-200 行、 6-8 時間
+
+## 依存関係 graph
+
+```
+Issue P2-1 (schema + AuthCleanupQueue)
+├─ Issue P2-2 (topup endpoint)
+│   └─ Issue P2-4 (UI)
+│       └─ Issue P2-5 (e2e + runbook)
+└─ Issue P2-3 (45 日超 cron)
+    └─ Issue P2-5 (e2e + runbook)
+```
+
+## 推定合計
+
+- 実装行数 = 1000-1500 行
+- 開発時間 = 40-54 時間 (1-2 週間、 1 人 fulltime 換算)
+- Issue 数 = 5 (grilling 想定の 4-5 の上限に着地)
+
+## GitHub Issue 起票
+
+Linear free issue limit で GitHub 単一経路 (Phase 1 と同じ)。 label = `phase-2-gmo-fiat-bid` を作成、 全 Issue に付与。 依存関係は body 内 「Blocked by #NNNN」 で明記。

--- a/tests/spec/gmo-fiat-bid/Phase2-03-scope-boundary.md
+++ b/tests/spec/gmo-fiat-bid/Phase2-03-scope-boundary.md
@@ -1,0 +1,42 @@
+# Phase 2 Scope Boundary — 明示的 in / out
+
+## in (本 Phase で対応)
+
+| 観点 | 内容 | 対応 Issue |
+|---|---|---|
+| Ponder schema 拡張 | fiat_bid table に reauthorizationCount / lastReauthorizedAt 追加 | Issue P2-1 |
+| async cleanup queue | 5 秒 delay + 1 req/sec + 3 retry で旧 auth alterTran VOID | Issue P2-1 |
+| topup endpoint | POST /api/v1/fiat-bid/topup で増額 bid pre-flight + BidRelay 再利用 | Issue P2-2 |
+| 45 日超 cron worker | 1h 周期で fiat_bid.createdAt から 45 日超検出 + 再 authorization | Issue P2-3 |
+| 増額 bid UI | FiatBidModal に「増額 bid」 branch + 5 phase stepper + validation | Issue P2-4 |
+| Playwright e2e | fiat-bid-topup.spec.ts golden path 1 spec | Issue P2-5 |
+| operations runbook 追記 | bid 増額 flow + 45 日超対応手順 | Issue P2-5 |
+
+## out (本 Phase で対応しない)
+
+| 観点 | 内容 | 委譲先 Phase | 理由 |
+|---|---|---|---|
+| subgraph fiat 別 track | fiat 落札 event を subgraph で別 entity 管理 | Phase 3 | Base Mainnet 切替 (Phase 3) と同時実施が spec upgrade の切替コスト削減、 backend DB fiat_bid table で observability 担保済 |
+| Base Mainnet 切替 | env + contract address + RPC 変更 | Phase 3 | Sepolia + GMO mock で Phase 2 検証確定後の本番化 |
+| GMO 本番切替 | 加盟店本番契約 + 3DS 本番認証 + PCI DSS 監査 | Phase 3 | GMO デモ環境再取得 + 本番契約 が Phase 3 prerequisite |
+| retry queue 自動化 | transfer fail / capture fail の 1h ごと自動 retry | Phase 4 | Phase 2 は手動 retry で許容 (Phase 1 と同じ)、 自動化は本番運用実績後 |
+| 監視 dashboard | fiat bid 成功率 / capture fail 率 / 増額 bid 頻度の可視化 | Phase 4 | 本番稼働後の必要機能 |
+| 運営 alert 自動化 | Slack / email / PagerDuty 経由の異常系通知 | Phase 4 | 本番稼働後の運用機能 |
+| Stripe fallback | GMO revoke 時の Stripe 経路切替 | Phase 4 | GMO 事前調整済で Phase 2-3 では不要 |
+| bidder 独自 KYC | 身分証提出 / 住所確認 | 対応しない | Phase 1 と同じ、 Terms 宣誓 + 3DS 2.0 で代替 |
+| custody model | wallet 不要 bidder の運営 EOA 保管 | 対応しない | 資金決済法カストディ業務該当リスク (Phase 1 の反例 2 と同じ) |
+| N 回目 bid の complex logic | 3+ 回目 bid の別 flow | 対応しない | 5 phase sequential が N 回反復可能な設計、 追加 logic 不要 |
+
+## 境界判定基準
+
+「in / out どちらか判断が難しい」 と感じた変更が発生した場合の判定基準。
+
+- Phase 2 の deliverable (bid 増額 + 45 日超 fallback の e2e) に必須か? → Yes なら in、 No なら out
+- 変更を追加すると Issue 1 つの推定行数 350 行超えるか? → 超えるなら Phase 3 に外出し
+- 変更が「AI slop」 (不要 try-catch / 過剰抽象 / dead code) 経路の下地になるか? → なるなら削除
+
+## 実装中の scope creep 予防
+
+- 新機能追加提案は必ず本 file に「Phase X 委譲」 として記録、 in 側追加は user 承認必須
+- refactor は Phase 2 実装対象 file のみ、 既存 Phase 1 file の「ついで整理」 禁止
+- subgraph 改修は Phase 3 まで一切禁止 (grilling 判断済)

--- a/tests/spec/gmo-fiat-bid/Phase2-04-counterexamples.md
+++ b/tests/spec/gmo-fiat-bid/Phase2-04-counterexamples.md
@@ -1,0 +1,100 @@
+# Phase 2 Counterexamples — 動かないはず / 対象外の反例
+
+## 反例の役割
+
+「将来こう拡張するから」 と先回り抽象化しないための制約装置。 反例に明記したシナリオは Phase 2 で対応せず、 実装中に「ついで対応」 したくなった時に本 doc を参照して踏みとどまる。
+
+## 反例 1 — 3+ 回目 bid の別 flow 実装
+
+### シナリオ
+
+fiat bidder が同 auction 内で 3 回、 4 回、 と bid 増額を繰り返す想定。
+
+### Phase 2 の期待挙動
+
+- 5 phase sequential は N 回反復可能な設計、 追加 logic 不要
+- 各回で AuthCleanupQueue に旧 auth を enqueue、 queue が rate limit + retry で順次 alterTran VOID を実行
+- 3+ 回目でも 2 回目と同じ topup endpoint を再呼出、 特別 branch なし
+
+### 対応しない理由
+
+「3 回目は別 endpoint」 のような特別 case 分岐は複雑度を増やすだけで意味なし、 sequential は N 回反復で完結する設計。
+
+## 反例 2 — 45 日超 fallback で新 authorization が繰り返し失敗
+
+### シナリオ
+
+45 日経過で再 authorization API 発火、 GMO 側で card 期限切れ等の理由で毎回失敗、 cron が 1h ごと発火し続けて log 洪水。
+
+### Phase 2 の期待挙動
+
+- 1 回目 fail = fiat_bid.status = cancelled + 運営 alert log + user 通知 email
+- status = cancelled 移行後は cron 検出対象外 (pending / 3ds-verified / bid-placed のみ対象)
+- 2 回目以降の cron 発火はなし
+
+### 対応しない理由
+
+「retry を N 回 attempt してから cancel」 は Phase 4 の retry queue 自動化 scope、 Phase 2 は 1 回 fail で cancel 確定の simple 設計。
+
+## 反例 3 — 増額 bid の atomicity 保証 (transaction 全体を rollback 可能に)
+
+### シナリオ
+
+5 phase 途中で fail した場合に 5 phase 全体を rollback したい要望。
+
+### Phase 2 の期待挙動
+
+- rollback は phase 別に個別実装 (grilling P3-b A 案の SSOT)
+- Phase 3 fail (chain tx revert) → 新 auth cancel + fiat_bid.status = cancelled + 旧 auth 保持
+- Phase 4 fail (tx confirm 監視) → chain tx 状態を尊重、 rollback せず monitoring alert
+- Phase 5 fail (cleanup queue) → retry 3 回 + fail 通知、 旧 auth は残す (orphan 検出は Phase 4)
+
+### 対応しない理由
+
+atomic rollback は on-chain 状態と off-chain 状態の 2 者を同時制御する必要があり、 grilling P6 A 案 (on-chain SSOT) と矛盾。 phase 別 rollback で運営 recovery 可能な状態を保つ。
+
+## 反例 4 — subgraph 側の fiat 落札可視化
+
+### シナリオ
+
+Phase 2 で subgraph に fiat 落札 event を別 track で記録、 dashboard で ETH bid vs fiat bid を区別表示。
+
+### Phase 2 の期待挙動
+
+- subgraph は完全無改修 (grilling 判断)、 fiat 落札は ETH bid として記録
+- fiat / crypto の区別は backend DB (Ponder fiat_bid table) のみ、 observability は担保
+
+### 対応しない理由 (grilling 判断)
+
+- Phase 3 の Base Mainnet 切替 (subgraph endpoint 変更) と同時実施が spec upgrade の切替コスト削減
+- Phase 2 の主目的 (bid 増額 + 45 日超 fallback) に subgraph 変更は不要
+
+## 反例 5 — Base Mainnet 環境での動作保証
+
+### シナリオ
+
+Phase 2 実装完了後、 user が「Mainnet で動かしたい」 と要望。
+
+### Phase 2 の期待挙動
+
+- Base Mainnet contract address / RPC endpoint / subgraph endpoint は Phase 3 で env 変更
+- Phase 2 は Sepolia 前提の env / test を hardcode 継続 (Phase 1 と同じ)
+
+### 対応しない理由
+
+Phase 3 (Mainnet + GMO 本番切替) を独立 phase として分離、 検証範囲を明確化 (Phase 1 の反例 5 と同じ理由)。
+
+## 反例 6 — 増額 bid の gas 料金を user に負担させる option
+
+### シナリオ
+
+「増額 bid の gas は運営でなく user が負担できる option」 の追加要望。
+
+### Phase 2 の期待挙動
+
+- Phase 1 と同じ、 全 fiat bidder の gas は運営負担 (grilling P3-c 確定)
+- user gas 負担 option は fiat bid の意義 (「wallet あるけど gas 払いたくない」) と矛盾
+
+### 対応しない理由
+
+fiat bid の primary use case が「gas を気にせず JPY で支払う」 なので、 user gas 負担 option は self-contradictory。

--- a/tests/spec/gmo-fiat-bid/Phase2-05-impact-analysis.md
+++ b/tests/spec/gmo-fiat-bid/Phase2-05-impact-analysis.md
@@ -1,0 +1,107 @@
+# Phase 2 Impact Analysis — 影響範囲と grep ベース列挙
+
+## 影響範囲 summary
+
+| package | 変更種別 | 主な変更内容 | 推定行数 |
+|---|---|---|---|
+| niji-webapp | 拡張 | FiatBidModal に「増額 bid」 branch + useFiatBid 拡張 + auctionAtom 追加 | 300-450 行 |
+| niji-api | 拡張 + 新規 | topup endpoint + AuthCleanupQueue + ReauthorizationWorker + schema 拡張 | 700-900 行 |
+| niji-contracts | 完全無改修 | grilling 確定、 一切触らない | 0 行 |
+| niji-subgraph | 完全無改修 | Phase 3 まで fiat 別 track 実装しない | 0 行 |
+| docs | 拡張 | operations runbook 追記 | 50-100 行 |
+| tests | 新規 | Playwright e2e 増額 bid golden path | 100-200 行 |
+
+## grep ベース列挙
+
+### niji-webapp 側の既存 file (触る予定)
+
+- `packages/niji-webapp/src/components/FiatBidModal/index.tsx` — 既存 bid record 存在時の「増額 bid」 branch 追加
+- `packages/niji-webapp/src/components/FiatBidModal/index.test.tsx` — 増額 bid case 追加
+- `packages/niji-webapp/src/hooks/useFiatBid.ts` — topup endpoint 呼出 + 5 phase state 管理
+- `packages/niji-webapp/src/state/atoms/auctionAtom.ts` — 増額 bid state 追加
+
+### niji-webapp 側の新規 file
+
+- `packages/niji-webapp/tests/e2e/fiat-bid-topup.spec.ts` (100-200 行、 Playwright golden path)
+
+### niji-api 側の既存 file (触る予定)
+
+- `packages/niji-api/ponder.schema.ts` — fiat_bid table に reauthorizationCount / lastReauthorizedAt 追加
+- `packages/niji-api/src/api/index.ts` — topup route 追加 + cron worker 起動
+- `packages/niji-api/src/services/bidRelay/index.ts` — 増額 bid の tx 発火再利用 (interface 拡張不要)
+- `packages/niji-api/src/services/gmo/client.ts` — 再 authorization API method 追加 (verifyTds2 / alterTran と同じ pattern)
+
+### niji-api 側の新規 file
+
+- `packages/niji-api/src/handlers/fiat-bid/topup.ts` (150-200 行、 hono handler)
+- `packages/niji-api/src/handlers/fiat-bid/topup.test.ts` (150-200 行、 behavior test 3 case)
+- `packages/niji-api/src/services/authCleanup/index.ts` (150-200 行、 queue + rate limit + retry)
+- `packages/niji-api/src/services/authCleanup/index.test.ts` (100-150 行、 behavior test)
+- `packages/niji-api/src/services/reauthorization/index.ts` (150-200 行、 cron worker)
+- `packages/niji-api/src/services/reauthorization/index.test.ts` (100-150 行、 behavior test)
+
+### niji-api 側の設定変更
+
+- `packages/niji-api/.env.example` — REAUTHORIZATION_INTERVAL_HOURS (default 1) 追加
+
+### docs / operations
+
+- `docs/operations/gmo-fiat-bid.md` — bid 増額 flow (5 phase の詳細) + 45 日超対応手順 追記 (50-100 行)
+
+## 触らないファイル (negative scope)
+
+- `packages/niji-contracts/**` — grilling 確定、 完全無改修
+- `packages/niji-subgraph/**` — Phase 3 まで fiat 別 track 実装しない
+- `packages/niji-sdk/**` — contract ABI / address は既存活用、 変更不要
+- `packages/niji-assets/**` — NFT trait data 関連、 payment flow と無関係
+- `packages/niji-docs/**` — 公開 docs、 Phase 2 も operations doc のみ内部運用
+- `packages/niji-webapp/src/components/FiatSettlementModal/**` — 落札後 flow は Phase 1 で完成、 Phase 2 では触らない
+- `packages/niji-api/src/handlers/fiat-bid/{authorize,3ds-callback,place-bid,capture,transfer-nft}.ts` — Phase 1 の 5 endpoint、 Phase 2 では topup のみ追加
+
+## test scope
+
+### 単体 test (Vitest)
+
+- `packages/niji-api/src/handlers/fiat-bid/topup.test.ts` — pre-flight 成功 / 増額額 validation / 100 万円上限 の 3 case
+- `packages/niji-api/src/services/authCleanup/index.test.ts` — enqueue / rate limit / retry / fail 通知 の 4 case
+- `packages/niji-api/src/services/reauthorization/index.test.ts` — 45 日超検出 / 再 auth 成功 / 再 auth 失敗 の 3 case
+- `packages/niji-webapp/src/components/FiatBidModal/index.test.tsx` — 増額 bid button 表示条件 / 5 phase stepper / validation 3 case 追加
+
+### e2e test (Playwright)
+
+- `packages/niji-webapp/tests/e2e/fiat-bid-topup.spec.ts` — golden path 1 spec (Phase 1 bid → 他 bidder 上乗せ → 増額 bid → 落札 → capture → transferFrom)、 Base Sepolia + GMO mock 前提
+
+## 依存 package 追加
+
+### niji-webapp
+
+- なし (既存 wagmi / viem / TanStack Query / shadcn/ui で完結)
+
+### niji-api
+
+- なし (既存 msw / vitest / undici / hono / ponder で完結、 cron worker は Ponder scheduler API 活用予定)
+
+## rollback 経路
+
+Phase 2 実装中に「やっぱり方針変える」 場合の rollback 経路。
+
+- Issue P2-1 (schema + cleanup queue) は独立性高い、 単独 revert 容易
+- Issue P2-2 (topup endpoint) は P2-1 依存、 全部 revert or 全部 keep の 2 択
+- Issue P2-3 (cron worker) は P2-1 のみ依存、 単独 revert 可能
+- Issue P2-4 (UI) は P2-2 依存
+- Issue P2-5 (e2e + runbook) は全 Issue 依存
+
+git branch strategy —
+
+- 各 Issue = 個別 branch `feature/{issue-num}-{slug}`、 master に直接 PR (Phase 1 と同じ)
+- Phase 2 完了時に統合 branch なし、 各 PR 独立 merge
+
+## 完了判定
+
+Phase 2 完了 = 以下 3 marker 全 active。
+
+- `test-passed-{repo-slug}-phase2-gmo-fiat-bid` — 全 Issue の unit test + e2e golden path pass
+- `verify-passed-{repo-slug}-phase2-gmo-fiat-bid` — Layer 3 compile pass (typecheck + build)
+- `review-passed-{repo-slug}-phase2-gmo-fiat-bid` — `/code-review-router` 完了
+
+3 marker 全 active で AI 自律 merge 可、 Issue #3012 修正で通常 merge 経路確立済のため admin merge 不要 (期待)。


### PR DESCRIPTION
## Summary

Phase 2 base infra として fiat_bid table に reauthorizationCount / lastReauthorizedAt を追加、 AuthCleanupQueue class で旧 authorization を 5 秒 delay + 1 req/sec rate limit + 3 回 retry の順次実行で GMO alterTran(JobCd=VOID) する非同期 queue を実装。 grilling P3-b A 案 (5 phase sequential + 非同期 cleanup) の base infra、 Issue #3023 (topup) + Issue #3024 (45 日超 cron) の blocker。

## 変更内容

### Phase A schema 拡張

- packages/niji-api/ponder.schema.ts の fiat_bid table に reauthorizationCount (integer default 0) + lastReauthorizedAt (timestamp nullable) を追加
- 既存 fiat_bid record は Ponder migration が default 値で埋める (backward compat)

### Phase B AuthCleanupQueue 実装

- packages/niji-api/src/services/authCleanup/index.ts に AuthCleanupQueue class を Write
- enqueue(authId) で 5 秒後に処理開始、 rate limit 1 req/sec で順次実行 (2 件目以降は 1 秒 slot ずれ)
- executor.cancelAuthorization 呼出、 fail 時 exponential backoff (1s / 2s / 4s) で 3 回まで retry
- 4 回全 fail で onAlert(authId, attempts, lastError) callback 発火 (default = console.error)

### Phase C 単体 test (fake timers 経由 behavior test 4 case)

- delay 検証 = enqueue → 5 秒 delay 経過後に cancelAuthorization が呼ばれる
- rate limit 検証 = 2 auth 連続 enqueue で 2 件目の実行が 1 秒後にずれる
- retry + backoff 検証 = fail 時 3 回 retry (1s / 2s / 4s) で成功時は alert 出さず
- 最終 fail 検証 = 3 回全 retry fail で onAlert 発火 + queue から drain

## 完了条件

- [x] ponder.schema.ts に reauthorizationCount + lastReauthorizedAt 追加、 本 PR 追加箇所は typecheck error 0
- [x] AuthCleanupQueue が enqueue 5 秒後に alterTran VOID を実行 (test 1)
- [x] rate limit 1 req/sec が enforced (test 2)
- [x] retry 3 回 + fail 通知が behavior test で検証済 (test 3, 4)
- [x] 単体 test 4 case 全 pass (188/188 全体テストも regression なし)

## Test plan

- [x] pnpm test (packages/niji-api) = 15 files / 188 tests pass
- [x] pnpm lint (packages/niji-api) = 0 errors, 0 warnings
- [x] pnpm typecheck (packages/niji-api) = 本 PR 追加箇所 0 error (pre-existing 3 件は master 同一)

## 影響範囲

- packages/niji-api/ponder.schema.ts (fiat_bid table 拡張)
- packages/niji-api/src/services/authCleanup/index.ts (新規)
- packages/niji-api/src/services/authCleanup/index.test.ts (新規)
- tests/spec/gmo-fiat-bid/Phase2-*.md (Phase 2 SSOT 5 docs)

## リスク・注意点

- AuthCleanupQueue は in-memory setTimeout ベース、 Ponder サーバ instance 1 台前提。 Phase 4 で SQS / Redis に置換予定 (cross-instance 対応)
- backend crash で queue 消失時の rebuild 経路は Issue P2-3 の 45 日超 fallback 経由で orphan auth 検出 → Phase 4 で監視 dashboard 追加
- reauthorizationCount / lastReauthorizedAt は本 PR では field 追加のみ、 実 UPDATE 発火は Issue P2-3 (ReauthorizationWorker) で配線

## 依存関係

- 依存なし (Phase 2 base infra、 最上流)
- 本 PR merge 後 Issue P2-2 (topup endpoint) + Issue P2-3 (45 日超 cron) が unblock

## Phase 2 SSOT

- tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md § P2, AC 4
- tests/spec/gmo-fiat-bid/Phase2-02-issue-breakdown.md § Issue P2-1

Closes #3022