### PR TITLE
🐛 fix(niji-webapp): e2e global-setup spawnSync maxBuffer 100MB 明示化 (23 分 hang 修正)

### DIFF
--- a/packages/niji-webapp/tests/e2e/global-setup.ts
+++ b/packages/niji-webapp/tests/e2e/global-setup.ts
@@ -174,6 +174,10 @@ export default async function globalSetup() {
   await waitForAnvil();
 
   // 3) deploy-niji-full (hardhat task)
+  //
+  // maxBuffer 100MB を明示 (Issue #3078)。 Node.js の spawnSync は default maxBuffer 1MB のため、
+  // deploy output が数 MB (12 trait × 数十 image のログ) 超過で子プロセスの write が block、
+  // 結果として e2e 全体が 23 分 hang する deadlock が発生した (実測)。 deploy 単体は 21 秒で完走する。
   const repoRoot = path.resolve(__dirname, '../../../..');
   const contractsDir = path.join(repoRoot, 'packages/niji-contracts');
   const result = spawnSync(
@@ -183,6 +187,7 @@ export default async function globalSetup() {
       cwd: contractsDir,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 100 * 1024 * 1024,
     },
   );
 


### PR DESCRIPTION
## ひとことサマリ

`packages/niji-webapp/tests/e2e/global-setup.ts` の `spawnSync` に `maxBuffer: 100 * 1024 * 1024` を明示。 default 1MB 上限で発生していた **deploy pipe deadlock による 23 分 hang** を解消する 1 行 fix + 意図コメント。

## 背景

Issue #3073 対応で SKIP_GLOBAL_SETUP なし経路の e2e が 23 分 hang する事象を実測。 プロセス調査で hardhat deploy-niji-full 単体は 21 秒で完走することを確認、 hang の real root cause は Node.js の `spawnSync` の default `maxBuffer` (1MB) が deploy output 数 MB (12 trait × 数十 image のログ) を受け切れず子プロセスが write block → deadlock。

## 変更内容

`packages/niji-webapp/tests/e2e/global-setup.ts` の `spawnSync('pnpm', ['exec', 'hardhat', 'deploy-niji-full', ...])` 呼出に `maxBuffer: 100 * 1024 * 1024` を追加、 意図コメントで判断根拠 (default 1MB / deploy output 数 MB / 実測 hang 経路) を明記。

## 動作証明

- lint = 0 error (2 warning は master baseline pre-existing の strictNullChecks)
- typecheck = global-setup.ts の error 0 (pre-existing dist TS6305 は master 由来で無関係)
- 変更 1 行 + 意図コメント 5 行、 behavior test 不能 (deploy output MB 級の再現に infra overhead 過大)、 Layer 3 compile pass で代替
- 実効果は Issue #3077 での fiat-bid e2e 実行時に間接的に確認予定

## 完了条件

- [x] `maxBuffer: 100 * 1024 * 1024` 明示 (Node.js API 標準 option)
- [x] 意図コメントで default 1MB / deploy output 数 MB / 実測 hang 経路 の 3 事実明記
- [x] lint 0 error / tsc 0 error
- [x] rules 準拠 (writing-style.md 縦長 layout、 git-workflow.md § commit trailer)

## リスク・注意点

100MB の値は数 MB output の 10 倍余裕、 メモリ使用量への影響は infinitesimal (実際は消費された分だけ確保、 100MB pre-allocate ではない)。 stdio inherit への切替も検討したが result.stdout / stderr で deploy error 詳細取得できる利点を維持するため maxBuffer 明示化を採用。

Closes #3078
