### PR TITLE
🐛 fix(niji-webapp): CSS 順序 = bootstrap.min.css を index.css の後に load (accordion 一瞬表示 → 消える bug fix) (Closes #3091)

### DIFF
--- a/packages/niji-webapp/src/App.tsx
+++ b/packages/niji-webapp/src/App.tsx
@@ -5,8 +5,14 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 import { useAccount } from 'wagmi';
 
-import 'bootstrap/dist/css/bootstrap.min.css';
+// CSS 順序 = index.css (@tailwind base 含む) を先に、 bootstrap.min.css を後に load する。
+// bootstrap → index.css の順だと tailwind preflight が bootstrap の accordion / collapse 系 style を
+// 上書きし、 Documentation accordion 開いた content が 一瞬表示 → 消える bug が発生していた (Issue #3091)。
+// tailwind utilities は class ベースで individual だが preflight (base reset) は universal reset で bootstrap の
+// component style と衝突する。 bootstrap を最後 load することで preflight を上書きし、
+// accordion transition / collapse display state が正常動作する。
 import '@/index.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 
 import { Footer } from '@/components/Footer';
 import NavBar from '@/components/NavBar';


### PR DESCRIPTION
Documentation accordion 開くと content 一瞬表示 → 消える bug の root cause fix。

## Root Cause
App.tsx で bootstrap.min.css → index.css (@tailwind base 含む) の順で load、 tailwind preflight が bootstrap accordion style を上書き → collapse transition 破綻。

## Fix
import 順を逆転 (index.css 先、 bootstrap 後) して preflight を bootstrap で上書き。

## 動作証明
- lint 0 error
- 手動 UI verify

Closes #3091