### PR TITLE
🐛 fix(niji-webapp): BidModal 見切れ scroll 対応 + 「Niji Auction House = 主催者」 誤訳修正 (#3049)

### DIFF
--- a/packages/niji-webapp/src/components/BidModal/BidModal.module.css
+++ b/packages/niji-webapp/src/components/BidModal/BidModal.module.css
@@ -12,12 +12,20 @@
  */
 
 /* ==================== Dialog Content root ==================== */
+/**
+ * BidModal 見切れ対策 (Issue #3049) — Dialog は fixed 中央配置 + translate-y[-50%] のため
+ * 内容が viewport を越えると上下切れる。 max-height: 90vh + overflow-y: auto でスクロール可能に。
+ * 90vh 選択理由 = 小画面 (iPhone SE 568px 縦) でも 512px の visible 領域を確保、 header + footer 分の
+ * 呼吸を上下 5vh ずつ残す。 shadcn/ui default class の !important 上書きに揃えて詳細度整合。
+ */
 .dialogContent {
   background-color: var(--brand-cool-background) !important;
   border: 1px solid var(--brand-cool-border) !important;
   border-radius: 12px !important;
   font-family: 'PT Root UI', sans-serif;
   color: var(--brand-cool-dark-text);
+  max-height: 90vh !important;
+  overflow-y: auto !important;
 }
 
 .dialogContent[data-palette='warm'] {

--- a/packages/niji-webapp/src/components/BidModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/BidModal/index.test.tsx
@@ -14,6 +14,9 @@ import type { Auction } from '@/wrappers/nijiAuction';
 
 import * as React from 'react';
 
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -411,5 +414,88 @@ describe('BidModal (Issue #3033)', () => {
     const fiatTab = getByTestId('bid-tab-fiat');
     expect(ethTab.className).toMatch(/tabsTrigger/);
     expect(fiatTab.className).toMatch(/tabsTrigger/);
+  });
+
+  // ==================== Issue #3049 見切れ対策 (max-height + overflow-y) ====================
+
+  it('dialogContent に scroll 用の CSS module class (dialogContent) 付与 (Issue #3049)', () => {
+    // BidModal.module.css .dialogContent に max-height: 90vh + overflow-y: auto を追加、
+    // vitest 環境 (identity-obj-proxy 相当) では class 名 "dialogContent" が data-testid=bid-modal に含まれる。
+    // 実 style の max-height / overflow は jsdom で computedStyle が空を返すため、 class 付与で代替検証。
+    const Wrapper = buildWrapper();
+    const { getByTestId } = render(
+      <Wrapper>
+        <BidModal open onClose={() => {}} auction={makeAuction()} bidderWallet="0xUSER" />
+      </Wrapper>,
+    );
+    const modal = getByTestId('bid-modal');
+    expect(modal.className).toMatch(/dialogContent/);
+  });
+
+  it('cool palette 時も dialogContent class が付与される (scroll 適用 palette 両対応 Issue #3049)', () => {
+    const Wrapper = buildWrapper();
+    const { getByTestId } = render(
+      <Wrapper>
+        <BidModal
+          open
+          onClose={() => {}}
+          auction={makeAuction()}
+          bidderWallet="0xUSER"
+          palette="cool"
+        />
+      </Wrapper>,
+    );
+    const modal = getByTestId('bid-modal');
+    expect(modal.className).toMatch(/dialogContent/);
+    expect(modal.getAttribute('data-palette')).toBe('cool');
+  });
+
+  it('warm palette 時も dialogContent class が付与される (scroll 適用 palette 両対応 Issue #3049)', () => {
+    const Wrapper = buildWrapper();
+    const { getByTestId } = render(
+      <Wrapper>
+        <BidModal
+          open
+          onClose={() => {}}
+          auction={makeAuction()}
+          bidderWallet="0xUSER"
+          palette="warm"
+        />
+      </Wrapper>,
+    );
+    const modal = getByTestId('bid-modal');
+    expect(modal.className).toMatch(/dialogContent/);
+    expect(modal.getAttribute('data-palette')).toBe('warm');
+  });
+
+  it('fiat tab (長い form) 表示時も dialogContent class は維持される (Issue #3049)', () => {
+    const Wrapper = buildWrapper();
+    const { getByTestId } = render(
+      <Wrapper>
+        <BidModal
+          open
+          onClose={() => {}}
+          auction={makeAuction()}
+          bidderWallet="0xUSER"
+          defaultTab="fiat"
+        />
+      </Wrapper>,
+    );
+    const modal = getByTestId('bid-modal');
+    expect(modal.className).toMatch(/dialogContent/);
+  });
+
+  it('BidModal.module.css .dialogContent に max-height: 90vh 定義がある (Issue #3049 静的検証)', () => {
+    // jsdom は CSS module の computedStyle を復元しないため、 CSS 定義 file を直接 read して
+    // max-height + overflow-y の存在を静的検証する。 実 browser 動作は Playwright e2e で確認、
+    // ここでは CSS 定義漏れ regression を防ぐ静的 guard として機能させる。
+    const cssPath = join(__dirname, 'BidModal.module.css');
+    const cssContent = readFileSync(cssPath, 'utf-8');
+    // .dialogContent block 内に max-height: 90vh + overflow-y: auto が両方あることを確認
+    const dialogContentBlockMatch = cssContent.match(/\.dialogContent\s*{[^}]*}/);
+    expect(dialogContentBlockMatch).not.toBeNull();
+    const dialogContentBlock = dialogContentBlockMatch![0];
+    expect(dialogContentBlock).toMatch(/max-height:\s*90vh/);
+    expect(dialogContentBlock).toMatch(/overflow-y:\s*auto/);
   });
 });

