### PR TITLE
🐛 fix(niji-webapp,make): spot rate env 不整合修正 + make dev に niji-api 追加 + JPY spinner 条件修正 (#3059)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,11 @@ ANVIL_LOG := $(LOG_DIR)/anvil.log
 WEBAPP_LOG := $(LOG_DIR)/webapp.log
 DEPLOY_LOG := $(LOG_DIR)/deploy.log
 SETTLER_LOG := $(LOG_DIR)/auto-settler.log
+API_LOG := $(LOG_DIR)/api.log
 ANVIL_PID := $(LOG_DIR)/anvil.pid
 WEBAPP_PID := $(LOG_DIR)/webapp.pid
 SETTLER_PID := $(LOG_DIR)/auto-settler.pid
+API_PID := $(LOG_DIR)/api.pid
 ANVIL_STATE := $(LOG_DIR)/anvil-state.json
 # fresh chain snapshot ... make dev-init で 1 回 deploy 済 anvil state を保存、
 # make dev-stop && make dev で snapshot を copy して load = 毎回 fresh chain を ~1s で起動する。
@@ -42,20 +44,21 @@ WEBAPP_ENV_EXAMPLE := $(ROOT)/packages/niji-webapp/.env.example.local
 
 ANVIL_PORT := 8547
 WEBAPP_PORT := 2424
+API_PORT := 42069
 
-.PHONY: help dev dev-init dev-refresh dev-sepolia dev-fg dev-stop dev-status dev-logs setup setup-env install build anvil-bg webapp-bg snapshot-if-needed auto-settler-bg
+.PHONY: help dev dev-init dev-refresh dev-sepolia dev-fg dev-stop dev-status dev-logs setup setup-env install build anvil-bg webapp-bg snapshot-if-needed auto-settler-bg api-bg
 
 help:
 	@echo "Niji DAO — local dev commands"
 	@echo ""
-	@echo "  make dev           anvil + snapshot load (~1s) + auto-settler + webapp 並列起動 (Recommended)"
+	@echo "  make dev           anvil + snapshot load (~1s) + niji-api + auto-settler + webapp 並列起動 (Recommended)"
 	@echo "  make dev-init      1 回 fresh chain deploy して snapshot 保存 (初回 or 手動再生成用)"
 	@echo "  make dev-refresh   snapshot 削除 + dev-init で snapshot 再生成 (contract 変更後)"
-	@echo "  make dev-stop      anvil + auto-settler + webapp を graceful shutdown + live state 削除"
+	@echo "  make dev-stop      anvil + niji-api + auto-settler + webapp を graceful shutdown + live state 削除"
 	@echo "  make dev-sepolia   webapp のみ sepolia mode で background 起動 (anvil 不要)"
 	@echo "  make dev-fg        anvil + webapp を foreground で並列起動 (Ctrl+C で停止)"
 	@echo "  make dev-status    起動状況を確認 (PID / port listen / HTTP 応答 / state / snapshot 有無)"
-	@echo "  make dev-logs      anvil / deploy / auto-settler / webapp log を tail -f で表示"
+	@echo "  make dev-logs      anvil / deploy / niji-api / auto-settler / webapp log を tail -f で表示"
 	@echo "  make setup         pnpm install + sdk/contracts build + .env 作成"
 	@echo "  make help          このヘルプを表示"
 	@echo ""
@@ -63,8 +66,9 @@ help:
 	@echo "  snapshot 不在時は make dev が自動的に dev-init を呼ぶ"
 	@echo ""
 	@echo "URL:"
-	@echo "  webapp  http://localhost:$(WEBAPP_PORT)"
-	@echo "  anvil   http://127.0.0.1:$(ANVIL_PORT) (chain id 31337)"
+	@echo "  webapp   http://localhost:$(WEBAPP_PORT)"
+	@echo "  niji-api http://127.0.0.1:$(API_PORT) (Ponder + Hono)"
+	@echo "  anvil    http://127.0.0.1:$(ANVIL_PORT) (chain id 31337)"
 	@echo ""
 	@echo "State:"
 	@echo "  live state  $(ANVIL_STATE) (make dev-stop で削除)"
@@ -148,6 +152,22 @@ auto-settler-bg: | $(LOG_DIR)
 		echo "🟢 auto-settler started (PID $$(cat $(SETTLER_PID)))"; \
 	fi
 
+# niji-api (Ponder + Hono、 port 42069) を background 起動。 既存プロセスがあれば再利用。
+# webapp から VITE_GMO_API_ENDPOINT 経由で spot rate / fiat bid endpoint を呼出するため必要。
+# Ponder 起動時間 10-30 秒、 起動直後 30 秒間は webapp からの GET /api/v1/spot-rate/eth-jpy が
+# undefined を返す (FiatBidForm 側で「取得中」 spinner 表示、 UX 上問題なし)。
+api-bg: | $(LOG_DIR)
+	@if [ -f "$(API_PID)" ] && kill -0 $$(cat $(API_PID)) 2>/dev/null; then \
+		echo "🟢 niji-api already running (PID $$(cat $(API_PID)))"; \
+	else \
+		echo "🚀 starting niji-api on :$(API_PORT) (Ponder + Hono、 10-30s 起動)..."; \
+		cd $(ROOT)/packages/niji-api && nohup pnpm dev \
+			> "$(API_LOG)" 2>&1 & \
+		echo $$! > "$(API_PID)"; \
+		sleep 1; \
+		echo "🟢 niji-api started (PID $$(cat $(API_PID)), log=$(API_LOG))"; \
+	fi
+
 # webapp を background 起動。 既存プロセスがあれば再利用。
 webapp-bg: | $(LOG_DIR)
 	@if [ -f "$(WEBAPP_PID)" ] && kill -0 $$(cat $(WEBAPP_PID)) 2>/dev/null; then \
@@ -161,13 +181,15 @@ webapp-bg: | $(LOG_DIR)
 		echo "🟢 webapp started (PID $$(cat $(WEBAPP_PID)))"; \
 	fi
 
-# make dev = snapshot copy (~100ms) + anvil load (~1s) + auto-settler + webapp。
+# make dev = snapshot copy (~100ms) + anvil load (~1s) + niji-api + auto-settler + webapp。
 # snapshot は事前に make dev-init で 1 回作成、 以降 make dev-stop && make dev で常に fresh chain を ~1s で復元。
-dev: setup-env snapshot-if-needed anvil-bg auto-settler-bg webapp-bg
+# niji-api は Ponder 起動時間 10-30 秒、 webapp からの spot rate fetch は Ponder 起動完了後に成功する。
+dev: setup-env snapshot-if-needed anvil-bg api-bg auto-settler-bg webapp-bg
 	@echo ""
 	@echo "✅ dev environment ready (snapshot load、 常に fresh chain)."
 	@echo ""
 	@echo "  webapp        http://localhost:$(WEBAPP_PORT)"
+	@echo "  niji-api      http://127.0.0.1:$(API_PORT) (Ponder + Hono、 起動 10-30s)"
 	@echo "  anvil         http://127.0.0.1:$(ANVIL_PORT) (chain 31337)"
 	@echo "  auto-settler  🤖 5s polling, next auction starts automatically on endTime"
 	@if [ -f "$(ANVIL_STATE)" ]; then \
@@ -261,9 +283,24 @@ dev-stop:
 		fi; \
 		rm -f "$(SETTLER_PID)"; \
 	fi
+	@if [ -f "$(API_PID)" ]; then \
+		PID=$$(cat "$(API_PID)"); \
+		if kill -0 $$PID 2>/dev/null; then \
+			pkill -P $$PID 2>/dev/null || true; \
+			kill $$PID 2>/dev/null || true; \
+			echo "  ⛔ niji-api stopped (PID $$PID)"; \
+		fi; \
+		rm -f "$(API_PID)"; \
+	fi
 	@# tsx + pnpm の 4 段 process tree で pkill -P が届かない子孫を確実に掃除。
 	@# script 名 pattern で残骸を一括 kill する fallback。
 	@pkill -9 -f "anvil-auto-settler" 2>/dev/null || true
+	@# fallback ... PID file が壊れていても port を listen している niji-api を殺す
+	@API_PIDS=$$(lsof -nP -iTCP:$(API_PORT) -sTCP:LISTEN -t 2>/dev/null); \
+	if [ -n "$$API_PIDS" ]; then \
+		echo "$$API_PIDS" | xargs kill 2>/dev/null || true; \
+		echo "  ⛔ killed lingering niji-api listeners on :$(API_PORT)"; \
+	fi
 	@# anvil は SIGTERM で --state dump 完了を待つ (最大 10 秒)。 dump 中に SIGKILL すると
 	@# JSON が途中で切れ、 次の make dev で "failed to parse json file: EOF" で起動失敗する。
 	@# graceful shutdown 経路 = SIGTERM 送信 → 1 秒間隔で process 死亡 poll (最大 10 秒) → 未死亡なら SIGKILL fallback。
@@ -324,6 +361,13 @@ dev-status:
 	else \
 		echo "  webapp        ⚪ stopped"; \
 	fi
+	@if [ -f "$(API_PID)" ] && kill -0 $$(cat $(API_PID)) 2>/dev/null; then \
+		echo "  niji-api      🟢 running (PID $$(cat $(API_PID)), port $(API_PORT))"; \
+		curl -s -o /dev/null -w "                HTTP          %{http_code}\n" \
+			http://127.0.0.1:$(API_PORT) || echo "                HTTP          no response"; \
+	else \
+		echo "  niji-api      ⚪ stopped (webapp spot rate / fiat bid endpoint が offline)"; \
+	fi
 	@if [ -f "$(SETTLER_PID)" ] && kill -0 $$(cat $(SETTLER_PID)) 2>/dev/null; then \
 		echo "  auto-settler  🤖 running (PID $$(cat $(SETTLER_PID)), 5s poll)"; \
 	else \
@@ -343,6 +387,6 @@ dev-status:
 	@echo "  log dir  $(LOG_DIR)"
 
 dev-logs:
-	@echo "📜 tailing anvil + deploy + auto-settler + webapp logs (Ctrl+C to exit)..."
-	@touch "$(ANVIL_LOG)" "$(DEPLOY_LOG)" "$(SETTLER_LOG)" "$(WEBAPP_LOG)"
-	@tail -f "$(ANVIL_LOG)" "$(DEPLOY_LOG)" "$(SETTLER_LOG)" "$(WEBAPP_LOG)"
+	@echo "📜 tailing anvil + deploy + niji-api + auto-settler + webapp logs (Ctrl+C to exit)..."
+	@touch "$(ANVIL_LOG)" "$(DEPLOY_LOG)" "$(API_LOG)" "$(SETTLER_LOG)" "$(WEBAPP_LOG)"
+	@tail -f "$(ANVIL_LOG)" "$(DEPLOY_LOG)" "$(API_LOG)" "$(SETTLER_LOG)" "$(WEBAPP_LOG)"

--- a/docs/operations/gmo-fiat-bid.md
+++ b/docs/operations/gmo-fiat-bid.md
@@ -30,17 +30,27 @@ Issue 1 段階では env 変数一覧 + mock server 切替手順のみ記載、 
 
 | 変数名 | 用途 | 例 (Phase 1 mock) | 本番切替時 |
 |---|---|---|---|
-| `VITE_GMO_API_ENDPOINT` | niji-api base URL | `http://127.0.0.1:42069` | `https://api.niji-dao.example` |
+| `VITE_GMO_API_ENDPOINT` | niji-api base URL (spot rate / fiat bid endpoint) | `http://127.0.0.1:42069` | `https://api.niji-dao.example` |
 | `VITE_ENABLE_FIAT_BID` | fiat bid UI 表示 flag (`true` / `false`) | `false` (開発中) | `true` (release 後) |
+
+`VITE_GMO_API_ENDPOINT` は Issue #3059 で SSOT に統一済。 `useSpotRate.ts` / `.env.example.local` は本 env 名で一致する (旧 `VITE_NIJI_API_BASE_URL` は同 Issue で撤廃)。 本 env 未設定時は同一 origin (webapp 2424 port) に fallback するが、 dev では niji-api の 42069 port を叩かないと `/api/v1/spot-rate/eth-jpy` が 404 になる (webapp origin に api endpoint 未実装のため)。
 
 ## mock server 切替手順
 
 Phase 1 開発期間中は mock server 経由で e2e 動作させる。 手順 —
 
 1. `packages/niji-api/.env` を `.env.example` からコピー、 `USE_GMO_MOCK=true` を設定
-2. `pnpm dev` を `packages/niji-api` で実行、 Ponder dev server が起動する
+2. repo root で `make dev` を実行、 niji-api (Ponder + Hono、 port 42069) は anvil / auto-settler / webapp と並列 bg 起動する (Issue #3059 で `api-bg` target 追加)
 3. Issue 3 以降で追加される hono handler 経由で GMO endpoint (mock) 呼出、 form-encoded 応答が返る
 4. Phase 3 本番切替時は `USE_GMO_MOCK=false` + `GMO_ENDPOINT=https://p01.mul-pay.jp` に変更
+
+### make dev で niji-api 起動 (Issue #3059)
+
+`make dev` は niji-api を含む 4 process (anvil / niji-api / auto-settler / webapp) を bg 起動する。 Ponder 起動時間は 10-30 秒、 起動直後 30 秒間は webapp からの `GET /api/v1/spot-rate/eth-jpy` が undefined を返す (FiatBidForm 側で「取得中」 spinner 表示、 UX 上問題なし)。
+
+- `make dev-status` で niji-api の PID / port listen / HTTP 応答を確認できる
+- `make dev-logs` で `.context/dev/api.log` を含む全 log を tail -f 表示
+- `make dev-stop` で niji-api の PID を graceful kill + port 42069 の残骸 listener を lsof 経由で掃除
 
 Issue 1 時点の behavior test 経路 —
 

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
@@ -4,12 +4,17 @@
  * Phase B — spot rate 取得中の spinner + 「取得中」 表示検証。
  * spot rate 未取得 (rate === undefined) 状態で、
  * (1) 現在 spot rate 欄に spinner + 「取得中」 表示
- * (2) JPY 換算欄に spinner + 「取得中」 表示
+ * (2) JPY 換算欄の spinner は Issue #3059 で条件変更 —「ETH 入力あり + spot rate 未取得」 に限定、
+ *     ETH 未入力時は「—」 表示 (spinner 出ない)
  * (3) rateSummary root に aria-busy="true" が付与される
  *
  * Phase A の 2 column card layout は CSS module 経路の変更 (visual)、
  * 挙動 test で覆う対象は「取得済 branch で spot rate 値 + JPY 換算値が
  * それぞれ rateSummaryValue class 系 element に表示される」 の 1 点。
+ *
+ * Issue #3059 追加 test —
+ * (4) ETH 未入力 + spot rate 未取得 → JPY 換算欄「—」 表示、 spinner 非表示
+ * (5) ETH 入力あり + spot rate 未取得 → JPY 換算欄 spinner + 「取得中」 表示
  */
 
 import type { SpotRate } from '@/hooks/useSpotRate';
@@ -17,7 +22,7 @@ import type { SpotRate } from '@/hooks/useSpotRate';
 import * as React from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -47,8 +52,8 @@ const successRate: SpotRate = {
   expiresAt: '2026-07-01T00:00:05.000Z',
 };
 
-describe('FiatBidForm loading spinner (Issue #3053 Phase B)', () => {
-  it('spot rate 未取得時に「現在 spot rate」 + 「JPY 換算」 両欄で spinner + 「取得中」 表示', () => {
+describe('FiatBidForm loading spinner (Issue #3053 Phase B、 Issue #3059 で JPY 側条件更新)', () => {
+  it('spot rate 未取得 + ETH 未入力時 → spot rate 欄は spinner 表示、 JPY 換算欄は「—」 (spinner 非表示、 Issue #3059)', () => {
     // spot rate fetcher = pending Promise (never resolve) で undefined 保持
     const pendingFetcher = vi.fn(() => new Promise<SpotRate>(() => {}));
 
@@ -68,17 +73,17 @@ describe('FiatBidForm loading spinner (Issue #3053 Phase B)', () => {
       { wrapper: buildWrapper() },
     );
 
-    // spot rate 欄の spinner + 「取得中」
+    // spot rate 欄の spinner + 「取得中」 (modal open 直後の情報提示、 独立して表示)
     const rateLoading = screen.getByTestId('fiat-bid-rate-summary-loading');
     expect(rateLoading).toBeInTheDocument();
     expect(rateLoading.textContent).toContain('取得中');
 
-    // JPY 換算欄の spinner + 「取得中」
-    const jpyLoading = screen.getByTestId('fiat-bid-jpy-display-loading');
-    expect(jpyLoading).toBeInTheDocument();
-    expect(jpyLoading.textContent).toContain('取得中');
+    // Issue #3059 — ETH 未入力時、 JPY 換算欄は「—」 表示 (spinner 非表示)
+    expect(screen.queryByTestId('fiat-bid-jpy-display-loading')).toBeNull();
+    const jpyDisplay = screen.getByTestId('fiat-bid-jpy-display');
+    expect(jpyDisplay.textContent).toContain('—');
 
-    // rateSummary root に aria-busy="true" 付与 (screen reader 対応)
+    // rateSummary root に aria-busy="true" 付与 (screen reader 対応、 spot rate 側 loading state)
     const rateSummary = screen.getByTestId('fiat-bid-rate-summary');
     expect(rateSummary.getAttribute('aria-busy')).toBe('true');
   });
@@ -122,5 +127,35 @@ describe('FiatBidForm loading spinner (Issue #3053 Phase B)', () => {
     const jpyDisplay = screen.getByTestId('fiat-bid-jpy-display');
     expect(jpyDisplay).toBeInTheDocument();
     expect(jpyDisplay.textContent).toContain('—');
+  });
+
+  it('spot rate 未取得 + ETH 入力あり → JPY 換算欄で spinner + 「取得中」 表示 (Issue #3059)', () => {
+    // spot rate fetcher = pending Promise (never resolve)、 rate === undefined 保持
+    const pendingFetcher = vi.fn(() => new Promise<SpotRate>(() => {}));
+
+    render(
+      <FiatBidForm
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn() },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: pendingFetcher, refetchInterval: 0 }}
+        isDev={true}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+    // ETH 入力を発火 (validation NG でも ethRaw に値が入っていれば spinner 判定 trigger)
+    const ethInput = screen.getByTestId('fiat-bid-eth-input');
+    fireEvent.change(ethInput, { target: { value: '0.05' } });
+
+    // JPY 換算欄で spinner + 「取得中」 表示 (ETH 入力あり + spot rate 未取得 branch)
+    const jpyLoading = screen.getByTestId('fiat-bid-jpy-display-loading');
+    expect(jpyLoading).toBeInTheDocument();
+    expect(jpyLoading.textContent).toContain('取得中');
   });
 });

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.tsx
@@ -286,6 +286,14 @@ export const FiatBidForm = ({
 
   const isSpotRateLoading = spotRate.rate === undefined;
   const isJpyEquivalentReady = ethValidation.ok && spotRate.rate !== undefined;
+  /**
+   * ETH input 欄に user が値を入力しているか (Issue #3059 Phase C)。
+   *
+   * JPY 換算欄の spinner 表示条件を「ETH 入力あり + spot rate 未取得」 に限定するために使う。
+   * ETH 未入力時 (初期 state or clear 直後) は spinner を出さず「—」 表示に落として、
+   * spot rate polling が回っているだけで JPY 換算欄が「取得中」 と回り続ける UX 問題を解消する。
+   */
+  const ethInputHasValue = ethRaw.trim() !== '';
 
   const submitDisabled =
     !ethValidation.ok ||
@@ -473,7 +481,7 @@ export const FiatBidForm = ({
               <div className={classes.rateSummaryValue} data-testid="fiat-bid-jpy-display">
                 {jpyDisplay}
               </div>
-            ) : isSpotRateLoading ? (
+            ) : ethInputHasValue && isSpotRateLoading ? (
               <div
                 className={classes.rateSummaryLoading}
                 data-testid="fiat-bid-jpy-display-loading"

--- a/packages/niji-webapp/src/hooks/useSpotRate.ts
+++ b/packages/niji-webapp/src/hooks/useSpotRate.ts
@@ -37,13 +37,16 @@ export type UseSpotRateOptions = {
 };
 
 /**
- * default fetcher = env の VITE_NIJI_API_BASE_URL 経由で /api/v1/spot-rate/eth-jpy を GET
+ * default fetcher = env の VITE_GMO_API_ENDPOINT 経由で /api/v1/spot-rate/eth-jpy を GET
  * env 未設定時は同一 origin (Vite proxy 前提)
+ *
+ * env var 名 SSOT = packages/niji-webapp/.env.example.local の VITE_GMO_API_ENDPOINT (Issue #3059)。
+ * dev = http://127.0.0.1:42069 (niji-api Ponder default port)、 prod = deploy URL。
  */
 export const defaultSpotRateFetcher = async (): Promise<SpotRate> => {
   const envValue =
     typeof import.meta !== 'undefined'
-      ? (import.meta as { env?: Record<string, string> }).env?.['VITE_NIJI_API_BASE_URL']
+      ? (import.meta as { env?: Record<string, string> }).env?.['VITE_GMO_API_ENDPOINT']
       : undefined;
   const apiBase = typeof envValue === 'string' ? envValue : '';
   const url = `${apiBase.replace(/\/$/, '')}/api/v1/spot-rate/eth-jpy`;


### PR DESCRIPTION
## Summary

- `useSpotRate.ts` の env var 名を `VITE_NIJI_API_BASE_URL` → `VITE_GMO_API_ENDPOINT` に統一 (`.env.example.local` と一致、 spot rate fetch が webapp origin に落ちて 404 になる問題を解消)
- `Makefile` に `api-bg` target 追加、 `make dev` で `niji-api` (Ponder + Hono、 port 42069) を anvil / auto-settler / webapp と並列 bg 起動、 `dev-stop` / `dev-status` / `dev-logs` も api 対応拡張
- `FiatBidForm` の JPY 換算欄 spinner 条件を「ETH 入力あり + spot rate 未取得」 に限定、 ETH 未入力時は「—」 表示 (spinner 出続ける UX 問題解消)

## 変更内容

### Phase A env var 名統一 (SSOT = `VITE_GMO_API_ENDPOINT`)

- `packages/niji-webapp/src/hooks/useSpotRate.ts:46` の `VITE_NIJI_API_BASE_URL` を `VITE_GMO_API_ENDPOINT` に変更
- JSDoc に SSOT source (`.env.example.local`) と dev/prod URL 例を明記

### Phase B `Makefile` に niji-api 起動 target 追加

- `api-bg` target 新規 (`packages/niji-api` で `pnpm dev` bg 起動、 log = `.context/dev/api.log`、 pid = `.context/dev/api.pid`)
- `dev` target 依存に `api-bg` 追加 (`setup-env snapshot-if-needed anvil-bg api-bg auto-settler-bg webapp-bg`)
- `dev-stop` で `api-bg` の PID kill + port 42069 の lsof 経路残骸掃除
- `dev-status` で niji-api の起動状況表示、 `dev-logs` で `api.log` tail、 `.PHONY` に `api-bg` 追加
- help / URL section も更新

### Phase C `FiatBidForm` JPY 換算 spinner 条件修正

- `ethInputHasValue = ethRaw.trim() !== ''` 変数追加
- JPY 換算欄条件を「ETH 入力あり かつ spot rate 未取得」 に限定 (else branch = 「—」 表示)
- spot rate 側 spinner は独立維持 (modal open 直後の情報提示)

### Phase D test 更新

- `FiatBidForm.test.tsx` で既存 1 test を新仕様に更新 (ETH 未入力時 spinner 非表示)、 新 test 1 個追加 (ETH 入力後 spinner 表示 = fireEvent 経由)
- 修正 file focused test = 23/23 pass、 webapp 全体 = 9845/9846 pass、 regression 0

### Phase E docs 更新

- `docs/operations/gmo-fiat-bid.md` の env 変数表を Issue #3059 SSOT 明示付き更新
- make dev で niji-api 起動 section 追加、 Ponder 起動時間の運用注意点 (10-30 秒、 起動直後は spot rate spinner 表示) を記載

## 完了条件 (Stated check)

- [x] Phase A: `useSpotRate.ts` が `VITE_GMO_API_ENDPOINT` を参照
- [x] Phase B: `make dev` で niji-api 並列起動、 `dev-stop` で停止、 `dev-status` で状況表示
- [x] Phase C: JPY 換算欄 ETH 未入力時「—」、 ETH 入力あり + spot rate 未取得時のみ spinner
- [x] Phase D: 新規 test 追加 + 既存 test regression 0 (9845 pass)
- [x] Phase E: docs 更新

## Test plan

- [x] `pnpm --filter @niji/webapp test --run` = 9845 pass / 1 skipped / 1 todo、 regression 0
- [x] `pnpm --filter @niji/webapp check` = typecheck pass
- [x] `pnpm --filter @niji/webapp build` = build success (14.86s)
- [x] `pnpm -w lint <修正 3 files>` = 0 errors (warning 3 は pre-existing react-refresh)
- [x] `make -n dev` = Makefile syntax dry-run pass

Closes #3059
Refs CAR-337

🤖 Generated with [Claude Code](https://claude.com/claude-code)