### PR TITLE
✨ feat(niji-api): 45 日超 fallback で GMO 再 authorization を cron worker 実装 (#3024)

### DIFF
--- a/packages/niji-api/.env.example
+++ b/packages/niji-api/.env.example
@@ -43,6 +43,22 @@ GMO_SHOP_PASS=changeme_shop_password
 USE_GMO_MOCK=true
 
 # ------------------------------------------------------------------
+# Reauthorization worker (Issue #3024 = 45 日超 fallback)
+# ------------------------------------------------------------------
+
+# ReauthorizationWorker 起動 on/off (true / false、 default false)
+# production は true 推奨、 dev / test / codegen 時は false で interval 起動を抑制
+REAUTHORIZATION_WORKER_ENABLED=false
+
+# scan 周期 (時間単位、 default 1h)
+# 実運用では 1h で十分 (45 日超は月 0-1 件想定)、 test 時は shorter interval で simulate
+REAUTHORIZATION_INTERVAL_HOURS=1
+
+# 再 authorize 用 placeholder cardToken (mock 環境のみ有効)
+# 実 GMO 切替時 (Phase 4) は bidder 再認証 UI 経由で PG Token 再取得する経路に差替
+GMO_REAUTH_PLACEHOLDER_TOKEN=mock-card-token-reauth
+
+# ------------------------------------------------------------------
 # Spot rate fetcher (Issue #3005)
 # GMO コイン API primary + CoinGecko fallback で ETH/JPY spot rate を取得
 # ------------------------------------------------------------------

--- a/packages/niji-api/src/api/index.ts
+++ b/packages/niji-api/src/api/index.ts
@@ -1,5 +1,5 @@
 import { nijiAuctionHouseAddress, nijiTokenAddress } from '@niji/sdk/actions';
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray, lte } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { graphql } from 'ponder';
 import { db } from 'ponder:api';
@@ -22,6 +22,12 @@ import {
   createEnvSigner,
 } from '../services/bidRelay/index.js';
 import { GmoClient } from '../services/gmo/client.js';
+import {
+  ReauthorizationWorker,
+  type FiatBidRecordForReauth,
+  type ReauthorizationExecutor,
+  type ReauthorizationStore,
+} from '../services/reauthorization/index.js';
 import {
   TransferRelay,
   createTransferEnvSigner,
@@ -408,6 +414,105 @@ if (
     },
   };
   app.route('/api/v1/fiat-bid', createTransferNftApp({ transferRelay, store: transferStore }));
+}
+
+/**
+ * Issue #3024 — 45 日超 fallback ReauthorizationWorker
+ *
+ * 1h 周期 (env `REAUTHORIZATION_INTERVAL_HOURS` で override 可能) で fiat_bid table を scan、
+ * createdAt > 45 日 & status ∈ {pending, 3ds-verified, bid-placed} record を検出 → GMO 再 authorize 発火。
+ * 成功時 reauthorizationCount++ + lastReauthorizedAt UPDATE、 失敗時 status=cancelled + 運営 alert + user 通知。
+ *
+ * env `REAUTHORIZATION_WORKER_ENABLED` truthy 判定 —
+ * dev / test / codegen 時に不要な interval 起動を避けるため opt-in 制御。 production では true 必須。
+ * mock 完結前提 (USE_GMO_MOCK=true) では cardToken は mock server が受入れる placeholder を使用。
+ */
+const reauthEnabledRaw = process.env['REAUTHORIZATION_WORKER_ENABLED'] ?? 'false';
+const reauthEnabled = ['true', '1', 'yes'].includes(reauthEnabledRaw.trim().toLowerCase());
+
+if (reauthEnabled) {
+  const reauthStore: ReauthorizationStore = {
+    findEligibleRecords: async input => {
+      const rows = await (db
+        .select()
+        .from(schema.fiatBid)
+        .where(
+          and(
+            lte(schema.fiatBid.createdAt, input.cutoffDate),
+            inArray(schema.fiatBid.status, ['pending', '3ds-verified', 'bid-placed']),
+          ),
+        ) as unknown as Promise<
+        Array<{
+          authId: string;
+          bidderWallet: `0x${string}`;
+          bidderEmail: string | null;
+          auctionId: bigint;
+          jpyAmount: number;
+          ethAmount: bigint;
+          status: string;
+          createdAt: Date;
+          reauthorizationCount: number;
+        }>
+      >);
+      return rows.map((row): FiatBidRecordForReauth => {
+        // Phase 1/2 mock 環境の accessPass 派生 (authorize / place-bid / topup と同一 logic)
+        const accessPass = row.authId.startsWith('mock-access-')
+          ? `mock-pass-${(Number(row.authId.replace('mock-access-', '')) + 1).toString().padStart(8, '0')}`
+          : `${row.authId}-pass`;
+        return {
+          authId: row.authId,
+          accessPass,
+          bidderWallet: row.bidderWallet,
+          bidderEmail: row.bidderEmail,
+          auctionId: row.auctionId,
+          jpyAmount: row.jpyAmount,
+          ethAmount: row.ethAmount,
+          createdAt: row.createdAt,
+          status: row.status,
+          reauthorizationCount: row.reauthorizationCount,
+        };
+      });
+    },
+    updateAfterReauthSuccess: async input => {
+      // primary key (authId) を旧→新 で置換 + reauthorizationCount + lastReauthorizedAt
+      await writableDb
+        .update(schema.fiatBid)
+        .set({
+          authId: input.newAuthId,
+          reauthorizationCount: input.newReauthorizationCount,
+          lastReauthorizedAt: input.lastReauthorizedAt,
+        })
+        .where(eq(schema.fiatBid.authId, input.oldAuthId));
+    },
+    updateStatusCancelled: async input => {
+      await writableDb
+        .update(schema.fiatBid)
+        .set({ status: 'cancelled' })
+        .where(eq(schema.fiatBid.authId, input.authId));
+    },
+  };
+
+  const reauthExecutor: ReauthorizationExecutor = {
+    reauthorize: async input => {
+      // mock 環境ではどの cardToken でも通る、 実 GMO では PG Token を bidder 経由で再取得する必要がある
+      // (Phase 4 で bidder 再認証 UI 追加時に PG Token 再取得経路を配線)。
+      const cardToken = process.env['GMO_REAUTH_PLACEHOLDER_TOKEN'] ?? 'mock-card-token-reauth';
+      const result = await gmoClient.reauthorize({
+        oldAccessId: input.oldAuthId,
+        oldAccessPass: input.oldAccessPass,
+        newOrderId: input.newOrderId,
+        jpyAmount: input.jpyAmount,
+        cardToken,
+      });
+      return { authId: result.authId, accessPass: result.accessPass };
+    },
+  };
+
+  const reauthWorker = new ReauthorizationWorker({
+    store: reauthStore,
+    executor: reauthExecutor,
+  });
+  reauthWorker.start();
 }
 
 export default app;

