### PR TITLE
🐛 fix(niji-webapp): BidModal placeBid に chainId 明示で wrong chain 時の switchChain prompt 自動発火 (Closes #3084)

### DIFF
--- a/packages/niji-webapp/src/components/BidModal/index.tsx
+++ b/packages/niji-webapp/src/components/BidModal/index.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { defaultChain } from '@/wagmi';
 
 import classes from './BidModal.module.css';
 
@@ -161,9 +162,14 @@ export const BidModal = ({
       setEthInput(minBidEth(minBid));
       return;
     }
+    // chainId 明示で wagmi が wallet の現 chain 不一致を検出、 switchChain prompt を
+    // 自動発火する (v2 の standard behavior)。 未指定だと wallet 現 chain (例 mainnet)
+    // に tx broadcast されて eth.merkle.io 等の public RPC に POST → CORS block で
+    // 送信失敗する root cause を回避。
     placeBid({
       args: [BigInt(auction.nounId)],
       value: parsed,
+      chainId: defaultChain.id,
     });
   };
 


### PR DESCRIPTION
## ひとことサマリ

user 実測で「ETH bid 署名 OK、 tx 送信 fail」 症状の root cause fix。 `BidModal` の `placeBid()` に `chainId: defaultChain.id` 明示で wagmi の wrong chain 自動 switchChain prompt 経路を有効化、 mainnet public RPC (`eth.merkle.io`) への誤 broadcast (CORS block) を防ぐ。

## 背景

user 実測 DevTools Console error:

```
Access to fetch at 'https://eth.merkle.io/' from origin 'http://localhost:2424' has been blocked by CORS policy
POST https://eth.merkle.io/ net::ERR_FAILED
```

wagmi `useWriteContract().writeContract()` は chainId 未指定時に wallet の現 chain を使う仕様、 wallet が anvil (31337) 以外に接続していると tx broadcast が mainnet に飛ぶ。 `NetworkAlert` component は自動 switchChain 実装済だが user reject or delay 中に Bid click すると wrong chain のまま broadcast されていた。

## 変更内容

`packages/niji-webapp/src/components/BidModal/index.tsx:169-173` の `placeBid({ args, value })` に `chainId: defaultChain.id` を追加。 wagmi v2 の standard behavior として wallet chain 不一致検出時に switchChain prompt が自動発火、 user approve すれば正しい chain 切替後 tx broadcast 続行。

## 動作証明

- lint = 0 error (4 warning は master baseline pre-existing)
- typecheck = 0 error
- unit test = BidModal 27/27 全 pass (regression 0)

## 完了条件

- [x] BidModal placeBid に chainId 明示
- [x] 意図コメントで root cause + fix logic 明記
- [x] unit test regression 0
- [x] rules 準拠

## リスク

ETH bid のみ対象、 他の useWriteContract 呼出 (settle auction / delegate / vote 等) も同 pattern の疑いあり、 個別 issue で追加調査候補。

Closes #3084
