### PR TITLE
🎨 fix(niji-webapp): BidModal auto close を 3s → 2s に短縮 (Closes #3093)

### DIFF
--- a/packages/niji-webapp/src/components/BidModal/index.tsx
+++ b/packages/niji-webapp/src/components/BidModal/index.tsx
@@ -156,8 +156,8 @@ export const BidModal = ({
       toastFiredRef.current = true;
       toast.success(t`Bid placed.`);
       setEthInput('');
-      // 3 秒間 modal 内 success 表示を維持 → auto close で UX 完結。
-      const closeTimer = setTimeout(() => onClose(), 3_000);
+      // 2 秒間 modal 内 success 表示を維持 → auto close で UX 完結 (user 明示要望で 3s → 2s 短縮)。
+      const closeTimer = setTimeout(() => onClose(), 2_000);
       return () => clearTimeout(closeTimer);
     }
     if (!placeBidSucceeded) {


### PR DESCRIPTION
user 明示要望で入札後 modal auto close を 3s → 2s に短縮。 setTimeout delay 1 行変更。

## 動作証明
- BidModal unit test 27/27 全 pass

Closes #3093