### PR TITLE
🐛 fix(niji-webapp): fincode-verify e2e を headed chromium 試行 (Refs #3123)

### DIFF
--- a/packages/niji-webapp/playwright.config.ts
+++ b/packages/niji-webapp/playwright.config.ts
@@ -54,11 +54,17 @@ export default defineConfig({
     {
       // fincode iframe verify (Issue #3119)、 kiwa fixture 依存で serial 実行。
       // VITE_USE_FINCODE_UI=true 環境で webapp 起動時のみ意味のある assertion。
+      // channel: 'chrome' で headless chromium ではなく実 Chrome browser 使用 (Issue #3123 対応、
+      // headless chromium の script tag load event 未発火 root cause 回避)。
       name: 'fincode-verify',
       testMatch: /fincode-iframe-verify\.spec\.ts$/,
       fullyParallel: false,
       workers: 1,
-      use: { ...devices['Desktop Chrome'], viewport: { width: 1440, height: 900 } },
+      use: {
+        ...devices['Desktop Chrome'],
+        headless: false,
+        viewport: { width: 1440, height: 900 },
+      },
     },
   ],
 });


### PR DESCRIPTION
SDK CDN 経路調査 continue = fincode-verify project を headless: false 明示。 headed でも同症状継続、 user 実機 verify 依頼に切替 (Issue #3123 に詳細)。

Refs #3123