### PR TITLE
🐛 fix(niji-webapp): Holder Held by ja 翻訳 主催者 → 保有者 (#3057)

### DIFF
--- a/packages/niji-webapp/src/locales/ja-JP.po
+++ b/packages/niji-webapp/src/locales/ja-JP.po
@@ -615,7 +615,7 @@ msgstr "象徴的なノグルズを含む Niji DAO 公式ブランドアセッ�
 
 #: src/components/Holder/index.tsx
 msgid "Held by"
-msgstr "主催者"
+msgstr "保有者"
 
 #: src/pages/Nounders/index.tsx
 msgid "The Nijiders"


### PR DESCRIPTION
Closes #3057

## Summary

- Holder component の `<Trans>Held by</Trans>` の ja 翻訳が「主催者」 と誤訳されていた点を「保有者」 に修正
- Issue #3055 で発覚した「auction ページの image が主催者 と表示される」 現象の真の root cause 修正
- 「Held by」 = NFT holder = 「保有者」、 「主催者」 は event organizer で意味完全に異なる
- packages/niji-webapp/src/locales/ja-JP.po の msgstr 1 行変更、 lingui compile で ja-JP.js (untracked、 build artifact) 自動反映
- en-US / zh-CN / pseudo は変更なし (en「Held by」 / zh「持有者」 で妥当)

## Test plan

- [x] Holder/index.test.tsx = 124 tests pass (Trans mock で children pass-through、 translation 期待値変更不要)
- [x] webapp 全 test = 9844 pass / 1 skipped / 1 todo (regression 0 件)
- [x] pnpm i18n:compile 成功、 ja-JP.js の msgid hash `eLJFbd` が「保有者」 に更新確認
- [x] pnpm -w lint 0 error
- [x] auction ページで Holder 表示が「保有者」 になる (dev 実機確認は user 側で最終確認)

## Rollback plan

- ja-JP.po の msgstr 「保有者」 → 「主催者」 に戻し、 pnpm i18n:compile 実行 → 単純 revert 可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)