### PR TITLE
⚡ perf(niji-webapp): useSubgraphQuery staleTime 60s + gcTime 5min default (Closes #3105)

### DIFF
--- a/packages/niji-webapp/src/hooks/useSubgraphQuery.ts
+++ b/packages/niji-webapp/src/hooks/useSubgraphQuery.ts
@@ -11,6 +11,10 @@ interface UseSubgraphQueryOptions<TResult, TVariables> {
   queryKey: unknown[];
   enabled?: boolean;
   refetchInterval?: number;
+  /** stale 判定までの時間 (ms)、 default 60_000 = 1 分。 caller が特定 query で短くしたい場合のみ override */
+  staleTime?: number;
+  /** unused query を GC する時間 (ms)、 default 300_000 = 5 分 */
+  gcTime?: number;
 }
 
 export function useSubgraphQuery<TResult, TVariables>({
@@ -19,6 +23,8 @@ export function useSubgraphQuery<TResult, TVariables>({
   queryKey,
   enabled = true,
   refetchInterval,
+  staleTime = 60_000,
+  gcTime = 300_000,
 }: UseSubgraphQueryOptions<TResult, TVariables>) {
   // subgraph endpoint が空なら query を発火させない (local 31337 で subgraph 未起動時)
   const subgraphEnabled = !!config.app.subgraphApiUri;
@@ -34,6 +40,11 @@ export function useSubgraphQuery<TResult, TVariables>({
     },
     enabled: enabled && subgraphEnabled,
     refetchInterval: refetchInterval ?? false,
+    // TanStack Query default staleTime=0 で mount 毎に refetch 発火し「サイトが重い」 一因になる。
+    // subgraph data は多くの case で分単位で stale してよい (auction / proposal 系は refetchInterval で
+    // 明示 polling)、 default staleTime 60_000 + gcTime 300_000 で unused query の refetch 抑制 (Issue #3105)。
+    staleTime,
+    gcTime,
   });
 
   return {


### PR DESCRIPTION
TanStack Query staleTime default 0 で mount 毎 refetch 発火する root cause fix。 60s stale + 5min GC を default に設定、 caller override 可能。

## 動作証明
- lint 0 error / tsc 0 error
- unit test 72/72 全 pass

Closes #3105