### PR TITLE
🎨 style(niji-webapp): bid button を Niji pink (#E9265C 系) の軽めトーンに統一 (#3043)

### DIFF
--- a/packages/niji-webapp/src/components/Bid/Bid.module.css
+++ b/packages/niji-webapp/src/components/Bid/Bid.module.css
@@ -7,13 +7,15 @@
 }
 
 /*
- * bid button — primary CTA として存在感を強化 (Issue #3041)
- *   - background-color = palette dark-text (cool #151c3b / warm #221b1a)、 auction 背景 (light) と明確に対比
- *   - color = white で高 contrast (WCAG AA 準拠、 dark bg × white text)
+ * bid button — primary CTA として Niji pink 単一色に統一 (Issue #3043)
+ *   - background-color = --brand-niji-pink (#EC4A7A、 logo #E9265C から明度 up した軽めトーン)
+ *   - color = white で高 contrast (WCAG AA 準拠、 pink bg × white text)
  *   - width 100% で auction container 全幅、 margin 0 で inline 位置ズレなし
- *   - padding 12px 24px + font-size 20px + letter-spacing 0.02em で存在感 up
- *   - hover は brightness(0.85) で濃色を維持したまま暗く (accent 用の 0.95 とは方向逆)
- *   - disabled 時は gray + white text 維持 (Nouns 原型踏襲、 filter none で hover と非干渉)
+ *   - padding 12px 24px + font-size 20px + letter-spacing 0.02em (Issue #3041 維持)
+ *   - hover = --brand-niji-pink-hover (#E9265C、 logo pink 直) で存在感 up (filter brightness 撤廃)
+ *   - disabled 時は gray + white text 維持 (Nouns 原型踏襲)
+ *   - data-palette 属性は tsx 側で維持 (test regression 回避 + BidModal 内部 palette 伝搬経路維持)、
+ *     CSS 側の cool/warm 分岐のみ撤廃 (auction 背景 cool/warm 両方で同じ pink 表示)
  */
 .bidBtn {
   font-family: 'PT Root UI';
@@ -24,20 +26,11 @@
   height: 3rem;
   color: white;
   border: transparent;
-  background-color: var(--brand-cool-dark-text);
+  background-color: var(--brand-niji-pink);
   font-weight: bold;
   letter-spacing: 0.02em;
   font-size: 20px;
   transition: all 0.2s ease-in-out;
-}
-
-.bidBtn[data-palette='warm'] {
-  color: white;
-  background-color: var(--brand-warm-dark-text);
-}
-
-.bidBtn:disabled {
-  cursor: not-allowed;
 }
 
 .bidBtn:hover,
