### PR TITLE
🐛 fix(niji-webapp): accordion 一瞬表示→消える bug 追加 fix (:global CSS override) (Closes #3108)

### DIFF
--- a/packages/niji-webapp/src/components/Documentation/Documentation.module.css
+++ b/packages/niji-webapp/src/components/Documentation/Documentation.module.css
@@ -84,3 +84,26 @@
     padding-left: 20px;
   }
 }
+
+/* Issue #3091 続 — accordion 開いた content が 一瞬表示 → 消える bug fix。
+ * root cause = tailwind preflight が bootstrap の transition / display 経路と conflict、
+ * react-bootstrap Collapse component の height animation が完了せず content が hidden に snap back。
+ * :global で bootstrap grid class を direct override、 open 済 accordion の content を強制 visible に保つ。
+ */
+.accordionItem :global(.accordion-collapse.show) {
+  display: block !important;
+  height: auto !important;
+  visibility: visible !important;
+  overflow: visible !important;
+}
+
+.accordionItem :global(.accordion-collapse.collapsing) {
+  height: auto !important;
+  overflow: hidden !important;
+  transition: none !important;
+}
+
+.accordionItem :global(.accordion-body) {
+  display: block !important;
+  visibility: visible !important;
+}


### PR DESCRIPTION
PR #3107 CSS 順序変更でも fix しない、 :global(.accordion-collapse.show) に display 強制 override 追加。

Closes #3108
Refs #3091