### PR TITLE
✨ feat(niji-webapp): FiatBidModal 増額 bid branch + 5 phase stepper を追加 (#3025)

### DIFF
--- a/packages/niji-webapp/src/components/FiatBidModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/index.test.tsx
@@ -1,14 +1,19 @@
 /**
- * FiatBidModal behavior test (Issue #3009 Phase D、 spec T13-T15)
+ * FiatBidModal behavior test (Issue #3009 Phase D、 spec T13-T15 + Issue #3025 Phase 2 増額 branch)
  *
- * spec で要求される 3 挙動 —
+ * Phase 1 (新規 bid mode) の 3 挙動 —
  * (1) modal 開閉 + stepper 遷移 (T13)
  * (2) bid 上限 100 万円超過で validation エラー + submit disable (T14)
  * (3) Terms checkbox 未 check で submit disable (追加、 spec 完了条件 6 番)
  * (4) modal 内 submit で authorize 呼出 → step="three-ds" 遷移
+ *
+ * Phase 2 (増額 bid mode、 Issue #3025) の 3 挙動 —
+ * (T1) existingFiatBid prop 存在時に「増額 bid」 modal 表示 (title / submit label / existing bid summary)
+ * (T2) validateTopupJpyAmount 経由の validation error (newJpy <= oldJpy) 表示 + submit disable
+ * (T3) submit で topup endpoint 呼出 + 5 phase stepper 表示 + cleanup disclaimer 表示
  */
 
-import type { AuthorizeResponse, PlaceBidResponse } from '@/hooks/useFiatBid';
+import type { AuthorizeResponse, PlaceBidResponse, TopupResponse } from '@/hooks/useFiatBid';
 import type { SpotRate } from '@/hooks/useSpotRate';
 
 import * as React from 'react';
@@ -19,7 +24,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
 
-import { BID_LIMIT_JPY, FiatBidModal, validateJpyAmount } from './index';
+import { BID_LIMIT_JPY, FiatBidModal, validateJpyAmount, validateTopupJpyAmount } from './index';
 
 // Radix Tooltip Portal を jsdom で render するため Provider を wrap
 
@@ -60,6 +65,18 @@ const placeBidResponse: PlaceBidResponse = {
   status: 'bid-placed',
   txHash: '0xTXHASH',
   message: 'bid tx を broadcast しました。',
+};
+
+const topupResponse: TopupResponse = {
+  authId: 'auth-2-new',
+  oldAuthId: 'auth-1',
+  status: 'bid-placed',
+  txHash: '0xTXHASH2',
+  jpyAmount: 80_000,
+  ethAmount: '160000000000000000',
+  spotRate: 500_000,
+  spotRateSource: 'gmo',
+  message: '増額 bid tx を broadcast しました。',
 };
 
 describe('validateJpyAmount', () => {
@@ -228,5 +245,224 @@ describe('modal close', () => {
 
     fireEvent.click(screen.getByTestId('fiat-bid-cancel'));
     expect(onClose).toHaveBeenCalled();
+  });
+});
+
+// ====================================================================
+// Phase 2 増額 bid mode (Issue #3025 T10-T11)
+// ====================================================================
+
+describe('validateTopupJpyAmount (Phase 2、 増額 bid mode)', () => {
+  it('旧 jpyAmount 以下で ng (増額のみ受付)', () => {
+    const r = validateTopupJpyAmount('50000', 50_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('増額のみ受付可能');
+  });
+
+  it('旧 jpyAmount 未満で ng', () => {
+    const r = validateTopupJpyAmount('30000', 50_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('増額のみ受付可能');
+  });
+
+  it('BID_LIMIT_JPY 超過で ng', () => {
+    const r = validateTopupJpyAmount(`${BID_LIMIT_JPY + 1}`, 50_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('bid 上限');
+  });
+
+  it('旧 jpyAmount より大 + BID_LIMIT_JPY 以下で ok', () => {
+    const r = validateTopupJpyAmount('80000', 50_000);
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe(80_000);
+  });
+
+  it('空文字で ng', () => {
+    const r = validateTopupJpyAmount('', 50_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.message).toContain('JPY 額');
+  });
+});
+
+describe('FiatBidModal 増額 bid mode (Issue #3025 T10-T11)', () => {
+  it('existingFiatBid 存在時に「増額 bid」 modal 表示 (title / summary / submit label)', async () => {
+    const spotFetcher = vi.fn().mockResolvedValue(successRate);
+
+    render(
+      <FiatBidModal
+        open
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        existingFiatBid={{ authId: 'auth-1', jpyAmount: 50_000 }}
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn(), topup: vi.fn() },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: spotFetcher, refetchInterval: 0 }}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('fiat-bid-rate-summary')).toBeInTheDocument();
+    });
+
+    // modal data-mode="topup" に切替済
+    const modal = screen.getByTestId('fiat-bid-modal');
+    expect(modal.getAttribute('data-mode')).toBe('topup');
+
+    // 既存 bid summary 表示
+    const summary = screen.getByTestId('fiat-topup-existing-bid-summary');
+    expect(summary.textContent).toContain('50,000');
+    expect(summary.textContent).toContain('auth-1');
+
+    // submit button の label が「増額 bid を実行」 に切替
+    const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
+    expect(submit.textContent).toContain('増額 bid を実行');
+
+    // 通知 email 欄は増額 mode では非表示
+    expect(screen.queryByTestId('fiat-bid-email-input')).toBeNull();
+  });
+
+  it('増額額 <= 旧 jpyAmount 入力で validation エラー + submit disable', async () => {
+    const topup = vi.fn();
+    const spotFetcher = vi.fn().mockResolvedValue(successRate);
+
+    render(
+      <FiatBidModal
+        open
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        existingFiatBid={{ authId: 'auth-1', jpyAmount: 50_000 }}
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn(), topup },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: spotFetcher, refetchInterval: 0 }}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('fiat-bid-rate-summary')).toBeInTheDocument();
+    });
+
+    // 旧 jpyAmount と同額入力 (増額のみ受付なので ng)
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '50000' } });
+
+    await waitFor(() => {
+      const err = screen.getByTestId('fiat-bid-jpy-error');
+      expect(err.textContent).toContain('増額のみ受付可能');
+    });
+
+    fireEvent.click(screen.getByTestId('fiat-bid-terms-checkbox'));
+    const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    expect(topup).not.toHaveBeenCalled();
+  });
+
+  it('合計 > BID_LIMIT_JPY で validation エラー + submit disable', async () => {
+    const topup = vi.fn();
+    const spotFetcher = vi.fn().mockResolvedValue(successRate);
+
+    render(
+      <FiatBidModal
+        open
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        existingFiatBid={{ authId: 'auth-1', jpyAmount: 500_000 }}
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn(), topup },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: spotFetcher, refetchInterval: 0 }}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('fiat-bid-rate-summary')).toBeInTheDocument();
+    });
+
+    // 100 万円 + 1 で BID_LIMIT_JPY 超過
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: `${BID_LIMIT_JPY + 1}` } });
+
+    await waitFor(() => {
+      const err = screen.getByTestId('fiat-bid-jpy-error');
+      expect(err.textContent).toContain('bid 上限');
+    });
+
+    fireEvent.click(screen.getByTestId('fiat-bid-terms-checkbox'));
+    const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+    expect(topup).not.toHaveBeenCalled();
+  });
+
+  it('submit で topup endpoint 呼出 + 5 phase stepper 表示 + cleanup disclaimer', async () => {
+    const topup = vi.fn().mockResolvedValue(topupResponse);
+    const spotFetcher = vi.fn().mockResolvedValue(successRate);
+
+    render(
+      <FiatBidModal
+        open
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        existingFiatBid={{ authId: 'auth-1', jpyAmount: 50_000 }}
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn(), topup },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: spotFetcher, refetchInterval: 0 }}
+        generateCardToken={() => 'mock-tok-topup-fixed'}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('fiat-bid-rate-summary').textContent).toContain('500,000');
+    });
+
+    // 増額額 80,000 円入力 (旧 50,000 円より大)
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '80000' } });
+
+    // Terms check
+    fireEvent.click(screen.getByTestId('fiat-bid-terms-checkbox'));
+
+    const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+
+    // submit → topup endpoint 呼出
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(topup).toHaveBeenCalledWith({
+        authId: 'auth-1',
+        newJpyAmount: 80_000,
+        cardToken: 'mock-tok-topup-fixed',
+      });
+    });
+
+    // topup 応答後 stepper が「cleanup-queued」 phase に遷移 (endpoint 完了時点で 4 phase 完了扱い)
+    await waitFor(() => {
+      const stepper = screen.getByTestId('fiat-topup-stepper');
+      expect(stepper.getAttribute('data-step')).toBe('cleanup-queued');
+      expect(stepper.textContent).toContain('cleanup 中');
+    });
+
+    // cleanup disclaimer 表示
+    const disclaimer = screen.getByTestId('fiat-topup-cleanup-disclaimer');
+    expect(disclaimer.textContent).toContain('非同期');
+    expect(disclaimer.textContent).toContain('別 tab');
   });
 });

