### PR TITLE
🐛 fix(niji-webapp): CardInputFincode SDK race hardening + AI 側 e2e verify spec (Refs #3119 #3123)

### DIFF
--- a/packages/niji-webapp/playwright.config.ts
+++ b/packages/niji-webapp/playwright.config.ts
@@ -51,5 +51,14 @@ export default defineConfig({
       workers: 1,
       use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
     },
+    {
+      // fincode iframe verify (Issue #3119)、 kiwa fixture 依存で serial 実行。
+      // VITE_USE_FINCODE_UI=true 環境で webapp 起動時のみ意味のある assertion。
+      name: 'fincode-verify',
+      testMatch: /fincode-iframe-verify\.spec\.ts$/,
+      fullyParallel: false,
+      workers: 1,
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+    },
   ],
 });

--- a/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.test.tsx
@@ -38,12 +38,10 @@ describe('CardInputFincode', () => {
     getCardTokenMock.mockReset();
     uiCreateMock.mockReset();
     uiMountMock.mockReset();
-    // @ts-expect-error env override for test
     import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
   });
 
   afterEach(() => {
-    // @ts-expect-error env restore
     import.meta.env.VITE_FINCODE_PUBLIC_KEY = originalKey;
   });
 
@@ -92,7 +90,6 @@ describe('CardInputFincode', () => {
   });
 
   it('publicKey 未設定時は initFincode 呼ばず error message 表示 + onReadyChange(false)', async () => {
-    // @ts-expect-error env override for test
     import.meta.env.VITE_FINCODE_PUBLIC_KEY = '';
     const onReadyChange = vi.fn();
     const { getByTestId } = render(<CardInputFincode onReadyChange={onReadyChange} />);

--- a/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * CardInputFincode unit test (Issue #3121)。
+ *
+ * @fincode/js を module mock、 initFincode / getCardToken の呼出 shape + ref.getToken() の
+ * token 返却 + VITE_FINCODE_PUBLIC_KEY 未設定時 error state の 3 経路を検証する。
+ * 実 fincode iframe は jsdom で mount 不可のため、 mount() は spy で呼出確認のみ。
+ */
+import { createRef } from 'react';
+
+import { render, act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CardInputFincode, type CardInputFincodeHandle } from './CardInputFincode';
+
+const initFincodeMock = vi.fn();
+const getCardTokenMock = vi.fn();
+const uiCreateMock = vi.fn();
+const uiMountMock = vi.fn();
+
+vi.mock('@fincode/js', () => ({
+  initFincode: (args: unknown) => initFincodeMock(args),
+  getCardToken: (args: unknown) => getCardTokenMock(args),
+}));
+
+const makeFincodeInstance = () => ({
+  ui: () => ({
+    create: uiCreateMock,
+    mount: uiMountMock,
+    getFormData: vi.fn(),
+  }),
+});
+
+describe('CardInputFincode', () => {
+  const originalKey = import.meta.env.VITE_FINCODE_PUBLIC_KEY;
+
+  beforeEach(() => {
+    initFincodeMock.mockReset();
+    getCardTokenMock.mockReset();
+    uiCreateMock.mockReset();
+    uiMountMock.mockReset();
+    // @ts-expect-error env override for test
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
+  });
+
+  afterEach(() => {
+    // @ts-expect-error env restore
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = originalKey;
+  });
+
+  it('publicKey 設定時に initFincode + ui.create + ui.mount が正しい引数で呼ばれる', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    render(<CardInputFincode />);
+    await waitFor(() => expect(initFincodeMock).toHaveBeenCalledTimes(1));
+    expect(initFincodeMock).toHaveBeenCalledWith({
+      publicKey: 'p_test_dummy',
+      isLiveMode: false,
+    });
+    await waitFor(() => expect(uiMountMock).toHaveBeenCalledTimes(1));
+    expect(uiCreateMock).toHaveBeenCalledWith('token', { layout: 'vertical' });
+    expect(uiMountMock).toHaveBeenCalledWith('niji-fincode-card-mount', '100%');
+  });
+
+  it('ready 完了で onReadyChange(true) が呼ばれる', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    const onReadyChange = vi.fn();
+    render(<CardInputFincode onReadyChange={onReadyChange} />);
+    await waitFor(() => expect(onReadyChange).toHaveBeenCalledWith(true));
+  });
+
+  it('ref.current.getToken() が fincode getCardToken の token を返す', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    getCardTokenMock.mockResolvedValue({ list: [{ token: 'tok_test_abc123' }] });
+    // eslint-disable-next-line @eslint-react/no-create-ref
+    const ref = createRef<CardInputFincodeHandle>();
+    render(<CardInputFincode ref={ref} />);
+    await waitFor(() => expect(uiMountMock).toHaveBeenCalled());
+    const token = await act(async () => await ref.current!.getToken());
+    expect(token).toBe('tok_test_abc123');
+    expect(getCardTokenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('getCardToken response に token 欠落時は throw する', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    getCardTokenMock.mockResolvedValue({ list: [] });
+    // eslint-disable-next-line @eslint-react/no-create-ref
+    const ref = createRef<CardInputFincodeHandle>();
+    render(<CardInputFincode ref={ref} />);
+    await waitFor(() => expect(uiMountMock).toHaveBeenCalled());
+    await expect(ref.current!.getToken()).rejects.toThrow(
+      'fincode getCardToken response に token が含まれていません',
+    );
+  });
+
+  it('publicKey 未設定時は initFincode 呼ばず error message 表示 + onReadyChange(false)', async () => {
+    // @ts-expect-error env override for test
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = '';
+    const onReadyChange = vi.fn();
+    const { getByTestId } = render(<CardInputFincode onReadyChange={onReadyChange} />);
+    await waitFor(() => expect(onReadyChange).toHaveBeenCalledWith(false));
+    expect(initFincodeMock).not.toHaveBeenCalled();
+    expect(getByTestId('card-input-fincode-error').textContent).toContain(
+      'VITE_FINCODE_PUBLIC_KEY 未設定',
+    );
+  });
+
+  it('initFincode reject 時は error state 表示 + onReadyChange(false)', async () => {
+    initFincodeMock.mockRejectedValue(new Error('network fail'));
+    const onReadyChange = vi.fn();
+    const { getByTestId } = render(<CardInputFincode onReadyChange={onReadyChange} />);
+    await waitFor(() =>
+      expect(getByTestId('card-input-fincode-error').textContent).toContain('network fail'),
+    );
+    expect(onReadyChange).toHaveBeenCalledWith(false);
+  });
+
+  it('mount target element が data-testid で render される', async () => {
+    initFincodeMock.mockResolvedValue(makeFincodeInstance());
+    const { getByTestId } = render(<CardInputFincode />);
+    const mountEl = getByTestId('card-input-fincode-mount');
+    expect(mountEl.id).toBe('niji-fincode-card-mount');
+  });
+});

--- a/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/CardInputFincode.tsx
@@ -47,8 +47,14 @@ export const CardInputFincode = ({
   const publicKey = import.meta.env.VITE_FINCODE_PUBLIC_KEY as string | undefined;
   const fincodeRef = useRef<FincodeInstance | null>(null);
   const uiRef = useRef<FincodeUI | null>(null);
+  const initedRef = useRef(false);
+  const onReadyChangeRef = useRef(onReadyChange);
   const [isReady, setIsReady] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    onReadyChangeRef.current = onReadyChange;
+  });
 
   useImperativeHandle(
     ref,
@@ -74,41 +80,51 @@ export const CardInputFincode = ({
   );
 
   useEffect(() => {
-    let cancelled = false;
+    // StrictMode 二重 mount 対策 = initedRef で 1 回のみ init 保証。 fincode SDK は internal で
+    // document.getElementById(MOUNT_TARGET_ID) を参照するため、 2 回目 invocation で element ref が
+    // null になり setAttribute で crash する race condition を回避 (実測 error 「Cannot read
+    // properties of null (reading 'setAttribute')」)。 onReadyChange は ref 経由で stable。
+    if (initedRef.current) return;
     if (publicKey === undefined || publicKey === '') {
       setInitError(
         'VITE_FINCODE_PUBLIC_KEY 未設定。 packages/niji-webapp/.env に fincode dashboard の public_key を追加してください。',
       );
-      onReadyChange?.(false);
+      onReadyChangeRef.current?.(false);
       return;
     }
-    void (async () => {
-      try {
-        const fincode = await initFincode({ publicKey, isLiveMode: false });
-        if (cancelled) return;
-        const ui = fincode.ui({ layout: 'vertical' });
-        ui.create('token', { layout: 'vertical' });
-        ui.mount(MOUNT_TARGET_ID, '100%');
-        fincodeRef.current = fincode;
-        uiRef.current = ui;
-        setIsReady(true);
-        onReadyChange?.(true);
-      } catch (err) {
-        if (cancelled) return;
-        const message = err instanceof Error ? err.message : String(err);
-        setInitError(`fincode SDK 初期化に失敗しました: ${message}`);
-        onReadyChange?.(false);
-      }
-    })();
+    initedRef.current = true;
+    // Radix Dialog Portal 経由で mount target div が render される timing と、 SDK が
+    // document.getElementById(MOUNT_TARGET_ID) を呼ぶ timing の race を回避するため、
+    // requestAnimationFrame で next paint 直前まで SDK init を defer する。
+    // (実測 error 「Cannot read properties of null (reading 'setAttribute')」 の対処)。
+    const raf = requestAnimationFrame(() => {
+      void (async () => {
+        try {
+          const fincode = await initFincode({ publicKey, isLiveMode: false });
+          const mountEl = document.getElementById(MOUNT_TARGET_ID);
+          if (mountEl === null) {
+            throw new Error(`mount target #${MOUNT_TARGET_ID} が DOM に存在しません`);
+          }
+          const ui = fincode.ui({ layout: 'vertical' });
+          ui.create('token', { layout: 'vertical' });
+          ui.mount(MOUNT_TARGET_ID, '100%');
+          fincodeRef.current = fincode;
+          uiRef.current = ui;
+          setIsReady(true);
+          onReadyChangeRef.current?.(true);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          setInitError(`fincode SDK 初期化に失敗しました: ${message}`);
+          onReadyChangeRef.current?.(false);
+          initedRef.current = false;
+        }
+      })();
+    });
     return () => {
-      cancelled = true;
-      // fincode SDK は explicit unmount API を expose しないため、 iframe は DOM 削除で自動 GC。
-      // fincodeRef / uiRef の cleanup は StrictMode 二重 mount 対応で null 化のみ。
-      fincodeRef.current = null;
-      uiRef.current = null;
-      setIsReady(false);
+      cancelAnimationFrame(raf);
     };
-  }, [publicKey, onReadyChange]);
+    // cleanup では ref を null 化しない (init 済 SDK を破壊しない)、 iframe は DOM 削除で GC。
+  }, [publicKey]);
 
   return (
     <div data-testid="card-input-fincode" data-palette={palette} className="flex flex-col gap-2">

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
@@ -270,9 +270,7 @@ describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
   const originalKey = import.meta.env.VITE_FINCODE_PUBLIC_KEY;
 
   afterEach(() => {
-    // @ts-expect-error env restore
     import.meta.env.VITE_USE_FINCODE_UI = originalFlag;
-    // @ts-expect-error env restore
     import.meta.env.VITE_FINCODE_PUBLIC_KEY = originalKey;
   });
 
@@ -294,7 +292,6 @@ describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
     );
 
   it('flag 未設定 (default) 時に CardInput (自前 form) が render される', () => {
-    // @ts-expect-error env override
     import.meta.env.VITE_USE_FINCODE_UI = undefined;
     renderFiat();
     expect(screen.getByTestId('card-input')).toBeInTheDocument();
@@ -302,7 +299,6 @@ describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
   });
 
   it('flag="false" 明示時も CardInput が render される (default 継続)', () => {
-    // @ts-expect-error env override
     import.meta.env.VITE_USE_FINCODE_UI = 'false';
     renderFiat();
     expect(screen.getByTestId('card-input')).toBeInTheDocument();
@@ -310,9 +306,7 @@ describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
   });
 
   it('flag="true" 時に CardInputFincode が render + label が「fincode.js iframe」 に変わる', async () => {
-    // @ts-expect-error env override
     import.meta.env.VITE_USE_FINCODE_UI = 'true';
-    // @ts-expect-error env override
     import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
     renderFiat();
     await waitFor(() => expect(screen.getByTestId('card-input-fincode')).toBeInTheDocument());
@@ -321,9 +315,7 @@ describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
   });
 
   it('flag="TRUE" 大文字 も case-insensitive で fincode 経路発動', async () => {
-    // @ts-expect-error env override
     import.meta.env.VITE_USE_FINCODE_UI = 'TRUE';
-    // @ts-expect-error env override
     import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
     renderFiat();
     await waitFor(() => expect(screen.getByTestId('card-input-fincode')).toBeInTheDocument());

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
@@ -23,7 +23,7 @@ import * as React from 'react';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { TooltipProvider } from '@/components/ui/tooltip';
 
@@ -246,5 +246,86 @@ describe('FiatBidForm mock badge (Issue #3061)', () => {
     expect(screen.queryByTestId('fiat-bid-rate-summary-mock-badge')).toBeNull();
     const rateSummary = screen.getByTestId('fiat-bid-rate-summary');
     expect(rateSummary.textContent).toContain('source: coingecko');
+  });
+});
+
+/**
+ * Issue #3119 — VITE_USE_FINCODE_UI env flag による CardInput / CardInputFincode 切替 test。
+ *
+ * default (flag 未設定 / 'false') = CardInput (自前 mock form) が render される (data-testid="card-input")。
+ * flag='true' = CardInputFincode (fincode.js iframe) が render される (data-testid="card-input-fincode")。
+ * @fincode/js は SDK 内部で iframe を mount するため vi.mock で fake instance を stub、
+ * env は import.meta.env の direct override で 2 pattern 検証。
+ */
+
+vi.mock('@fincode/js', () => ({
+  initFincode: vi.fn().mockResolvedValue({
+    ui: () => ({ create: vi.fn(), mount: vi.fn(), getFormData: vi.fn() }),
+  }),
+  getCardToken: vi.fn().mockResolvedValue({ list: [{ token: 'tok_stub' }] }),
+}));
+
+describe('FiatBidForm useFincode env flag 分岐 (Issue #3119)', () => {
+  const originalFlag = import.meta.env.VITE_USE_FINCODE_UI;
+  const originalKey = import.meta.env.VITE_FINCODE_PUBLIC_KEY;
+
+  afterEach(() => {
+    // @ts-expect-error env restore
+    import.meta.env.VITE_USE_FINCODE_UI = originalFlag;
+    // @ts-expect-error env restore
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = originalKey;
+  });
+
+  const renderFiat = () =>
+    render(
+      <FiatBidForm
+        onClose={() => {}}
+        auctionId="42"
+        bidderWallet="0xUSER"
+        fetchersOverride={{
+          fetchers: { authorize: vi.fn(), placeBid: vi.fn() },
+          saveState: vi.fn(),
+          redirect: vi.fn(),
+        }}
+        spotRateOverride={{ fetcher: vi.fn().mockResolvedValue(successRate), refetchInterval: 0 }}
+        isDev={true}
+      />,
+      { wrapper: buildWrapper() },
+    );
+
+  it('flag 未設定 (default) 時に CardInput (自前 form) が render される', () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = undefined;
+    renderFiat();
+    expect(screen.getByTestId('card-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-input-fincode')).toBeNull();
+  });
+
+  it('flag="false" 明示時も CardInput が render される (default 継続)', () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = 'false';
+    renderFiat();
+    expect(screen.getByTestId('card-input')).toBeInTheDocument();
+    expect(screen.queryByTestId('card-input-fincode')).toBeNull();
+  });
+
+  it('flag="true" 時に CardInputFincode が render + label が「fincode.js iframe」 に変わる', async () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = 'true';
+    // @ts-expect-error env override
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
+    renderFiat();
+    await waitFor(() => expect(screen.getByTestId('card-input-fincode')).toBeInTheDocument());
+    expect(screen.queryByTestId('card-input')).toBeNull();
+    expect(screen.getByText(/fincode.js iframe/)).toBeInTheDocument();
+  });
+
+  it('flag="TRUE" 大文字 も case-insensitive で fincode 経路発動', async () => {
+    // @ts-expect-error env override
+    import.meta.env.VITE_USE_FINCODE_UI = 'TRUE';
+    // @ts-expect-error env override
+    import.meta.env.VITE_FINCODE_PUBLIC_KEY = 'p_test_dummy';
+    renderFiat();
+    await waitFor(() => expect(screen.getByTestId('card-input-fincode')).toBeInTheDocument());
   });
 });

