### PR TITLE
🐛 fix(niji-webapp): e2e globalSetup で Niji 0 (Nijider 枠) settle → Niji 1 (通常 auction) 開始 (Issue #3077 続き、 5→9 pass)

### DIFF
--- a/packages/niji-webapp/tests/e2e/global-setup.ts
+++ b/packages/niji-webapp/tests/e2e/global-setup.ts
@@ -214,6 +214,20 @@ export default async function globalSetup() {
   await waitForSpotRateReady();
   console.log(`[e2e globalSetup] spot-rate ready on :${SPOT_RATE_PORT}`);
 
+  // 5.5) Niji 0 (Nijider 枠) を settle して Niji 1 (通常 auction) に進める (Issue #3077)。
+  //
+  // deploy 直後の active auction = Niji 0 だが、 utils/nounderNiji.ts の判定
+  // `nounId % 10n === 0n && nounId <= 1820n` で Niji 0/10/20/... は Nijider 枠 (NijiContent)、
+  // 常に auctionEnded=true 固定 + Winner UI 固定 + Bid form が render されない仕様
+  // (Nouns 派生プロジェクト慣例、 コミュニティ創設メンバー配布)。 fiat-bid.spec.ts は
+  // 「Bid form 表示」 を assume するため、 通常 auction (Niji 1+) に進める必要がある。
+  //
+  // seedPastAuctions(1) 経路 = anvil の block timestamp を Niji 0 endTime 越えまで進めて
+  // settleCurrentAndCreateNewAuction() 呼出、 Niji 1 (通常 auction、 24h duration) を開始。
+  const { seedPastAuctions } = await import('./helpers/chain.js');
+  await seedPastAuctions(1);
+  console.log('[e2e globalSetup] Niji 0 settled → Niji 1 (standard auction) started');
+
   // 6) post-deploy state を evm_snapshot で保存 (Issue #3073、 高速化 A 案)
   //
   // 各 spec の beforeEach で `revertChain(snapshotId)` を呼んで post-deploy 状態に戻すことで、


### PR DESCRIPTION
## ひとことサマリ

Issue #3077 続き = **e2e globalSetup で Niji 0 (Nijider 枠) を settle → Niji 1 (通常 auction) を開始する `seedPastAuctions(1)` 呼出** を追加。 5 pass → **9 pass** で 4 test 新規活性化 (TC-FB23 wallet 未接続 + TC-FB20 / TC-FB22 / TC-FB24 validation edge case)。

## 背景

`packages/niji-webapp/src/utils/nounderNiji.ts:4-6` で `nounId % 10n === 0n && nounId <= 1820n` = **Niji 0/10/20/... は Nijider 枠** (NijiContent 表示、 auctionEnded=true 固定、 Bid form 無し) の仕様、 Nouns 派生プロジェクトの慣例 (コミュニティ創設メンバー配布 flow)。

deploy 直後の active auction = Niji 0 のため、 fiat-bid.spec.ts が「Bid form 表示」 を assume しても Bid area が render されない状態が続いていた。 24h duration 化 (PR #3080) では解決しなかった残 root cause の 1 つ。

## 変更内容

`packages/niji-webapp/tests/e2e/global-setup.ts` の step 5.5 に dynamic import 経由で `seedPastAuctions(1)` 呼出を追加、 anvil block timestamp 進行 + `settleCurrentAndCreateNewAuction()` で Niji 0 → Niji 1 に advance。

## 動作証明

- lint = 0 error (2 warning は master baseline pre-existing の strictNullChecks)
- typecheck = 0 error
- e2e 実測 = **5 pass → 9 pass** (4 test 新規活性化)、 実行時間 2.0 分

## 部分 fix scope 明示

本 PR は Issue #3077 の完全 close ではなく **partial progress**。 「Nijider 枠 vs 通常 auction」 の 1 要因は解消したが、 残 9 failed test は helper wallet option filter (ConnectKit modal 内 wallet 名 mismatch) の別 root cause、 追加調査は別 branch で継続。 Issue #3077 は open のまま。

Refs #3077