--- a/packages/niji-webapp/src/components/FiatBidModal/index.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/index.tsx
@@ -1,5 +1,5 @@
 /**
- * FiatBidModal — クレカで JPY 建てで bid する modal (Issue #3009 Phase C)
+ * FiatBidModal — クレカで JPY 建てで bid する modal (Issue #3009 Phase C + Issue #3025 Phase 2 増額 branch)
  *
  * 役割 —
  * (1) auction ページの Bid component から open される modal
@@ -9,12 +9,19 @@
  * (5) bid 上限 100 万円 client-side validation + backend validation の 2 層
  * (6) 4 段 stepper (「与信枠取得中」 → 「3DS 認証中」 → 「bid 送信中」 → 「bid 成功」)
  *     を useFiatBid hook step と同期表示
+ * (7) [Phase 2、 Issue #3025] existingFiatBid prop で「増額 bid」 branch に切替
+ *     - 既存 fiat_bid record が bid-placed 状態なら「増額 bid」 mode で render
+ *     - 5 phase stepper (Phase 1 の 4 段 + async cleanup phase 追加)
+ *     - client-side validation = newJpyAmount > 旧 jpyAmount + 100 万円上限
+ *     - cleanup phase は非同期完了なので「別 tab で作業続行可」 disclaimer 表示
  *
- * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P7 (A' 案 = wallet 接続必須 + fiat modal 切替)、
- *        Phase1-02-issue-breakdown.md § Issue 6。
+ * SSOT — tests/spec/gmo-fiat-bid/Phase1-01-master-spec.md § P7、
+ *        Phase1-02-issue-breakdown.md § Issue 6、
+ *        Phase2-01-master-spec.md § P7、
+ *        Phase2-02-issue-breakdown.md § Issue P2-4。
  */
 