--- a/packages/niji-webapp/tests/e2e/fincode-iframe-verify.spec.ts
+++ b/packages/niji-webapp/tests/e2e/fincode-iframe-verify.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * fincode iframe 描画 verification (Issue #3119 追加 verify、 AI 側で実 dev server + Playwright で assert)
+ *
+ * VITE_USE_FINCODE_UI=true 環境で dev server (localhost:2424) を起動した状態で、
+ * (1) auction ページ navigate
+ * (2) Bid button click → BidModal open
+ * (3) 「クレカで払う (JPY)」 tab click
+ * (4) CardInputFincode component の mount target div 存在確認
+ * (5) label が「fincode.js iframe」 表示 (mock 表示ではない)
+ * (6) fincode.js SDK が iframe を append することを DOM 検査で確認
+ * を pure Playwright で assert する (kiwa fixture 経由 wallet inject 済想定)。
+ *
+ * SDK 実 API 呼出は VITE_FINCODE_PUBLIC_KEY 有効時のみ、
+ * 未設定時は error state で「VITE_FINCODE_PUBLIC_KEY 未設定」 message 検証に fall back。
+ */
+import { dappE2eTest as baseTest } from '@kiwa-test/core';
+import { expect } from '@playwright/test';
+
+const test = baseTest.extend<{ _anvilHandle: { port: number; stop: () => Promise<void> } }>({
+  _anvilHandle: async ({}, use) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    await use({ port: 8547, stop: async () => {} });
+  },
+});
+
+test.describe('fincode iframe verify (Issue #3119)', () => {
+  test('VITE_USE_FINCODE_UI=true 時 CardInputFincode が render + label 変化 + mount target 存在', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.locator('img[alt="Niji DAO"]').first().waitFor({ timeout: 20_000 });
+
+    // wallet connect (kiwa 経由 auto inject) を wait
+    const bidOpenButton = page.getByTestId('bid-open-button').first();
+    await bidOpenButton.waitFor({ state: 'visible', timeout: 20_000 });
+    await bidOpenButton.click();
+
+    // BidModal open + Fiat tab 切替
+    await page.getByTestId('bid-tab-fiat').click();
+
+    // fincode 経路 = CardInputFincode の mount target + label 確認
+    const fincodeMount = page.getByTestId('card-input-fincode-mount');
+    await expect(fincodeMount).toBeVisible({ timeout: 5_000 });
+
+    // 従来 CardInput (data-testid="card-input") は render されない
+    await expect(page.getByTestId('card-input')).toHaveCount(0);
+
+    // label が「fincode.js iframe」 に変わる (mock 表示ではない)
+    await expect(page.getByText(/fincode\.js iframe/)).toBeVisible();
+
+    // SDK init 完了 wait (10s 上限) = iframe append or error state のいずれかが確実に成立するまで
+    await page
+      .waitForFunction(
+        () => {
+          const mount = document.getElementById('niji-fincode-card-mount');
+          const hasIframe = mount !== null && mount.querySelectorAll('iframe').length > 0;
+          const errorEl = document.querySelector('[data-testid="card-input-fincode-error"]');
+          return hasIframe || errorEl !== null;
+        },
+        null,
+        { timeout: 10_000 },
+      )
+      .catch(() => {
+        // timeout 時も screenshot 取って report、 assert で fail 判定
+      });
+
+    // screenshot 保存 (verify report 用)
+    await page.screenshot({
+      path: 'test-results/fincode-iframe-verify.png',
+      fullPage: false,
+    });
+
+    // fincode SDK 動作確認 = iframe が mount target 内に append されているか
+    // (VITE_FINCODE_PUBLIC_KEY 未設定なら error state、 有効なら iframe が生える)
+    const iframeCount = await fincodeMount.locator('iframe').count();
+    const errorEl = page.getByTestId('card-input-fincode-error');
+    const hasError = (await errorEl.count()) > 0;
+
+    console.log('=== fincode iframe verify result ===');
+    console.log('iframe count in mount target:', iframeCount);
+    console.log('error state visible:', hasError);
+    if (hasError) {
+      console.log('error message:', await errorEl.textContent());
+    }
+
+    // 判定 = iframe あり OR error state (どちらか成立で fincode 経路が render されたことを確認)
+    expect(iframeCount > 0 || hasError).toBeTruthy();
+  });
+});


### PR DESCRIPTION
user 要望 「そっちで確認」 に対する Playwright headless verify で実測 = CardInputFincode render + label 切替 OK、 SDK 実 iframe append は SDK CDN fetch 依存で local dev timeout (Issue #3123 で継続調査)。

## Fix
- StrictMode 対策 (initedRef guard)
- requestAnimationFrame defer で mount target 確実存在後 SDK init
- mount target getElementById 存在 check + null throw

## e2e 実測
- ✅ CardInputFincode render + label 変化 OK
- ❌ SDK 実 iframe append は 10s timeout (Issue #3123 defer)

Refs #3119
Refs #3123