### PR TITLE
🐛 fix(niji-contracts,niji-webapp): AUCTION_DURATION env override + e2e で 24h 化 (Issue #3077 部分 fix)

### DIFF
--- a/packages/niji-contracts/tasks/deploy-niji-full.ts
+++ b/packages/niji-contracts/tasks/deploy-niji-full.ts
@@ -327,7 +327,16 @@ task('deploy-niji-full', 'Deploy full Niji stack (Art, Descriptor, Seeder, Token
       // (Niji 0 / 任意の auction の endTime を 1 分で越えさせ Bid.tsx の auctionEnded を
       // すぐ true にして既存の SettleManuallyBtn を表示させる狙い、 auto-settler が
       // 5s polling で速やかに次 auction に進める)
-      const AUCTION_DURATION = 60; // 1 分
+      //
+      // env NIJI_AUCTION_DURATION で override 可能 (Issue #3077、 e2e 対応)。
+      // e2e globalSetup が 86400 (24h) を set することで、 webapp の Date.now() ベースの
+      // auctionEnded 判定が e2e 実行時間 (数分) 中に true になるのを防ぐ。
+      // default は既存 dev flow 互換で 60 秒維持。
+      const AUCTION_DURATION_ENV = process.env.NIJI_AUCTION_DURATION;
+      const AUCTION_DURATION =
+        AUCTION_DURATION_ENV && Number.isFinite(Number(AUCTION_DURATION_ENV))
+          ? Number(AUCTION_DURATION_ENV)
+          : 60;
       const AUCTION_RESERVE_PRICE = ethers.parseEther('0.001'); // 0.001 ETH
       const AUCTION_TIME_BUFFER = 10; // 10 秒 (1 分 auction に合わせる、 snipe 延長は最小限)
       const AUCTION_MIN_BID_INCREMENT_PRCT = 2; // 2%

--- a/packages/niji-webapp/tests/e2e/global-setup.ts
+++ b/packages/niji-webapp/tests/e2e/global-setup.ts
@@ -180,11 +180,20 @@ export default async function globalSetup() {
   // 結果として e2e 全体が 23 分 hang する deadlock が発生した (実測)。 deploy 単体は 21 秒で完走する。
   const repoRoot = path.resolve(__dirname, '../../../..');
   const contractsDir = path.join(repoRoot, 'packages/niji-contracts');
+  // NIJI_AUCTION_DURATION=86400 (24h) を deploy に渡す (Issue #3077)。
+  // webapp の auctionEnded 判定は JS Date.now() vs auction.endTime で行われるため、
+  // default 60 秒 duration では deploy 完了後 1 分で全 e2e test が auctionEnded=true state に入り
+  // Bid form が render されなくなる。 24h に拡張することで e2e 実行時間 (数分) 中は active 維持。
+  const deployEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    NIJI_AUCTION_DURATION: '86400',
+  };
   const result = spawnSync(
     'pnpm',
     ['exec', 'hardhat', 'deploy-niji-full', '--network', 'localhost'],
     {
       cwd: contractsDir,
+      env: deployEnv,
       encoding: 'utf-8',
       stdio: ['ignore', 'pipe', 'pipe'],
       maxBuffer: 100 * 1024 * 1024,


### PR DESCRIPTION
## ひとことサマリ

Issue #3077 の Bid form 未 render root cause の **1 要因 (auction ended state by JS Date.now() 判定)** を解消する部分 fix。 AUCTION_DURATION を env override 対応にし、 e2e globalSetup で 24h (86400 秒) を注入。 残要因 (webapp auction data 取得経路の他 root cause) は Issue #3077 open で追加調査継続。

## 背景

Issue #3077 で fiat-bid e2e 13 failed の root cause を追加調査、 webapp `AuctionActivity/index.tsx:78` で `Number(auction.endTime) - Math.floor(Date.now() / 1000)` の JS Date.now() (wall clock) ベース ended 判定を発見。 anvil の evm_snapshot/revert では JS wall clock 進行を戻せないため、 default 60 秒 duration では deploy から 1 分後の全 e2e test が auction ended state で Bid form 未 render になっていた。

## 変更内容

### deploy-niji-full.ts に env override 対応

```typescript
const AUCTION_DURATION_ENV = process.env.NIJI_AUCTION_DURATION;
const AUCTION_DURATION =
  AUCTION_DURATION_ENV && Number.isFinite(Number(AUCTION_DURATION_ENV))
    ? Number(AUCTION_DURATION_ENV)
    : 60;
```

default 60 秒維持で既存 dev flow (auto-settler + SettleManuallyBtn 表示) 互換。

### global-setup.ts で 86400 注入

```typescript
const deployEnv: NodeJS.ProcessEnv = {
  ...process.env,
  NIJI_AUCTION_DURATION: '86400',
};
```

spawnSync に env option 追加、 e2e 経路のみ 24h 化。

## 動作証明

- lint = 0 error (3 warning は master baseline pre-existing の strictNullChecks)
- typecheck = 0 error
- 変更 20 行 + 意図コメント、 behavior test 不能 (infra config change) で Layer 3 compile pass 代替

## 部分 fix scope 明示

本 PR は Issue #3077 の完全 close ではなく **partial progress**。 24h 化で 「auction ended 状態による Bid form 未 render」 の 1 要因は解消したが、 実 e2e で他要因が残存 (kiwa spec 13 failed 継続、 wallet 未接続 spec の Bid area そのものが render されない別 root cause)。 Issue #3077 は open のまま、 残要因の追加調査は別 branch で継続する。

## 完了条件

- [x] AUCTION_DURATION env override 対応
- [x] e2e globalSetup で 86400 注入
- [x] default 60 秒維持で既存 dev flow 互換
- [x] lint 0 error / tsc 0 error
- [x] rules 準拠

## リスク・注意点

24h 化は e2e 経路のみで、 default 60 秒 dev flow は不変。 24h 化した状態で他 e2e (chain-past-auctions.spec.ts 等) が影響受ける可能性あるが、 本 PR scope は fiat-bid e2e のみで chain-past-auctions は本 project 対象外 (別 spec)。

Refs #3077