@@ -45,13 +38,13 @@
 .bidBtn:focus {
   outline: none !important;
   box-shadow: none !important;
-  filter: brightness(0.85);
+  background-color: var(--brand-niji-pink-hover);
 }
 
 .bidBtn:disabled {
   background-color: gray !important;
   color: white;
-  filter: none;
+  cursor: not-allowed;
 }
 
 .minBidCopy {

--- a/packages/niji-webapp/src/components/Bid/index.test.tsx
+++ b/packages/niji-webapp/src/components/Bid/index.test.tsx
@@ -274,6 +274,39 @@ describe('Bid (Issue #3033 単一 button + BidModal 経路)', () => {
       expect((bidBtn as HTMLButtonElement).disabled).toBe(true);
     });
 
+    // Issue #3043 Niji pink 統一 (CSS 分岐撤廃、 data-palette 属性は tsx 側で維持)
+    // 本 test は「data-palette 属性は cool/warm 両方で維持されるが、
+    // 適用される class は単一 bidBtn のみで palette 別の追加 class が付かない」 ことを確認する。
+    it('applies same single bidBtn class on cool + warm palette (Issue #3043 単一 pink CTA)', () => {
+      hookState.account = '0xUSER';
+
+      // cool palette 時の class
+      hookState.isCoolAuction = true;
+      const { getAllByTestId: getCool, unmount: unmountCool } = render(
+        <Bid auction={makeAuction() as never} auctionEnded={false} />,
+      );
+      const bidBtnCool = getCool('bid-open-button')[0];
+      const clsCool = bidBtnCool.getAttribute('class') || '';
+      const paletteCool = bidBtnCool.getAttribute('data-palette');
+      unmountCool();
+
+      // warm palette 時の class
+      hookState.isCoolAuction = false;
+      const { getAllByTestId: getWarm } = render(
+        <Bid auction={makeAuction() as never} auctionEnded={false} />,
+      );
+      const bidBtnWarm = getWarm('bid-open-button')[0];
+      const clsWarm = bidBtnWarm.getAttribute('class') || '';
+      const paletteWarm = bidBtnWarm.getAttribute('data-palette');
+
+      // data-palette 属性は分岐維持 (tsx 側、 test regression 回避 + BidModal 伝搬経路維持)
+      expect(paletteCool).toBe('cool');
+      expect(paletteWarm).toBe('warm');
+      // class は cool / warm で完全一致 (CSS 側の palette 分岐撤廃、 単一 pink CTA)
+      expect(clsCool).toBe(clsWarm);
+      expect(clsCool).toMatch(/bidBtn/);
+    });
+
     // Issue #3039 palette 伝搬 (Bid → BidModal)
     it('BidModal に palette="cool" が伝搬 (isCoolAuction=true でモーダル open 時)', () => {
       hookState.account = '0xUSER';

--- a/packages/niji-webapp/src/index.css
+++ b/packages/niji-webapp/src/index.css
@@ -104,6 +104,11 @@ code {
     --brand-color-blue-translucent: rgba(73, 101, 240, 0.1);
     --brand-color-green-translucent: rgba(67, 179, 105, 0.1);
     --brand-color-blue-darker: #3a52c7;
+    /* Niji logo pink #E9265C を primary CTA 色として採用 (Issue #3043)。 */
+    /* bid button primary は logo pink から明度 up した軽めトーン。 */
+    /* hover 時は logo pink 直で存在感 up。 */
+    --brand-niji-pink: #ec4a7a;
+    --brand-niji-pink-hover: #e9265c;
   }
   .dark {
     --background: 0 0% 3.9%;


### PR DESCRIPTION
## Summary

- bid button の palette 別 dark-text 色 (cool #151c3b 濃紺 / warm #221b1a 濃茶) を撤廃、 Niji ロゴピンク #E9265C を基準にした軽めトーンに統一
- `--brand-niji-pink` (#EC4A7A、 logo pink から明度 up) + `--brand-niji-pink-hover` (#E9265C、 logo pink 直) の 2 token 追加、 `[data-palette='warm']` override + `filter: brightness(0.85)` 撤廃
- `data-palette` 属性は tsx 側維持 (test regression 回避 + BidModal 内部 palette 伝搬経路維持)、 CSS 側の cool/warm 分岐のみ撤廃

## Test plan

- [x] `pnpm test src/components/Bid` = 34 pass (既存 33 + 追加 1 test: cool / warm 両 palette で class 完全一致 assertion)
- [x] `pnpm test src/components/BidModal` = 21 pass (regression 0)
- [x] `pnpm -w lint` = 0 error (既存 warning のみ)
- [x] `pnpm tsc --noEmit` = clean

## 完了条件 (Stated check)

- [x] bid button 背景色が Niji pink (#EC4A7A) になる
- [x] hover 時 #E9265C (logo pink) に変化
- [x] text が white で可読性確保 (WCAG AA)
- [x] width 100% / padding 12px 24px / font-size 20 / border-radius 8 は Issue #3041 維持
- [x] cool / warm auction 両方で同じ pink 表示 (CSS 分岐撤廃)
- [x] pnpm test webapp regression 0

## 影響範囲

- `packages/niji-webapp/src/index.css` (`--brand-niji-pink` / `--brand-niji-pink-hover` token 追加)
- `packages/niji-webapp/src/components/Bid/Bid.module.css` (bidBtn 色統一 + `filter` 撤廃 + `:disabled` block 集約)
- `packages/niji-webapp/src/components/Bid/index.test.tsx` (単一 pink CTA class assertion 追加)

## Notes

- BidModal 内部 button の pink 統一は本 PR scope 外 (Issue body 明記通り、 別 Issue 対応)
- Niji logo #E9265C は community 認知 primary color、 明度 up した #EC4A7A で「重たすぎず 存在感あり」 の CTA トーン
- 3 marker 全 active (test-passed / verify-passed / review-passed)、 AI 自律 merge 経路

Closes #3043
Refs CAR-333

🤖 Generated with [Claude Code](https://claude.com/claude-code)