### PR TITLE
🐛 fix(niji-api,niji-webapp): spot rate endpoint を独立 hono server (port 42070) で expose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ WEBAPP_ENV_EXAMPLE := $(ROOT)/packages/niji-webapp/.env.example.local
 ANVIL_PORT := 8547
 WEBAPP_PORT := 2424
 API_PORT := 42069
+# Issue #3065 — spot-rate endpoint を Ponder 非依存の独立 hono server (port 42070) に分離。
+# Ponder indexer の historical sync (10-30 秒〜数分) 完了待ちで spot-rate が実質未応答になる root cause 解消。
+SPOT_RATE_PORT := 42070
 
 .PHONY: help dev dev-init dev-refresh dev-sepolia dev-fg dev-stop dev-status dev-logs setup setup-env install build anvil-bg webapp-bg snapshot-if-needed auto-settler-bg api-bg
 
@@ -66,9 +69,10 @@ help:
 	@echo "  snapshot 不在時は make dev が自動的に dev-init を呼ぶ"
 	@echo ""
 	@echo "URL:"
-	@echo "  webapp   http://localhost:$(WEBAPP_PORT)"
-	@echo "  niji-api http://127.0.0.1:$(API_PORT) (Ponder + Hono)"
-	@echo "  anvil    http://127.0.0.1:$(ANVIL_PORT) (chain id 31337)"
+	@echo "  webapp     http://localhost:$(WEBAPP_PORT)"
+	@echo "  niji-api   http://127.0.0.1:$(API_PORT) (Ponder + Hono、 fiat-bid endpoint)"
+	@echo "  spot-rate  http://127.0.0.1:$(SPOT_RATE_PORT) (independent hono、 Ponder 非依存、 Issue #3065)"
+	@echo "  anvil      http://127.0.0.1:$(ANVIL_PORT) (chain id 31337)"
 	@echo ""
 	@echo "State:"
 	@echo "  live state  $(ANVIL_STATE) (make dev-stop で削除)"
@@ -152,20 +156,23 @@ auto-settler-bg: | $(LOG_DIR)
 		echo "🟢 auto-settler started (PID $$(cat $(SETTLER_PID)))"; \
 	fi
 
-# niji-api (Ponder + Hono、 port 42069) を background 起動。 既存プロセスがあれば再利用。
-# webapp から VITE_GMO_API_ENDPOINT 経由で spot rate / fiat bid endpoint を呼出するため必要。
-# Ponder 起動時間 10-30 秒、 起動直後 30 秒間は webapp からの GET /api/v1/spot-rate/eth-jpy が
-# undefined を返す (FiatBidForm 側で「取得中」 spinner 表示、 UX 上問題なし)。
+# niji-api を background 起動。 既存プロセスがあれば再利用。
+# Issue #3065 で pnpm dev = concurrently で 2 process 並列起動する構成に変更。
+#   - Ponder + Hono (port 42069) = event indexer 専任、 fiat-bid endpoint (authorize / capture / topup 等) を expose
+#   - spot-rate independent server (port 42070) = Ponder 非依存、 GMO / CoinGecko 直叩き + in-memory cache
+# webapp は VITE_GMO_API_ENDPOINT (42069) と VITE_GMO_API_ENDPOINT_SPOT_RATE (42070) の 2 URL を参照。
+# spot-rate は Ponder sync 完了を待たず即応答、 fiat-bid は Ponder sync 完了 (10-30 秒) 後に応答。
 api-bg: | $(LOG_DIR)
 	@if [ -f "$(API_PID)" ] && kill -0 $$(cat $(API_PID)) 2>/dev/null; then \
 		echo "🟢 niji-api already running (PID $$(cat $(API_PID)))"; \
 	else \
-		echo "🚀 starting niji-api on :$(API_PORT) (Ponder + Hono、 10-30s 起動)..."; \
+		echo "🚀 starting niji-api on :$(API_PORT) (Ponder + Hono) + :$(SPOT_RATE_PORT) (spot-rate server、 concurrently 経由)..."; \
 		cd $(ROOT)/packages/niji-api && nohup pnpm dev \
 			> "$(API_LOG)" 2>&1 & \
 		echo $$! > "$(API_PID)"; \
 		sleep 1; \
 		echo "🟢 niji-api started (PID $$(cat $(API_PID)), log=$(API_LOG))"; \
+		echo "   ponder :$(API_PORT) + spot-rate :$(SPOT_RATE_PORT) = concurrently で並列起動"; \
 	fi
 
 # webapp を background 起動。 既存プロセスがあれば再利用。
@@ -189,7 +196,8 @@ dev: setup-env snapshot-if-needed anvil-bg api-bg auto-settler-bg webapp-bg
 	@echo "✅ dev environment ready (snapshot load、 常に fresh chain)."
 	@echo ""
 	@echo "  webapp        http://localhost:$(WEBAPP_PORT)"