-import type { FiatBidStep } from '@/hooks/useFiatBid';
+import type { FiatBidStep, FiatTopupPhase } from '@/hooks/useFiatBid';
 
 import * as React from 'react';
 import { useCallback, useMemo, useState } from 'react';
@@ -35,7 +42,7 @@ import { formatEthFromWei, jpyToEthWei, useSpotRate } from '@/hooks/useSpotRate'
 /** bid 上限 (spec P4、 100 万円 client-side + backend validation の 2 層) */
 export const BID_LIMIT_JPY = 1_000_000;
 
-/** stepper label 表示 (spec P7 の 4 段) */
+/** stepper label 表示 (spec P7 の 4 段、 Phase 1) */
 const STEP_LABELS: Record<FiatBidStep, string> = {
   idle: '',
   authorizing: '与信枠を取得しています',
@@ -43,6 +50,47 @@ const STEP_LABELS: Record<FiatBidStep, string> = {
   placing: 'bid を送信しています',
   success: 'bid が成立しました',
   failure: '決済確保に失敗しました',
+};
+
+/** topup 5 phase stepper label (Phase 2、 Issue #3025) */
+const TOPUP_PHASE_LABELS: Record<FiatTopupPhase, string> = {
+  idle: '',
+  pending: '新与信枠を取得しています',
+  'auth-taken': '新 3D セキュア 2.0 認証中',
+  'tx-broadcast': '新 bid を送信しています',
+  'tx-confirmed': '新 bid が成立しました',
+  'cleanup-queued': '旧与信枠の cleanup 中 (別 tab で作業続行可)',
+  failure: '増額 bid に失敗しました',
+};
+
+/**
+ * 増額 bid 用 JPY validation。 旧 jpyAmount より大きく、 100 万円上限に収まる整数のみ ok。
+ *
+ * Phase 1 の validateJpyAmount は「1 以上 + 100 万円以下」 のみ、 増額 branch では
+ * 旧 jpyAmount 超過の追加 check を強制する (backend validation と 2 層で重畳)。
+ */
+export const validateTopupJpyAmount = (
+  raw: string,
+  oldJpyAmount: number,
+): { ok: true; value: number } | { ok: false; message: string } => {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return { ok: false, message: 'JPY 額を入力してください' };
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return { ok: false, message: 'JPY 額は正の整数で入力してください' };
+  }
+  if (parsed > BID_LIMIT_JPY) {
+    return { ok: false, message: `bid 上限 ${BID_LIMIT_JPY.toLocaleString()} 円を超えています` };
+  }
+  if (parsed <= oldJpyAmount) {
+    return {
+      ok: false,
+      message: `増額のみ受付可能です (現 bid 額 ${oldJpyAmount.toLocaleString()} 円より大きい額を入力してください)`,
+    };
+  }
+  return { ok: true, value: parsed };
 };
 
 /**
@@ -74,6 +122,22 @@ export const validateJpyAmount = (
   return { ok: true, value: parsed };
 };
 
+/**
+ * 既存 fiat_bid record 情報 (親から渡す、 Phase 2 増額 branch trigger)
+ *
+ * 存在する場合 = user が同 auction で既に fiat bid 成立済 → 「増額 bid」 mode 表示
+ * undefined 時 = Phase 1 の新規 bid mode (default)
+ *
+ * 親側は fiat_bid record が status = "bid-placed" のときのみ prop を渡す契約、
+ * status が "pending" / "3ds-verified" / "cancelled" 等は増額 branch trigger 対象外。
+ */
+export type ExistingFiatBid = {
+  /** 既存 fiat_bid の authId (topup endpoint request の authId) */
+  authId: string;
+  /** 既存 fiat_bid の jpyAmount (増額 validation の下限、 backend と 2 層で強制) */
+  jpyAmount: number;
+};
+
 /** modal Props (親 Bid から open state を受渡し) */
 export type FiatBidModalProps = {
   /** modal open state (親から制御) */
@@ -84,6 +148,13 @@ export type FiatBidModalProps = {
   auctionId: string;
   /** bidder wallet address (親から wagmi useAccount 経由で渡す) */
   bidderWallet: string;
+  /**
+   * 既存 fiat_bid record (存在すれば「増額 bid」 branch に切替、 Phase 2 Issue #3025)
+   *
+   * 親側は auction ページで user の fiat_bid record を lookup し、 status = "bid-placed"
+   * のときのみ本 prop を渡す。 undefined なら Phase 1 の新規 bid mode で動作。
+   */
+  existingFiatBid?: ExistingFiatBid;
   /** test 用 injectable — useFiatBid の fetchers 差替経路 */
   fetchersOverride?: Parameters<typeof useFiatBid>[0];
   /** test 用 injectable — useSpotRate の option 差替経路 */
@@ -95,14 +166,17 @@ export type FiatBidModalProps = {
 /**
  * FiatBidModal component
  *
- * open=true で modal を描画、 submit で useFiatBid.authorize を呼出、
- * 成功時は hook 側で 3DS 画面へ full redirect、 fail 時は stepper に error 表示。
+ * open=true で modal を描画、 submit で useFiatBid.authorize (Phase 1) or
+ * useFiatBid.topup (Phase 2 増額 branch、 existingFiatBid prop 経路) を呼出、
+ * 新規 bid 成功時は hook 側で 3DS 画面へ full redirect、
+ * 増額 bid 成功時は modal 内 5 phase stepper で最終 phase まで表示。
  */
 export const FiatBidModal = ({
   open,
   onClose,
   auctionId,
   bidderWallet,
+  existingFiatBid,
   fetchersOverride,
   spotRateOverride,
   generateCardToken = generateMockCardToken,
@@ -115,7 +189,22 @@ export const FiatBidModal = ({
   const spotRate = useSpotRate(spotRateOverride);
   const fiatBid = useFiatBid(fetchersOverride);
 
-  const jpyValidation = useMemo(() => validateJpyAmount(jpyRaw), [jpyRaw]);
+  // Phase 2 の増額 branch trigger — existingFiatBid prop が存在すれば増額 mode で render
+  const isTopupMode = existingFiatBid !== undefined;
+
+  // Phase 1 validation (新規 bid mode)
+  const newBidValidation = useMemo(() => validateJpyAmount(jpyRaw), [jpyRaw]);
+  // Phase 2 validation (増額 bid mode、 旧 jpyAmount 超過 + 100 万円上限 の 2 層)
+  const topupValidation = useMemo(
+    () =>
+      existingFiatBid !== undefined
+        ? validateTopupJpyAmount(jpyRaw, existingFiatBid.jpyAmount)
+        : undefined,
+    [jpyRaw, existingFiatBid],
+  );
+
+  const jpyValidation = isTopupMode ? topupValidation! : newBidValidation;
+
   const ethWei = useMemo(() => {
     if (!jpyValidation.ok || spotRate.rate === undefined) return 0n;
     return jpyToEthWei(jpyValidation.value, spotRate.rate);
@@ -127,7 +216,8 @@ export const FiatBidModal = ({
     spotRate.rate === undefined ||
     fiatBid.step === 'authorizing' ||
     fiatBid.step === 'three-ds' ||
-    fiatBid.step === 'placing';
+    fiatBid.step === 'placing' ||
+    fiatBid.topupPhase === 'pending';
 
   const handleSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
@@ -144,6 +234,18 @@ export const FiatBidModal = ({
       }
 
       const cardToken = generateCardToken();
+
+      if (isTopupMode && existingFiatBid !== undefined) {
+        // Phase 2 増額 bid 経路 — topup endpoint 呼出 (5 phase stepper 表示)
+        await fiatBid.topup({
+          authId: existingFiatBid.authId,
+          newJpyAmount: jpyValidation.value,
+          cardToken,
+        });
+        return;
+      }
+
+      // Phase 1 新規 bid 経路 — authorize endpoint 呼出 + 3DS full redirect
       await fiatBid.authorize({
         auctionId,
         bidderWallet,
@@ -152,11 +254,25 @@ export const FiatBidModal = ({
         cardToken,
       });
     },
-    [jpyValidation, termsChecked, generateCardToken, fiatBid, auctionId, bidderWallet, emailRaw],
+    [
+      jpyValidation,
+      termsChecked,
+      generateCardToken,
+      fiatBid,
+      auctionId,
+      bidderWallet,
+      emailRaw,
+      isTopupMode,
+      existingFiatBid,
+    ],
   );
 
   const handleClose = useCallback(() => {
-    if (fiatBid.step === 'authorizing' || fiatBid.step === 'placing') {
+    if (
+      fiatBid.step === 'authorizing' ||
+      fiatBid.step === 'placing' ||
+      fiatBid.topupPhase === 'pending'
+    ) {
       // 通信中は close させない (与信枠取得済 + tx 発火中の state 不整合防止)
       return;
     }
@@ -168,8 +284,19 @@ export const FiatBidModal = ({
     onClose();
   }, [fiatBid, onClose]);
 
-  const currentStepLabel = STEP_LABELS[fiatBid.step];
+  const currentStepLabel = isTopupMode
+    ? TOPUP_PHASE_LABELS[fiatBid.topupPhase]
+    : STEP_LABELS[fiatBid.step];
   const errorMessage = localError ?? fiatBid.errorMessage;
+
+  const currentStepValue = isTopupMode ? fiatBid.topupPhase : fiatBid.step;
+  const stepperTestId = isTopupMode ? 'fiat-topup-stepper' : 'fiat-bid-stepper';
+
+  const modalTitle = isTopupMode ? '増額 bid (JPY)' : 'クレカで bid (JPY)';
+  const modalDescription = isTopupMode
+    ? `現在の bid 額 ${existingFiatBid!.jpyAmount.toLocaleString()} 円を増額します。 上限 ${BID_LIMIT_JPY.toLocaleString()} 円、 現在の spot rate に基づき ETH 換算されます。`
+    : `JPY 建てで bid します。 上限 ${BID_LIMIT_JPY.toLocaleString()} 円、 現在の spot rate に基づき ETH 換算されます。`;
+  const submitButtonLabel = isTopupMode ? '増額 bid を実行' : 'bid を実行';
 
   return (
     <Dialog
@@ -178,20 +305,30 @@ export const FiatBidModal = ({
         if (!next) handleClose();
       }}
     >
-      <DialogContent data-testid="fiat-bid-modal">
+      <DialogContent data-testid="fiat-bid-modal" data-mode={isTopupMode ? 'topup' : 'new-bid'}>
         <DialogHeader>
-          <DialogTitle>クレカで bid (JPY)</DialogTitle>
-          <DialogDescription>
-            JPY 建てで bid します。 上限 {BID_LIMIT_JPY.toLocaleString()} 円、 現在の spot rate
-            に基づき ETH 換算されます。
-          </DialogDescription>
+          <DialogTitle>{modalTitle}</DialogTitle>
+          <DialogDescription>{modalDescription}</DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} noValidate>
           <div className="space-y-4">
+            {isTopupMode && existingFiatBid !== undefined && (
+              <div
+                className="rounded-md bg-blue-50 p-3 text-sm"
+                data-testid="fiat-topup-existing-bid-summary"
+              >
+                <div className="font-medium">現 bid 額</div>
+                <div>
+                  {existingFiatBid.jpyAmount.toLocaleString()} 円 (auth ID ={' '}
+                  {existingFiatBid.authId})
+                </div>
+              </div>
+            )}
+
             <div>
               <label htmlFor="fiat-bid-jpy-amount" className="mb-1 block text-sm font-medium">
-                bid 額 (JPY)
+                {isTopupMode ? '新 bid 額 (JPY、 現額より大きい額)' : 'bid 額 (JPY)'}
               </label>
               <Input
                 id="fiat-bid-jpy-amount"
@@ -200,7 +337,11 @@ export const FiatBidModal = ({
                 max={BID_LIMIT_JPY}
                 value={jpyRaw}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => setJpyRaw(e.target.value)}
-                placeholder="例) 50000"
+                placeholder={
+                  isTopupMode && existingFiatBid !== undefined
+                    ? `例) ${(existingFiatBid.jpyAmount + 10_000).toLocaleString()}`
+                    : '例) 50000'
+                }
                 data-testid="fiat-bid-jpy-input"
                 required
               />
@@ -224,19 +365,21 @@ export const FiatBidModal = ({
               <div>ETH 換算 = {ethWei === 0n ? '—' : `${formatEthFromWei(ethWei)} ETH`}</div>
             </div>
 
-            <div>
-              <label htmlFor="fiat-bid-email" className="mb-1 block text-sm font-medium">
-                通知 email (任意)
-              </label>
-              <Input
-                id="fiat-bid-email"
-                type="email"
-                value={emailRaw}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmailRaw(e.target.value)}
-                placeholder="you@example.com"
-                data-testid="fiat-bid-email-input"
-              />
-            </div>
+            {!isTopupMode && (
+              <div>
+                <label htmlFor="fiat-bid-email" className="mb-1 block text-sm font-medium">
+                  通知 email (任意)
+                </label>
+                <Input
+                  id="fiat-bid-email"
+                  type="email"
+                  value={emailRaw}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEmailRaw(e.target.value)}
+                  placeholder="you@example.com"
+                  data-testid="fiat-bid-email-input"
+                />
+              </div>
+            )}
 
             <div>
               <label htmlFor="fiat-bid-card-token-hint" className="mb-1 block text-sm font-medium">
@@ -275,10 +418,20 @@ export const FiatBidModal = ({
             {currentStepLabel !== '' && (
               <div
                 className="rounded-md border p-3 text-sm"
-                data-testid="fiat-bid-stepper"
-                data-step={fiatBid.step}
+                data-testid={stepperTestId}
+                data-step={currentStepValue}
               >
                 {currentStepLabel}
+              </div>
+            )}
+
+            {isTopupMode && fiatBid.topupPhase === 'cleanup-queued' && (
+              <div
+                className="rounded-md bg-yellow-50 p-3 text-xs"
+                data-testid="fiat-topup-cleanup-disclaimer"
+              >
+                旧 authorization の cleanup 処理は非同期で進行しています。 modal を閉じたり、 別 tab
+                で他の操作を続けても問題ありません。
               </div>
             )}
 
@@ -299,7 +452,7 @@ export const FiatBidModal = ({
               キャンセル
             </Button>
             <Button type="submit" disabled={submitDisabled} data-testid="fiat-bid-submit">
-              bid を実行
+              {submitButtonLabel}
             </Button>
           </DialogFooter>
         </form>

--- a/packages/niji-webapp/src/hooks/useFiatBid.ts
+++ b/packages/niji-webapp/src/hooks/useFiatBid.ts
@@ -23,6 +23,30 @@ import { FIAT_BID_STATE_KEY } from '@/pages/FiatBid/ThreeDSRedirect';
 /** 4 段 stepper の識別子 (spec P7 の A' 案) */
 export type FiatBidStep = 'idle' | 'authorizing' | 'three-ds' | 'placing' | 'success' | 'failure';
 
+/**
+ * 5 段 stepper の識別子 (Phase 2 grilling P7 A' 案の増額 bid 経路、 Issue #3025)
+ *
+ * pending → auth-taken → tx-broadcast → tx-confirmed → cleanup-queued
+ *
+ * 各 phase の対応 —
+ * - pending      = topup endpoint 呼出開始 (旧 auth verify 中 = Phase A / B)
+ * - auth-taken   = GMO 新 authorize 完了 (新 authId 取得済 = Phase B 完了)
+ * - tx-broadcast = BidRelay で chain bid tx broadcast 中 (Phase C)
+ * - tx-confirmed = bid tx 確定 (Phase C 完了 + fiat_bid record 新 authId に UPDATE = Phase E)
+ * - cleanup-queued = 旧 auth cleanup queue に enqueue 済 (Phase D 完了、 async cleanup 走行中)
+ * - failure       = 各 phase の error 停止 (Phase 1 の failure と共用)
+ *
+ * async cleanup 完了 (旧 auth VOID 成功) は endpoint 応答時点で観測不能なので stepper 外
+ */
+export type FiatTopupPhase =
+  | 'idle'
+  | 'pending'
+  | 'auth-taken'
+  | 'tx-broadcast'
+  | 'tx-confirmed'
+  | 'cleanup-queued'
+  | 'failure';
+
 /** authorize endpoint 応答 shape */
 export type AuthorizeResponse = {
   authId: string;
@@ -51,10 +75,40 @@ export type AuthorizeRequest = {
   cardToken: string;
 };
 
+/** topup endpoint 応答 shape (POST /api/v1/fiat-bid/topup、 Issue #3023) */
+export type TopupResponse = {
+  /** 新 authId (増額後の GMO 与信枠 ID) */
+  authId: string;
+  /** 旧 authId (async cleanup queue に enqueue 済) */
+  oldAuthId: string;
+  /** bid tx hash (成功時)、 revert 時 null */
+  txHash: string | null;
+  /** 遷移後 status */
+  status: 'bid-placed' | 'cancelled';
+  /** 新 JPY 額 (増額後) */
+  jpyAmount: number;
+  /** 新 ETH 額 wei (増額後、 文字列) */
+  ethAmount: string;
+  /** 新 spot rate */
+  spotRate: number;
+  /** spot rate 取得元 */
+  spotRateSource: 'gmo' | 'coingecko';
+  /** user 通知 msg */
+  message: string;
+};
+
+/** topup request body (webapp が backend に送出) */
+export type TopupRequest = {
+  authId: string;
+  newJpyAmount: number;
+  cardToken: string;
+};
+
 /** hook 内で使う fetcher 契約 (test 差替可能) */
 export type FiatBidFetchers = {
   authorize: (body: AuthorizeRequest) => Promise<AuthorizeResponse>;
   placeBid: (body: { authId: string }) => Promise<PlaceBidResponse>;
+  topup: (body: TopupRequest) => Promise<TopupResponse>;
 };
 
 /**
@@ -104,6 +158,28 @@ export const defaultPlaceBidFetch = async (body: { authId: string }): Promise<Pl
   return (await response.json()) as PlaceBidResponse;
 };
 
+/**
+ * default topup fetcher = env base + /api/v1/fiat-bid/topup に POST
+ *
+ * backend (Issue #3023) は 5 phase sequential + async cleanup enqueue を実施、
+ * 応答時点で Phase D (enqueue) 完了、 async cleanup 完了は観測不能。
+ */
+export const defaultTopupFetch = async (body: TopupRequest): Promise<TopupResponse> => {
+  const response = await fetch(buildEndpoint('/api/v1/fiat-bid/topup'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = (await response.json().catch(() => ({ error: 'InternalError' }))) as {
+      error?: string;
+      message?: string;
+    };
+    throw new Error(`topup failed: ${err.error ?? 'unknown'} — ${err.message ?? ''}`);
+  }
+  return (await response.json()) as TopupResponse;
+};
+
 /** hook option */
 export type UseFiatBidOptions = {
   fetchers?: Partial<FiatBidFetchers>;
@@ -137,18 +213,21 @@ const defaultRedirect = (url: string): void => {
 export const useFiatBid = (options: UseFiatBidOptions = {}) => {
   const authorizeFetch = options.fetchers?.authorize ?? defaultAuthorizeFetch;
   const placeBidFetch = options.fetchers?.placeBid ?? defaultPlaceBidFetch;
+  const topupFetch = options.fetchers?.topup ?? defaultTopupFetch;
   // fetchers を useMemo で安定化 (react-hooks/exhaustive-deps warn 対応、 useCallback deps を安定 ref に)
   const fetchers: FiatBidFetchers = useMemo(
-    () => ({ authorize: authorizeFetch, placeBid: placeBidFetch }),
-    [authorizeFetch, placeBidFetch],
+    () => ({ authorize: authorizeFetch, placeBid: placeBidFetch, topup: topupFetch }),
+    [authorizeFetch, placeBidFetch, topupFetch],
   );
   const saveState = options.saveState ?? defaultSaveState;
   const redirect = options.redirect ?? defaultRedirect;
 
   const [step, setStep] = useState<FiatBidStep>('idle');
+  const [topupPhase, setTopupPhase] = useState<FiatTopupPhase>('idle');
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
   const [authResult, setAuthResult] = useState<AuthorizeResponse | undefined>(undefined);
   const [placeBidResult, setPlaceBidResult] = useState<PlaceBidResponse | undefined>(undefined);
+  const [topupResult, setTopupResult] = useState<TopupResponse | undefined>(undefined);
 
   /**
    * authorize + 3DS redirect action。
@@ -212,20 +291,66 @@ export const useFiatBid = (options: UseFiatBidOptions = {}) => {
     [fetchers],
   );
 
+  /**
+   * topup action — 増額 bid endpoint 呼出 + 5 phase state 遷移。
+   *
+   * topup endpoint (POST /api/v1/fiat-bid/topup、 Issue #3023) は同期返却で
+   * Phase A-E を sequential 実行、 応答時点で Phase D (旧 auth cleanup enqueue) 完了。
+   * async cleanup 実行完了は観測不能なので stepper 外 (別 tab disclaimer で説明)。
+   *
+   * 5 phase の遷移経路 —
+   * - 呼出前 → pending (呼出直前 setState)
+   * - topup fetch 成功 → auth-taken → tx-broadcast → tx-confirmed → cleanup-queued の即時遷移 (endpoint 応答時に 4 phase 完了扱い)
+   * - status = "cancelled" → failure (bid tx revert、 旧 auth 保持)
+   * - fetch error → failure
+   *
+   * grilling P7 A' 案の設計 = endpoint 応答は「全 phase 完了」 で観測可能な 1 event なので
+   * 5 phase の視覚遷移は「呼出直前 = pending → 応答 = cleanup-queued」 の 2 event 表示。
+   * 中間 phase は progress bar の label 順次 show で simulate (setState + setTimeout の連鎖ではなく、
+   * endpoint 応答直後に final phase に飛ばす + label 順次 show は modal 側で管理する契約)。
+   */
+  const topup = useCallback(
+    async (body: TopupRequest): Promise<TopupResponse | undefined> => {
+      setTopupPhase('pending');
+      setErrorMessage(undefined);
+      try {
+        const result = await fetchers.topup(body);
+        setTopupResult(result);
+        if (result.status === 'bid-placed') {
+          setTopupPhase('cleanup-queued');
+        } else {
+          setTopupPhase('failure');
+          setErrorMessage(result.message);
+        }
+        return result;
+      } catch (err) {
+        setTopupPhase('failure');
+        setErrorMessage(err instanceof Error ? err.message : String(err));
+        return undefined;
+      }
+    },
+    [fetchers],
+  );
+
   const reset = useCallback(() => {
     setStep('idle');
+    setTopupPhase('idle');
     setErrorMessage(undefined);
     setAuthResult(undefined);
     setPlaceBidResult(undefined);
+    setTopupResult(undefined);
   }, []);
 
   return {
     step,
+    topupPhase,
     errorMessage,
     authResult,
     placeBidResult,
+    topupResult,
     authorize,
     placeBid,
+    topup,
     reset,
   };
 };

--- a/packages/niji-webapp/src/state/atoms/auctionAtom.ts
+++ b/packages/niji-webapp/src/state/atoms/auctionAtom.ts
@@ -20,6 +20,84 @@ const initialState: AuctionState = {
 };
 
 /**
+ * 増額 bid の 5 phase state 識別子 (Issue #3025 Phase 2 grilling P7 A' 案)
+ *
+ * webapp UI が topup endpoint 応答に応じて stepper 遷移する際の SSOT。
+ * useFiatBid hook 側の FiatTopupPhase と同 shape、 hook 内 state と atom 間で
+ * 直接 share せず, 起動元 (Bid component) が hook state を atom へ反映する契約。
+ */
+export type TopupStatePhase =
+  | 'idle'
+  | 'pending'
+  | 'auth-taken'
+  | 'tx-broadcast'
+  | 'tx-confirmed'
+  | 'cleanup-queued'
+  | 'failure';
+
+/**
+ * 旧 authorization の async cleanup phase 識別子 (endpoint 応答後の非同期経路)
+ *
+ * queued  = topup endpoint 応答時点 (cleanup queue に enqueue 済、 実行 5 秒 delay 待機中)
+ * running = cleanup worker が GMO alterTran VOID を発火中 (webapp から観測不能、 backend log のみ)
+ * done    = cleanup 完了 (旧 authorization VOID 成功、 webapp から観測不能)
+ *
+ * 観測不能 phase のため webapp 表示は queued 固定 + 「別 tab で作業続行可」 disclaimer で説明する。
+ */
+export type CleanupPhase = 'idle' | 'queued' | 'running' | 'done';
+
+/**
+ * 増額 bid 中の transient state (auction 落札状態と分離)。
+ *
+ * Phase 2 mvp は modal ローカル state で完結、 atom へ晒すのは
+ * (a) 他 component から「増額 bid 中」 を参照したい場合の hook 経路
+ * (b) chain event 経由で bid 増額を検知したときの表示更新の 2 用途に閉じる。
+ */
+export interface TopupState {
+  /** 増額 bid の現 phase (5 phase stepper 表示用) */
+  phase: TopupStatePhase;
+  /** 旧 authorization の cleanup phase (async 完了は観測不能) */
+  cleanupPhase: CleanupPhase;
+  /** 増額 bid 対象の旧 authId (topup endpoint request の authId) */
+  oldAuthId?: string;
+  /** 増額 bid 完了後の新 authId (endpoint 応答の authId) */
+  newAuthId?: string;
+}
+
+const initialTopupState: TopupState = {
+  phase: 'idle',
+  cleanupPhase: 'idle',
+};
+
+/**
+ * 増額 bid の 5 phase + async cleanup state atom (Issue #3025)
+ *
+ * FiatBidModal 内の useFiatBid hook state を setter 経由で反映する契約、
+ * atom 側は presentation state のみ管理 (network call は hook が担当、 SoC 保持)。
+ */
+export const topupStateAtom = atom<TopupState>(initialTopupState);
+
+export const applyTopupPhase = (
+  state: TopupState,
+  payload: { phase: TopupStatePhase; oldAuthId?: string; newAuthId?: string },
+): TopupState => ({
+  ...state,
+  phase: payload.phase,
+  oldAuthId: payload.oldAuthId ?? state.oldAuthId,
+  newAuthId: payload.newAuthId ?? state.newAuthId,
+});
+
+export const applyCleanupPhase = (
+  state: TopupState,
+  payload: { cleanupPhase: CleanupPhase },
+): TopupState => ({
+  ...state,
+  cleanupPhase: payload.cleanupPhase,
+});
+
+export const resetTopupState = (): TopupState => initialTopupState;
+
+/**
  * Current auction の view state (websocket / wagmi watch event 経由で更新)。
  *
  * 旧 Redux slice (state/slices/auction.ts) を Jotai atom に 1:1 移行したもの (Issue #215、


### PR DESCRIPTION
## Summary

FiatBidModal に「増額 bid」 branch と 5 phase stepper (Phase 1 の 4 段 + async cleanup phase 追加) を実装する。
Phase 2 grilling P7 A' 案の webapp 実装、 backend topup endpoint (#3023) を消費して 5 phase state を管理する。

## 主な変更点

- `packages/niji-webapp/src/hooks/useFiatBid.ts` — `topup` action + `FiatTopupPhase` state + `TopupResponse` / `TopupRequest` 型追加、 `defaultTopupFetch` 実装
- `packages/niji-webapp/src/state/atoms/auctionAtom.ts` — `topupStateAtom` + `TopupState` / `CleanupPhase` / `TopupStatePhase` 型 + 3 pure updater (applyTopupPhase / applyCleanupPhase / resetTopupState) 追加
- `packages/niji-webapp/src/components/FiatBidModal/index.tsx` — `existingFiatBid` prop 経路で「増額 bid」 mode 切替、 `validateTopupJpyAmount` (旧 jpyAmount 超過 + 100 万円上限 の 2 層 client validation)、 5 phase stepper label + cleanup phase disclaimer 表示
- `packages/niji-webapp/src/components/FiatBidModal/index.test.tsx` — 増額 bid 9 case 追加 (5 validation unit + 4 modal behavior)

## Test plan

- [x] `validateTopupJpyAmount` unit 5 case (旧 jpyAmount 以下 / 未満 / 上限超過 / 正常 / 空文字)
- [x] existingFiatBid 存在時に modal `data-mode=topup` + title「増額 bid」 + 既存 bid summary 表示 + submit label「増額 bid を実行」
- [x] 増額額 <= 旧 jpyAmount 入力で validation エラー「増額のみ受付可能」 + submit disable
- [x] 増額額 > BID_LIMIT_JPY で validation エラー「bid 上限」 + submit disable
- [x] submit で topup endpoint 呼出 (`authId: auth-1`, `newJpyAmount: 80000`, `cardToken`) + 5 phase stepper `data-step=cleanup-queued` 遷移 + cleanup disclaimer「非同期」「別 tab」 表示確認
- [x] Phase 1 既存 8 case 100% 維持 (validateJpyAmount 5 + FiatBidModal 3)
- [x] FiatBidModal 全 17 case pass
- [x] niji-webapp 全 9849 case pass (regression 0)
- [x] `pnpm tsc --noEmit` 0 error
- [x] `pnpm -w lint packages/niji-webapp/src/...` 0 error (warnings は既存パターン維持)

## Closes

Closes #3025

## Refs

- Phase 2 spec — `tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md` § P7
- Phase 2 breakdown — `tests/spec/gmo-fiat-bid/Phase2-02-issue-breakdown.md` § Issue P2-4
- Backend topup endpoint — #3023 (merged)
- Next blocker — #3026 (e2e spec、 本 PR merge 後)

Test plan details

- [x] Local vitest — `pnpm exec vitest run src/components/FiatBidModal/index.test.tsx` = 17 pass
- [x] Local vitest full — `pnpm exec vitest run` = 9849 pass / 1 skipped / 1 todo (Phase 1 baseline 維持)
- [x] Local tsc — `pnpm --filter @niji/webapp exec tsc --noEmit` = 0 error
- [x] Local lint — `pnpm -w lint <4 files>` = 0 error / 4 warnings (既存パターン)