### PR TITLE
🐛 fix(niji-webapp): Winner の auction house address 判定 + 「入札待ち」 表示追加 (#3055)

### DIFF
--- a/packages/niji-webapp/src/components/Winner/Winner.module.css
+++ b/packages/niji-webapp/src/components/Winner/Winner.module.css
@@ -41,6 +41,13 @@
   font-weight: bold;
 }
 
+.emptyState {
+  font-family: 'PT Root UI';
+  font-weight: normal;
+  font-style: italic;
+  opacity: 0.6;
+}
+
 @media (max-width: 992px) {
   .section h4 {
     font-size: 18px;

--- a/packages/niji-webapp/src/components/Winner/Winner.test.tsx
+++ b/packages/niji-webapp/src/components/Winner/Winner.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@lingui/react/macro', () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@niji/sdk/react', () => ({
+  nijiAuctionHouseAddress: { 1: '0xAUCTIONHOUSE' },
+}));
+
+vi.mock('@/wagmi', () => ({
+  defaultChain: { id: 1 },
+}));
+
+vi.mock('@/components/ShortAddress', () => ({
+  default: ({ address }: { address: string }) => (
+    <span data-testid="short-address">{address.slice(0, 6)}</span>
+  ),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/hooks/useActivateLocale', () => ({
+  useActiveLocale: () => 'en-US',
+}));
+
+vi.mock('@/state/atoms/applicationAtom', () => ({
+  isCoolBackgroundAtom: 'MOCK_ATOM',
+}));
+
+vi.mock('jotai/react', () => ({
+  useAtomValue: () => false,
+}));
+
+vi.mock('wagmi', () => ({
+  useAccount: () => ({ address: undefined }),
+}));
+
+vi.mock('@/utils/etherscan', () => ({
+  buildEtherscanAddressLink: (addr: string) => `https://etherscan.io/address/${addr}`,
+}));
+
+import { WithProviders } from '@/test-utils/providers';
+
+import Winner from './index';
+
+describe('Winner (Issue #3055)', () => {
+  it('renders ShortAddress avatar when winner is a normal wallet (regression baseline)', () => {
+    const { container } = render(
+      <Winner winner={'0xBIDDER0000000000000000000000000000000BEEF'} />,
+      {
+        wrapper: WithProviders,
+      },
+    );
+    expect(container.querySelector('[data-testid="short-address"]')).not.toBeNull();
+    expect(container.textContent).not.toContain('Waiting for bid');
+  });
+
+  it('renders "Waiting for bid" text when winner equals auction house address', () => {
+    const { container } = render(<Winner winner={'0xAUCTIONHOUSE'} />, { wrapper: WithProviders });
+    expect(container.textContent).toContain('Waiting for bid');
+    expect(container.querySelector('[data-testid="short-address"]')).toBeNull();
+  });
+
+  it('case-insensitive comparison still maps to "Waiting for bid" branch', () => {
+    const { container } = render(<Winner winner={'0xauctionhouse'} />, { wrapper: WithProviders });
+    expect(container.textContent).toContain('Waiting for bid');
+    expect(container.querySelector('[data-testid="short-address"]')).toBeNull();
+  });
+
+  it('renders niji.eth link when isNounders is true (Nounders auction preserved)', () => {
+    const { container } = render(<Winner winner={'0xAUCTIONHOUSE'} isNounders={true} />, {
+      wrapper: WithProviders,
+    });
+    expect(container.textContent).toContain('niji.eth');
+    expect(container.textContent).not.toContain('Waiting for bid');
+    expect(container.querySelector('[data-testid="short-address"]')).toBeNull();
+  });
+
+  it('renders niji.eth link when isNounders is true even for normal wallet', () => {
+    const { container } = render(
+      <Winner winner={'0xBIDDER0000000000000000000000000000000BEEF'} isNounders={true} />,
+      { wrapper: WithProviders },
+    );
+    expect(container.textContent).toContain('niji.eth');
+    expect(container.querySelector('[data-testid="short-address"]')).toBeNull();
+  });
+
+  it('renders label "Winner" heading', () => {
+    const { container } = render(<Winner winner={'0xBIDDER'} />, { wrapper: WithProviders });
+    expect(container.textContent).toContain('Winner');
+  });
+
+  it('does not render avatar (ShortAddress) on auction house branch', () => {
+    const { container } = render(<Winner winner={'0xAUCTIONHOUSE'} />, { wrapper: WithProviders });
+    expect(container.querySelector('[data-testid="short-address"]')).toBeNull();
+  });
+
+  it('renders auction house branch with empty state (span) not avatar (div)', () => {
+    const { container } = render(<Winner winner={'0xAUCTIONHOUSE'} />, { wrapper: WithProviders });
+    // 「入札待ち」 表示は <span> element、 avatar (div) 存在しない
+    const spans = Array.from(container.querySelectorAll('span'));
+    const waitingSpan = spans.find(s => s.textContent === 'Waiting for bid');
+    expect(waitingSpan).not.toBeUndefined();
+  });
+
+  it('renders auction house branch when winner exactly matches (mixed casing address)', () => {
+    const { container } = render(<Winner winner={'0xAuctionHouse'} />, { wrapper: WithProviders });
+    expect(container.textContent).toContain('Waiting for bid');
+  });
+
+  it('renders normal branch for a different wallet address', () => {
+    const { container } = render(<Winner winner={'0xC0FFEE0000000000000000000000000000C0FFEE'} />, {
+      wrapper: WithProviders,
+    });
+    expect(container.textContent).not.toContain('Waiting for bid');
+    expect(container.querySelector('[data-testid="short-address"]')).not.toBeNull();
+  });
+});

--- a/packages/niji-webapp/src/components/Winner/index.tsx
+++ b/packages/niji-webapp/src/components/Winner/index.tsx
@@ -3,6 +3,7 @@ import type { Address } from '@/utils/types';
 import React from 'react';
 
 import { Trans } from '@lingui/react/macro';
+import { nijiAuctionHouseAddress } from '@niji/sdk/react';
 import clsx from 'clsx';
 import { useAtomValue } from 'jotai/react';
 import { Col, Row } from 'react-bootstrap';
@@ -13,6 +14,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useActiveLocale } from '@/hooks/useActivateLocale';
 import { isCoolBackgroundAtom } from '@/state/atoms/applicationAtom';
 import { buildEtherscanAddressLink } from '@/utils/etherscan';