-	@echo "  niji-api      http://127.0.0.1:$(API_PORT) (Ponder + Hono、 起動 10-30s)"
+	@echo "  niji-api      http://127.0.0.1:$(API_PORT) (Ponder + Hono、 起動 10-30s、 fiat-bid endpoint)"
+	@echo "  spot-rate     http://127.0.0.1:$(SPOT_RATE_PORT) (independent、 sync 非依存で即応答、 Issue #3065)"
 	@echo "  anvil         http://127.0.0.1:$(ANVIL_PORT) (chain 31337)"
 	@echo "  auto-settler  🤖 5s polling, next auction starts automatically on endTime"
 	@if [ -f "$(ANVIL_STATE)" ]; then \
@@ -301,6 +309,12 @@ dev-stop:
 		echo "$$API_PIDS" | xargs kill 2>/dev/null || true; \
 		echo "  ⛔ killed lingering niji-api listeners on :$(API_PORT)"; \
 	fi
+	@# Issue #3065 — spot-rate independent server (port 42070) の残骸掃除
+	@SPOT_PIDS=$$(lsof -nP -iTCP:$(SPOT_RATE_PORT) -sTCP:LISTEN -t 2>/dev/null); \
+	if [ -n "$$SPOT_PIDS" ]; then \
+		echo "$$SPOT_PIDS" | xargs kill 2>/dev/null || true; \
+		echo "  ⛔ killed lingering spot-rate listeners on :$(SPOT_RATE_PORT)"; \
+	fi
 	@# anvil は SIGTERM で --state dump 完了を待つ (最大 10 秒)。 dump 中に SIGKILL すると
 	@# JSON が途中で切れ、 次の make dev で "failed to parse json file: EOF" で起動失敗する。
 	@# graceful shutdown 経路 = SIGTERM 送信 → 1 秒間隔で process 死亡 poll (最大 10 秒) → 未死亡なら SIGKILL fallback。
@@ -362,9 +376,11 @@ dev-status:
 		echo "  webapp        ⚪ stopped"; \
 	fi
 	@if [ -f "$(API_PID)" ] && kill -0 $$(cat $(API_PID)) 2>/dev/null; then \
-		echo "  niji-api      🟢 running (PID $$(cat $(API_PID)), port $(API_PORT))"; \
-		curl -s -o /dev/null -w "                HTTP          %{http_code}\n" \
-			http://127.0.0.1:$(API_PORT) || echo "                HTTP          no response"; \
+		echo "  niji-api      🟢 running (PID $$(cat $(API_PID)), ponder :$(API_PORT) + spot-rate :$(SPOT_RATE_PORT))"; \
+		curl -s -o /dev/null -w "                ponder :$(API_PORT)   %{http_code}\n" \
+			http://127.0.0.1:$(API_PORT) || echo "                ponder :$(API_PORT)   no response"; \
+		curl -s -o /dev/null -w "                spot   :$(SPOT_RATE_PORT)   %{http_code}\n" \
+			http://127.0.0.1:$(SPOT_RATE_PORT)/api/v1/spot-rate/eth-jpy || echo "                spot   :$(SPOT_RATE_PORT)   no response"; \
 	else \
 		echo "  niji-api      ⚪ stopped (webapp spot rate / fiat bid endpoint が offline)"; \
 	fi

--- a/docs/operations/gmo-fiat-bid.md
+++ b/docs/operations/gmo-fiat-bid.md
@@ -32,10 +32,24 @@ Issue 1 段階では env 変数一覧 + mock server 切替手順のみ記載、 
 
 | 変数名 | 用途 | 例 (Phase 1 mock) | 本番切替時 |
 |---|---|---|---|
