### PR TITLE
🎨 style(niji-webapp): FiatBidForm 決済 UI 磨き込み (loading spinner + rate card + dropdown chevron 修正) (#3053)

### DIFF
--- a/packages/niji-webapp/src/components/FiatBidModal/CardInput.module.css
+++ b/packages/niji-webapp/src/components/FiatBidModal/CardInput.module.css
@@ -123,15 +123,27 @@
   color: var(--brand-cool-dark-text);
   font-family: 'PT Root UI', sans-serif;
   font-size: 15px;
-  padding: 0 12px;
+  padding: 0 40px 0 12px;
   outline: none;
   cursor: pointer;
   transition: all 0.2s ease-in-out;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='%23151c3b'%3E%3Cpath d='M6 8L0 0h12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 14px center;
+  background-size: 12px;
 }
 
 .cardInput[data-palette='warm'] .testCardSelect {
   border-color: var(--brand-warm-border);
   color: var(--brand-warm-dark-text);
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 8' fill='%23221b1a'%3E%3Cpath d='M6 8L0 0h12z'/%3E%3C/svg%3E");
+}
+
+.testCardSelect::-ms-expand {
+  display: none;
 }
 
 .testCardSelect:focus,

--- a/packages/niji-webapp/src/components/FiatBidModal/CardInput.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/CardInput.test.tsx
@@ -255,4 +255,13 @@ describe('CardInput render 動作', () => {
 
     expect(screen.getByTestId('card-input').getAttribute('data-palette')).toBe('warm');
   });
+
+  it('テストカード dropdown = appearance:none + カスタム SVG chevron 適用 (Issue #3053 Phase C)', () => {
+    const onChange = vi.fn();
+    render(<CardInput onChange={onChange} isDev={true} />);
+
+    const select = screen.getByTestId('card-input-test-card-select') as HTMLSelectElement;
+    // CSS Module による testCardSelect class 付与 (module 経路の hash 変換前 identifier 検査)
+    expect(select.className).toContain('testCardSelect');
+  });
 });

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.module.css
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.module.css
@@ -127,13 +127,15 @@
   box-shadow: 0 0 0 1px var(--brand-warm-dark-text) !important;
 }
 
-/* ==================== rate summary + existing bid summary ==================== */
+/* ==================== rate summary (Issue #3053、 2 column card layout) ==================== */
 .rateSummary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
   background-color: var(--brand-cool-accent);
-  border-radius: 8px;
-  padding: 12px;
+  border-radius: 12px;
+  padding: 16px;
   font-family: 'PT Root UI', sans-serif;
-  font-size: 14px;
   color: var(--brand-cool-dark-text);
 }
 
@@ -142,14 +144,74 @@
   color: var(--brand-warm-dark-text);
 }
 
