### PR TITLE
🧪 test(niji-webapp): CardInputFincode 単体 test + FiatBidForm env flag 分岐 test (11 test 追加)

### DIFF
--- a/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * CardInputFincode unit test (Issue #3121)。
+ *
+ * @fincode/js を module mock、 initFincode / getCardToken の呼出 shape + ref.getToken() の
+ * token 返却 + VITE_FINCODE_PUBLIC_KEY 未設定時 error state の 3 経路を検証する。
+ * 実 fincode iframe は jsdom で mount 不可のため、 mount() は spy で呼出確認のみ。
+ */
+import { createRef } from 'react';
+
+import { render, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CardInputFincode, type CardInputFincodeHandle } from './CardInputFincode';
+
+const initFincodeMock = vi.fn();
+const getCardTokenMock = vi.fn();
+const uiCreateMock = vi.fn();
+const uiMountMock = vi.fn();
+
+vi.mock('@fincode/js', () => ({
+  initFincode: (args: unknown) => initFincodeMock(args),
+  getCardToken: (args: unknown) => getCardTokenMock(args),
+}));
+
+const makeFincodeInstance = () => ({
+  ui: () => ({
+    create: uiCreateMock,
+    mount: uiMountMock,
+    getFormData: vi.fn(),
+  }),
+});
+
+describe('CardInputFincode', () => {
+  const originalKey = import.meta.env.VITE_FINCODE_PUBLIC_KEY;
+
+  beforeEach(() => {
+    initFincodeMock.mockReset();
+    getCardTokenMock.mockReset();
+    uiCreateMock.mockReset();
+    uiMountMock.mockReset();
+    // @ts-expect-error env override for test
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
+  });
+
+  afterEach(() => {
+    // @ts-expect-error env restore
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = originalKey;
+  });
+
+  it('publicKey 設定時に initFincode + ui.create + ui.mount が正しい引数で呼ばれる', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    render(<CardInputFincode />);
+    await waitFor(() => expect(initFincodeMock).toHaveBeenCalledTimes(1));
+    expect(initFincodeMock).toHaveBeenCalledWith({
+      publicKey: 'p_test_dummy',
+      isLiveMode: false,
+    });
+    await waitFor(() => expect(uiMountMock).toHaveBeenCalledTimes(1));
+    expect(uiCreateMock).toHaveBeenCalledWith('token', { layout: 'vertical' });
+    expect(uiMountMock).toHaveBeenCalledWith('niji-fincode-card-mount', '100%');
+  });
+
+  it('ready 完了で onReadyChange(true) が呼ばれる', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    const onReadyChange = vi.fn();
+    render(<CardInputFincode onReadyChange={onReadyChange} />);
+    await waitFor(() => expect(onReadyChange).toHaveBeenCalledWith(true));
+  });
+
+  it('ref.current.getToken() が fincode getCardToken の token を返す', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    getCardTokenMock.mockResolvedValue({ list: [{ token: 'tok_test_abc123' }] });
+    // eslint-disable-next-line @eslint-react/no-create-ref
+    const ref = createRef<CardInputFincodeHandle>();
+    render(<CardInputFincode ref={ref} />);
+    await waitFor(() => expect(uiMountMock).toHaveBeenCalled());
+    const token = await act(async () => await ref.current!.getToken());
+    expect(token).toBe('tok_test_abc123');
+    expect(getCardTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('getCardToken response に token 欠落時は throw する', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    getCardTokenMock.mockResolvedValue({ list: [] });
+    // eslint-disable-next-line @eslint-react/no-create-ref
+    const ref = createRef<CardInputFincodeHandle>();
+    render(<CardInputFincode ref={ref} />);
+    await waitFor(() => expect(uiMountMock).toHaveBeenCalled());
+    await expect(ref.current!.getToken()).rejects.toThrow(
+      'fincode getCardToken response に token が含まれていません',
+    );
+  });
+
+  it('publicKey 未設定時は initFincode 呼ばず error message 表示 + onReadyChange(false)', async () => {
+    // @ts-expect-error env override for test
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = '';
+    const onReadyChange = vi.fn();
+    const { getByTestId } = render(<CardInputFincode onReadyChange={onReadyChange} />);
+    await waitFor(() => expect(onReadyChange).toHaveBeenCalledWith(false));
+    expect(initFincodeMock).not.toHaveBeenCalled();
+    expect(getByTestId('card-input-fincode-error').textContent).toContain(
+      'VITE_FINCODE_PUBLIC_KEY 未設定',
+    );
+  });
+
+  it('initFincode reject 時は error state 表示 + onReadyChange(false)', async () => {
+    initFincodeMock.mockRejectedValue(new Error('network fail'));
+    const onReadyChange = vi.fn();
+    const { getByTestId } = render(<CardInputFincode onReadyChange={onReadyChange} />);
+    await waitFor(() =>
+      expect(getByTestId('card-input-fincode-error').textContent).toContain('network fail'),
+    );
+    expect(onReadyChange).toHaveBeenCalledWith(false);
+  });
+
+  it('mount target element が data-testid で render される', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    const { getByTestId } = render(<CardInputFincode />);
+    const mountEl = getByTestId('card-input-fincode-mount');
+    expect(mountEl.id).toBe('niji-fincode-card-mount');
+  });
+});

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -246,5 +246,86 @@ describe('FiatBidForm mock badge (Issue #3061)', () => {
     expect(screen.queryByTestId('fiat-bid-rate-summary-mock-badge')).toBeNull();
     const rateSummary = screen.getByTestId('fiat-bid-rate-summary');
     expect(rateSummary.textContent).toContain('source: coingecko');
+  });
+});
+
+/**
+ * Issue #3119 — VITE_USE_FINCODE_UI env flag による CardInput / CardInputFincode 切替 test。
+ *
+ * default (flag 未設定 / 'false') = CardInput (自前 mock form) が render される (data-testid="card-input")。
+ * flag='true' = CardInputFincode (fincode.js iframe) が render される (data-testid="card-input-fincode")。
+ * @fincode/js は SDK 内部で iframe を mount するため vi.mock で fake instance を stub、
+ * env は import.meta.env の direct override で 2 pattern 検証。
+ */
+
+vi.mock('@fincode/js', () => ({
+  initFincode: vi.fn().mockResolvedValue({
+    ui: () => ({ create: vi.fn(), mount: vi.fn(), getFormData: vi.fn() }),
+  }),
+  getCardToken: vi.fn().mockResolvedValue({ list: [{ token: 'tok_stub' }] }),
+}));
+
+describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
+  const originalFlag = import.meta.env.VITE_USE_FINCODE_UI;
+  const originalKey = import.meta.env.VITE_FINCODE_PUBLIC_KEY;
+
+  afterEach(() => {
+    // @ts-expect-error env restore
+    import.meta.env.VITE_USE_FINCODE_UI = originalFlag;
+    // @ts-expect-error env restore
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = originalKey;
+  });
+
+  const renderFiat = () =>
+    render(
+      <FiatBidForm
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn() },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: vi.fn().mockResolvedValue(successRate), refetchInterval: 0 }}
+        isDev={true}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+  it('flag 未設定 (default) 時に CardInput (自前 form) が render される', () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = undefined;
+    renderFiat();
+    expect(screen.getByTestId('card-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-input-fincode')).toBeNull();
+  });
+
+  it('flag="false" 明示時も CardInput が render される (default 継続)', () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = 'false';
+    renderFiat();
+    expect(screen.getByTestId('card-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-input-fincode')).toBeNull();
+  });
+
+  it('flag="true" 時に CardInputFincode が render + label が「fincode.js iframe」 に変わる', async () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = 'true';
+    // @ts-expect-error env override
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
+    renderFiat();
+    await waitFor(() => expect(screen.getByTestId('card-input-fincode')).toBeInTheDocument());
+    expect(screen.queryByTestId('card-input')).toBeNull();
+    expect(screen.getByText(/fincode.js iframe/)).toBeInTheDocument();
+  });
+
+  it('flag="TRUE" 大文字 も case-insensitive で fincode 経路発動', async () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = 'TRUE';
+    // @ts-expect-error env override
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
+    renderFiat();
+    await waitFor(() => expect(screen.getByTestId('card-input-fincode')).toBeInTheDocument());
   });
 });


### PR DESCRIPTION
fincode iframe 経路の unit test 追加、 SDK は vi.mock で呼出 shape verify。

- CardInputFincode 7 test
- FiatBidForm 4 test 追加

全 77/77 pass regression 0。

Closes #3121