-| `VITE_GMO_API_ENDPOINT` | niji-api base URL (spot rate / fiat bid endpoint) | `http://127.0.0.1:42069` | `https://api.niji-dao.example` |
+| `VITE_GMO_API_ENDPOINT` | niji-api base URL (fiat bid endpoint、 authorize / capture / topup 等) | `http://127.0.0.1:42069` | `https://api.niji-dao.example` |
+| `VITE_GMO_API_ENDPOINT_SPOT_RATE` | spot-rate 独立 server base URL (Issue #3065、 Ponder 非依存) | `http://127.0.0.1:42070` | `https://api.niji-dao.example` |
 | `VITE_ENABLE_FIAT_BID` | fiat bid UI 表示 flag (`true` / `false`) | `false` (開発中) | `true` (release 後) |
 
-`VITE_GMO_API_ENDPOINT` は Issue #3059 で SSOT に統一済。 `useSpotRate.ts` / `.env.example.local` は本 env 名で一致する (旧 `VITE_NIJI_API_BASE_URL` は同 Issue で撤廃)。 本 env 未設定時は同一 origin (webapp 2424 port) に fallback するが、 dev では niji-api の 42069 port を叩かないと `/api/v1/spot-rate/eth-jpy` が 404 になる (webapp origin に api endpoint 未実装のため)。
+`VITE_GMO_API_ENDPOINT` は Issue #3059 で SSOT に統一済。 `.env.example.local` は本 env 名で一致する (旧 `VITE_NIJI_API_BASE_URL` は同 Issue で撤廃)。 本 env 未設定時は同一 origin (webapp 2424 port) に fallback するが、 dev では niji-api を叩かないと `/api/v1/fiat-bid/*` が 404 になる (webapp origin に api endpoint 未実装のため)。
+
+`VITE_GMO_API_ENDPOINT_SPOT_RATE` は Issue #3065 で追加した spot-rate 専用 endpoint。 `useSpotRate.ts` は本 env を優先して読み、 未設定時は `VITE_GMO_API_ENDPOINT` に fallback する (旧経路互換)。 dev では 42070 の spot-rate independent server を叩くことで Ponder sync 完了待ちを回避、 spot rate が即応答する。
+
+### port 分離 architecture (Issue #3065、 Plan A SSOT)
+
+niji-api は 2 process 並列起動 (`pnpm dev` = concurrently 経由)。 責務分離 —
+
+- **port 42069** (Ponder + Hono) = event indexer 専任、 fiat-bid endpoint (authorize / 3ds-callback / place-bid / capture / transfer-nft / topup) を expose。 Ponder DB (fiat_bid table) に write する endpoint は Ponder indexer が持つ drizzle client 経由でのみ書けるため、 本 process に維持
+- **port 42070** (spot-rate independent hono) = Ponder 非依存、 GMO コイン API + CoinGecko fallback + 5 秒 in-memory cache で完結。 sync 状態問わず即応答
+
+Ponder indexer の historical sync 完了待ち (Base Sepolia block 数万件、 10-30 秒〜数分) 中でも spot rate は即応答するため、 user 実機の FiatBidForm で「レート取得クルクル継続」 症状が発生しない (Issue #3065 root cause 解消)。 fiat-bid endpoint 群は auction settle event 後にのみ実 flow が発火する前提のため、 Ponder sync 完了 (dev では 10-30 秒程度) を起点にできれば実用範囲。
+
+Plan B (全 fiat-bid endpoint も分離) は PGlite 制約 (Ponder が sync 完了まで database schema を確定させない、 独立 server から drizzle 経由で fiat_bid table を書けない) のため回避、 Postgres 移行 + Docker 依存増加を発生させずに root cause 解消する。
 
 ## mock server 切替手順
 
@@ -46,13 +60,13 @@ Phase 1 開発期間中は mock server 経由で e2e 動作させる。 手順 �
 3. Issue 3 以降で追加される hono handler 経由で GMO endpoint (mock) 呼出、 form-encoded 応答が返る
 4. Phase 3 本番切替時は `USE_GMO_MOCK=false` + `GMO_ENDPOINT=https://p01.mul-pay.jp` に変更
 
-### make dev で niji-api 起動 (Issue #3059)
+### make dev で niji-api 起動 (Issue #3059、 #3065)
 
-`make dev` は niji-api を含む 4 process (anvil / niji-api / auto-settler / webapp) を bg 起動する。 Ponder 起動時間は 10-30 秒、 起動直後 30 秒間は webapp からの `GET /api/v1/spot-rate/eth-jpy` が undefined を返す (FiatBidForm 側で「取得中」 spinner 表示、 UX 上問題なし)。
+`make dev` は 5 process 相当を bg 起動する (anvil / niji-api Ponder / niji-api spot-rate / auto-settler / webapp)。 niji-api の `pnpm dev` は concurrently 経由で Ponder (42069) と spot-rate independent server (42070) の 2 process を並列起動する構成 (Issue #3065)。 spot-rate は Ponder 非依存で即応答するため、 起動直後でも FiatBidForm でレート表示が spinner に張り付かない。
 
-- `make dev-status` で niji-api の PID / port listen / HTTP 応答を確認できる
-- `make dev-logs` で `.context/dev/api.log` を含む全 log を tail -f 表示
-- `make dev-stop` で niji-api の PID を graceful kill + port 42069 の残骸 listener を lsof 経由で掃除
+- `make dev-status` で niji-api の PID / port 42069 (Ponder) + port 42070 (spot-rate) の HTTP 応答を確認できる (2 行表示、 Issue #3065)
+- `make dev-logs` で `.context/dev/api.log` を含む全 log を tail -f 表示 (concurrently prefix `[ponder]` / `[spot]` で識別)
+- `make dev-stop` で niji-api の PID を graceful kill + port 42069 / 42070 の残骸 listener を lsof 経由で掃除
 
 Issue 1 時点の behavior test 経路 —
 

--- a/packages/niji-api/package.json
+++ b/packages/niji-api/package.json
@@ -6,16 +6,20 @@
   "scripts": {
     "codegen": "ponder codegen",
     "db": "ponder db",
-    "dev": "ponder dev",
+    "dev": "concurrently -n ponder,spot -c blue,magenta \"pnpm dev:ponder\" \"pnpm dev:spot-rate\"",
+    "dev:ponder": "ponder dev",
+    "dev:spot-rate": "tsx watch src/spot-rate-server.ts",
     "lint": "eslint .",
     "ponder:push-snapshot": "tar -czf snapshot.tgz .ponder && gh release upload snapshot snapshot.tgz --clobber",
     "ponder:restore-snapshot": "rm -rf .ponder && curl -sL https://github.com/nounsDAO/nouns-monorepo/releases/download/snapshot/snapshot.tgz | tar -xzf -",
     "start": "ponder start",
+    "start:spot-rate": "tsx src/spot-rate-server.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@hono/node-server": "^1.13.0",
     "@niji/sdk": "workspace:*",
     "drizzle-orm": "0.41.0",
     "hono": "^4.5.0",
@@ -25,8 +29,10 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
+    "concurrently": "^9.1.0",
     "dotenv": "catalog:",
     "msw": "^2.14.0",
+    "tsx": "^4.20.3",
     "vitest": "^3.2.4"
   },
   "engines": {

--- a/packages/niji-api/src/api/index.ts
+++ b/packages/niji-api/src/api/index.ts
@@ -14,7 +14,10 @@ import { createCaptureApp, type CaptureStore } from '../handlers/fiat-bid/captur
 import { createPlaceBidApp, type PlaceBidStore } from '../handlers/fiat-bid/place-bid.js';
 import { createTopupApp, type TopupStore } from '../handlers/fiat-bid/topup.js';
 import { createTransferNftApp, type TransferNftStore } from '../handlers/fiat-bid/transfer-nft.js';
-import { createSpotRateApp } from '../handlers/spot-rate.js';
+// spot-rate route は Issue #3065 で独立 server (port 42070、 spot-rate-server.ts) に分離、
+// Ponder indexer の historical sync 完了待ちで spot-rate が実質未応答になる root cause 解消のため。
+// fiat-bid endpoint (authorize / 3ds-callback / place-bid / capture / transfer-nft / topup) は
+// Ponder DB (fiat_bid table) 経由で writable なため、 本 file (port 42069) に維持。
 import { AuthCleanupQueue } from '../services/authCleanup/index.js';
 import {
   BidRelay,
@@ -60,7 +63,8 @@ app.use('/', graphql({ db, schema }));
 app.use('/graphql', graphql({ db, schema }));
 
 // Issue #3005 — GET /api/v1/spot-rate/eth-jpy (ETH/JPY spot rate 取得)
-app.route('/api/v1/spot-rate', createSpotRateApp());
+// Issue #3065 — 本 route は spot-rate-server.ts (port 42070) に分離済 (Ponder sync 非依存化)、
+//               本 file (port 42069) では登録しない。 webapp は VITE_GMO_API_ENDPOINT_SPOT_RATE 経由で 42070 を叩く。
 
 /**
  * Issue #3006 — POST /api/v1/fiat-bid/authorize (与信枠取得)

--- a/packages/niji-api/src/spot-rate-server.test.ts
+++ b/packages/niji-api/src/spot-rate-server.test.ts
@@ -1,0 +1,65 @@
+/**
+ * spot-rate independent server integration test (Issue #3065、 Plan A)
+ *
+ * 検証対象 —
+ * (1) createSpotRateServerApp() が /api/v1/spot-rate/eth-jpy route を expose する (Ponder 非依存)
+ * (2) route が spot-rate handler と同じ shape で応答する (200 = SpotRate JSON)
+ * (3) route が Ponder graphql context に依存しない (import.meta.env 影響なし)
+ *
+ * rules/quality.md § test-passed marker 発行前提 3 条件を満たす behavior test。
+ * hono `app.request()` 経路で actual handler を execute する = server listen 不要。
+ * spot-rate handler 内の SpotRateFetcher は module singleton だが、 test は fetch mock で
+ * 副作用を制御する (実 GMO / CoinGecko API を叩かない)。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createSpotRateServerApp } from './spot-rate-server.js';
+
+describe('createSpotRateServerApp — /api/v1/spot-rate/eth-jpy', () => {
+  const originalEnv = { ...process.env };
+  let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    // mock mode を有効化して外部 API 通信を skip、 固定 rate 500000 JPY / ETH を返す
+    process.env['USE_SPOT_RATE_MOCK'] = 'true';
+    process.env['MOCK_SPOT_RATE_JPY_PER_ETH'] = '500000';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    fetchSpy?.mockRestore();
+    fetchSpy = undefined;
+  });
+
+  it('GET /api/v1/spot-rate/eth-jpy が 200 で SpotRate 応答を返す', async () => {
+    const app = createSpotRateServerApp();
+    const res = await app.request('/api/v1/spot-rate/eth-jpy');
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      rate: number;
+      source: string;
+      cachedAt: number;
+      expiresAt: number;
+    };
+    // mock mode 時は rate = 500000、 source = 'mock' 固定
+    expect(body.rate).toBe(500_000);
+    expect(body.source).toBe('mock');
+    expect(typeof body.cachedAt).toBe('number');
+    expect(typeof body.expiresAt).toBe('number');
+  });
+
+  it('未知 route (/api/v1/fiat-bid/*) は 404 を返す (spot-rate 単独 server)', async () => {
+    // Plan A では fiat-bid endpoint は Ponder 側 (42069) に維持、 spot-rate server は spot-rate のみ
+    const app = createSpotRateServerApp();
+    const res = await app.request('/api/v1/fiat-bid/authorize', { method: 'POST' });
+    expect(res.status).toBe(404);
+  });
+
+  it('root path (/) は 404 (graphql route を持たない、 Ponder 非依存 SSOT)', async () => {
+    const app = createSpotRateServerApp();
+    const res = await app.request('/');
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/niji-api/src/spot-rate-server.ts
+++ b/packages/niji-api/src/spot-rate-server.ts
@@ -1,0 +1,69 @@
+/**
+ * Spot rate independent Hono server (Issue #3065、 Plan A、 port 42070)
+ *
+ * root cause SSOT — Ponder 0.12 indexer が Base Sepolia の historical sync (block 数万件、 10-30 秒 -
+ * 数分) を完了するまで hono `context.get('graphql')` 経路の全 route が実質未応答となる。
+ * spot-rate endpoint は event data に依存せず GMO / CoinGecko 外部 API + in-memory cache のみで
+ * 完結するため、 Ponder 非依存の独立 server で expose すれば sync 状態と無関係に 200 応答できる。
+ *
+ * PGlite 制約 (Ponder が sync 完了まで database schema を確定させない = topup / capture 等の
+ * DB access 経路は独立 server から呼べない) のため、 本 server は spot-rate 単独。
+ * fiat-bid endpoint 全体 (authorize / 3ds-callback / place-bid / capture / transfer-nft / topup) は
+ * 従来通り Ponder 側 (port 42069) に維持する。 dev 実運用では auction settle event 後にのみ
+ * fiat bid の実 flow が発火するため、 Ponder sync 完了 (10-30 秒) が起点となり実用範囲。
+ *
+ * Plan B (全 endpoint 分離) は Postgres 移行 + Docker 依存増加が発生するため回避、
+ * root cause である spot-rate 分離のみで user 実機の「クルクル継続」 症状を解消する。
+ *
+ * SSOT — packages/niji-api/README (Issue #3065 追記予定) + docs/operations/gmo-fiat-bid.md § port 分離 architecture
+ */
+
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+
+import { createSpotRateApp } from './handlers/spot-rate.js';
+
+/**
+ * spot rate 独立 server の app instance を生成する factory。
+ * 本 factory を export することで integration test (spot-rate-server.test.ts) から
+ * server 起動なしで route の存在確認ができる (hono `app.request()` 経路)。
+ */
+export const createSpotRateServerApp = (): Hono => {
+  const app = new Hono();
+  app.route('/api/v1/spot-rate', createSpotRateApp());
+  return app;
+};
+
+/**
+ * server 起動 entrypoint。 `pnpm dev:spot-rate` (tsx watch) 経由で invoke される。
+ *
+ * port は env `NIJI_SPOT_RATE_API_PORT` で override 可能 (default = 42070)、
+ * Ponder (default 42069) と衝突しない番号に固定する。 dev では localhost 直接 listen で十分、
+ * 本番切替時は reverse proxy 経由で公開する想定。
+ *
+ * import.meta.url === entrypoint 判定で test import 時の副作用 (server listen) を回避する。
+ */
+export const startSpotRateServer = (): { port: number } => {
+  const port = Number.parseInt(process.env['NIJI_SPOT_RATE_API_PORT'] ?? '42070', 10);
+  const resolvedPort = Number.isFinite(port) && port > 0 ? port : 42070;
+  const app = createSpotRateServerApp();
+  serve({ fetch: app.fetch, port: resolvedPort }, info => {
+    console.log(`[spot-rate-server] listening on http://127.0.0.1:${info.port}`);
+  });
+  return { port: resolvedPort };
+};
+
+// entrypoint 判定 = tsx / node で本 file を直接実行した時のみ server 起動
+// test import 時は listen しない (副作用回避)
+const isEntrypoint = (): boolean => {
+  const argv1 = process.argv[1];
+  if (argv1 === undefined) return false;
+  // import.meta.url = file:///.../spot-rate-server.ts
+  // argv[1] = /.../spot-rate-server.ts or .js (tsx compile 後)
+  const normalizedArgv = argv1.replace(/\.js$/, '.ts');
+  return import.meta.url === `file://${argv1}` || import.meta.url === `file://${normalizedArgv}`;
+};
+
+if (isEntrypoint()) {
+  startSpotRateServer();
+}

--- a/packages/niji-webapp/.env.example.local
+++ b/packages/niji-webapp/.env.example.local
@@ -37,10 +37,16 @@ VITE_ENABLE_TANSTACK_QUERY_DEVTOOLS=false
 # 用途詳細 = docs/operations/gmo-fiat-bid.md § env 変数 SSOT
 # ------------------------------------------------------------------
 
-# niji-api (Ponder + Hono) の base URL、 fiat bid endpoint 呼出に使用
-# dev = http://127.0.0.1:42069 (Ponder default port)
+# niji-api (Ponder + Hono) の base URL、 fiat bid endpoint (authorize / capture / topup 等) 呼出に使用
+# dev = http://127.0.0.1:42069 (Ponder default port、 event indexer + hono)
 # prod = https://api.niji-dao.example (Railway deploy 後の URL)
 VITE_GMO_API_ENDPOINT=http://127.0.0.1:42069
+
+# spot-rate endpoint (ETH/JPY レート取得) の base URL、 Issue #3065 で Ponder 非依存の独立 server に分離
+# dev = http://127.0.0.1:42070 (spot-rate independent hono、 Ponder sync 状態に依存せず即応答)
+# prod = 同上の Railway deploy URL (spot-rate は独立 process で deploy)
+# 未設定時は VITE_GMO_API_ENDPOINT に fallback (旧経路互換、 dev では 42069 だと Ponder sync 待ち症状再発)
+VITE_GMO_API_ENDPOINT_SPOT_RATE=http://127.0.0.1:42070
 
 # fiat bid ボタン表示 flag (true / false)、 Phase 1 開発時は true、 本番 release まで false 推奨
 VITE_ENABLE_FIAT_BID=false

--- a/packages/niji-webapp/src/hooks/useSpotRate.test.ts
+++ b/packages/niji-webapp/src/hooks/useSpotRate.test.ts
@@ -17,6 +17,7 @@ import {
   ethToWei,
   formatEthFromWei,
   jpyToEthWei,
+  resolveSpotRateEndpoint,
   useSpotRate,
   type SpotRate,
 } from './useSpotRate';
@@ -167,5 +168,50 @@ describe('formatEthFromWei', () => {
 
   it('0 wei は 0.0000 表示', () => {
     expect(formatEthFromWei(0n)).toBe('0.0000');
+  });
+});
+
+describe('resolveSpotRateEndpoint env 優先順 (Issue #3065、 spot-rate 独立 server)', () => {
+  it('VITE_GMO_API_ENDPOINT_SPOT_RATE が優先される (42070、 Ponder 非依存)', () => {
+    const base = resolveSpotRateEndpoint({
+      VITE_GMO_API_ENDPOINT_SPOT_RATE: 'http://127.0.0.1:42070',
+      VITE_GMO_API_ENDPOINT: 'http://127.0.0.1:42069',
+    });
+    expect(base).toBe('http://127.0.0.1:42070');
+  });
+
+  it('VITE_GMO_API_ENDPOINT_SPOT_RATE 未設定時は VITE_GMO_API_ENDPOINT (42069) に fallback', () => {
+    const base = resolveSpotRateEndpoint({
+      VITE_GMO_API_ENDPOINT: 'http://127.0.0.1:42069',
+    });
+    expect(base).toBe('http://127.0.0.1:42069');
+  });
+
+  it('VITE_GMO_API_ENDPOINT_SPOT_RATE 空文字時は legacy env に fallback', () => {
+    const base = resolveSpotRateEndpoint({
+      VITE_GMO_API_ENDPOINT_SPOT_RATE: '',
+      VITE_GMO_API_ENDPOINT: 'http://127.0.0.1:42069',
+    });
+    expect(base).toBe('http://127.0.0.1:42069');
+  });
+
+  it('VITE_GMO_API_ENDPOINT_SPOT_RATE 空白文字時は legacy env に fallback (trim 判定)', () => {
+    const base = resolveSpotRateEndpoint({
+      VITE_GMO_API_ENDPOINT_SPOT_RATE: '   ',
+      VITE_GMO_API_ENDPOINT: 'http://127.0.0.1:42069',
+    });
+    expect(base).toBe('http://127.0.0.1:42069');
+  });
+
+  it('両 env 未設定時は空文字 (同一 origin fallback)', () => {
+    const base = resolveSpotRateEndpoint({});
+    expect(base).toBe('');
+  });
+
+  it('trailing slash は正規化される', () => {
+    const base = resolveSpotRateEndpoint({
+      VITE_GMO_API_ENDPOINT_SPOT_RATE: 'http://127.0.0.1:42070/',
+    });
+    expect(base).toBe('http://127.0.0.1:42070');
   });
 });

--- a/packages/niji-webapp/src/hooks/useSpotRate.ts
+++ b/packages/niji-webapp/src/hooks/useSpotRate.ts
@@ -42,19 +42,44 @@ export type UseSpotRateOptions = {
 };
 
 /**
- * default fetcher = env の VITE_GMO_API_ENDPOINT 経由で /api/v1/spot-rate/eth-jpy を GET
- * env 未設定時は同一 origin (Vite proxy 前提)
+ * spot-rate endpoint URL を env source から解決する pure helper (Issue #3065)。
  *
- * env var 名 SSOT = packages/niji-webapp/.env.example.local の VITE_GMO_API_ENDPOINT (Issue #3059)。
- * dev = http://127.0.0.1:42069 (niji-api Ponder default port)、 prod = deploy URL。
+ * env 優先順 —
+ * (1) VITE_GMO_API_ENDPOINT_SPOT_RATE = spot-rate independent server (port 42070、 Ponder 非依存)
+ * (2) VITE_GMO_API_ENDPOINT = 旧 niji-api (port 42069、 Ponder + Hono) の fallback、 互換性維持
+ * (3) 未設定 = 同一 origin (空 prefix、 Vite proxy 前提)
+ *
+ * 空白のみの env 値 (`'   '`) は未設定扱い、 trailing slash は正規化する。
+ * 引数 envSource は test で差替可能に、 default は `import.meta.env`。
+ */
+export const resolveSpotRateEndpoint = (
+  envSource: Record<string, string | undefined> = ((): Record<string, string | undefined> => {
+    if (typeof import.meta === 'undefined') return {};
+    const env = (import.meta as { env?: Record<string, string | undefined> }).env;
+    return env ?? {};
+  })(),
+): string => {
+  const spotRateEndpoint = envSource['VITE_GMO_API_ENDPOINT_SPOT_RATE'];
+  const legacyEndpoint = envSource['VITE_GMO_API_ENDPOINT'];
+  const preferred =
+    typeof spotRateEndpoint === 'string' && spotRateEndpoint.trim() !== ''
+      ? spotRateEndpoint
+      : typeof legacyEndpoint === 'string' && legacyEndpoint.trim() !== ''
+        ? legacyEndpoint
+        : '';
+  return preferred.replace(/\/$/, '');
+};
+
+/**
+ * default fetcher = env 経由で /api/v1/spot-rate/eth-jpy を GET (Issue #3065)。
+ *
+ * dev では VITE_GMO_API_ENDPOINT_SPOT_RATE の 42070 を叩くことで Ponder indexer の
+ * historical sync 完了待ち (10-30 秒〜数分) を回避、 user 実機の「レート取得クルクル継続」
+ * 症状を即応答で解消する (Issue #3065 root cause)。
  */
 export const defaultSpotRateFetcher = async (): Promise<SpotRate> => {
-  const envValue =
-    typeof import.meta !== 'undefined'
-      ? (import.meta as { env?: Record<string, string> }).env?.['VITE_GMO_API_ENDPOINT']
-      : undefined;
-  const apiBase = typeof envValue === 'string' ? envValue : '';
-  const url = `${apiBase.replace(/\/$/, '')}/api/v1/spot-rate/eth-jpy`;
+  const base = resolveSpotRateEndpoint();
+  const url = `${base}/api/v1/spot-rate/eth-jpy`;
   const response = await fetch(url, {
     method: 'GET',
     headers: { Accept: 'application/json' },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
 
   packages/niji-api:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.0
+        version: 1.13.3(hono@4.7.9)
       '@niji/sdk':
         specifier: workspace:*
         version: link:../niji-sdk
@@ -208,12 +211,18 @@ importers:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.11
+      concurrently:
+        specifier: ^9.1.0
+        version: 9.2.3
       dotenv:
         specifier: 'catalog:'
         version: 16.5.0
       msw:
         specifier: ^2.14.0
         version: 2.14.6(@types/node@22.19.11)(typescript@5.9.2)
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.11)(@vitest/browser@3.2.4)(happy-dom@20.10.6(bufferutil@4.0.9)(utf-8-validate@5.0.7))(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.7))(lightningcss@1.30.1)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0)
@@ -447,7 +456,7 @@ importers:
         version: 2.3.1(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
+        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
       dotenv:
         specifier: 'catalog:'
         version: 16.5.0
@@ -567,7 +576,7 @@ importers:
         version: 6.6.3
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.4.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
+        version: 2.18.0(@tanstack/query-core@5.85.3)(@types/react@19.1.8)(immer@10.1.1)(react@19.1.0)(typescript@5.9.2)(use-sync-external-store@1.5.0(react@19.1.0))(viem@2.33.0(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.7)(zod@3.25.76))
       bad-words:
         specifier: ^3.0.4
         version: 3.0.4
@@ -7281,6 +7290,11 @@ packages:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
 
+  concurrently@9.2.3:
+    resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   conf@12.0.0:
     resolution: {integrity: sha512-fIWyWUXrJ45cHCIQX+Ck1hrZDIf/9DR0P0Zewn3uNht28hbt5OfGUq8rRWsxi96pZWPyBEd0eY9ama01JTaknA==}
     engines: {node: '>=18'}
@@ -13661,6 +13675,10 @@ packages:
 
   shell-quote@1.8.2:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
+    engines: {node: '>= 0.4'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -22482,11 +22500,11 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@3.2.4(bufferutil@4.0.9)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(playwright@1.61.0)(utf-8-validate@5.0.7)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(bufferutil@4.0.9)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(playwright@1.61.0)(utf-8-validate@5.0.7)(vite@5.0.7(@types/node@22.19.11)(lightningcss@1.30.1)(terser@5.46.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(vite@5.0.7(@types/node@22.19.11)(lightningcss@1.30.1)(terser@5.46.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.21
       sirv: 3.0.2
@@ -22544,6 +22562,16 @@ snapshots:
       '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
+    optional: true
+
+  '@vitest/mocker@3.2.4(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(vite@5.0.7(@types/node@22.19.11)(lightningcss@1.30.1)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.14.6(@types/node@22.19.11)(typescript@5.9.2)
+      vite: 5.0.7(@types/node@22.19.11)(lightningcss@1.30.1)(terser@5.46.0)
     optional: true
 
   '@vitest/mocker@3.2.4(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))':
@@ -24770,6 +24798,15 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
+
+  concurrently@9.2.3:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   conf@12.0.0:
     dependencies:
@@ -32674,6 +32711,8 @@ snapshots:
 
   shell-quote@1.8.2: {}
 
+  shell-quote@1.8.4: {}
+
   shelljs@0.8.5:
     dependencies:
       glob: 7.2.3
@@ -34479,7 +34518,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.19.11
-      '@vitest/browser': 3.2.4(bufferutil@4.0.9)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(playwright@1.61.0)(utf-8-validate@5.0.7)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.20.3)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(bufferutil@4.0.9)(msw@2.14.6(@types/node@22.19.11)(typescript@5.9.2))(playwright@1.61.0)(utf-8-validate@5.0.7)(vite@5.0.7(@types/node@22.19.11)(lightningcss@1.30.1)(terser@5.46.0))(vitest@3.2.4)
       happy-dom: 20.10.6(bufferutil@4.0.9)(utf-8-validate@5.0.7)
       jsdom: 26.1.0(bufferutil@4.0.9)(utf-8-validate@5.0.7)
     transitivePeerDependencies:


### PR DESCRIPTION
## ひとことサマリ

Ponder indexer の historical sync 完了待ちで spot-rate endpoint が実質未応答になる問題を解決、 spot rate を独立 hono server (port 42070) に分離。 fiat-bid endpoint は Ponder 側 (42069) 維持で PGlite constraint 回避。

## 背景

user 実機確認で spot rate クルクル継続 = niji-api の Ponder indexer が 「Waiting to start... Progress 0.0%」 で historical sync 中、 Ponder の hono API が indexer sync 完了まで実質未応答が root cause。 Base Sepolia の block 数万件 の historical sync 完了を待つのは dev 環境で非現実的。

前 session の chain 中に PGlite single-writer semantics で外部 process 並行 open 不可 と発見、 fiat-bid endpoint 全体の port 分離は Postgres 移行が必要になるため案 A (spot-rate のみ分離) を採用。

## 変更内容

- packages/niji-api/src/spot-rate-server.ts (新規) — 独立 hono server + @hono/node-server で port 42070 listen、 spot-rate app 登録
- packages/niji-api/src/spot-rate-server.test.ts (新規、 3 test) — 起動確認 + endpoint 存在確認
- packages/niji-api/src/api/index.ts — Ponder 側から spot-rate route 登録削除 (Ponder = event indexer 専任)
- packages/niji-api/package.json — @hono/node-server + concurrently dep 追加、 dev script を concurrently で 2 process 並列起動
- Makefile — api-bg target で 2 server の並列起動、 dev-status で port 42069/42070 別列表示
- packages/niji-webapp/.env.example.local — VITE_GMO_API_ENDPOINT_SPOT_RATE (42070) 追加、 既存 VITE_GMO_API_ENDPOINT (42069) は fiat bid 用として維持
- packages/niji-webapp/src/hooks/useSpotRate.ts — VITE_GMO_API_ENDPOINT_SPOT_RATE を優先参照、 fallback = VITE_GMO_API_ENDPOINT
- packages/niji-webapp/src/hooks/useSpotRate.test.ts — 新 env var 参照 test 追加
- docs/operations/gmo-fiat-bid.md — port 分離 architecture + env SSOT 更新

## 動作証明

- niji-api 231 test PASS (spot-rate-server 3 test 追加、 regression 0)
- webapp useSpotRate 26 test PASS
- lint 0 error (React warning は既存)
- typecheck 4 error は master baseline の pre-existing (ponder.config.ts の Nouns 旧 abi 参照、 本 PR 由来なし)

## 完了条件

- [x] make dev 起動時に Ponder (42069) と spot-rate server (42070) が並列起動
- [x] curl http://127.0.0.1:42070/api/v1/spot-rate/eth-jpy が Ponder sync 状態問わず 200 応答
- [x] webapp が spot-rate を 42070、 fiat-bid を 42069 の 2 URL 参照
- [x] make dev-status で両 server 状況表示
- [x] pnpm test niji-api + webapp regression 0

## リスク・注意点

fiat-bid endpoint (authorize / 3ds-callback / place-bid / capture / transfer-nft / topup) は Ponder 側維持で Ponder sync 完了後応答 (dev 実用範囲、 実 auction は sync 済 block 後の event 対象)。 Phase 3 本番切替時に Postgres 移行を検討して fiat-bid endpoint も port 分離可能。

Closes #3065