### PR TITLE
🐛 fix(niji-webapp): kiwa wallet inject race condition 検知で connect flow skip (Issue #3082、 9→14 pass)

### DIFF
--- a/packages/niji-webapp/tests/e2e/helpers/fiat-bid.ts
+++ b/packages/niji-webapp/tests/e2e/helpers/fiat-bid.ts
@@ -270,10 +270,24 @@ export const connectWalletAndWaitForBid = async (
 
   const wrapper = page.getByTestId('bid-open-button-wrapper');
   const bidOpenButton = page.getByTestId('bid-open-button');
-  const wrapperExists = (await wrapper.count()) > 0;
+  let wrapperExists = (await wrapper.count()) > 0;
+
+  // kiwa `dappE2eTest` fixture の wallet inject が wrapper 判定直後に完了する race condition を回避 (Issue #3082)。
+  // wrapper 検知後 2 秒 wait して wrapper が disappear すれば「inject 済 = connect flow skip」 と判定、
+  // wrapper 継続 visible なら本当に未接続 → ConnectKit modal 経由の connect flow を実行する。
+  if (wrapperExists) {
+    const wrapperDisappeared = await wrapper
+      .first()
+      .waitFor({ state: 'hidden', timeout: 2_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (wrapperDisappeared) {
+      wrapperExists = false;
+    }
+  }
 
   if (wrapperExists) {
-    // 未接続 → ConnectKit modal 経由で connect flow を実行
+    // 未接続確定 → ConnectKit modal 経由で connect flow を実行
     const connectButton = page.getByRole('button', { name: 'Connect', exact: true }).first();
     await connectButton.waitFor({ state: 'visible', timeout: 10_000 });
     await connectButton.click();


### PR DESCRIPTION
## ひとことサマリ

Issue #3082 部分 fix = kiwa `dappE2eTest` fixture の wallet inject race condition を検知して connect flow を skip する分岐追加。 **9 pass → 14 pass** (5 test 新規活性化) + 実行時間 **2.0 分 → 1.3 分** (35% 短縮)。

## 背景

Issue #3082 の Playwright trace zip 分析で判明 = kiwa fixture の wallet inject は wagmi hydration 中の任意 timing で完了、 helper の `wrapperExists` 判定時点は未接続 → 直後に inject 完了 → Connect button click 時点で「wallet 選択 modal」 でなく **account details modal (「接続されました / ネットワーク切替 / 切断」)** が open、 helper の walletOption pattern match 失敗で 12 kiwa spec 全 timeout。

## 変更内容

`packages/niji-webapp/tests/e2e/helpers/fiat-bid.ts` の `connectWalletAndWaitForBid` に race condition 検知 + skip 分岐を追加、 wrapper 検知後 2 秒 wait で wrapper が disappear すれば inject 済判定 → connect flow skip、 wrapper 継続 visible なら本当の未接続で従来 connect flow に fall through。

## 動作証明

- lint = 0 error / typecheck = 0 error
- e2e = **9 → 14 pass** (5 test 新規活性化 TC-FB20/21/22/24 + TC-FB40-43)、 **1.3 分**

## 部分 fix scope 明示

本 PR は Issue #3082 の完全 close ではなく **partial progress**。 race condition の 1 要因は解消したが、 残 4 fail (TC-FB10 golden path / TC-FB30 3DS fail / TC-FB31 GMO 5xx / TC-FB44 testcard 切替) は「実 connect flow → bid tx or 3DS 遷移」 経路の別 root cause、 追加調査は Issue #3082 open で継続。

Refs #3082