-.rateSource {
-  font-size: 12px;
-  color: var(--brand-cool-light-text);
-  margin-left: 8px;
+.rateSummaryCol {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
 }
 
-.form[data-palette='warm'] .rateSource {
+.rateSummaryLabel {
+  font-size: 12px;
+  color: var(--brand-cool-light-text);
+  font-weight: 500;
+}
+
+.form[data-palette='warm'] .rateSummaryLabel {
   color: var(--brand-warm-light-text);
+}
+
+.rateSummaryValue {
+  font-size: 20px;
+  font-weight: bold;
+  color: var(--brand-cool-dark-text);
+  word-break: break-word;
+}
+
+.form[data-palette='warm'] .rateSummaryValue {
+  color: var(--brand-warm-dark-text);
+}
+
+.rateSummarySource {
+  font-size: 11px;
+  color: var(--brand-cool-light-text);
+}
+
+.form[data-palette='warm'] .rateSummarySource {
+  color: var(--brand-warm-light-text);
+}
+
+.rateSummaryLoading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  color: var(--brand-cool-light-text);
+}
+
+.form[data-palette='warm'] .rateSummaryLoading {
+  color: var(--brand-warm-light-text);
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--brand-cool-border);
+  border-top-color: var(--brand-cool-dark-text);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+.form[data-palette='warm'] .spinner {
+  border-color: var(--brand-warm-border);
+  border-top-color: var(--brand-warm-dark-text);
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .existingBidSummary {

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * FiatBidForm behavior test (Issue #3053、 決済 UI 磨き込み 3 fix)
+ *
+ * Phase B — spot rate 取得中の spinner + 「取得中」 表示検証。
+ * spot rate 未取得 (rate === undefined) 状態で、
+ * (1) 現在 spot rate 欄に spinner + 「取得中」 表示
+ * (2) JPY 換算欄に spinner + 「取得中」 表示
+ * (3) rateSummary root に aria-busy="true" が付与される
+ *
+ * Phase A の 2 column card layout は CSS module 経路の変更 (visual)、
+ * 挙動 test で覆う対象は「取得済 branch で spot rate 値 + JPY 換算値が
+ * それぞれ rateSummaryValue class 系 element に表示される」 の 1 点。
+ */
+
+import type { SpotRate } from '@/hooks/useSpotRate';
+
+import * as React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TooltipProvider } from '@/components/ui/tooltip';
+
+import { FiatBidForm } from './FiatBidForm';
+
+const buildWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
+    </QueryClientProvider>
+  );
+  Wrapper.displayName = 'FiatBidFormTestWrapper';
+  return Wrapper;
+};
+
+const successRate: SpotRate = {
+  rate: 500_000,
+  source: 'gmo',
+  cachedAt: '2026-07-01T00:00:00.000Z',
+  expiresAt: '2026-07-01T00:00:05.000Z',
+};
+
+describe('FiatBidForm loading spinner (Issue #3053 Phase B)', () => {
+  it('spot rate 未取得時に「現在 spot rate」 + 「JPY 換算」 両欄で spinner + 「取得中」 表示', () => {
+    // spot rate fetcher = pending Promise (never resolve) で undefined 保持
+    const pendingFetcher = vi.fn(() => new Promise<SpotRate>(() => {}));
+
+    render(
+      <FiatBidForm
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn() },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: pendingFetcher, refetchInterval: 0 }}
+        isDev={true}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    // spot rate 欄の spinner + 「取得中」
+    const rateLoading = screen.getByTestId('fiat-bid-rate-summary-loading');
+    expect(rateLoading).toBeInTheDocument();
+    expect(rateLoading.textContent).toContain('取得中');
+
+    // JPY 換算欄の spinner + 「取得中」
+    const jpyLoading = screen.getByTestId('fiat-bid-jpy-display-loading');
+    expect(jpyLoading).toBeInTheDocument();
+    expect(jpyLoading.textContent).toContain('取得中');
+
+    // rateSummary root に aria-busy="true" 付与 (screen reader 対応)
+    const rateSummary = screen.getByTestId('fiat-bid-rate-summary');
+    expect(rateSummary.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('spot rate 取得後は spinner 非表示、 spot rate 値 + source が rateSummaryValue で表示', async () => {
+    const spotFetcher = vi.fn().mockResolvedValue(successRate);
+
+    render(
+      <FiatBidForm
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn() },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: spotFetcher, refetchInterval: 0 }}
+        isDev={true}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    // spot rate 取得完了まで待機
+    await waitFor(() => {
+      expect(screen.queryByTestId('fiat-bid-rate-summary-loading')).toBeNull();
+    });
+
+    // rateSummary root の aria-busy="false" (取得完了 state)
+    const rateSummary = screen.getByTestId('fiat-bid-rate-summary');
+    expect(rateSummary.getAttribute('aria-busy')).toBe('false');
+
+    // 現在 spot rate 表示 (500,000 JPY / ETH)
+    expect(rateSummary.textContent).toContain('500,000');
+    expect(rateSummary.textContent).toContain('JPY / ETH');
+    // source 表示
+    expect(rateSummary.textContent).toContain('source: gmo');
+
+    // JPY 換算欄 (ETH 未入力 state = 「—」 表示、 spinner 非表示)
+    expect(screen.queryByTestId('fiat-bid-jpy-display-loading')).toBeNull();
+    const jpyDisplay = screen.getByTestId('fiat-bid-jpy-display');
+    expect(jpyDisplay).toBeInTheDocument();
+    expect(jpyDisplay.textContent).toContain('—');
+  });
+});

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.tsx
@@ -284,6 +284,9 @@ export const FiatBidForm = ({
     return `約 ${ethValidation.jpyEquivalent.toLocaleString()} 円`;
   }, [ethValidation, spotRate.rate]);
 
+  const isSpotRateLoading = spotRate.rate === undefined;
+  const isJpyEquivalentReady = ethValidation.ok && spotRate.rate !== undefined;
+
   const submitDisabled =
     !ethValidation.ok ||
     !termsChecked ||
@@ -437,15 +440,53 @@ export const FiatBidForm = ({
           )}
         </div>
 