--- a/packages/niji-webapp/src/components/NijiInfoRowHolder.test.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoRowHolder.test.tsx
@@ -64,11 +64,11 @@ describe('NijiInfoRowHolder', () => {
     expect(container.querySelector('a')?.getAttribute('rel')).toBe('noreferrer');
   });
 
-  it('renders "Niji Auction House" when winner equals auction house address', async () => {
+  it('renders "Waiting for bid" when winner equals auction house address (Issue #3049)', async () => {
     executeMock.mockResolvedValue({ auction: { bidder: { id: '0xAUCTIONHOUSE' } } });
     const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
     await waitFor(() => {
-      expect(container.textContent).toContain('Niji Auction House');
+      expect(container.textContent).toContain('Waiting for bid');
     });
     expect(container.querySelector('[data-testid="short"]')).toBeNull();
   });
@@ -126,20 +126,20 @@ describe('NijiInfoRowHolder', () => {
     });
   });
 
-  it('auction house lowercase comparison still maps to "Niji Auction House" branch', async () => {
+  it('auction house lowercase comparison still maps to "Waiting for bid" branch (Issue #3049)', async () => {
     // mock auction house = '0xAUCTIONHOUSE'、 case-insensitive comparison で同一判定
     executeMock.mockResolvedValue({ auction: { bidder: { id: '0xauctionhouse' } } });
     const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
     await waitFor(() => {
-      expect(container.textContent).toContain('Niji Auction House');
+      expect(container.textContent).toContain('Waiting for bid');
     });
   });
 
-  it('renders anchor even when winner is auction house (with Niji Auction House label)', async () => {
+  it('renders anchor even when winner is auction house (with Waiting for bid label) (Issue #3049)', async () => {
     executeMock.mockResolvedValue({ auction: { bidder: { id: '0xAUCTIONHOUSE' } } });
     const { container } = render(<NijiInfoRowHolder nounId={1n} />, { wrapper: WithProviders });
     await waitFor(() => {
-      expect(container.textContent).toContain('Niji Auction House');
+      expect(container.textContent).toContain('Waiting for bid');
     });
     // anchor は残る (svg link icon が残るため)
     expect(container.querySelector('a')).not.toBeNull();

--- a/packages/niji-webapp/src/components/NijiInfoRowHolder.tsx
+++ b/packages/niji-webapp/src/components/NijiInfoRowHolder.tsx
@@ -49,7 +49,10 @@ const NijiInfoRowHolder: React.FC<NounInfoRowHolderProps> = props => {
       <Trans>Winner</Trans>{' '}
       <a className="text-muted-foreground" href={etherscanURL} target={'_blank'} rel="noreferrer">
         {winner.toLowerCase() === nijiAuctionHouseAddress[chainId].toLowerCase() ? (
-          <Trans>Niji Auction House</Trans>
+          // Issue #3049: auction 開始直後 or settle 済で NFT が Auction House 保有中の状態は
+          // user 視点で「入札待ち」 が意図 (「Niji Auction House = 主催者」 訳出で「落札者 = 主催者」
+          // の misleading 表示を回避)。
+          <Trans>Waiting for bid</Trans>
         ) : (
           shortAddressComponent
         )}

--- a/packages/niji-webapp/src/locales/en-US.po
+++ b/packages/niji-webapp/src/locales/en-US.po
@@ -25,6 +25,10 @@ msgstr "At this time only USDC and WETH streams are supported"
 msgid "Current bid"
 msgstr "Current bid"
 
+#: src/components/BidModal/index.tsx
+msgid "bid 額 (ETH)"
+msgstr "bid 額 (ETH)"
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "To"
 msgstr "To"
@@ -99,6 +103,7 @@ msgstr "You've already delegated to this address"
 msgid "Daily Auctions"
 msgstr "Daily Auctions"
 
+#: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
 msgid "Bid"
 msgstr "Bid"
@@ -223,8 +228,8 @@ msgstr "Add as many or as few of your Nijis as you’d like. Additional Nijis ca
 
 #: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
-msgid "クレカで bid (JPY)"
-msgstr "クレカで bid (JPY)"
+#~ msgid "クレカで bid (JPY)"
+#~ msgstr "クレカで bid (JPY)"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "Add Proposal Action"
@@ -277,6 +282,10 @@ msgstr "There are no active forks."
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 
+#: src/components/NijiInfoRowHolder.tsx
+msgid "Waiting for bid"
+msgstr "Waiting for bid"
+
 #: src/components/BidHistoryModal/index.tsx
 msgid "Bids for"
 msgstr "Bids for"
@@ -286,8 +295,8 @@ msgid "Go to playground"
 msgstr "Go to playground"
 
 #: src/components/Bid/index.tsx
-msgid "or more"
-msgstr "or more"
+#~ msgid "or more"
+#~ msgstr "or more"
 
 #: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
@@ -484,6 +493,11 @@ msgstr "You voted <0>For</0> this proposal"
 msgid "Black monochrome Noggles"
 msgstr "Black monochrome Noggles"
 
+#. placeholder {0}: minBidEth(minBid)
+#: src/components/BidModal/index.tsx
+msgid "minimum bid — Ξ {0} or more"
+msgstr "minimum bid — Ξ {0} or more"
+
 #: src/components/AuctionTimer/index.tsx
 msgid "Time left"
 msgstr "Time left"
@@ -609,6 +623,10 @@ msgstr "送信中…"
 msgid "Edit"
 msgstr "Edit"
 
+#: src/components/BidModal/index.tsx
+msgid "ETH か クレカ (JPY) を選んで bid してください"
+msgstr "ETH か クレカ (JPY) を選んで bid してください"
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsDateDetailsStep/index.tsx
 msgid "Review Action Details"
 msgstr "Review Action Details"
@@ -676,8 +694,7 @@ msgstr "More than {0} Nijis ({1}% of the DAO) are required to pass the threshold
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
-#: src/components/Bid/index.tsx
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SubmitUpdateProposal.tsx
@@ -792,6 +809,11 @@ msgstr "Failed to fetch"
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr "unequally withdraw the treasury for personal gain"
+
+#. placeholder {0}: auction.nounId.toString()
+#: src/components/BidModal/index.tsx
+msgid "Niji #{0} に bid"
+msgstr "Niji #{0} に bid"
 
 #: src/components/AuctionTimer/index.tsx
 msgid "m"
@@ -998,6 +1020,10 @@ msgstr "<0>Delegated Niji: </0>"
 msgid "All Nijis are members of Niji DAO."
 msgstr "All Nijis are members of Niji DAO."
 
+#: src/components/BidModal/index.tsx
+msgid "ETH で bid"
+msgstr "ETH で bid"
+
 #: src/components/DelegationCandidateInfo/index.tsx
 msgid "Now has"
 msgstr "Now has"
@@ -1055,6 +1081,10 @@ msgstr "Submit Vote"
 msgid "Niji Traits"
 msgstr "Niji Traits"
 
+#: src/components/BidModal/index.tsx
+msgid "キャンセル"
+msgstr "キャンセル"
+
 #: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
@@ -1098,7 +1128,7 @@ msgid "Select Language"
 msgstr "Select Language"
 
 #. placeholder {0}: minBidEth(minBid)
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Please place a bid higher than or equal to the minimum bid amount of {0} ETH"
 msgstr "Please place a bid higher than or equal to the minimum bid amount of {0} ETH"
 
@@ -1139,7 +1169,6 @@ msgstr "Review Function Call Action"
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 
-#: src/components/Bid/index.tsx
 #: src/components/NijiContent/index.tsx
 msgid "Settled auction successfully!"
 msgstr "Settled auction successfully!"
@@ -1222,8 +1251,8 @@ msgid "Withdraw"
 msgstr "Withdraw"
 
 #: src/components/Bid/index.tsx
-msgid "Bid was placed successfully!"
-msgstr "Bid was placed successfully!"
+#~ msgid "Bid was placed successfully!"
+#~ msgstr "Bid was placed successfully!"
 
 #: src/pages/Vote/index.tsx
 msgid "Current Threshold"
@@ -1341,6 +1370,10 @@ msgstr "Starts {0}"
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
+
+#: src/components/BidModal/index.tsx
+msgid "bid"
+msgstr "bid"
 
 #: src/components/CurrentDelegatePannel/index.tsx
 msgid "Current Delegate"
@@ -1579,8 +1612,8 @@ msgid "Withdraw Nijis from escrow"
 msgstr "Withdraw Nijis from escrow"
 
 #: src/components/NijiInfoRowHolder.tsx
-msgid "Niji Auction House"
-msgstr "Niji Auction House"
+#~ msgid "Niji Auction House"
+#~ msgstr "Niji Auction House"
 
 #: src/pages/NijisPage.tsx
 msgid "Go to auction"
@@ -1804,7 +1837,7 @@ msgstr "Editing a proposal will clear all previous feedback"
 msgid "Execute"
 msgstr "Execute"
 
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Bid placed."
 msgstr "Bid placed."
 
@@ -1827,6 +1860,10 @@ msgstr "Proposer functions"
 #: src/components/Banner/index.tsx
 #~ msgid "EVERY DAY,"
 #~ msgstr "EVERY DAY,"
+
+#: src/components/BidModal/index.tsx
+msgid "クレカで払う (JPY)"
+msgstr "クレカで払う (JPY)"
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"

--- a/packages/niji-webapp/src/locales/ja-JP.po
+++ b/packages/niji-webapp/src/locales/ja-JP.po
@@ -30,6 +30,10 @@ msgstr "現時点では、USDCとWETHのストリームのみがサポートさ�
 msgid "Current bid"
 msgstr "現在の入札額"
 
+#: src/components/BidModal/index.tsx
+msgid "bid 額 (ETH)"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "To"
 msgstr "宛先"
@@ -104,6 +108,7 @@ msgstr "あなたはすでにこのアドレスに委任しています"
 msgid "Daily Auctions"
 msgstr "デイリーオークション"
 
+#: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
 msgid "Bid"
 msgstr "入札"
@@ -228,8 +233,8 @@ msgstr "お好きなだけ多くまたは少なくNijisを追加してくださ�
 
 #: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
-msgid "クレカで bid (JPY)"
-msgstr "クレカで bid (JPY)"
+#~ msgid "クレカで bid (JPY)"
+#~ msgstr "クレカで bid (JPY)"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "Add Proposal Action"
@@ -282,6 +287,10 @@ msgstr "アクティブなフォークはありません。"
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr "その結果、Niji Foundation は Niji DAO が代替案を実装する準備が整うまで、拒否権の管理者となることを想定しており、したがってこの権限を行使する条件を明確にしたいと考えています。"
 
+#: src/components/NijiInfoRowHolder.tsx
+msgid "Waiting for bid"
+msgstr "入札待ち"
+
 #: src/components/BidHistoryModal/index.tsx
 msgid "Bids for"
 msgstr "入札"
@@ -291,8 +300,8 @@ msgid "Go to playground"
 msgstr "プレイグラウンドに行く"
 
 #: src/components/Bid/index.tsx
-msgid "or more"
-msgstr "かそれ以上"
+#~ msgid "or more"
+#~ msgstr "かそれ以上"
 
 #: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
@@ -489,6 +498,11 @@ msgstr "あなたはこの提案<0>に</0>投票しました"
 msgid "Black monochrome Noggles"
 msgstr "黒の単色ノグル"
 
+#. placeholder {0}: minBidEth(minBid)
+#: src/components/BidModal/index.tsx
+msgid "minimum bid — Ξ {0} or more"
+msgstr ""
+
 #: src/components/AuctionTimer/index.tsx
 msgid "Time left"
 msgstr "残り時間"
@@ -614,6 +628,10 @@ msgstr "送信中…"
 msgid "Edit"
 msgstr "編集"
 
+#: src/components/BidModal/index.tsx
+msgid "ETH か クレカ (JPY) を選んで bid してください"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsDateDetailsStep/index.tsx
 msgid "Review Action Details"
 msgstr "アクション詳細の確認"
@@ -681,8 +699,7 @@ msgstr "閾値を通過するには、{0}以上のNijis（DAOの{1}%）が必要
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
-#: src/components/Bid/index.tsx
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SubmitUpdateProposal.tsx
@@ -797,6 +814,11 @@ msgstr "取得できませんでした"
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr "個人的な利益のために不平等に財務省を引き出す"
+
+#. placeholder {0}: auction.nounId.toString()
+#: src/components/BidModal/index.tsx
+msgid "Niji #{0} に bid"
+msgstr ""
 
 #: src/components/AuctionTimer/index.tsx
 msgid "m"
@@ -1003,6 +1025,10 @@ msgstr "委任Niji: "
 msgid "All Nijis are members of Niji DAO."
 msgstr "すべての Niji は Niji DAO のメンバーです。"
 
+#: src/components/BidModal/index.tsx
+msgid "ETH で bid"
+msgstr ""
+
 #: src/components/DelegationCandidateInfo/index.tsx
 msgid "Now has"
 msgstr "今持っています"
@@ -1060,6 +1086,10 @@ msgstr "投票を提出"
 msgid "Niji Traits"
 msgstr "Niji トレイト"
 
+#: src/components/BidModal/index.tsx
+msgid "キャンセル"
+msgstr ""
+
 #: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr "Niji は Ethereum のブロックハッシュに基づいてランダムに生成されます。Niji トレイトの希少性を支配する 'if' 文やその他のルールは存在せず、すべての Niji が等しくレアです。執筆時点では、Niji は以下で構成されています。"
@@ -1103,7 +1133,7 @@ msgid "Select Language"
 msgstr "言語を選択"
 
 #. placeholder {0}: minBidEth(minBid)
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Please place a bid higher than or equal to the minimum bid amount of {0} ETH"
 msgstr "最低入札額の {0} ETHと同じかそれ以上の入札額を設定してください"
 
@@ -1144,7 +1174,6 @@ msgstr "関数呼び出しアクションのレビュー"
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "Niji Seeder コントラクトは、ミントプロセス中に Niji のトレイトを決定するために使用されます。Seeder コントラクトは、将来のトレイト生成アルゴリズムのアップグレードを可能にするために置き換え可能です。さらに、Niji DAO によってロックして、将来の更新を防ぐこともできます。現在、Niji トレイトは疑似乱数生成を使用して決定されます。"
 
-#: src/components/Bid/index.tsx
 #: src/components/NijiContent/index.tsx
 msgid "Settled auction successfully!"
 msgstr "オークションが正常に決済されました！"
@@ -1227,8 +1256,8 @@ msgid "Withdraw"
 msgstr "撤回"
 
 #: src/components/Bid/index.tsx
-msgid "Bid was placed successfully!"
-msgstr "正常に入札されました！"
+#~ msgid "Bid was placed successfully!"
+#~ msgstr "正常に入札されました！"
 
 #: src/pages/Vote/index.tsx
 msgid "Current Threshold"
@@ -1346,6 +1375,10 @@ msgstr "あと{0}で始まります"
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "提案拒否権は当初、Niji DAO トレジャリーに対する '51% 攻撃' 問題への一時的な解決策として構想されました。Nijider は当初、Niji の健全な配布が DAO の保護として十分であると考えていましたが、インセンティブとリスクのより完全な理解により、権利が削除される前により堅牢なゲーム理論的解決策を実装すべきという一般的な合意が Nijider、Niji Foundation、より広いコミュニティ内で形成されました。"
+
+#: src/components/BidModal/index.tsx
+msgid "bid"
+msgstr ""
 
 #: src/components/CurrentDelegatePannel/index.tsx
 msgid "Current Delegate"
@@ -1584,8 +1617,8 @@ msgid "Withdraw Nijis from escrow"
 msgstr "Niji をエスクローから引き出す"
 
 #: src/components/NijiInfoRowHolder.tsx
-msgid "Niji Auction House"
-msgstr "Niji オークションハウス"
+#~ msgid "Niji Auction House"
+#~ msgstr "Niji オークションハウス"
 
 #: src/pages/NijisPage.tsx
 msgid "Go to auction"
@@ -1809,7 +1842,7 @@ msgstr "提案を編集すると、以前のすべてのフィードバックが
 msgid "Execute"
 msgstr "実行する"
 
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Bid placed."
 msgstr "入札が行われました。"
 
@@ -1832,6 +1865,10 @@ msgstr "提案者の機能"
 #: src/components/Banner/index.tsx
 #~ msgid "EVERY DAY,"
 #~ msgstr "毎日"
+
+#: src/components/BidModal/index.tsx
+msgid "クレカで払う (JPY)"
+msgstr ""
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"

--- a/packages/niji-webapp/src/locales/pseudo.po
+++ b/packages/niji-webapp/src/locales/pseudo.po
@@ -25,6 +25,10 @@ msgstr ""
 msgid "Current bid"
 msgstr ""
 
+#: src/components/BidModal/index.tsx
+msgid "bid 額 (ETH)"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "To"
 msgstr ""
@@ -103,6 +107,7 @@ msgstr ""
 msgid "Daily Auctions"
 msgstr ""
 
+#: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
 msgid "Bid"
 msgstr ""
@@ -239,8 +244,8 @@ msgstr ""
 
 #: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
-msgid "クレカで bid (JPY)"
-msgstr ""
+#~ msgid "クレカで bid (JPY)"
+#~ msgstr ""
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "Add Proposal Action"
@@ -293,6 +298,10 @@ msgstr ""
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr ""
 
+#: src/components/NijiInfoRowHolder.tsx
+msgid "Waiting for bid"
+msgstr ""
+
 #: src/components/BidHistoryModal/index.tsx
 msgid "Bids for"
 msgstr ""
@@ -310,8 +319,8 @@ msgid "Go to playground"
 msgstr ""
 
 #: src/components/Bid/index.tsx
-msgid "or more"
-msgstr ""
+#~ msgid "or more"
+#~ msgstr ""
 
 #: src/pages/Playground/index.tsx
 #~ msgid "Nouns Protocol"
@@ -525,6 +534,11 @@ msgstr ""
 msgid "Black monochrome Noggles"
 msgstr ""
 
+#. placeholder {0}: minBidEth(minBid)
+#: src/components/BidModal/index.tsx
+msgid "minimum bid — Ξ {0} or more"
+msgstr ""
+
 #: src/components/AuctionTimer/index.tsx
 msgid "Time left"
 msgstr ""
@@ -658,6 +672,10 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
+#: src/components/BidModal/index.tsx
+msgid "ETH か クレカ (JPY) を選んで bid してください"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsDateDetailsStep/index.tsx
 msgid "Review Action Details"
 msgstr ""
@@ -729,8 +747,7 @@ msgstr ""
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
-#: src/components/Bid/index.tsx
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SubmitUpdateProposal.tsx
@@ -848,6 +865,11 @@ msgstr ""
 
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
+msgstr ""
+
+#. placeholder {0}: auction.nounId.toString()
+#: src/components/BidModal/index.tsx
+msgid "Niji #{0} に bid"
 msgstr ""
 
 #: src/components/AuctionTimer/index.tsx
@@ -1063,6 +1085,10 @@ msgstr ""
 msgid "All Nijis are members of Niji DAO."
 msgstr ""
 
+#: src/components/BidModal/index.tsx
+msgid "ETH で bid"
+msgstr ""
+
 #: src/components/DelegationCandidateInfo/index.tsx
 msgid "Now has"
 msgstr ""
@@ -1124,6 +1150,10 @@ msgstr ""
 msgid "Niji Traits"
 msgstr ""
 
+#: src/components/BidModal/index.tsx
+msgid "キャンセル"
+msgstr ""
+
 #: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr ""
@@ -1171,7 +1201,7 @@ msgid "Select Language"
 msgstr ""
 
 #. placeholder {0}: minBidEth(minBid)
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Please place a bid higher than or equal to the minimum bid amount of {0} ETH"
 msgstr ""
 
@@ -1216,7 +1246,6 @@ msgstr ""
 #~ msgid "Only Nouns you owned or were delegated to you before {0} are eligible to vote."
 #~ msgstr ""
 
-#: src/components/Bid/index.tsx
 #: src/components/NijiContent/index.tsx
 msgid "Settled auction successfully!"
 msgstr ""
@@ -1307,8 +1336,8 @@ msgid "Withdraw"
 msgstr ""
 
 #: src/components/Bid/index.tsx
-msgid "Bid was placed successfully!"
-msgstr ""
+#~ msgid "Bid was placed successfully!"
+#~ msgstr ""
 
 #: src/pages/Vote/index.tsx
 msgid "Current Threshold"
@@ -1433,6 +1462,10 @@ msgstr ""
 
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
+msgstr ""
+
+#: src/components/BidModal/index.tsx
+msgid "bid"
 msgstr ""
 
 #: src/components/CurrentDelegatePannel/index.tsx
@@ -1692,8 +1725,8 @@ msgid "Withdraw Nijis from escrow"
 msgstr ""
 
 #: src/components/NijiInfoRowHolder.tsx
-msgid "Niji Auction House"
-msgstr ""
+#~ msgid "Niji Auction House"
+#~ msgstr ""
 
 #: src/pages/NijisPage.tsx
 msgid "Go to auction"
@@ -1925,7 +1958,7 @@ msgstr ""
 msgid "Execute"
 msgstr ""
 
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Bid placed."
 msgstr ""
 
@@ -1948,6 +1981,10 @@ msgstr ""
 #: src/components/Banner/index.tsx
 #~ msgid "EVERY DAY,"
 #~ msgstr ""
+
+#: src/components/BidModal/index.tsx
+msgid "クレカで払う (JPY)"
+msgstr ""
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"

--- a/packages/niji-webapp/src/locales/zh-CN.po
+++ b/packages/niji-webapp/src/locales/zh-CN.po
@@ -25,6 +25,10 @@ msgstr "目前仅支持 USDC 和 WETH 流支付"
 msgid "Current bid"
 msgstr "当前出价"
 
+#: src/components/BidModal/index.tsx
+msgid "bid 額 (ETH)"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsReviewStep/index.tsx
 msgid "To"
 msgstr "至"
@@ -99,6 +103,7 @@ msgstr "您已将投票委托给此地址"
 msgid "Daily Auctions"
 msgstr "每日拍卖"
 
+#: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
 msgid "Bid"
 msgstr "出价"
@@ -223,8 +228,8 @@ msgstr "根据您的喜好添加任意数量的 Nijis。在托管和分叉期间
 
 #: src/components/Bid/index.tsx
 #: src/components/Bid/index.tsx
-msgid "クレカで bid (JPY)"
-msgstr "用信用卡竞标 (日元)"
+#~ msgid "クレカで bid (JPY)"
+#~ msgstr "用信用卡竞标 (日元)"
 
 #: src/components/ProposalActionsModal/steps/SelectProposalActionStep/index.tsx
 msgid "Add Proposal Action"
@@ -277,6 +282,10 @@ msgstr "当前无正在进行的分叉。"
 msgid "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 msgstr "因此,Niji 基金会预计将担任否决权的管理者,直到 Niji DAO 准备好实施替代方案,因此希望明确行使此权力的条件。"
 
+#: src/components/NijiInfoRowHolder.tsx
+msgid "Waiting for bid"
+msgstr "等待竞拍"
+
 #: src/components/BidHistoryModal/index.tsx
 msgid "Bids for"
 msgstr "竞拍记录："
@@ -286,8 +295,8 @@ msgid "Go to playground"
 msgstr "前往游乐场"
 
 #: src/components/Bid/index.tsx
-msgid "or more"
-msgstr "或以上"
+#~ msgid "or more"
+#~ msgstr "或以上"
 
 #: src/components/Documentation/AboutSection.tsx
 msgid "Niji artwork is in the {publicDomainLink}."
@@ -484,6 +493,11 @@ msgstr "您对此提案投了<0>赞成</0>票"
 msgid "Black monochrome Noggles"
 msgstr "黑色单色眼镜"
 
+#. placeholder {0}: minBidEth(minBid)
+#: src/components/BidModal/index.tsx
+msgid "minimum bid — Ξ {0} or more"
+msgstr ""
+
 #: src/components/AuctionTimer/index.tsx
 msgid "Time left"
 msgstr "剩余时间"
@@ -609,6 +623,10 @@ msgstr "发送中…"
 msgid "Edit"
 msgstr "编辑"
 
+#: src/components/BidModal/index.tsx
+msgid "ETH か クレカ (JPY) を選んで bid してください"
+msgstr ""
+
 #: src/components/ProposalActionsModal/steps/StreamPaymentsDateDetailsStep/index.tsx
 msgid "Review Action Details"
 msgstr "审核操作详情"
@@ -676,8 +694,7 @@ msgstr "需要超过 {0} 个 Niji（占 DAO 的 {1}%）才能通过门槛"
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
 #: src/components/AddNijisToForkModal/index.tsx
-#: src/components/Bid/index.tsx
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SelectSponsorsToPropose.tsx
 #: src/components/CandidateSponsors/SubmitUpdateProposal.tsx
@@ -792,6 +809,11 @@ msgstr "获取失败"
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "unequally withdraw the treasury for personal gain"
 msgstr "不平等地从国库中提取资金以谋取个人利益"
+
+#. placeholder {0}: auction.nounId.toString()
+#: src/components/BidModal/index.tsx
+msgid "Niji #{0} に bid"
+msgstr ""
 
 #: src/components/AuctionTimer/index.tsx
 msgid "m"
@@ -998,6 +1020,10 @@ msgstr "<0>已委托 Niji：</0>"
 msgid "All Nijis are members of Niji DAO."
 msgstr "所有 Niji 都是 Niji DAO 的成员。"
 
+#: src/components/BidModal/index.tsx
+msgid "ETH で bid"
+msgstr ""
+
 #: src/components/DelegationCandidateInfo/index.tsx
 msgid "Now has"
 msgstr "现在拥有"
@@ -1055,6 +1081,10 @@ msgstr "提交投票"
 msgid "Niji Traits"
 msgstr "Niji 特征"
 
+#: src/components/BidModal/index.tsx
+msgid "キャンセル"
+msgstr ""
+
 #: src/components/Documentation/ArtAndTraitsSection.tsx
 msgid "Nijis are generated randomly based Ethereum block hashes. There are no 'if' statements or other rules governing Niji trait scarcity, which makes all Nijis equally rare. As of this writing, Nijis are made up of:"
 msgstr "Niji 基于以太坊区块哈希随机生成。没有 'if' 语句或其他规则来管理 Niji 特征的稀缺性,这使得所有 Niji 同样稀有。截至撰写本文时,Niji 由以下组成:"
@@ -1098,7 +1128,7 @@ msgid "Select Language"
 msgstr "选择语言"
 
 #. placeholder {0}: minBidEth(minBid)
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Please place a bid higher than or equal to the minimum bid amount of {0} ETH"
 msgstr "请出价大于或等于最低竞标金额 {0} ETH"
 
@@ -1139,7 +1169,6 @@ msgstr "审核函数调用操作"
 msgid "The Niji Seeder contract is used to determine Niji traits during the minting process. The seeder contract can be replaced to allow for future trait generation algorithm upgrades. Additionally, it can be locked by the Niji DAO to prevent any future updates. Currently, Niji traits are determined using pseudo-random number generation:"
 msgstr "Niji Seeder 合约用于在铸造过程中确定 Niji 特征。Seeder 合约可以被替换以允许未来的特征生成算法升级。此外,它可以被 Niji DAO 锁定以防止任何未来的更新。目前,Niji 特征使用伪随机数生成确定:"
 
-#: src/components/Bid/index.tsx
 #: src/components/NijiContent/index.tsx
 msgid "Settled auction successfully!"
 msgstr "成功结算拍卖！"
@@ -1222,8 +1251,8 @@ msgid "Withdraw"
 msgstr "提取"
 
 #: src/components/Bid/index.tsx
-msgid "Bid was placed successfully!"
-msgstr "出价成功！"
+#~ msgid "Bid was placed successfully!"
+#~ msgstr "出价成功！"
 
 #: src/pages/Vote/index.tsx
 msgid "Current Threshold"
@@ -1341,6 +1370,10 @@ msgstr "{0}开始"
 #: src/components/Documentation/GovernanceSection.tsx
 msgid "The proposal veto right was initially envisioned as a temporary solution to the problem of ‘51% attacks’ on the Niji DAO treasury. While Nijiders initially believed that a healthy distribution of Nijis would be sufficient protection for the DAO, a more complete understanding of the incentives and risks has led to general consensus within the Nijiders, the Niji Foundation, and the wider community that a more robust game-theoretic solution should be implemented before the right is removed."
 msgstr "提案否决权最初被设想为对 Niji DAO 金库 '51% 攻击' 问题的临时解决方案。虽然 Nijider 最初认为 Niji 的健康分配将为 DAO 提供足够的保护,但对激励和风险的更完整理解使 Nijider、Niji 基金会和更广泛的社区内达成了普遍共识,即在删除该权利之前应实施更强大的博弈论解决方案。"
+
+#: src/components/BidModal/index.tsx
+msgid "bid"
+msgstr ""
 
 #: src/components/CurrentDelegatePannel/index.tsx
 msgid "Current Delegate"
@@ -1579,8 +1612,8 @@ msgid "Withdraw Nijis from escrow"
 msgstr "从托管中取出 Niji"
 
 #: src/components/NijiInfoRowHolder.tsx
-msgid "Niji Auction House"
-msgstr "Niji 拍卖行"
+#~ msgid "Niji Auction House"
+#~ msgstr "Niji 拍卖行"
 
 #: src/pages/NijisPage.tsx
 msgid "Go to auction"
@@ -1804,7 +1837,7 @@ msgstr "编辑提案将清除所有先前的反馈"
 msgid "Execute"
 msgstr "执行"
 
-#: src/components/Bid/index.tsx
+#: src/components/BidModal/index.tsx
 msgid "Bid placed."
 msgstr "出价已提交。"
 
@@ -1827,6 +1860,10 @@ msgstr "提案者功能"
 #: src/components/Banner/index.tsx
 #~ msgid "EVERY DAY,"
 #~ msgstr "每一天，"
+
+#: src/components/BidModal/index.tsx
+msgid "クレカで払う (JPY)"
+msgstr ""
 
 #: src/components/NijiContent/index.tsx
 msgid "Learn more"


### PR DESCRIPTION
## Summary

- BidModal.module.css .dialogContent に `max-height: 90vh` + `overflow-y: auto` 追加、 shadcn/ui Dialog fixed 中央配置での上下見切れを scroll で解消 (Phase A)
- NijiInfoRowHolder.tsx の `<Trans>Niji Auction House</Trans>` を `<Trans>Waiting for bid</Trans>` に変更、 auction 開始直後の bidder = Niji Auction House address 分岐で「落札者: Niji オークションハウス」 = 「主催者」 の misleading 表示を「入札待ち」 に統一 (Phase B)
- lingui extract で 4 locale .po file 自動更新、 ja 「入札待ち」 + zh 「等待竞拍」 + en 「Waiting for bid」 手動追加 (Phase C)

## 変更ファイル

| file | 変更内容 |
|---|---|
| `packages/niji-webapp/src/components/BidModal/BidModal.module.css` | `.dialogContent` に `max-height: 90vh !important` + `overflow-y: auto !important` 追加、 shadcn `!important` 詳細度整合 |
| `packages/niji-webapp/src/components/NijiInfoRowHolder.tsx` | `<Trans>Niji Auction House</Trans>` → `<Trans>Waiting for bid</Trans>` (Issue #3049 コメント付き) |
| `packages/niji-webapp/src/locales/{en-US,ja-JP,zh-CN,pseudo}.po` | lingui extract 自動更新、 ja / zh msgstr 手動追加 |
| `packages/niji-webapp/src/components/BidModal/index.test.tsx` | 5 件新規 (dialogContent class 付与 3 + fiat tab 対応 1 + CSS 静的検証 1) |
| `packages/niji-webapp/src/components/NijiInfoRowHolder.test.tsx` | 既存 3 件 assert を "Waiting for bid" に更新 |

## Test plan

- [x] `pnpm test BidModal` — 26/26 tests PASS (5 件新規、 index.test.tsx `bid-modal` `dialogContent` class 付与 palette cool/warm 両検証 + fiat tab 表示時 + CSS module file 静的 read で `max-height: 90vh` + `overflow-y: auto` grep pass)
- [x] `pnpm test NijiInfoRowHolder` — 76/76 tests PASS (既存 3 件 assert 更新: "Niji Auction House" → "Waiting for bid"、 76 件は round-1〜round-12 の mount/unmount cycle stress test 含む既存 test 数)
- [x] `pnpm test` (全 webapp suite) — 9814 pass + 1 todo + 1 skipped (regression 0、 test 数は 5 件新規追加で 9809 → 9814)
- [x] `pnpm exec tsc --noEmit` — 0 errors
- [x] `pnpm -w lint packages/niji-webapp/src/components/BidModal/index.test.tsx packages/niji-webapp/src/components/NijiInfoRowHolder.{tsx,test.tsx}` — 0 errors, 3 warnings (pre-existing、 react default export + import order の既存 warning)
- [x] `pnpm build` (webapp) — built in 14.23s、 dist 生成成功、 lingui compile で locale .js 再生成 (`.gitignore` 対象)

## Design SSOT 準拠

`rules/dev-flow.md` § 軽微変更時 phase skip 適用対象 = CSS + locale + component text 修正のみ、 6 phase chain の Simplify / Review phase は自己 review で完結、 e2e Playwright は skip (jsdom で `computedStyle` 空、 CSS 静的検証で代替、 実 iPhone SE 縦 568px viewport 確認は follow-up 可)。

翻訳戦略として「Auction House 保有」 表記案は却下、 「入札待ち」 で 3 言語統一 (Recommended、 「主催者」 誤訳の根本解決 + 英語 fallback で二重負担を避ける)。

## リスク・注意点

- BidModal.max-height: 90vh は viewport 依存、 iPhone SE 縦 568px でも 512px の visible 領域は確保できる想定。 実機確認は follow-up e2e で
- 旧 msgid "Niji Auction House" (`uUwiWN`) は po file で `#~` deprecate 済、 compiled .js には残るが code path 参照なしで dead entry (lingui default 挙動、 次回 catalog 再構成タイミングで自然消滅)
- `packages/niji-webapp/src/locales/pseudo.po` の Waiting for bid は空 msgstr (pseudo locale の慣例踏襲)

Closes #3049

🤖 Generated with [Claude Code](https://claude.com/claude-code)