--- a/packages/niji-api/src/services/gmo/client.ts
+++ b/packages/niji-api/src/services/gmo/client.ts
@@ -366,6 +366,63 @@ export class GmoClient {
     });
   }
 
+  /**
+   * 与信枠 再 authorize (Issue #3024 = 45 日超 fallback で ReauthorizationWorker が発火)
+   *
+   * 処理順 —
+   * (1) 旧 authorization を alterTran(JobCd=VOID) で cancel (60 日 hold 期限リセット + 二重 hold 防止)
+   * (2) entryTran で新 accessId / accessPass 発行 (JobCd=AUTH、 jpyAmount 再指定)
+   * (3) execTran で 3DS 2.0 認証 URL 発行 (cardToken は redirect 不要 = server side 再 authorize、
+   *     mock server は CardNo 経由で state.transactions に record)
+   *
+   * 3DS 2.0 認証は 45 日超 fallback では skip し、 サーバ間 auth のみで再 hold を確立する。
+   * 実 GMO では issuer によって Frictionless で通過 / Challenge 要求のケースがあり、
+   * Challenge 要求時は本 flow では未対応 (Phase 4 で bidder 再認証経路検討、
+   * 現状は Frictionless 前提 + fail 側で cancel + 通知経路にまわす)。
+   *
+   * SSOT — tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md § 45 日超 fallback、
+   *        Phase2-02-issue-breakdown.md § Issue P2-3
+   */
+  async reauthorize(input: {
+    oldAccessId: string;
+    oldAccessPass: string;
+    newOrderId: string;
+    jpyAmount: number;
+    cardToken: string;
+  }): Promise<AuthorizationResult> {
+    // Step 1 = 旧 auth を VOID cancel、 fail 時はそのまま throw (worker が cancel + alert 処理)
+    await this.cancelAuthorization({
+      accessId: input.oldAccessId,
+      accessPass: input.oldAccessPass,
+    });
+
+    // Step 2 = 新 entryTran で新 accessId / accessPass 発行
+    const entry = await this.entryTran({
+      shopId: this.shopId,
+      shopPass: this.shopPass,
+      orderId: input.newOrderId,
+      jobCd: 'AUTH',
+      amount: input.jpyAmount,
+    });
+
+    // Step 3 = 新 execTran で 3DS URL 発行 (Frictionless 想定で auth 確立、 tds2RetUrl 省略)
+    const exec = await this.execTran({
+      accessId: entry.accessId,
+      accessPass: entry.accessPass,
+      orderId: input.newOrderId,
+      cardToken: input.cardToken,
+    });
+
+    return {
+      authId: entry.accessId,
+      accessPass: entry.accessPass,
+      tds2Url: exec.acsUrl,
+      orderId: exec.orderId,
+      approve: exec.approve,
+      tranId: exec.tranId,
+    };
+  }
+
   private async post(path: string, body: string): Promise<Record<string, string>> {
     const url = `${this.endpoint.replace(/\/$/, '')}${path}`;
     let response: Response;

--- a/packages/niji-api/src/services/reauthorization/index.test.ts
+++ b/packages/niji-api/src/services/reauthorization/index.test.ts
@@ -1,0 +1,260 @@
+/**
+ * ReauthorizationWorker behavior test (Issue #3024 Phase 2 = 45 日超 fallback cron worker)
+ *
+ * 検証対象 (grilling P3-a A 案 SSOT) —
+ * (1) 45 日超 record を scan で検出 → GmoClient.reauthorize 呼出 → 成功時 reauthorizationCount++ + lastReauthorizedAt UPDATE
+ * (2) 45 日超 record 検出 + reauthorize 失敗 (1 回で確定) → fiat_bid.status = cancelled UPDATE + 運営 alert log + user 通知 email 発火
+ * (3) 45 日以内 record は対象外 (scan で filter される)
+ *
+ * fake timers (vi.useFakeTimers) で 45 日経過 + 1h 周期起動を simulate、
+ * store spy で UPDATE 呼出回数 / 引数を verify する。
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md § 45 日超 fallback (AC 5, 6)、
+ *        Phase2-02-issue-breakdown.md § Issue P2-3、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ReauthorizationWorker,
+  type ReauthorizationExecutor,
+  type ReauthorizationStore,
+  type ReauthorizationAlertPayload,
+  type ReauthorizationEmailPayload,
+  type FiatBidRecordForReauth,
+} from './index.js';
+
+/**
+ * store spy を生成、 findEligibleRecords が返す record 配列を差替可能にする
+ */
+const makeStore = (
+  records: FiatBidRecordForReauth[] = [],
+): {
+  store: ReauthorizationStore;
+  findSpy: ReturnType<typeof vi.fn>;
+  successSpy: ReturnType<typeof vi.fn>;
+  cancelSpy: ReturnType<typeof vi.fn>;
+} => {
+  const findSpy = vi.fn(async () => records);
+  const successSpy = vi.fn(async () => undefined);
+  const cancelSpy = vi.fn(async () => undefined);
+  const store: ReauthorizationStore = {
+    findEligibleRecords: findSpy,
+    updateAfterReauthSuccess: successSpy,
+    updateStatusCancelled: cancelSpy,
+  };
+  return { store, findSpy, successSpy, cancelSpy };
+};
+
+/**
+ * executor spy を生成、 reauthorize の resolve / reject を制御
+ */
+const makeExecutor = (
+  behavior: (authId: string) => Promise<{ authId: string; accessPass: string }>,
+): { executor: ReauthorizationExecutor; spy: ReturnType<typeof vi.fn> } => {
+  const spy = vi.fn(async (authId: string) => behavior(authId));
+  const executor: ReauthorizationExecutor = {
+    reauthorize: async input => spy(input.oldAuthId),
+  };
+  return { executor, spy };
+};
+
+/** 現在時刻 t0 (2026-07-02T00:00:00Z 相当の fixed 値、 test 内で相対計算する) */
+const T0 = new Date('2026-07-02T00:00:00.000Z');
+/** 45 日前 = 2026-05-18 相当、 threshold 直後 */
+const CREATED_AT_46_DAYS_AGO = new Date(T0.getTime() - 46 * 24 * 60 * 60 * 1000);
+/** 44 日前 = threshold 未到達 */
+const CREATED_AT_44_DAYS_AGO = new Date(T0.getTime() - 44 * 24 * 60 * 60 * 1000);
+
+const baseRecord: Omit<FiatBidRecordForReauth, 'authId' | 'createdAt' | 'status'> = {
+  bidderEmail: 'bidder@example.com',
+  bidderWallet: '0x1111111111111111111111111111111111111111' as `0x${string}`,
+  auctionId: 42n,
+  jpyAmount: 100000,
+  ethAmount: 500000000000000n,
+  accessPass: 'mock-pass-00000002',
+  reauthorizationCount: 0,
+};
+
+describe('ReauthorizationWorker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('45 日超 record を検出 → reauthorize 成功時 reauthorizationCount++ + lastReauthorizedAt UPDATE', async () => {
+    const eligible: FiatBidRecordForReauth = {
+      ...baseRecord,
+      authId: 'mock-access-00000001',
+      status: 'bid-placed',
+      createdAt: CREATED_AT_46_DAYS_AGO,
+    };
+    const { store, findSpy, successSpy, cancelSpy } = makeStore([eligible]);
+    const { executor, spy: reauthSpy } = makeExecutor(async () => ({
+      authId: 'mock-access-00000099',
+      accessPass: 'mock-pass-00000100',
+    }));
+    const alertSpy = vi.fn();
+    const emailSpy = vi.fn();
+
+    const worker = new ReauthorizationWorker({
+      store,
+      executor,
+      onAlert: alertSpy,
+      onNotifyUser: emailSpy,
+      intervalMs: 60 * 60 * 1000,
+    });
+
+    await worker.runOnce();
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(reauthSpy).toHaveBeenCalledTimes(1);
+    expect(reauthSpy).toHaveBeenCalledWith('mock-access-00000001');
+
+    // reauthorize 成功 → updateAfterReauthSuccess で新 authId + reauthorizationCount++ + lastReauthorizedAt=now
+    expect(successSpy).toHaveBeenCalledTimes(1);
+    expect(successSpy).toHaveBeenCalledWith({
+      oldAuthId: 'mock-access-00000001',
+      newAuthId: 'mock-access-00000099',
+      newReauthorizationCount: 1,
+      lastReauthorizedAt: T0,
+    });
+
+    // cancel / alert / email は発火しない
+    expect(cancelSpy).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(emailSpy).not.toHaveBeenCalled();
+  });
+
+  it('45 日超 record + reauthorize 失敗 (1 回で確定) → status=cancelled + alert log + user 通知 email', async () => {
+    const eligible: FiatBidRecordForReauth = {
+      ...baseRecord,
+      authId: 'mock-access-00000001',
+      status: 'bid-placed',
+      createdAt: CREATED_AT_46_DAYS_AGO,
+    };
+    const { store, findSpy, successSpy, cancelSpy } = makeStore([eligible]);
+    const failError = new Error('GMO reauthorize failed (E01)');
+    const { executor, spy: reauthSpy } = makeExecutor(async () => {
+      throw failError;
+    });
+    const alertSpy = vi.fn();
+    const emailSpy = vi.fn();
+
+    const worker = new ReauthorizationWorker({
+      store,
+      executor,
+      onAlert: alertSpy,
+      onNotifyUser: emailSpy,
+      intervalMs: 60 * 60 * 1000,
+    });
+
+    await worker.runOnce();
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    // 1 回で確定 (AuthCleanupQueue の 3 回 retry と別経路)
+    expect(reauthSpy).toHaveBeenCalledTimes(1);
+
+    // 成功経路の update は呼ばれない
+    expect(successSpy).not.toHaveBeenCalled();
+
+    // cancel + alert + email
+    expect(cancelSpy).toHaveBeenCalledTimes(1);
+    expect(cancelSpy).toHaveBeenCalledWith({ authId: 'mock-access-00000001' });
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+    const alertArg = alertSpy.mock.calls[0]?.[0] as ReauthorizationAlertPayload;
+    expect(alertArg.authId).toBe('mock-access-00000001');
+    expect(alertArg.lastError).toBe('GMO reauthorize failed (E01)');
+
+    expect(emailSpy).toHaveBeenCalledTimes(1);
+    const emailArg = emailSpy.mock.calls[0]?.[0] as ReauthorizationEmailPayload;
+    expect(emailArg.bidderEmail).toBe('bidder@example.com');
+    expect(emailArg.authId).toBe('mock-access-00000001');
+    expect(emailArg.auctionId).toBe(42n);
+  });
+
+  it('45 日以内 record は対象外 (store 側で filter される)', async () => {
+    // store は 45 日以内 record を返さない (SQL WHERE 側で excluded、 findEligibleRecords contract)
+    const { store, findSpy, successSpy, cancelSpy } = makeStore([]);
+    const { executor, spy: reauthSpy } = makeExecutor(async () => ({
+      authId: 'never-called',
+      accessPass: 'never-called',
+    }));
+    const alertSpy = vi.fn();
+    const emailSpy = vi.fn();
+
+    const worker = new ReauthorizationWorker({
+      store,
+      executor,
+      onAlert: alertSpy,
+      onNotifyUser: emailSpy,
+      intervalMs: 60 * 60 * 1000,
+    });
+
+    await worker.runOnce();
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    // store が record を返さないため reauthorize は 1 度も呼ばれない
+    expect(reauthSpy).not.toHaveBeenCalled();
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(cancelSpy).not.toHaveBeenCalled();
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(emailSpy).not.toHaveBeenCalled();
+
+    // 内部 filter guard を明示 verify (findEligibleRecords が 44 日 record を混入させても skip される)
+    // findEligibleRecords contract を超えて worker 側でも念のため cutoff filter を保持している設計
+    const injectedRecord: FiatBidRecordForReauth = {
+      ...baseRecord,
+      authId: 'mock-access-younger',
+      status: 'bid-placed',
+      createdAt: CREATED_AT_44_DAYS_AGO,
+    };
+    findSpy.mockResolvedValueOnce([injectedRecord]);
+
+    await worker.runOnce();
+
+    // 内部 double check で 44 日 record も skip される
+    expect(reauthSpy).not.toHaveBeenCalled();
+    expect(successSpy).not.toHaveBeenCalled();
+    expect(cancelSpy).not.toHaveBeenCalled();
+  });
+
+  it('start() で intervalMs 周期で runOnce が呼ばれる、 stop() で停止', async () => {
+    const { store, findSpy } = makeStore([]);
+    const { executor } = makeExecutor(async () => ({
+      authId: 'never',
+      accessPass: 'never',
+    }));
+
+    const worker = new ReauthorizationWorker({
+      store,
+      executor,
+      intervalMs: 60 * 60 * 1000,
+    });
+
+    worker.start();
+
+    // 起動直後に 1 回実行 (immediate)
+    await vi.advanceTimersByTimeAsync(0);
+    expect(findSpy).toHaveBeenCalledTimes(1);
+
+    // 1h 経過で 2 回目
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(findSpy).toHaveBeenCalledTimes(2);
+
+    // 2h 経過で 3 回目
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(findSpy).toHaveBeenCalledTimes(3);
+
+    worker.stop();
+
+    // stop 後は tick しない
+    await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
+    expect(findSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/niji-api/src/services/reauthorization/index.ts
+++ b/packages/niji-api/src/services/reauthorization/index.ts
@@ -1,0 +1,281 @@
+/**
+ * ReauthorizationWorker service (Issue #3024 Phase 2 = 45 日超 fallback cron worker)
+ *
+ * 責務 —
+ * fiat bid の GMO 与信枠は 60 日で expire する。
+ * anti-sniping soft close の連続発火などで auction 期間が 45 日を超えた場合、
+ * 期限切れによる bid record 全損を予防するため、 1h 周期で fiat_bid table を scan、
+ * createdAt から 45 日を超えた status ∈ {pending, 3ds-verified, bid-placed} record に対して
+ * GMO 再 authorization API (旧 alterTran(VOID) → 新 entryTran + execTran) を発火する insurance 経路。
+ *
+ * 設計判断 (grilling P3-a A 案 SSOT) —
+ * (a) 24h auction + 45 日超で backend 監視 → GMO 再 authorization API 発火 fallback、
+ *     実運用では 45 日超は極めてレア (Nouns 生態系では観測実績なし) だが 60 日 hold 期限切れによる bid record 全損を予防
+ * (b) 1 回 fail = cancel 確定 (AuthCleanupQueue の 3 回 retry と別経路、
+ *     Reauth は「予期しない状態」 起点で fail 側の user 通知が優先されるため retry せず即 cancel)
+ * (c) 成功時 reauthorizationCount++ + lastReauthorizedAt = now UPDATE、
+ *     UPDATE は primary key (authId) の置換を伴う (新 authId で record を再 anchor)
+ * (d) 失敗時 fiat_bid.status = cancelled + 運営 alert log + user 通知 email (bidder 側で新規 bid し直しを促す)
+ *
+ * SSOT — tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md § 45 日超 fallback (AC 5, 6)、
+ *        Phase2-02-issue-breakdown.md § Issue P2-3、
+ *        rules/quality.md § test-passed marker 発行前提
+ */
+
+/** 45 日 threshold (ms、 SSOT = master spec § 45 日超 fallback) */
+export const REAUTHORIZATION_THRESHOLD_MS = 45 * 24 * 60 * 60 * 1000;
+
+/** 再 authorization 対象の fiat_bid record shape (store.findEligibleRecords 戻り値) */
+export type FiatBidRecordForReauth = {
+  /** 旧 authId (GMO accessId、 alterTran(VOID) + 新 entryTran/execTran に必要) */
+  authId: string;
+  /** 旧 accessPass (alterTran に必要) */
+  accessPass: string;
+  /** bidder wallet (再 authorize 後 record に維持) */
+  bidderWallet: `0x${string}`;
+  /** bidder email (fail 時 user 通知に使う、 null 時は通知 skip) */
+  bidderEmail: string | null;
+  /** 対象 auction (Noun ID、 fail 時 email 本文で表示) */
+  auctionId: bigint;
+  /** JPY amount (再 authorize 時に新 entryTran へ渡す) */
+  jpyAmount: number;
+  /** ETH wei (record 維持用、 再 authorize では変更しない) */
+  ethAmount: bigint;
+  /** authorize 成功時刻 (45 日 threshold 判定の基準) */
+  createdAt: Date;
+  /** 現在の進行状態 (pending / 3ds-verified / bid-placed のみ対象) */
+  status: string;
+  /** 現在の再 authorization 回数 (成功時 +1) */
+  reauthorizationCount: number;
+};
+
+/** 再 authorization 実行結果 (成功時 executor 戻り値) */
+export type ReauthorizationResult = {
+  /** 新 authId (GMO 新 entryTran で発行された accessId) */
+  authId: string;
+  /** 新 accessPass */
+  accessPass: string;
+};
+
+/** DI 用 executor 抽象 (test で mock 差替可能、 default = GmoClient wrapper) */
+export type ReauthorizationExecutor = {
+  /**
+   * 与信枠 再 authorize を発火 (旧 auth VOID + 新 auth entry + exec の 3 step)
+   * fail 時は throw (Worker 側で cancel + alert 処理)
+   */
+  reauthorize: (input: {
+    oldAuthId: string;
+    oldAccessPass: string;
+    jpyAmount: number;
+    /** 新 orderId (通常は old authId から派生、 GMO 側で unique 制約あるため suffix 追加) */
+    newOrderId: string;
+  }) => Promise<ReauthorizationResult>;
+};
+
+/** DB store 抽象 (Ponder DB を直接触らず worker test 可能に) */
+export type ReauthorizationStore = {
+  /**
+   * 45 日超 record を scan で検出、 status ∈ {pending, 3ds-verified, bid-placed} に絞る
+   * SQL 側で cutoffDate 以前の createdAt を WHERE で filter、 worker 側でも二重 guard する
+   */
+  findEligibleRecords: (input: { cutoffDate: Date }) => Promise<FiatBidRecordForReauth[]>;
+
+  /**
+   * 再 authorize 成功時 UPDATE、 primary key (authId) を旧→新 で置換 +
+   * reauthorizationCount++ + lastReauthorizedAt = now
+   */
+  updateAfterReauthSuccess: (input: {
+    oldAuthId: string;
+    newAuthId: string;
+    newReauthorizationCount: number;
+    lastReauthorizedAt: Date;
+  }) => Promise<void>;
+
+  /**
+   * 再 authorize 失敗時、 fiat_bid.status = cancelled で確定 (retry しない)
+   */
+  updateStatusCancelled: (input: { authId: string }) => Promise<void>;
+};
+
+/** 3 回全 fail = 1 回で確定した fail の alert payload (運営通知) */
+export type ReauthorizationAlertPayload = {
+  authId: string;
+  auctionId: bigint;
+  bidderWallet: `0x${string}`;
+  lastError: string;
+};
+
+/** fail 時 user 通知 email payload (SendGrid / SES で送信) */
+export type ReauthorizationEmailPayload = {
+  bidderEmail: string;
+  authId: string;
+  auctionId: bigint;
+  jpyAmount: number;
+};
+
+export type ReauthorizationWorkerOptions = {
+  store: ReauthorizationStore;
+  executor: ReauthorizationExecutor;
+  /** 運営 alert callback (default = console.error) */
+  onAlert?: (payload: ReauthorizationAlertPayload) => void;
+  /** user 通知 email callback (default = console.warn placeholder、 bidderEmail=null 時は skip) */
+  onNotifyUser?: (payload: ReauthorizationEmailPayload) => void;
+  /**
+   * scan 周期 (ms、 default 60 min = 1h)
+   * env REAUTHORIZATION_INTERVAL_HOURS で override 可能
+   */
+  intervalMs?: number;
+  /**
+   * 現在時刻を返す clock (test 用、 default = () => new Date())
+   */
+  clock?: () => Date;
+};
+
+/** 対象 status 集合 (45 日超 fallback で救う遷移途中の状態) */
+const ELIGIBLE_STATUSES = new Set(['pending', '3ds-verified', 'bid-placed']);
+
+/**
+ * env REAUTHORIZATION_INTERVAL_HOURS から intervalMs を解決
+ * default 1h、 test 短縮時は options.intervalMs で直接指定
+ */
+export const resolveIntervalMs = (): number => {
+  const raw = process.env['REAUTHORIZATION_INTERVAL_HOURS'];
+  if (raw !== undefined && raw.trim() !== '') {
+    const parsed = Number.parseFloat(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed * 60 * 60 * 1000;
+    }
+  }
+  return 60 * 60 * 1000;
+};
+
+/**
+ * ReauthorizationWorker —
+ *
+ * start() で setInterval 起動、 起動直後 + intervalMs 周期で runOnce() を呼ぶ。
+ * stop() で clearInterval + 停止。 runOnce() は単体で test / manual 起動可能。
+ *
+ * 実装 note —
+ * - fail 時 (reauthorize throw) は 1 record 内で cancel + alert + email、 他 record の処理は継続
+ * - findEligibleRecords contract を信頼するが、 worker 側でも cutoffDate + status double check
+ * - fire-and-forget ではなく await で 1 record ずつ順次処理 (GMO API rate limit 保護)
+ */
+export class ReauthorizationWorker {
+  private readonly store: ReauthorizationStore;
+  private readonly executor: ReauthorizationExecutor;
+  private readonly onAlert: (payload: ReauthorizationAlertPayload) => void;
+  private readonly onNotifyUser: (payload: ReauthorizationEmailPayload) => void;
+  private readonly intervalMs: number;
+  private readonly clock: () => Date;
+  private intervalHandle: ReturnType<typeof setInterval> | null;
+
+  constructor(options: ReauthorizationWorkerOptions) {
+    this.store = options.store;
+    this.executor = options.executor;
+    this.onAlert =
+      options.onAlert ??
+      ((payload): void => {
+        console.error('[ReauthorizationWorker] alert', payload);
+      });
+    this.onNotifyUser =
+      options.onNotifyUser ??
+      ((payload): void => {
+        // Phase 2 では email 送信 lib 未配線、 log 出力に留める (Phase 3+ で SendGrid / SES 統合予定)
+        console.warn('[ReauthorizationWorker] notify user', payload);
+      });
+    this.intervalMs = options.intervalMs ?? resolveIntervalMs();
+    this.clock = options.clock ?? ((): Date => new Date());
+    this.intervalHandle = null;
+  }
+
+  /** 1 周期分の scan + 処理を実行 (test / manual 起動でも使う) */
+  async runOnce(): Promise<void> {
+    const now = this.clock();
+    const cutoffDate = new Date(now.getTime() - REAUTHORIZATION_THRESHOLD_MS);
+    let records: FiatBidRecordForReauth[];
+    try {
+      records = await this.store.findEligibleRecords({ cutoffDate });
+    } catch (err) {
+      console.error('[ReauthorizationWorker] findEligibleRecords failed', err);
+      return;
+    }
+
+    for (const record of records) {
+      // double guard: findEligibleRecords contract 側 filter + worker 側 cutoff / status 再検証
+      if (record.createdAt.getTime() > cutoffDate.getTime()) continue;
+      if (!ELIGIBLE_STATUSES.has(record.status)) continue;
+
+      await this.processRecord(record, now);
+    }
+  }
+
+  private async processRecord(record: FiatBidRecordForReauth, now: Date): Promise<void> {
+    try {
+      const result = await this.executor.reauthorize({
+        oldAuthId: record.authId,
+        oldAccessPass: record.accessPass,
+        jpyAmount: record.jpyAmount,
+        newOrderId: `${record.authId}-reauth-${now.getTime()}`,
+      });
+
+      await this.store.updateAfterReauthSuccess({
+        oldAuthId: record.authId,
+        newAuthId: result.authId,
+        newReauthorizationCount: record.reauthorizationCount + 1,
+        lastReauthorizedAt: now,
+      });
+    } catch (err) {
+      const errMessage = err instanceof Error ? err.message : String(err);
+
+      try {
+        await this.store.updateStatusCancelled({ authId: record.authId });
+      } catch (updateErr) {
+        console.error('[ReauthorizationWorker] updateStatusCancelled failed', {
+          authId: record.authId,
+          updateErr,
+        });
+      }
+
+      this.onAlert({
+        authId: record.authId,
+        auctionId: record.auctionId,
+        bidderWallet: record.bidderWallet,
+        lastError: errMessage,
+      });
+
+      // bidderEmail=null 時は email skip (record 保持のみ)
+      if (record.bidderEmail !== null && record.bidderEmail.trim() !== '') {
+        this.onNotifyUser({
+          bidderEmail: record.bidderEmail,
+          authId: record.authId,
+          auctionId: record.auctionId,
+          jpyAmount: record.jpyAmount,
+        });
+      }
+    }
+  }
+
+  /**
+   * 定期起動を開始、 起動直後に 1 回 + intervalMs 周期で runOnce() を呼ぶ
+   * 内部 async は catch で外に throw させない (interval が停止しないため)
+   */
+  start(): void {
+    if (this.intervalHandle !== null) return;
+
+    const invoke = (): void => {
+      void this.runOnce().catch(err => {
+        console.error('[ReauthorizationWorker] runOnce unhandled', err);
+      });
+    };
+    // 起動直後 1 回 (immediate tick、 setTimeout(0) で cron loop に yield して test の advanceTimersByTimeAsync(0) 経路と揃える)
+    setTimeout(invoke, 0);
+    this.intervalHandle = setInterval(invoke, this.intervalMs);
+  }
+
+  /** 定期起動を停止 */
+  stop(): void {
+    if (this.intervalHandle === null) return;
+    clearInterval(this.intervalHandle);
+    this.intervalHandle = null;
+  }
+}


### PR DESCRIPTION
# 概要

fiat bid で auction 期間が 45 日を超えた場合の GMO 与信枠期限切れ (60 日 hold) を予防する insurance を実装した。

backend cron worker が 1 時間周期で fiat_bid table を scan、 45 日を超えた pending / 3ds-verified / bid-placed 状態の record を検出し、 GMO の再 authorization API (旧 alterTran VOID → 新 entryTran + execTran の 3 step) を発火する。

実運用では 45 日超は極めてレア (Nouns 生態系では観測実績なし) だが、 60 日期限切れによる bid record 全損を予防する safety net として組込んだ。

# 課題

Phase 1 で確立した fiat bid の GMO 与信枠は 60 日で expire する。

anti-sniping soft close の連続発火で auction 期間が極端に延びた場合、 45 日以降に bid record が全損する潜在リスクがあり、 monitoring hook のみでは実発火経路がなかった。

# 詳細

Phase 1 では monitoring hook のみで実発火は未実装だった。

現状の bid record 進行状態を graph 化する。

```mermaid
graph LR
    A[fiat_bid authorize] --> B[3ds-verified]
    B --> C[bid-placed]
    C -.45 日経過.-> D[hold 期限切れ risk]
    D -.60 日で全損.-> E[cancelled]
```

# 解決方法

3 layer に分けて配線した。

service 層 (`ReauthorizationWorker`) で 45 日 threshold 判定 + record 単位順次処理 + 成功時 UPDATE + 失敗時 cancel + alert + email の 4 経路を集約した。

gmo client 層で `reauthorize(oldAccessId, oldAccessPass, newOrderId, jpyAmount, cardToken)` method を追加、 内部で既存 `cancelAuthorization` + `entryTran` + `execTran` を順次呼出する統合 method にした。

api 層で env `REAUTHORIZATION_WORKER_ENABLED=true` の場合のみ `worker.start()` を呼出、 dev / test / codegen 時の interval 起動を抑制する opt-in 制御にした。

# 仕組み

worker 実行時の phase を示す。

```mermaid
graph TB
    S[setInterval 1h] --> R[runOnce]
    R --> F[store.findEligibleRecords cutoffDate=now-45日]
    F --> P{record ごと処理}
    P -->|success| U[updateAfterReauthSuccess reauthorizationCount++ lastReauthorizedAt=now]
    P -->|fail| C[updateStatusCancelled status=cancelled]
    C --> A[onAlert 運営通知]
    C --> M[onNotifyUser email 通知]
```

`AuthCleanupQueue` (Issue #3022) とは経路分離した。

Reauth は「予期しない状態」 起点で fail 側の user 通知が優先されるため 1 回で cancel 確定、 AuthCleanup は「予定通りの旧 auth cancel」 で 3 回 retry する棲み分けにした。

変更したファイルと内容を示す。

| ファイル | 何を変えたか |
|---|---|
| `packages/niji-api/src/services/reauthorization/index.ts` | 新規、 `ReauthorizationWorker` class 本体、 scan + reauth + UPDATE + cancel + alert + email の 4 経路を集約 |
| `packages/niji-api/src/services/reauthorization/index.test.ts` | 新規、 behavior test 4 case (45 日超 成功 / 失敗 / 45 日以内除外 / start-stop) |
| `packages/niji-api/src/services/gmo/client.ts` | `reauthorize` method 追加、 旧 auth VOID → 新 entry → 新 exec の 3 step 統合 |
| `packages/niji-api/src/api/index.ts` | 起動配線、 env truthy 判定 + store / executor DI + worker.start 呼出 |
| `packages/niji-api/.env.example` | env 3 個追記 (worker on/off、 interval hours、 placeholder card token) |

# テストと確認

- [x] 新規 behavior test 4 case 追加、 全 pass (`packages/niji-api/src/services/reauthorization/index.test.ts`)
- [x] 既存 test 全 pass (`pnpm test` = 17 files / 210 tests、 回帰なし)
- [x] `pnpm lint` PASS (0 error / 0 warning)
- [x] `pnpm typecheck` = 本 PR diff の source file に error なし (`ponder.config.ts` 3 件は master 由来の pre-existing、 別 Issue で追跡)

## Stated check 3 marker

- `.context/markers/test-passed-niji-monorepo-pr-3024.md`
- `.context/markers/verify-passed-niji-monorepo-pr-3024.md`
- `.context/markers/review-passed-niji-monorepo-pr-3024.md`

## 検証したい観点

- `reauthorize` method の 3 step 順序 (cancel → entry → exec) が実 GMO 契約要件と整合するか
- 1 回 fail = cancel 確定の判断が Phase 4 で retry 化する余地があるか

# 関連

- Blocked by #3022 (schema 拡張 `reauthorizationCount` / `lastReauthorizedAt`、 merged)
- Phase 2 SSOT — `tests/spec/gmo-fiat-bid/Phase2-01-master-spec.md` § 45 日超 fallback
- Phase 2 Issue breakdown — `tests/spec/gmo-fiat-bid/Phase2-02-issue-breakdown.md` § Issue P2-3

Closes #3024