-        <div className={classes.rateSummary} data-testid="fiat-bid-rate-summary">
-          <div>
-            現在 spot rate ={' '}
-            {spotRate.rate !== undefined ? `${spotRate.rate.toLocaleString()} JPY / ETH` : '取得中'}
-            {spotRate.source !== undefined && (
-              <span className={classes.rateSource}>(source: {spotRate.source})</span>
+        <div
+          className={classes.rateSummary}
+          data-testid="fiat-bid-rate-summary"
+          aria-busy={isSpotRateLoading}
+          aria-live="polite"
+        >
+          <div className={classes.rateSummaryCol}>
+            <div className={classes.rateSummaryLabel}>現在 spot rate</div>
+            {spotRate.rate !== undefined ? (
+              <>
+                <div className={classes.rateSummaryValue}>
+                  {spotRate.rate.toLocaleString()} JPY / ETH
+                </div>
+                {spotRate.source !== undefined && (
+                  <div className={classes.rateSummarySource}>source: {spotRate.source}</div>
+                )}
+              </>
+            ) : (
+              <div
+                className={classes.rateSummaryLoading}
+                data-testid="fiat-bid-rate-summary-loading"
+              >
+                <div className={classes.spinner} aria-hidden="true" />
+                <span>取得中</span>
+              </div>
             )}
           </div>
-          <div data-testid="fiat-bid-jpy-display">JPY 換算 = {jpyDisplay}</div>
+          <div className={classes.rateSummaryCol}>
+            <div className={classes.rateSummaryLabel}>JPY 換算</div>
+            {isJpyEquivalentReady ? (
+              <div className={classes.rateSummaryValue} data-testid="fiat-bid-jpy-display">
+                {jpyDisplay}
+              </div>
+            ) : isSpotRateLoading ? (
+              <div
+                className={classes.rateSummaryLoading}
+                data-testid="fiat-bid-jpy-display-loading"
+              >
+                <div className={classes.spinner} aria-hidden="true" />
+                <span>取得中</span>
+              </div>
+            ) : (
+              <div className={classes.rateSummaryValue} data-testid="fiat-bid-jpy-display">
+                {jpyDisplay}
+              </div>
+            )}
+          </div>
         </div>
 
         {!isTopupMode && (


### PR DESCRIPTION
## Summary

Issue #3053 対応。 FiatBidForm の 3 fix を統合 PR で解消する。

- Phase A rateSummary を 2 column card layout に磨き込み (label 12px light + value 20px bold + source 11px の 3 tier hierarchy)
- Phase B spot rate 取得中に CSS-only spinner + 「取得中」 テキストを「現在 spot rate」 「JPY 換算」 両欄で表示 (aria-busy / aria-live 対応)
- Phase C テストカード切替 dropdown に appearance:none + カスタム SVG chevron (data URI、 cool/warm 2 variant) + padding-right 40 で数値との重なり回避

## 変更概要

| file | 内容 |
|---|---|
| FiatBidForm.tsx | rateSummary DOM を 2 col + rateSummaryCol wrap 化、 spinner conditional (spotRate.rate === undefined 判定)、 aria-busy 動的付与 |
| FiatBidForm.module.css | .rateSummary を display:grid + grid-template-columns 1fr 1fr 化、 .rateSummaryLabel / .rateSummaryValue / .rateSummarySource / .rateSummaryLoading / .spinner 追加、 @keyframes spin 追加、 palette cool/warm 対応 |
| CardInput.module.css | .testCardSelect を appearance:none + -webkit-appearance:none + -moz-appearance:none + SVG chevron data URI + padding-right 40 + background-position right 14 化、 palette cool = %23151c3b / warm = %23221b1a の 2 variant |
| FiatBidForm.test.tsx | 新規 file、 2 test 追加 (pending Promise fetcher で spinner 表示 + aria-busy=true 検証、 mockResolvedValue で取得完了 + spot rate 値 + source + aria-busy=false 検証) |
| CardInput.test.tsx | 1 test 拡張 (testCardSelect class 適用検証) |

## Test plan

- [x] pnpm vitest run src/components/FiatBidModal/ = 61 pass (CardInput 32 + FiatBidForm 2 + index 27)
- [x] pnpm test (webapp full) = 9834 pass / 1 skipped / 1 todo (baseline 9831 → +3 = FiatBidForm 2 + CardInput 1、 regression 0)
- [x] pnpm -w lint = 0 errors、 3 pre-existing warnings (react-refresh、 本 PR 起因なし)
- [x] pnpm tsc --noEmit = 0 errors
- [x] pnpm build = 15.99s success

## 完了条件検証 (Issue #3053)

- [x] spot rate 取得中に「現在 spot rate」 + 「JPY 換算」 両欄で spinner + 「取得中」 表示
- [x] spot rate 取得後は 2 column card layout で「見出し + 値」 表示、 value = 20px bold
- [x] テストカード切替 dropdown の chevron が右端から 14px 内側、 padding-right 40px で数値と重ならない
- [x] palette (cool/warm) で spinner border + chevron fill が切替
- [x] pnpm test webapp regression 0

Closes #3053

🤖 Generated with [Claude Code](https://claude.com/claude-code)