### PR TITLE
🎨 fix(niji-contracts,niji-webapp): compositeOrder で special を 8 位、 choker を 9 位に移動 (#3066)

### DIFF
--- a/packages/niji-assets/scripts/niji-encoder.ts
+++ b/packages/niji-assets/scripts/niji-encoder.ts
@@ -67,13 +67,15 @@ export const NIJI_TRAITS: NijiTraitDef[] = [
  * COMPOSITE_ORDER (下 → 上) matches NijiDescriptor.sol's SVG <image> emission order.
  *
  * SSOT alignment = packages/niji-contracts/scripts/niji-encoder.ts の NIJI_COMPOSITE_ORDER と同順。
- * user 指定 (Issue #3063) = leftHand を clothing の背面側 (6 位) に配置し 服が手を隠す 整合を実現する。
+ * user 指定 (Issue #3066) = special / choker を 8 / 9 位に配置し、
+ * leftHand / clothing / ear を前詰め (5-7 位) にして 前面 3 trait (hat / hair / headphone) を邪魔しない。
  *
- * solidBackground(10) → background(9) → backDecoration(8) → back(7) → special(0)
- *  → leftHand(3) → clothing(5) → choker(1) → ear(6)
+ * solidBackground(10) → background(9) → backDecoration(8) → back(7)
+ *  → leftHand(3) → clothing(5) → ear(6)
+ *  → special(0) → choker(1)
  *  → hat(4) → hair(11) → headphone(2)
  */
-export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2];
+export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2];
 
 export interface ColorInfo {
   r: number;

--- a/packages/niji-contracts/scripts/niji-encoder.ts
+++ b/packages/niji-contracts/scripts/niji-encoder.ts
@@ -67,27 +67,28 @@ export const NIJI_TRAITS: NijiTraitDef[] = [
  * COMPOSITE_ORDER (下 → 上) matches NijiDescriptor.sol's SVG <image> emission order.
  *
  * 完璧仕様 = 12 trait 全てを user が視認できる + variation 豊富な trait を前面配置。
- * special(0) は 2 個しかなく最前面配置すると「常に同じ overlay」 と見え変化を隠す、
- * back(7)/choker(1)/ear(6) も 2-4 個で少数、 これらを後方に置く。
  *
- * user 指定 (Issue #3063) = leftHand(3) を clothing(5) の背面側 (6 位) に配置、
- * 服が手を隠す整合を実現する (旧配置では leftHand が最前面 = 手が服の上に描画されて不自然)。
+ * user 指定 (Issue #3066) = special(0) を 8 位 / choker(1) を 9 位に移動、
+ * leftHand(3) / clothing(5) / ear(6) を前詰め (5-7 位)、
+ * hat(4) / hair(11) / headphone(2) は最前面 3 trait として現状維持。
+ * special / choker を中間前後 (8/9 位) に配置することで前面 3 trait の描画を邪魔せず、
+ * 中背面 3 trait (leftHand / clothing / ear) を明示的に前詰めして層構造を整える。
  *
- * 描画順序 (下 layer → 上 layer、 少数 → 多数 の順で variation impact 最大化)。
+ * 描画順序 (下 layer → 上 layer)。
  *   1. solidBackground(10) ... 42 通り、 背景単色 (最背面)
  *   2. background(9)       ... 25 通り、 背景 pattern
  *   3. backDecoration(8)   ... 12 通り、 背中装飾
  *   4. back(7)             ... 2 通り (少)、 胴体後面
- *   5. special(0)          ... 2 通り (少)、 エフェクト背景
- *   6. leftHand(3)         ... 13 通り、 左手 / 武器 (clothing 背面に配置し 服が手を隠す 整合実現)
- *   7. clothing(5)         ... 166 通り、 服 (胴体前面 + 手を隠す)
- *   8. choker(1)           ... 4 通り (少)、 首元
- *   9. ear(6)              ... 3 通り (少)、 顔サイド
+ *   5. leftHand(3)         ... 13 通り、 左手 / 武器 (clothing 背面に配置し 服が手を隠す 整合実現)
+ *   6. clothing(5)         ... 166 通り、 服 (胴体前面 + 手を隠す)
+ *   7. ear(6)              ... 3 通り (少)、 顔サイド
+ *   8. special(0)          ... 2 通り (少)、 エフェクト overlay (前面 3 trait の背面)
+ *   9. choker(1)           ... 4 通り (少)、 首元 overlay (hat 直下)
  *   10. hat(4)             ... 32 通り、 帽子 (頭上部)
  *   11. hair(11)           ... 235 通り、 髪 (hat 上、 最も variation 豊富)
  *   12. headphone(2)       ... 14 通り、 ヘッドホン (最前面)
  */
-export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2];
+export const NIJI_COMPOSITE_ORDER = [10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2];
 
 export interface ColorInfo {
   r: number;

--- a/packages/niji-contracts/test/foundry/NijiFuzz.t.sol
+++ b/packages/niji-contracts/test/foundry/NijiFuzz.t.sol
@@ -40,18 +40,20 @@ contract NijiFuzz is Test {
         traitNames[11] = 'hair';
 
         // Composite order (bottom to top)
+        // SSOT alignment = packages/niji-contracts/scripts/niji-encoder.ts の NIJI_COMPOSITE_ORDER と同順。
+        // user 指定 (Issue #3066) = [10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2]
         uint256[] memory compositeOrder = new uint256[](TRAIT_COUNT);
         compositeOrder[0] = 10;
         compositeOrder[1] = 9;
         compositeOrder[2] = 8;
-        compositeOrder[3] = 0;
+        compositeOrder[3] = 7;
         compositeOrder[4] = 3;
-        compositeOrder[5] = 7;
-        compositeOrder[6] = 5;
-        compositeOrder[7] = 1;
-        compositeOrder[8] = 6;
-        compositeOrder[9] = 11;
-        compositeOrder[10] = 4;
+        compositeOrder[5] = 5;
+        compositeOrder[6] = 6;
+        compositeOrder[7] = 0;
+        compositeOrder[8] = 1;
+        compositeOrder[9] = 4;
+        compositeOrder[10] = 11;
         compositeOrder[11] = 2;
 
         // Deploy contracts

--- a/packages/niji-contracts/test/foundry/helpers/DeployUtils.sol
+++ b/packages/niji-contracts/test/foundry/helpers/DeployUtils.sol
@@ -81,19 +81,23 @@ abstract contract DeployUtils is Test {
         traitNames[11] = 'hair';
     }
 
+    /// SSOT alignment = packages/niji-contracts/scripts/niji-encoder.ts の NIJI_COMPOSITE_ORDER と同順。
+    /// user 指定 (Issue #3066) = special / choker を 8 / 9 位に配置、
+    /// leftHand / clothing / ear を前詰め (5-7 位) にして 前面 3 trait (hat / hair / headphone) を邪魔しない。
+    /// = [10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2]
     function _compositeOrder() internal pure returns (uint256[] memory order) {
         order = new uint256[](12);
         order[0] = 10;
         order[1] = 9;
         order[2] = 8;
-        order[3] = 0;
+        order[3] = 7;
         order[4] = 3;
-        order[5] = 7;
-        order[6] = 5;
-        order[7] = 1;
-        order[8] = 6;
-        order[9] = 11;
-        order[10] = 4;
+        order[5] = 5;
+        order[6] = 6;
+        order[7] = 0;
+        order[8] = 1;
+        order[9] = 4;
+        order[10] = 11;
         order[11] = 2;
     }
 

--- a/packages/niji-contracts/test/niji/helpers/constants.ts
+++ b/packages/niji-contracts/test/niji/helpers/constants.ts
@@ -27,9 +27,10 @@ export const RESOLUTION = 320;
 /**
  * Default composite order — determines layer stacking in SVG.
  * SSOT alignment = packages/niji-contracts/scripts/niji-encoder.ts の NIJI_COMPOSITE_ORDER と同順。
- * user 指定 (Issue #3063) = leftHand を clothing の背面側 (6 位) に配置し 服が手を隠す 整合を実現する。
+ * user 指定 (Issue #3066) = special / choker を 8 / 9 位に配置、
+ * leftHand / clothing / ear を前詰め (5-7 位) にして 前面 3 trait (hat / hair / headphone) を邪魔しない。
  */
-export const COMPOSITE_ORDER = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2];
+export const COMPOSITE_ORDER = [10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2];
 
 /** Minimal valid PNG: 1x1 transparent pixel (67 bytes) */
 export const SAMPLE_PNG = Buffer.from([

--- a/packages/niji-webapp/src/lib/nijiAssets.ts
+++ b/packages/niji-webapp/src/lib/nijiAssets.ts
@@ -64,23 +64,20 @@ export const nijiTraitKeys = [
 ] as const satisfies readonly (keyof NijiSeed)[];
 
 // SSOT — packages/niji-contracts/scripts/niji-encoder.ts の `NIJI_COMPOSITE_ORDER`
-// = [10, 9, 8, 7, 0, 3, 5, 1, 6, 4, 11, 2]、 NIJI_TRAITS[id] の name で表記したもの。
+// = [10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2]、 NIJI_TRAITS[id] の name で表記したもの。
 // 配列順 = SVG z-order (先頭が最背面、 末尾が最前面)。
-// 少数 trait (special 2 / back 2 / choker 4 / ear 3) を後方配置、
-// variation 豊富な trait (hair 235 / clothing 166 / hat 32) を前面配置し
-// user 目視で「変化する印象」 を最大化。
-// user 指定 (Issue #3063) = leftHand を clothing の背面側 (6 位) に配置、
-// 服が手を隠す整合を実現する。
+// user 指定 (Issue #3066) = special / choker を 8 / 9 位に配置、
+// leftHand / clothing / ear を前詰め (5-7 位) にして 前面 3 trait (hat / hair / headphone) を邪魔しない。
 const compositeOrder = [
   'solidBackground',
   'background',
   'backDecoration',
   'back',
-  'special',
   'leftHand',
   'clothing',
-  'choker',
   'ear',
+  'special',
+  'choker',
   'hat',
   'hair',
   'headphone',


### PR DESCRIPTION
## Summary

- NIJI_COMPOSITE_ORDER を `[10,9,8,7,0,3,5,1,6,4,11,2]` → `[10,9,8,7,3,5,6,0,1,4,11,2]` に変更
- special (0) を 8 位、 choker (1) を 9 位に配置、 leftHand (3) / clothing (5) / ear (6) を 5-7 位に前詰め
- 前面 3 trait (hat / hair / headphone) の描画を邪魔しない層構造に整える
- 6 SSOT 同期 (contract encoder + assets encoder + webapp assets + hardhat test constants + foundry DeployUtils + foundry NijiFuzz)

## 新順序 (背面 → 前面)

| 順 | trait id | trait 名 |
|---|---|---|
| 1 | 10 | solidBackground |
| 2 | 9 | background |
| 3 | 8 | backDecoration |
| 4 | 7 | back |
| 5 | 3 | leftHand |
| 6 | 5 | clothing |
| 7 | 6 | ear |
| **8** | **0** | **special** (新配置) |
| **9** | **1** | **choker** (新配置) |
| 10 | 4 | hat |
| 11 | 11 | hair |
| 12 | 2 | headphone |

## 変更 file (6 SSOT)

- packages/niji-contracts/scripts/niji-encoder.ts (NIJI_COMPOSITE_ORDER + comment)
- packages/niji-assets/scripts/niji-encoder.ts (NIJI_COMPOSITE_ORDER + comment)
- packages/niji-webapp/src/lib/nijiAssets.ts (compositeOrder 名前配列 + comment)
- packages/niji-contracts/test/niji/helpers/constants.ts (hardhat test SSOT)
- packages/niji-contracts/test/foundry/helpers/DeployUtils.sol (foundry test SSOT)
- packages/niji-contracts/test/foundry/NijiFuzz.t.sol (foundry fuzz test)

## Test plan

- [x] niji-contracts hardhat test 179 passing (45 NijiDescriptor + 134 edge/NijiToken)
- [x] niji-contracts foundry test 756 passing (0 failed / 0 skipped)
- [x] niji-webapp test 9849 passing (1 skipped / 1 todo)
- [x] niji-sdk test 35 passing
- [x] niji-assets test 1 passing (2 todo)
- [x] webapp typecheck 0 error
- [x] 全 SSOT で `[10, 9, 8, 7, 3, 5, 6, 0, 1, 4, 11, 2]` 統一済、旧配列の残存なし
- [ ] local anvil で `make dev-stop && make dev` fresh chain redeploy 後、 新順序が反映されることを目視確認
- [ ] Base Sepolia / Mainnet は Phase 3 で `setCompositeOrder` setter or 再 deploy 対応

Closes #3066

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYoiaxwjT3BACwVL22zotb