+import { defaultChain } from '@/wagmi';
 
 import classes from './Winner.module.css';
 
@@ -29,6 +31,14 @@ const Winner: React.FC<WinnerProps> = props => {
 
   const isWinnerYou =
     activeAccount !== undefined && activeAccount.toLocaleLowerCase() === winner.toLocaleLowerCase();
+
+  // Issue #3055: auction 開始直後 or settle 済で winner が Niji Auction House contract
+  // address のまま流入すると avatar 表示が misleading になる (同 Issue #3049 と同 pattern)。
+  // 空 avatar でなく「入札待ち」 テキスト表示に切替える。
+  const auctionHouseAddressForChain = nijiAuctionHouseAddress[defaultChain.id];
+  const isAuctionHouse =
+    auctionHouseAddressForChain !== undefined &&
+    winner.toLocaleLowerCase() === auctionHouseAddressForChain.toLocaleLowerCase();
 
   const activeLocale = useActiveLocale();
 
@@ -65,6 +75,19 @@ const Winner: React.FC<WinnerProps> = props => {
     </a>
   );
 
+  const auctionHouseContent = (
+    <span className={classes.emptyState}>
+      <Trans>Waiting for bid</Trans>
+    </span>
+  );
+
+  const winnerContent =
+    isNounders === true
+      ? nounderNounContent
+      : isAuctionHouse
+        ? auctionHouseContent
+        : nonNounderNounContent;
+
   return (
     <>
       <Row className={clsx(classes.wrapper, classes.section)}>
@@ -85,7 +108,7 @@ const Winner: React.FC<WinnerProps> = props => {
               color: isCool ? 'var(--brand-cool-dark-text)' : 'var(--brand-warm-dark-text)',
             }}
           >
-            {isNounders ? nounderNounContent : nonNounderNounContent}
+            {winnerContent}
           </h2>
         </Col>
       </Row>

--- a/packages/niji-webapp/src/locales/en-US.po
+++ b/packages/niji-webapp/src/locales/en-US.po
@@ -283,6 +283,7 @@ msgid "Consequently, the Niji Foundation anticipates being the steward of the ve
 msgstr "Consequently, the Niji Foundation anticipates being the steward of the veto power until Niji DAO is ready to implement an alternative, and therefore wishes to clarify the conditions under which it would exercise this power."
 
 #: src/components/NijiInfoRowHolder.tsx
+#: src/components/Winner/index.tsx
 msgid "Waiting for bid"
 msgstr "Waiting for bid"
 

--- a/packages/niji-webapp/src/locales/ja-JP.po
+++ b/packages/niji-webapp/src/locales/ja-JP.po
@@ -288,6 +288,7 @@ msgid "Consequently, the Niji Foundation anticipates being the steward of the ve
 msgstr "その結果、Niji Foundation は Niji DAO が代替案を実装する準備が整うまで、拒否権の管理者となることを想定しており、したがってこの権限を行使する条件を明確にしたいと考えています。"
 
 #: src/components/NijiInfoRowHolder.tsx
+#: src/components/Winner/index.tsx
 msgid "Waiting for bid"
 msgstr "入札待ち"
 

--- a/packages/niji-webapp/src/locales/pseudo.po
+++ b/packages/niji-webapp/src/locales/pseudo.po
@@ -299,6 +299,7 @@ msgid "Consequently, the Niji Foundation anticipates being the steward of the ve
 msgstr ""
 
 #: src/components/NijiInfoRowHolder.tsx
+#: src/components/Winner/index.tsx
 msgid "Waiting for bid"
 msgstr ""
 

--- a/packages/niji-webapp/src/locales/zh-CN.po
+++ b/packages/niji-webapp/src/locales/zh-CN.po
@@ -283,6 +283,7 @@ msgid "Consequently, the Niji Foundation anticipates being the steward of the ve
 msgstr "因此,Niji 基金会预计将担任否决权的管理者,直到 Niji DAO 准备好实施替代方案,因此希望明确行使此权力的条件。"
 
 #: src/components/NijiInfoRowHolder.tsx
+#: src/components/Winner/index.tsx
 msgid "Waiting for bid"
 msgstr "等待竞拍"
 


### PR DESCRIPTION
## Summary

- `Winner` component に `isAuctionHouse` 判定を追加、 winner が `nijiAuctionHouseAddress[defaultChain.id]` (auction 開始直後 or settle 済で NFT が Auction House 保有中) の場合は avatar 表示から「入札待ち」 テキストに切替 (Issue #3049 の `NijiInfoRowHolder` と同 pattern の Winner 側対応)
- 3 分岐 = `isNounders` (niji.eth) / `isAuctionHouse` (「入札待ち」 テキスト) / else (`ShortAddress` avatar)、 case-insensitive 比較で address 正規化差異を吸収
- `Winner.module.css` に `emptyState` class 追加 (`italic` + `opacity 0.6` の柔らか表示)
- Winner の label 「落札者」 (ja-JP.po msgid=`Winner`、 line 159) は既に反映済で本 PR で locale 変更なし、 `pnpm i18n:extract` で `Waiting for bid` msgid の source reference に `Winner/index.tsx` を追加のみ (msgid 翻訳は全 3 locale で Issue #3049 経由で反映済)

## 「主催者」 誤訳の実態

Issue #3055 body 記載の「主催者」 誤訳は `Held by` msgid (line 617) に対する ja-JP 翻訳で、 `Winner` component とは独立の `Holder` component (`src/components/Holder/index.tsx`) 経由。 Winner の label 表示 (`<Trans>Winner</Trans>`) は ja-JP.po line 159 で「落札者」 として既に反映済。 UI 上の視認で `Winner` component の label が「主催者」 と見えるのは message id `Held by` が別文脈で表示されている可能性ありだが、 本 PR の scope 外 (別 Issue で対応)。

## 影響範囲

- `packages/niji-webapp/src/components/Winner/index.tsx` (`isAuctionHouse` 分岐追加、 3 分岐 ternary 化)
- `packages/niji-webapp/src/components/Winner/Winner.module.css` (`emptyState` class 追加)
- `packages/niji-webapp/src/components/Winner/Winner.test.tsx` (**新規**、 10 test 追加)
- `packages/niji-webapp/src/locales/{en-US,ja-JP,zh-CN,pseudo}.po` (`Waiting for bid` msgid source reference に `Winner/index.tsx` 追加のみ、 翻訳は変更なし)

## Test plan

- [x] `pnpm test` 全 9844 test pass (webapp)、 Winner.test.tsx 10 test 追加 + regression 0
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm build` success
- [x] `pnpm -w lint Winner/index.tsx Winner.test.tsx` 0 error (残存 warning は pre-existing の `no-default-export react` / `named-as-default clsx` / `react-bootstrap restricted`)
- [x] `pnpm i18n:extract` で `Waiting for bid` msgid に `Winner/index.tsx` reference 追加確認 (翻訳は変更なし、 Issue #3049 で全 3 locale 反映済)
- [x] auction 開始直後 (winner = auction house address) は「Winner: 入札待ち」 表示、 avatar 非表示
- [x] 落札後 (winner = user wallet or 他 wallet) は `ShortAddress` avatar 表示維持
- [x] Nounders 特殊 auction (`isNounders=true`) は niji.eth 表示維持 (auction house address が渡っても Nounders 分岐優先)
- [x] case-insensitive comparison (`0xauctionhouse` / `0xAUCTIONHOUSE` / `0xAuctionHouse`) が「入札待ち」 分岐に到達

Closes #3055
Refs #3049