### PR TITLE
🎨 fix(niji-contracts,niji-webapp): compositeOrder で leftHand を clothing の背面側 (6 位) に移動 (#3063)

### DIFF
--- a/packages/niji-assets/scripts/niji-encoder.ts
+++ b/packages/niji-assets/scripts/niji-encoder.ts
@@ -65,11 +65,15 @@ export const NIJI_TRAITS: NijiTraitDef[] = [
 
 /**
  * COMPOSITE_ORDER (下 → 上) matches NijiDescriptor.sol's SVG <image> emission order.
- * solidBackground(10) → background(9) → backDecoration(8) → special(0)
- *  → leftHand(3) → back(7) → clothing(5) → choker(1)
- *  → ear(6) → hair(11) → hat(4) → headphone(2)
+ *
+ * SSOT alignment = packages/niji-contracts/scripts/niji-encoder.ts の NIJI_COMPOSITE_ORDER と同順。
+ * user 指定 (Issue #3063) = leftHand を clothing の背面側 (6 位) に配置し 服が手を隠す 整合を実現する。
+ *
+ * solidBackground(10) → background(9) → backDecoration(8) → back(7) → special(0)
+ *  → leftHand(3) → clothing(5) → choker(1) → ear(6)
+ *  → hat(4) → hair(11) → headphone(2)
  */
-export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 0, 3, 7, 5, 1, 6, 11, 4, 2];
+export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2];
 
 export interface ColorInfo {
   r: number;

--- a/packages/niji-contracts/scripts/niji-encoder.ts
+++ b/packages/niji-contracts/scripts/niji-encoder.ts
@@ -70,21 +70,24 @@ export const NIJI_TRAITS: NijiTraitDef[] = [
  * special(0) は 2 個しかなく最前面配置すると「常に同じ overlay」 と見え変化を隠す、
  * back(7)/choker(1)/ear(6) も 2-4 個で少数、 これらを後方に置く。
  *
+ * user 指定 (Issue #3063) = leftHand(3) を clothing(5) の背面側 (6 位) に配置、
+ * 服が手を隠す整合を実現する (旧配置では leftHand が最前面 = 手が服の上に描画されて不自然)。
+ *
  * 描画順序 (下 layer → 上 layer、 少数 → 多数 の順で variation impact 最大化)。
  *   1. solidBackground(10) ... 42 通り、 背景単色 (最背面)
  *   2. background(9)       ... 25 通り、 背景 pattern
  *   3. backDecoration(8)   ... 12 通り、 背中装飾
  *   4. back(7)             ... 2 通り (少)、 胴体後面
  *   5. special(0)          ... 2 通り (少)、 エフェクト背景
- *   6. clothing(5)         ... 166 通り、 服 (胴体前面)
- *   7. choker(1)           ... 4 通り (少)、 首元
- *   8. ear(6)              ... 3 通り (少)、 顔サイド
- *   9. hat(4)              ... 32 通り、 帽子 (頭上部)
- *   10. hair(11)           ... 235 通り、 髪 (hat 上、 最も variation 豊富)
- *   11. headphone(2)       ... 14 通り、 ヘッドホン (hair 上)
- *   12. leftHand(3)        ... 13 通り、 左手 / 武器 (最前面)
+ *   6. leftHand(3)         ... 13 通り、 左手 / 武器 (clothing 背面に配置し 服が手を隠す 整合実現)
+ *   7. clothing(5)         ... 166 通り、 服 (胴体前面 + 手を隠す)
+ *   8. choker(1)           ... 4 通り (少)、 首元
+ *   9. ear(6)              ... 3 通り (少)、 顔サイド
+ *   10. hat(4)             ... 32 通り、 帽子 (頭上部)
+ *   11. hair(11)           ... 235 通り、 髪 (hat 上、 最も variation 豊富)
+ *   12. headphone(2)       ... 14 通り、 ヘッドホン (最前面)
  */
-export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 0, 5, 1, 6, 4, 11, 2, 3];
+export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2];
 
 export interface ColorInfo {
   r: number;

--- a/packages/niji-contracts/test/niji/helpers/constants.ts
+++ b/packages/niji-contracts/test/niji/helpers/constants.ts
@@ -24,8 +24,12 @@ export const TRAIT_COUNT = TRAIT_NAMES.length;
 /** Default SVG resolution (px) */
 export const RESOLUTION = 320;
 
-/** Default composite order — determines layer stacking in SVG */
-export const COMPOSITE_ORDER = [10, 9, 8, 0, 3, 7, 5, 1, 6, 11, 4, 2];
+/**
+ * Default composite order — determines layer stacking in SVG.
+ * SSOT alignment = packages/niji-contracts/scripts/niji-encoder.ts の NIJI_COMPOSITE_ORDER と同順。
+ * user 指定 (Issue #3063) = leftHand を clothing の背面側 (6 位) に配置し 服が手を隠す 整合を実現する。
+ */
+export const COMPOSITE_ORDER = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2];
 
 /** Minimal valid PNG: 1x1 transparent pixel (67 bytes) */
 export const SAMPLE_PNG = Buffer.from([

--- a/packages/niji-webapp/src/lib/nijiAssets.ts
+++ b/packages/niji-webapp/src/lib/nijiAssets.ts
@@ -64,24 +64,26 @@ export const nijiTraitKeys = [
 ] as const satisfies readonly (keyof NijiSeed)[];
 
 // SSOT — packages/niji-contracts/scripts/niji-encoder.ts の `NIJI_COMPOSITE_ORDER`
-// = [10, 9, 8, 7, 0, 5, 1, 6, 4, 11, 2, 3]、 NIJI_TRAITS[id] の name で表記したもの。
+// = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2]、 NIJI_TRAITS[id] の name で表記したもの。
 // 配列順 = SVG z-order (先頭が最背面、 末尾が最前面)。
 // 少数 trait (special 2 / back 2 / choker 4 / ear 3) を後方配置、
-// variation 豊富な trait (hair 235 / clothing 166 / hat 32 / leftHand 13) を前面配置し
+// variation 豊富な trait (hair 235 / clothing 166 / hat 32) を前面配置し
 // user 目視で「変化する印象」 を最大化。
+// user 指定 (Issue #3063) = leftHand を clothing の背面側 (6 位) に配置、
+// 服が手を隠す整合を実現する。
 const compositeOrder = [
   'solidBackground',
   'background',
   'backDecoration',
   'back',
   'special',
+  'leftHand',
   'clothing',
   'choker',
   'ear',
   'hat',
   'hair',
   'headphone',
-  'leftHand',
 ] as const satisfies readonly (keyof NijiSeed)[];
 
 export const humanizeTraitKey = (key: keyof NijiSeed) => {


### PR DESCRIPTION
## Summary

- `NIJI_COMPOSITE_ORDER` を `[10,9,8,7,0,5,1,6,4,11,2,3]` → `[10,9,8,7,0,3,5,1,6,4,11,2]` に変更、 `leftHand` (trait id 3) を 12 位 (最前面) から 6 位に前進、 `clothing` (trait id 5) が `leftHand` より前面に来ることで **服が手を隠す** 視覚整合を実現
- 4 file (contract SSOT + webapp SSOT + test constants + build-time script SSOT) を新順序で同期、 SSOT drift を解消
- niji-sdk fixture (expected-noun.svg) は root/accessory/head 構造で `NIJI_COMPOSITE_ORDER` に依存しないため regen 不要、 35 test 全 pass 確認済

## 背景

user 実機確認で「leftHand は clothing の後ろにないとダメ」 の指摘。 現状 `leftHand` が最前面 (12 位) で `clothing` (6 位) より前にあるため、 手の trait が服の上に描画されて不自然。

正しい描画順 = 「服が手を隠す」 = `clothing` が `leftHand` の前面。 `compositeOrder` は先頭が最背面、 末尾が最前面なので、 `leftHand` を `clothing` より背面側 (小さい index) に配置。

## 新順序 (背面 → 前面)

| 順 | trait id | trait 名 |
|---|---|---|
| 1 | 10 | solidBackground |
| 2 | 9 | background |
| 3 | 8 | backDecoration |
| 4 | 7 | back |
| 5 | 0 | special |
| **6** | **3** | **leftHand** (新配置) |
| 7 | 5 | clothing |
| 8 | 1 | choker |
| 9 | 6 | ear |
| 10 | 4 | hat |
| 11 | 11 | hair |
| 12 | 2 | headphone |

## 修正内容

**Phase A contract SSOT 更新**

- `packages/niji-contracts/scripts/niji-encoder.ts` の `NIJI_COMPOSITE_ORDER` を新順序に変更
- SSOT comment に「leftHand を clothing 背面側に配置し 服が手を隠す 整合実現」 追記

**Phase B webapp SSOT 更新**

- `packages/niji-webapp/src/lib/nijiAssets.ts` の `compositeOrder` 名前配列を新順序に変更
- SSOT comment を contract 側と同期

**Phase C SSOT alignment 復元**

- `packages/niji-contracts/test/niji/helpers/constants.ts` の `COMPOSITE_ORDER` (test default) も新順序に統一
- `packages/niji-assets/scripts/niji-encoder.ts` (build-time script SSOT duplicate) も同順序に復元

**Phase D fixture 再生成 = 不要**

- `packages/niji-sdk/test/lib/data/expected-noun.svg` は root/accessory/head の 3 part 構造で `NIJI_COMPOSITE_ORDER` に依存しないため regen 不要
- svg-builder test で確認、 35 test 全 pass (fixture unaffected)

**Phase E test 更新 = 不要**

- test は `COMPOSITE_ORDER` 定数の deep.equal 自己参照検証 pattern で、 定数側を新順序に統一したので追加変更不要
- 329 hardhat + 756 foundry + 9849 webapp + 35 sdk + 3 assets = 全 pass 確認済

## deploy 経路

- **local anvil (31337)** ... `make dev-stop && make dev` で fresh chain redeploy されて新順序反映
- **Base Sepolia / Mainnet** ... Issue #3063 記載通り Phase 3 で対応 (本 PR scope 外、 `setCompositeOrder` 呼出 or 再 deploy が必要)

## Test plan

- [x] `packages/niji-contracts` — `pnpm test` (329 hardhat passing) + `forge test` (756 foundry passed)
- [x] `packages/niji-webapp` — `pnpm test` (9849 tests passed、 regression 0)
- [x] `packages/niji-sdk` — `pnpm test` (35 tests passed、 fixture unaffected 確認)
- [x] `packages/niji-assets` — `pnpm test` (3 tests passed)
- [x] `packages/niji-webapp` typecheck clean (`pnpm tsc --noEmit` 0 errors)
- [x] lint diff = 2 prettier warnings (Japanese comment 全角の width)、 pre-existing lint errors は master と同数 (regression 0)
- [ ] local anvil redeploy 目視確認 — `make dev-stop && make dev` で fresh chain 起動後 auction ページで Niji NFT の描画で服が手を隠すこと (user 実機確認)

Closes #3063

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYoiaxwjT3BACwVL22zotb