### PR TITLE
🎉 feat(fincode): Phase 2 backend fincode byGMO 統合 = client + handler + webapp routing (Closes #3115)

### DIFF
--- a/packages/niji-api/.env.example
+++ b/packages/niji-api/.env.example
@@ -1,3 +1,9 @@
+# ================================================================
+# [SECURITY] 本 file (.env.example) は template のみ、 実 secret 含まず。
+# コピー先の .env は KMS / 1Password / hardware wallet 経由で管理し、
+# chat / PR / GitHub Issue / Slack / paste bin に絶対貼付禁止。
+# ================================================================
+
 # Niji API (Ponder + Hono) 環境変数 example
 # コピー先 = packages/niji-api/.env
 # 用途詳細 = docs/operations/gmo-fiat-bid.md § env 変数 SSOT
@@ -18,7 +24,46 @@ PONDER_RPC_URL_1=https://<json-rpc-url>
 # PONDER_WS_URL_11155111=wss://<websockets-url>
 
 # ------------------------------------------------------------------
-# GMO PGマルチペイメント (Phase 1 = mock server、 Phase 3 = 本番切替)
+# fincode byGMO (GMO Payment Gateway, Inc. 提供の新決済 product、
+# 同社の旧 product = GMO PGマルチペイメントから移行中、 Issue #3115)
+# Phase 1c = webapp SDK iframe 描画完了 (PR #3127 merge 済、 e2e 2/2 pass 実測)、
+# Phase 2 = backend fincode SDK Node 統合予定。
+# card tokenize は webapp 側 fincode.js iframe で完結 (PCI DSS SAQ-A-EP)、
+# 本 section は Phase 2 で backend 側 payment/{id}/execute API 呼出用 secret。
+# ------------------------------------------------------------------
+
+# fincode API secret key (機微、 webapp 側 public key と対、 backend からのみ使用)
+# test env = dashboard.test.fincode.jp 発行の m_test_XXXX
+# 本番 env = dashboard.fincode.jp 発行の m_live_XXXX (別 key、 互換なし)
+# 本番切替時は env 直書き禁止、 KMS / 1Password / hardware wallet 経由で管理
+FINCODE_API_KEY_SECRET=
+
+# fincode live mode 切替 (true = 本番 / false = test)、 default = false
+# test env で secret key m_test_XXXX を使う時は false、
+# 本番 env で secret key m_live_XXXX を使う時のみ true に切替
+FINCODE_IS_LIVE_MODE=false
+
+# fincode tenant shop id (テナント運用時のみ必須、 単一店舗運用時は空 OK)
+# 複数店舗運用 / 委託販売時に対象 shop を特定する識別子、
+# 単一店舗契約時は fincode 側で自動判定されるため空で OK
+FINCODE_TENANT_SHOP_ID=
+
+# fincode webhook 署名検証 secret (受信 webhook が fincode 発行であることを HMAC 検証)
+# dashboard.test.fincode.jp / dashboard.fincode.jp の webhook 設定画面で発行、
+# 未設定時は署名検証 skip (dev のみ許容、 本番は必須設定で backend 側 401 return)
+FINCODE_WEBHOOK_SECRET=
+
+# fincode mock 切替 (true / false、 default = true で dev / e2e 環境完結)
+# true = MSW mock handler が fincode API を intercept、 dev / e2e 時に使用
+# false = 実 fincode API を叩く (Phase 2 backend 統合完了後、 本番切替時)
+USE_FINCODE_MOCK=true
+
+# ------------------------------------------------------------------
+# GMO PGマルチペイメント (GMO Payment Gateway, Inc. 提供の旧 product、
+# 同社の新 product = fincode byGMO に移行中、 Phase 2 統合完了後削除予定)
+# ⚠️ Phase 1c 時点で backend src に 50+ 参照 active、 削除は Phase 2 完了を待つ。
+# 削除時は本 section 全体 + mock server + fetcher / worker の code path をまとめて撤去。
+# 決済 vendor 自体は GMO Payment Gateway 継続、 API 契約 product だけ差替。
 # ------------------------------------------------------------------
 
 # GMO PG API base URL
@@ -27,23 +72,26 @@ PONDER_RPC_URL_1=https://<json-rpc-url>
 # ステージング = https://pt01.mul-pay.jp
 GMO_ENDPOINT=http://127.0.0.1:2426
 
-# 加盟店 ID (13 桁)、 Phase 1 は placeholder、 Phase 3 で GMO 契約後の実値に差替
+# 加盟店 ID (13 桁)、 Phase 1 は placeholder、 fincode 移行完了で不要
 GMO_MERCHANT_ID=tshop00000001
 
 # サイト ID (13 桁)、 Phase 1 は placeholder
 GMO_SITE_ID=tsite00000001
 
 # ショップパスワード (可変長 8-20 文字)、 Phase 1 は placeholder
-# 本番切替時は KMS / 1Password / hardware wallet 経由で管理、 env 直書き禁止
+# 本 file 内は placeholder 固定、 万一残置期間中に本番切替する場合は
+# KMS / 1Password / hardware wallet 経由で管理、 env 直書き禁止
 GMO_SHOP_PASS=changeme_shop_password
 
 # GMO mock server 切替 (true / false)
 # true = MSW mock handler が GMO_ENDPOINT を intercept、 dev / e2e 時に使用
-# false = 実 GMO API を叩く (Phase 2 以降、 本番 / ステージング切替時)
+# false = 実 GMO API を叩く (fincode 移行前の Phase では意味あり、 Phase 2 後は削除)
 USE_GMO_MOCK=true
 
 # ------------------------------------------------------------------
-# Reauthorization worker (Issue #3024 = 45 日超 fallback)
+# Reauthorization worker (Issue #3024 = 45 日超 fallback、 GMO PGマルチペイメント世代の実装)
+# ⚠️ Phase 2 fincode byGMO 統合完了後に fincode 用の再認証機構として再設計予定、
+# 現状 code path は GMO_REAUTH_PLACEHOLDER_TOKEN + GMO PG reauthorize API 前提で残置。
 # ------------------------------------------------------------------
 
 # ReauthorizationWorker 起動 on/off (true / false、 default false)
@@ -54,16 +102,19 @@ REAUTHORIZATION_WORKER_ENABLED=false
 # 実運用では 1h で十分 (45 日超は月 0-1 件想定)、 test 時は shorter interval で simulate
 REAUTHORIZATION_INTERVAL_HOURS=1
 
-# 再 authorize 用 placeholder cardToken (mock 環境のみ有効)
-# 実 GMO 切替時 (Phase 4) は bidder 再認証 UI 経由で PG Token 再取得する経路に差替
+# 再 authorize 用 placeholder cardToken (mock 環境のみ有効、 GMO 世代の遺物)
+# Phase 2 fincode 切替時は bidder 再認証 UI 経由で fincode card ID 再取得する経路に差替
 GMO_REAUTH_PLACEHOLDER_TOKEN=mock-card-token-reauth
 
 # ------------------------------------------------------------------
 # Spot rate fetcher (Issue #3005)
-# GMO コイン API primary + CoinGecko fallback で ETH/JPY spot rate を取得
+# ETH/JPY spot rate 取得、 GMO コイン Public API = GMO Internet Group 傘下の
+# 暗号通貨取引所 (GMO コイン株式会社)、 決済 vendor の GMO Payment Gateway, Inc.
+# とは同 group 内の別 company。 GMO PGマルチペイメント → fincode byGMO の
+# product 差替とは無関係、 本 section の GMO コイン API 依存は継続 (影響なし)。
 # ------------------------------------------------------------------
 
-# ==================== spot rate mock (Issue #3061、 Phase 1 dev mock 完結) ====================
+# spot rate mock 切替 (Issue #3061、 Phase 1 dev mock 完結)
 # true = 固定 rate MOCK_SPOT_RATE_JPY_PER_ETH を即返却、 外部 API 通信 0 (offline dev 可)
 # false = 実 GMO コイン API primary + CoinGecko fallback で fetch (Phase 3 本番切替時)
 # 未設定 = false 扱い (安全側、 誤って本番で mock が動くのを防ぐ)
@@ -78,6 +129,8 @@ MOCK_SPOT_RATE_JPY_PER_ETH=500000
 # GMO コイン Public API base URL (primary、 USE_SPOT_RATE_MOCK=false 時のみ有効)
 # 認証不要、 rate limit 1 req/sec (Public API 仕様)
 # 本番 / mock いずれも同 URL、 mock 時は MSW 経由で intercept
+# 注 = 決済 vendor GMO Payment Gateway とは別 company、 GMO コイン = 暗号通貨取引所
+# (GMO Internet Group 傘下、 fincode byGMO 移行の影響なし)
 GMO_COIN_API_ENDPOINT=https://api.coin.z.com/public
 
 # CoinGecko API base URL (fallback)

--- a/packages/niji-api/src/api/index.ts
+++ b/packages/niji-api/src/api/index.ts
@@ -9,6 +9,7 @@ import {
   createThreeDsCallbackApp,
   type ThreeDsCallbackStore,
 } from '../handlers/fiat-bid/3ds-callback.js';
+import { createAuthorizeFincodeApp } from '../handlers/fiat-bid/authorize-fincode.js';
 import { createAuthorizeApp, type FiatBidStore } from '../handlers/fiat-bid/authorize.js';
 import { createCaptureApp, type CaptureStore } from '../handlers/fiat-bid/capture.js';
 import { createPlaceBidApp, type PlaceBidStore } from '../handlers/fiat-bid/place-bid.js';
@@ -24,6 +25,7 @@ import {
   createBaseSepoliaPublicClient,
   createEnvSigner,
 } from '../services/bidRelay/index.js';
+import { FincodeClient } from '../services/fincode/client.js';
 import { GmoClient } from '../services/gmo/client.js';
 import {
   ReauthorizationWorker,
@@ -75,6 +77,11 @@ app.use('/graphql', graphql({ db, schema }));
 const spotRateFetcher = new SpotRateFetcher();
 const gmoClient = new GmoClient();
 /**
+ * Phase 2 fincode byGMO API client (Issue #3115、 GMO PGマルチペイメント → fincode byGMO product 差替)
+ * 決済 vendor = GMO Payment Gateway, Inc. 継続、 product だけ差替。 GMO 経路と並列共存で feature flag 経路確保。
+ */
+const fincodeClient = new FincodeClient();
+/**
  * Ponder 0.12 の api-side `db` は ReadonlyDrizzle (insert / update / delete が型 strip 済)。
  * offchain write は `db.sql` (raw drizzle instance、 full Drizzle exposed via Db.sql) 経由で実施する。
  * Ponder 内部 schema は onchain table 扱いだが、 SQL 発行自体は許容される (write 責務は indexing 層と HTTP 層で分担、
@@ -99,6 +106,17 @@ const fiatBidStore: FiatBidStore = {
 app.route(
   '/api/v1/fiat-bid',
   createAuthorizeApp({ gmoClient, spotRateFetcher, store: fiatBidStore }),
+);
+
+/**
+ * Phase 2 fincode byGMO — POST /api/v1/fiat-bid/authorize-fincode (与信枠取得)
+ * GMO PG 経路 (authorize.ts) と並列共存、 webapp 側 VITE_USE_FINCODE_UI で経路振り分け。
+ * cardToken 引数 = fincode.js iframe tokenize 発行の card_id を格納 (GMO PG 経路の GMO Token 相当)。
+ * Issue #3115。
+ */
+app.route(
+  '/api/v1/fiat-bid',
+  createAuthorizeFincodeApp({ fincodeClient, spotRateFetcher, store: fiatBidStore }),
 );
 
 /**

--- a/packages/niji-api/src/handlers/fiat-bid/authorize-fincode.test.ts
+++ b/packages/niji-api/src/handlers/fiat-bid/authorize-fincode.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Fiat bid authorize-fincode handler behavior test (Phase 2 backend 統合、 Issue #3115)
+ *
+ * 検証対象 —
+ * (1) happy path — 200 OK で { authId, tds2Url, jpyAmount, ethAmount, spotRate, spotRateSource, status } 返し
+ *     fiat_bid.pending record が INSERT される
+ * (2) 3DS 必要 pattern — status = AUTHENTICATED + acs_url 応答
+ * (3) bid 上限 100 万円超過 — 400 BidLimitExceeded、 FincodeClient 呼ばない、 DB 書込なし
+ * (4) fincode 障害 — 500 FincodeAuthorizationFailed、 DB 書込なし
+ * (5) request validation fail — 400 InvalidRequest
+ * (6) spot rate fetch fail → 503 SpotRateUnavailable、 FincodeClient 呼ばない
+ *
+ * hono の app.request() 経由で actual handler を execute する。
+ * SpotRateFetcher / FincodeClient は class extend + override method で stub、
+ * fiat_bid store は in-memory Map で受けて insertPending 呼出を観測する。
+ *
+ * SSOT — packages/niji-api/src/handlers/fiat-bid/authorize.test.ts (GMO 経路と対比 mirror pattern)、
+ *        rules/quality.md § test-passed marker 発行前提 4 条件準拠。
+ */
+
+import type { FiatBidRecord, FiatBidStore } from './authorize.js';
+import type { FincodeAuthorizationResult } from '../../services/fincode/types.js';
+
+import { describe, expect, it } from 'vitest';
+
+import { FincodeAuthorizationError, FincodeClient } from '../../services/fincode/client.js';
+import {
+  SpotRateFetcher,
+  SpotRateFetchError,
+  type SpotRate,
+} from '../../services/spotRate/index.js';
+
+import { createAuthorizeFincodeApp } from './authorize-fincode.js';
+
+/** SpotRateFetcher stub */
+class StubSpotRateFetcher extends SpotRateFetcher {
+  constructor(private readonly behavior: () => Promise<SpotRate>) {
+    super({
+      gmoCoinEndpoint: 'http://stub-primary',
+      coingeckoEndpoint: 'http://stub-fallback',
+    });
+  }
+
+  override async getEthJpyRate(): Promise<SpotRate> {
+    return this.behavior();
+  }
+}
+
+/** FincodeClient stub */
+class StubFincodeClient extends FincodeClient {
+  constructor(private readonly behavior: () => Promise<FincodeAuthorizationResult>) {
+    super({ endpoint: 'http://stub-fincode', apiKeySecret: 'm_test_stub' });
+  }
+
+  override async authorize(): Promise<FincodeAuthorizationResult> {
+    return this.behavior();
+  }
+}
+
+/** in-memory FiatBidStore stub */
+const makeStore = (): FiatBidStore & { records: FiatBidRecord[] } => {
+  const records: FiatBidRecord[] = [];
+  return {
+    records,
+    insertPending: async record => {
+      records.push(record);
+    },
+  };
+};
+
+/** happy path 共通の payload (authorize.ts と同 shape) */
+const validBody = {
+  ethAmount: '200000000000000000',
+  spotRate: 500_000,
+  jpyAmount: 100_000,
+  cardToken: 'card_token_visa_4111',
+  bidderWallet: '0x1234567890abcdef1234567890abcdef12345678',
+  auctionId: '42',
+};
+
+const stableOrderId = (input: { auctionId: string; bidderWallet: string }): string =>
+  `test-fincode-order-${input.auctionId}-${input.bidderWallet.slice(2, 8)}`;
+
+const stableNow = () => new Date('2026-07-15T12:00:00Z');
+
+describe('POST /authorize-fincode — happy path (AUTHORIZED)', () => {
+  it('200 OK で auth 結果を返し fiat_bid.pending を INSERT する', async () => {
+    const spotRateFetcher = new StubSpotRateFetcher(async () => ({
+      rate: 500_000,
+      source: 'gmo-coin',
+      cachedAt: Date.parse('2026-07-15T12:00:00Z'),
+      expiresAt: Date.parse('2026-07-15T12:00:05Z'),
+    }));
+    const fincodeClient = new StubFincodeClient(async () => ({
+      authId: 'acc-happy-001',
+      accessId: 'acc-happy-001',
+      tds2Url: undefined,
+      orderId: 'test-fincode-order-42-123456',
+      status: 'AUTHORIZED',
+      approve: '9876543',
+      transactionId: 'tx-happy-001',
+    }));
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+      generateOrderId: stableOrderId,
+      now: stableNow,
+    });
+
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      authId: string;
+      status: string;
+      jpyAmount: number;
+      ethAmount: string;
+      spotRate: number;
+      spotRateSource: string;
+    };
+    expect(body.authId).toBe('acc-happy-001');
+    expect(body.status).toBe('AUTHORIZED');
+    expect(body.jpyAmount).toBe(100_000);
+    expect(body.ethAmount).toBe('200000000000000000');
+    expect(body.spotRate).toBe(500_000);
+    expect(body.spotRateSource).toBe('gmo-coin');
+
+    expect(store.records).toHaveLength(1);
+    const record = store.records[0];
+    if (record === undefined) throw new Error('record missing');
+    expect(record.authId).toBe('acc-happy-001');
+    expect(record.status).toBe('pending');
+    expect(record.jpyAmount).toBe(100_000);
+    expect(record.ethAmount).toBe(200000000000000000n);
+    expect(record.spotRateSource).toBe('gmo-coin');
+  });
+});
+
+describe('POST /authorize-fincode — 3DS 必要 (AUTHENTICATED)', () => {
+  it('200 OK + status=AUTHENTICATED + tds2Url を返す', async () => {
+    const spotRateFetcher = new StubSpotRateFetcher(async () => ({
+      rate: 500_000,
+      source: 'gmo-coin',
+      cachedAt: Date.parse('2026-07-15T12:00:00Z'),
+      expiresAt: Date.parse('2026-07-15T12:00:05Z'),
+    }));
+    const fincodeClient = new StubFincodeClient(async () => ({
+      authId: 'acc-3ds-001',
+      accessId: 'acc-3ds-001',
+      tds2Url: 'https://acs.example/3ds?token=xyz',
+      orderId: 'test-fincode-order-42-123456',
+      status: 'AUTHENTICATED',
+      approve: undefined,
+      transactionId: 'tx-3ds-001',
+    }));
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+      generateOrderId: stableOrderId,
+      now: stableNow,
+    });
+
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; tds2Url: string };
+    expect(body.status).toBe('AUTHENTICATED');
+    expect(body.tds2Url).toBe('https://acs.example/3ds?token=xyz');
+  });
+});
+
+describe('POST /authorize-fincode — 400 BidLimitExceeded', () => {
+  it('jpyAmount > 100 万円 の request を 400 で reject、 fincode 呼ばない', async () => {
+    let fincodeCalled = false;
+    const spotRateFetcher = new StubSpotRateFetcher(async () => ({
+      rate: 500_000,
+      source: 'gmo-coin',
+      cachedAt: Date.parse('2026-07-15T12:00:00Z'),
+      expiresAt: Date.parse('2026-07-15T12:00:05Z'),
+    }));
+    const fincodeClient = new StubFincodeClient(async () => {
+      fincodeCalled = true;
+      throw new Error('fincode should not be called');
+    });
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+      generateOrderId: stableOrderId,
+      now: stableNow,
+    });
+
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...validBody, jpyAmount: 1_000_001 }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('BidLimitExceeded');
+    expect(fincodeCalled).toBe(false);
+    expect(store.records).toHaveLength(0);
+  });
+});
+
+describe('POST /authorize-fincode — 500 FincodeAuthorizationFailed', () => {
+  it('fincode error 時に 500 FincodeAuthorizationFailed を返し DB 書込しない', async () => {
+    const spotRateFetcher = new StubSpotRateFetcher(async () => ({
+      rate: 500_000,
+      source: 'gmo-coin',
+      cachedAt: Date.parse('2026-07-15T12:00:00Z'),
+      expiresAt: Date.parse('2026-07-15T12:00:05Z'),
+    }));
+    const fincodeClient = new StubFincodeClient(async () => {
+      throw new FincodeAuthorizationError('fincode declined', {
+        errorCode: 'CARD_DECLINED',
+        errorMessage: 'card declined by issuer',
+      });
+    });
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+      generateOrderId: stableOrderId,
+      now: stableNow,
+    });
+
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(500);
+    const body = (await res.json()) as { error: string; errorCode: string };
+    expect(body.error).toBe('FincodeAuthorizationFailed');
+    expect(body.errorCode).toBe('CARD_DECLINED');
+    expect(store.records).toHaveLength(0);
+  });
+});
+
+describe('POST /authorize-fincode — 400 InvalidRequest', () => {
+  it('invalid JSON body で 400 を返す', async () => {
+    const spotRateFetcher = new StubSpotRateFetcher(async () => ({
+      rate: 500_000,
+      source: 'gmo-coin',
+      cachedAt: Date.parse('2026-07-15T12:00:00Z'),
+      expiresAt: Date.parse('2026-07-15T12:00:05Z'),
+    }));
+    const fincodeClient = new StubFincodeClient(async () => {
+      throw new Error('should not be called');
+    });
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+    });
+
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-json',
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('InvalidRequest');
+  });
+
+  it('cardToken 欠損で 400 InvalidRequest', async () => {
+    const spotRateFetcher = new StubSpotRateFetcher(async () => ({
+      rate: 500_000,
+      source: 'gmo-coin',
+      cachedAt: Date.parse('2026-07-15T12:00:00Z'),
+      expiresAt: Date.parse('2026-07-15T12:00:05Z'),
+    }));
+    const fincodeClient = new StubFincodeClient(async () => {
+      throw new Error('should not be called');
+    });
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+    });
+
+    const { cardToken: _unused, ...rest } = validBody;
+    void _unused;
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(rest),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('POST /authorize-fincode — 503 SpotRateUnavailable', () => {
+  it('spot rate fetch fail 時に 503 を返し fincode 呼ばない', async () => {
+    let fincodeCalled = false;
+    const spotRateFetcher = new StubSpotRateFetcher(async () => {
+      throw new SpotRateFetchError('all sources failed');
+    });
+    const fincodeClient = new StubFincodeClient(async () => {
+      fincodeCalled = true;
+      throw new Error('should not be called');
+    });
+    const store = makeStore();
+    const app = createAuthorizeFincodeApp({
+      fincodeClient,
+      spotRateFetcher,
+      store,
+      generateOrderId: stableOrderId,
+      now: stableNow,
+    });
+
+    const res = await app.request('/authorize-fincode', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('SpotRateUnavailable');
+    expect(fincodeCalled).toBe(false);
+    expect(store.records).toHaveLength(0);
+  });
+});

--- a/packages/niji-api/src/handlers/fiat-bid/authorize-fincode.ts
+++ b/packages/niji-api/src/handlers/fiat-bid/authorize-fincode.ts
@@ -1,0 +1,211 @@
+/**
+ * Fiat bid authorize hono handler (fincode 経路、 Phase 2 backend 統合、 Issue #3115)
+ *
+ * POST /api/v1/fiat-bid/authorize-fincode
+ * request body — { ethAmount, spotRate, jpyAmount, cardToken, bidderWallet, auctionId, bidderEmail? }
+ *                (Phase 1c で GMO 経路 (authorize.ts) と同 body 契約、 cardToken は fincode.js iframe 発行の card_id を格納)
+ * 応答 body    — { authId, tds2Url, jpyAmount, ethAmount, spotRate, spotRateSource, status }
+ *
+ * 処理順 (GMO 経路 authorize.ts と同 flow、 GmoClient → FincodeClient に差替) —
+ * (1) request body 検証 (欠損 / 型 / ETH primary 3 値の相互整合、 authorize.ts の parseAuthorizeBody を re-use)
+ * (2) bid 上限 100 万円 check (webapp + backend 2 層強制の backend 側)
+ * (3) spot rate 取得 (Issue #3005 の SpotRateFetcher 経由、 primary/fallback 切替 + 5 秒 cache)
+ * (4) 記録用の ethWei / jpyAmount 確定 (webapp 提示値と backend 再計算値のうち保守的な方を採用)
+ * (5) orderId 生成 (auth ID PK に一致させて後段 handler で lookup 可能に)
+ * (6) FincodeClient.authorize (register + execute) 呼出、 fincode 請求額は JPY 単位
+ * (7) fiat_bid table に pending status で INSERT
+ * (8) 応答 body 返却 (status = AUTHORIZED / AUTHENTICATED / CAPTURED)
+ *
+ * error 変換 —
+ * - request validation fail       → 400 InvalidRequest
+ * - bid 上限超過                    → 400 BidLimitExceeded
+ * - spot rate fetch fail            → 503 SpotRateUnavailable (bid 発火不可 signal)
+ * - FincodeAuthorizationError       → 500 FincodeAuthorizationFailed
+ * - unexpected error                → 500 InternalError
+ *
+ * SSOT — packages/niji-api/src/handlers/fiat-bid/authorize.ts (GMO 経路と対比 mirror pattern)、
+ *        packages/niji-api/src/services/fincode/client.ts
+ */
+
+import { Hono } from 'hono';
+
+import { FincodeAuthorizationError, FincodeClient } from '../../services/fincode/client.js';
+import {
+  SpotRateFetcher,
+  SpotRateFetchError,
+  type SpotRate,
+} from '../../services/spotRate/index.js';
+
+import {
+  BID_LIMIT_JPY,
+  parseAuthorizeBody,
+  type AuthorizeRequestBody,
+  type FiatBidRecord,
+  type FiatBidStore,
+} from './authorize.js';
+
+/** fincode authorize 応答 body shape (公開 API 契約、 authorize.ts の AuthorizeResponseBody に status 追加) */
+export type AuthorizeFincodeResponseBody = {
+  authId: string;
+  /** 3DS 認証 URL (fincode 3DS 必要時のみ、 通常決済では空文字列 or undefined) */
+  tds2Url: string | undefined;
+  jpyAmount: number;
+  ethAmount: string;
+  spotRate: number;
+  spotRateSource: SpotRate['source'];
+  /** 決済 status (AUTHORIZED = 与信成功 / AUTHENTICATED = 3DS 必要 / CAPTURED = 売上確定) */
+  status: 'AUTHORIZED' | 'AUTHENTICATED' | 'CAPTURED';
+};
+
+export type CreateAuthorizeFincodeAppOptions = {
+  fincodeClient: FincodeClient;
+  spotRateFetcher: SpotRateFetcher;
+  store: FiatBidStore;
+  /** orderId 生成 (test 用に決定的、 default = fincode-{auctionId}-{ts}-{rand}) */
+  generateOrderId?: (input: { auctionId: string; bidderWallet: string }) => string;
+  /** 現在時刻 source (test 用、 default = () => new Date()) */
+  now?: () => Date;
+};
+
+const defaultGenerateOrderId = (input: { auctionId: string; bidderWallet: string }): string => {
+  const ts = Date.now().toString(36);
+  const rand = Math.floor(Math.random() * 1e6)
+    .toString(36)
+    .padStart(4, '0');
+  return `fincode-${input.auctionId}-${input.bidderWallet.slice(2, 8)}-${ts}-${rand}`;
+};
+
+/**
+ * fincode authorize handler の Hono app を返す factory
+ * options で FincodeClient / SpotRateFetcher / DB store を DI、 test 時に mock 差替
+ */
+export const createAuthorizeFincodeApp = (options: CreateAuthorizeFincodeAppOptions): Hono => {
+  const app = new Hono();
+  const generateOrderId = options.generateOrderId ?? defaultGenerateOrderId;
+  const now = options.now ?? (() => new Date());
+
+  app.post('/authorize-fincode', async c => {
+    let rawBody: unknown;
+    try {
+      rawBody = await c.req.json();
+    } catch {
+      return c.json({ error: 'InvalidRequest', message: 'request body must be valid JSON' }, 400);
+    }
+
+    const parsed = parseAuthorizeBody(rawBody);
+    if (!parsed.ok) {
+      return c.json({ error: 'InvalidRequest', message: parsed.message }, 400);
+    }
+    const body: AuthorizeRequestBody = parsed.value;
+
+    // bid 上限 100 万円 check (webapp + backend 2 層強制の backend 側)
+    if (body.jpyAmount > BID_LIMIT_JPY) {
+      return c.json(
+        {
+          error: 'BidLimitExceeded',
+          message: `jpyAmount ${body.jpyAmount} exceeds bid limit ${BID_LIMIT_JPY}`,
+        },
+        400,
+      );
+    }
+
+    // spot rate 取得 (5 秒 cache + primary/fallback 切替、 Issue #3005 経由)
+    let spotRate: SpotRate;
+    try {
+      spotRate = await options.spotRateFetcher.getEthJpyRate();
+    } catch (err) {
+      if (err instanceof SpotRateFetchError) {
+        return c.json(
+          {
+            error: 'SpotRateUnavailable',
+            message: err.message,
+          },
+          503,
+        );
+      }
+      return c.json(
+        {
+          error: 'InternalError',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        500,
+      );
+    }
+
+    // ETH wei = webapp 提示値を primary で採用 (Issue #3051、 入力軸 ETH 反転)
+    const ethWei = BigInt(body.ethAmount);
+
+    // orderId 生成 (fiat_bid.authId PK に紐付けて後段で lookup 可能に、 fincode-prefix で GMO orderId と識別可能)
+    const orderId = generateOrderId({
+      auctionId: body.auctionId,
+      bidderWallet: body.bidderWallet,
+    });
+
+    // fincode register + execute 順次呼出 (cardToken は fincode.js iframe tokenize で受領した card_id)
+    let authResult;
+    try {
+      authResult = await options.fincodeClient.authorize({
+        orderId,
+        amount: body.jpyAmount,
+        cardToken: body.cardToken,
+      });
+    } catch (err) {
+      if (err instanceof FincodeAuthorizationError) {
+        return c.json(
+          {
+            error: 'FincodeAuthorizationFailed',
+            message: err.message,
+            errorCode: err.errorCode ?? null,
+            errorMessage: err.errorMessage ?? null,
+          },
+          500,
+        );
+      }
+      return c.json(
+        {
+          error: 'InternalError',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        500,
+      );
+    }
+
+    // fiat_bid table に pending status で INSERT
+    const record: FiatBidRecord = {
+      authId: authResult.authId,
+      bidderWallet: body.bidderWallet,
+      bidderEmail: body.bidderEmail ?? null,
+      auctionId: BigInt(body.auctionId),
+      jpyAmount: body.jpyAmount,
+      ethAmount: ethWei,
+      spotRate: Math.round(spotRate.rate),
+      spotRateSource: spotRate.source,
+      status: 'pending',
+      createdAt: now(),
+    };
+    try {
+      await options.store.insertPending(record);
+    } catch (err) {
+      return c.json(
+        {
+          error: 'InternalError',
+          message: `fiat_bid store failed: ${err instanceof Error ? err.message : String(err)}`,
+        },
+        500,
+      );
+    }
+
+    const response: AuthorizeFincodeResponseBody = {
+      authId: authResult.authId,
+      tds2Url: authResult.tds2Url,
+      jpyAmount: body.jpyAmount,
+      ethAmount: ethWei.toString(),
+      spotRate: Math.round(spotRate.rate),
+      spotRateSource: spotRate.source,
+      status: authResult.status,
+    };
+    return c.json<AuthorizeFincodeResponseBody>(response, 200);
+  });
+
+  return app;
+};

--- a/packages/niji-api/src/mocks/fincode-server.ts
+++ b/packages/niji-api/src/mocks/fincode-server.ts
@@ -1,0 +1,221 @@
+/**
+ * fincode byGMO mock server (Phase 2 backend 統合、 Issue #3115)
+ *
+ * MSW の setupServer で fincode API endpoint 2 本を intercept する。
+ * `USE_FINCODE_MOCK=true` (default) の場合に `pnpm dev` 起動時 conditional に start される。
+ *
+ * 実装対象 endpoint (fincode 公式 API リファレンス準拠) —
+ *  - POST /v1/payments        ... 決済登録 (access_id 発行、 status = CHECKED)
+ *  - PUT  /v1/payments/{id}   ... 決済実行 (与信 authorization、 status = AUTHORIZED / AUTHENTICATED)
+ *
+ * response 仕様 (application/json) は fincode 公式仕様に準拠、 実 API 応答を再現する。
+ * GMO 世代 mock (gmo-server.ts) と対比 pattern で maintenance 容易性確保。
+ */
+
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+/**
+ * fincode 決済 mock state (テスト間で共有される in-memory store)
+ * 実 API との差異 = access_id の永続化は Ponder DB (fiat_bid schema) が担う、
+ * mock は request 単位で成功応答を返すだけの最小実装。
+ */
+type MockFincodeState = {
+  payments: Map<
+    string,
+    {
+      accessId: string;
+      status: 'CHECKED' | 'AUTHORIZED' | 'CAPTURED' | 'AUTHENTICATED';
+      amount: string;
+      jobCode: string;
+    }
+  >;
+};
+
+const createMockState = (): MockFincodeState => ({
+  payments: new Map(),
+});
+
+const state = createMockState();
+
+/**
+ * mock state reset (test 用 export、 test 間の payment state 干渉排除)
+ */
+export const resetFincodeMockState = (): void => {
+  state.payments.clear();
+  idCounter = 0;
+};
+
+/**
+ * 決定的 mock ID 生成器 (テスト再現性のため counter ベース)
+ * 実 fincode は 26 桁 ULID を返す、 mock は "mock-fincode-" prefix + counter で十分。
+ */
+let idCounter = 0;
+const nextMockId = (prefix: string): string => {
+  idCounter += 1;
+  return `${prefix}${String(idCounter).padStart(8, '0')}`;
+};
+
+/**
+ * fincode mock server の base URL 前提 = env `FINCODE_MOCK_ENDPOINT` (default `http://127.0.0.1:2427`)
+ * MSW は wildcard host にも match するが、 明示的に env から取ることで prod 切替時の port 衝突回避。
+ */
+export const fincodeMockBaseUrl = (): string => {
+  return process.env['FINCODE_MOCK_ENDPOINT'] ?? 'http://127.0.0.1:2427';
+};
+
+/** fincode error 応答 build helper */
+const buildFincodeErrorResponse = (
+  status: number,
+  errorCode: string,
+  errorMessage: string,
+): HttpResponse<string> => {
+  return new HttpResponse(
+    JSON.stringify({
+      errors: [{ error_code: errorCode, error_message: errorMessage }],
+    }),
+    {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    },
+  );
+};
+
+/**
+ * MSW handler 2 本 (POST /v1/payments / PUT /v1/payments/{id})
+ * 各 handler は JSON body を parse、 mock state を update、 JSON response を返す。
+ * fincode API secret verify は mock ではしない (test 環境完結のため)、 実 API は Authorization header 必須。
+ */
+export const fincodeHandlers = [
+  /**
+   * POST /v1/payments — 決済登録
+   * 必須 param = pay_type / job_code / amount / id
+   * 応答 = id / access_id / status = CHECKED
+   */
+  http.post(`${fincodeMockBaseUrl()}/v1/payments`, async ({ request }) => {
+    let body: {
+      pay_type?: string;
+      job_code?: string;
+      amount?: string;
+      id?: string;
+    };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return buildFincodeErrorResponse(400, 'E10000', 'invalid JSON body');
+    }
+
+    if (body.id === undefined || body.id === '') {
+      return buildFincodeErrorResponse(400, 'E10001', 'id is required');
+    }
+    if (body.amount === undefined || body.amount === '') {
+      return buildFincodeErrorResponse(400, 'E10002', 'amount is required');
+    }
+
+    const amountNum = Number.parseInt(body.amount, 10);
+    if (!Number.isFinite(amountNum) || amountNum <= 0) {
+      return buildFincodeErrorResponse(400, 'E10003', 'amount must be positive integer');
+    }
+
+    // bid 上限 100 万円 check (webapp + backend 2 層強制の backend 側、 Phase 1 SSOT)
+    if (amountNum > 1_000_000) {
+      return buildFincodeErrorResponse(400, 'E10010', 'amount exceeds bid limit 1,000,000 JPY');
+    }
+
+    const accessId = nextMockId('mock-fincode-acc-');
+    state.payments.set(body.id, {
+      accessId,
+      status: 'CHECKED',
+      amount: body.amount,
+      jobCode: body.job_code ?? 'AUTH',
+    });
+
+    return HttpResponse.json({
+      id: body.id,
+      access_id: accessId,
+      status: 'CHECKED',
+      job_code: body.job_code ?? 'AUTH',
+      amount: body.amount,
+      pay_type: body.pay_type ?? 'Card',
+    });
+  }),
+
+  /**
+   * PUT /v1/payments/{id} — 決済実行 (与信 authorization + 3DS 判定)
+   * 必須 param = pay_type / access_id / method / token
+   * 応答 = status = AUTHORIZED (通常) / AUTHENTICATED (3DS 必要、 acs_url 併記)
+   */
+  http.put(`${fincodeMockBaseUrl()}/v1/payments/:id`, async ({ request, params }) => {
+    const orderId = params['id'] as string;
+    let body: {
+      pay_type?: string;
+      access_id?: string;
+      method?: string;
+      token?: string;
+      tds2_ret_url?: string;
+      tds2_type?: string;
+    };
+    try {
+      body = (await request.json()) as typeof body;
+    } catch {
+      return buildFincodeErrorResponse(400, 'E10000', 'invalid JSON body');
+    }
+
+    const existing = state.payments.get(orderId);
+    if (existing === undefined) {
+      return buildFincodeErrorResponse(404, 'E10100', `payment ${orderId} not found`);
+    }
+
+    if (body.access_id !== existing.accessId) {
+      return buildFincodeErrorResponse(400, 'E10101', 'access_id mismatch');
+    }
+    if (body.token === undefined || body.token === '') {
+      return buildFincodeErrorResponse(400, 'E10102', 'token is required');
+    }
+
+    // fail 経路 mock = テスト用に特定 token で fail 応答
+    if (body.token === 'card_token_declined') {
+      return buildFincodeErrorResponse(402, 'CARD_DECLINED', 'card declined by issuer');
+    }
+
+    // 3DS 必要 mock = tds2_ret_url 送信時に AUTHENTICATED + acs_url 返却
+    if (body.tds2_ret_url !== undefined) {
+      state.payments.set(orderId, {
+        ...existing,
+        status: 'AUTHENTICATED',
+      });
+      return HttpResponse.json({
+        id: orderId,
+        access_id: existing.accessId,
+        status: 'AUTHENTICATED',
+        job_code: existing.jobCode,
+        amount: existing.amount,
+        pay_type: 'Card',
+        acs_url: `${fincodeMockBaseUrl()}/mock-3ds?orderId=${encodeURIComponent(orderId)}&accessId=${encodeURIComponent(existing.accessId)}&returnUrl=${encodeURIComponent(body.tds2_ret_url)}`,
+        transaction_id: nextMockId('mock-fincode-tx-'),
+      });
+    }
+
+    // 通常経路 = AUTHORIZED 応答 (3DS 不要 pattern)
+    state.payments.set(orderId, {
+      ...existing,
+      status: 'AUTHORIZED',
+    });
+    return HttpResponse.json({
+      id: orderId,
+      access_id: existing.accessId,
+      status: 'AUTHORIZED',
+      job_code: existing.jobCode,
+      amount: existing.amount,
+      pay_type: 'Card',
+      approve: nextMockId('9'),
+      transaction_id: nextMockId('mock-fincode-tx-'),
+    });
+  }),
+];
+
+/**
+ * fincode mock server (Ponder dev server 起動時に conditional listen)
+ * export された server 変数 = test 側で beforeAll に listen / afterAll に close
+ */
+export const fincodeMockServer = setupServer(...fincodeHandlers);

--- a/packages/niji-api/src/mocks/index.ts
+++ b/packages/niji-api/src/mocks/index.ts
@@ -14,6 +14,7 @@
  * Phase 1 base infra の本 Issue 段階では export のみで actual 起動は Issue 3 で配線する。
  */
 
+import { fincodeMockServer } from './fincode-server.js';
 import { gmoMockServer } from './gmo-server.js';
 
 /**
@@ -22,6 +23,15 @@ import { gmoMockServer } from './gmo-server.js';
  */
 export const isGmoMockEnabled = (): boolean => {
   const value = (process.env['USE_GMO_MOCK'] ?? 'false').trim().toLowerCase();
+  return value === 'true' || value === '1' || value === 'yes';
+};
+
+/**
+ * USE_FINCODE_MOCK=true 時のみ fincode mock server を起動する
+ * Phase 2 backend 統合、 Issue #3115。
+ */
+export const isFincodeMockEnabled = (): boolean => {
+  const value = (process.env['USE_FINCODE_MOCK'] ?? 'false').trim().toLowerCase();
   return value === 'true' || value === '1' || value === 'yes';
 };
 
@@ -38,8 +48,22 @@ export const startGmoMockIfEnabled = (): void => {
 };
 
 /**
+ * fincode mock server の conditional 起動 (GMO と並列、 Phase 2 統合中は両方同時起動可)
+ */
+export const startFincodeMockIfEnabled = (): void => {
+  if (!isFincodeMockEnabled()) {
+    return;
+  }
+  fincodeMockServer.listen({ onUnhandledRequest: 'warn' });
+};
+
+/**
  * mock server の停止 (Ponder dev server の shutdown hook / test tearDown で使用)
  */
 export const stopGmoMock = (): void => {
   gmoMockServer.close();
+};
+
+export const stopFincodeMock = (): void => {
+  fincodeMockServer.close();
 };

--- a/packages/niji-api/src/services/fincode/client.test.ts
+++ b/packages/niji-api/src/services/fincode/client.test.ts
@@ -1,0 +1,534 @@
+/**
+ * FincodeClient behavior test (Phase 2 backend 統合、 Issue #3115)
+ *
+ * 検証対象 —
+ * (1) registerPayment 成功時に access_id を parse して返す
+ * (2) executePayment 成功時に status / acs_url / approve を parse して返す
+ * (3) fincode error 応答 (HTTP 4xx + { errors: [{ error_code }] }) 時に FincodeAuthorizationError を throw
+ * (4) network error 時に FincodeAuthorizationError (cause 付) を throw
+ * (5) authorize (register + execute) が順次呼出し FincodeAuthorizationResult を返す
+ * (6) authorize 中に register fail → execute 呼ばず即 throw
+ * (7) endpoint 解決 (USE_FINCODE_MOCK=true → mock endpoint、 false + live=false → test endpoint)
+ *
+ * mock server は import せず、 fetch 実装を DI で差替えて fincode 応答 shape を単体検証する。
+ * rules/quality.md § test-passed marker 発行前提 4 条件準拠 (behavior test + 実行 pass + 層 0 指示項目)。
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FincodeClient } from './client.js';
+
+/**
+ * fetch stub を作る helper
+ * responses = URL path ごとに JSON body + status を返す map
+ * method 別 dispatch は URL match で十分 (POST /v1/payments と PUT /v1/payments/{id} は path 別)
+ */
+const resolveUrl = (input: string | URL | Request): string => {
+  if (input instanceof URL) return input.toString();
+  if (typeof input === 'string') return input;
+  return input.url;
+};
+
+const makeFetchStub = (responses: Record<string, { status?: number; body: unknown }>) => {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = resolveUrl(input);
+    // longest match で URL 判定 (PUT /v1/payments/{id} が POST /v1/payments より優先)
+    const matched = Object.entries(responses)
+      .sort((a, b) => b[0].length - a[0].length)
+      .find(([path]) => url.endsWith(path) || url.includes(path));
+    if (matched === undefined) {
+      throw new Error(`fetch stub: unmatched URL ${url}`);
+    }
+    const [, res] = matched;
+    return new Response(JSON.stringify(res.body), {
+      status: res.status ?? 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+};
+
+/** env override helper (test 前後で env をきれいに保つ) */
+const withEnv = (overrides: Record<string, string | undefined>) => {
+  const original: Record<string, string | undefined> = {};
+  for (const [key, value] of Object.entries(overrides)) {
+    original[key] = process.env[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  return () => {
+    for (const [key, value] of Object.entries(original)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  };
+};
+
+describe('FincodeClient.registerPayment', () => {
+  it('成功応答から access_id を parse して返す', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments': {
+          body: {
+            id: 'order-001',
+            access_id: 'acc-001',
+            status: 'CHECKED',
+            job_code: 'AUTH',
+            amount: '25000',
+          },
+        },
+      }),
+    });
+
+    const result = await client.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: '25000',
+      id: 'order-001',
+    });
+
+    expect(result).toMatchObject({
+      id: 'order-001',
+      access_id: 'acc-001',
+      status: 'CHECKED',
+    });
+  });
+
+  it('HTTP 400 + errors 応答時に FincodeAuthorizationError を throw', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments': {
+          status: 400,
+          body: {
+            errors: [
+              {
+                error_code: 'E10000',
+                error_message: 'amount must be positive integer',
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    await expect(
+      client.registerPayment({
+        pay_type: 'Card',
+        job_code: 'AUTH',
+        amount: '0',
+        id: 'order-002',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FincodeAuthorizationError',
+      errorCode: 'E10000',
+      errorMessage: 'amount must be positive integer',
+    });
+  });
+
+  it('access_id 欠損時に error を throw', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments': {
+          body: {
+            id: 'order-003',
+            status: 'CHECKED',
+            job_code: 'AUTH',
+            amount: '25000',
+          },
+        },
+      }),
+    });
+
+    await expect(
+      client.registerPayment({
+        pay_type: 'Card',
+        job_code: 'AUTH',
+        amount: '25000',
+        id: 'order-003',
+      }),
+    ).rejects.toThrow(/access_id/);
+  });
+
+  it('network error 時に FincodeAuthorizationError を throw (cause 付)', async () => {
+    const networkErr = new Error('fetch aborted');
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: vi.fn(async () => {
+        throw networkErr;
+      }),
+    });
+
+    await expect(
+      client.registerPayment({
+        pay_type: 'Card',
+        job_code: 'AUTH',
+        amount: '25000',
+        id: 'order-004',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FincodeAuthorizationError',
+    });
+  });
+
+  it('Authorization header に Bearer + secret を送信', async () => {
+    const fetchStub = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          id: 'order-005',
+          access_id: 'acc-005',
+          status: 'CHECKED',
+          job_code: 'AUTH',
+          amount: '25000',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_secret_xxx',
+      fetch: fetchStub,
+    });
+
+    await client.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: '25000',
+      id: 'order-005',
+    });
+
+    expect(fetchStub).toHaveBeenCalledTimes(1);
+    const call = fetchStub.mock.calls[0];
+    if (call === undefined) throw new Error('fetch not called');
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer m_test_secret_xxx');
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('Tenant-Shop-Id を設定時のみ header に付与', async () => {
+    const fetchStub = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          id: 'order-006',
+          access_id: 'acc-006',
+          status: 'CHECKED',
+          job_code: 'AUTH',
+          amount: '25000',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      tenantShopId: 's_test_tenant',
+      fetch: fetchStub,
+    });
+
+    await client.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: '25000',
+      id: 'order-006',
+    });
+
+    const call = fetchStub.mock.calls[0];
+    if (call === undefined) throw new Error('fetch not called');
+    const init = call[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Tenant-Shop-Id']).toBe('s_test_tenant');
+  });
+});
+
+describe('FincodeClient.executePayment', () => {
+  it('AUTHORIZED 応答から status を parse して返す', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments/order-101': {
+          body: {
+            id: 'order-101',
+            access_id: 'acc-101',
+            status: 'AUTHORIZED',
+            job_code: 'AUTH',
+            amount: '25000',
+            approve: '1234567',
+            transaction_id: 'tx-101',
+          },
+        },
+      }),
+    });
+
+    const result = await client.executePayment('order-101', {
+      pay_type: 'Card',
+      access_id: 'acc-101',
+      method: '1',
+      token: 'card_token_xxx',
+    });
+
+    expect(result).toMatchObject({
+      id: 'order-101',
+      status: 'AUTHORIZED',
+      approve: '1234567',
+    });
+  });
+
+  it('AUTHENTICATED (3DS 必要) 応答から acs_url を parse', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments/order-102': {
+          body: {
+            id: 'order-102',
+            access_id: 'acc-102',
+            status: 'AUTHENTICATED',
+            job_code: 'AUTH',
+            amount: '25000',
+            acs_url: 'https://acs.example/3ds?token=xyz',
+          },
+        },
+      }),
+    });
+
+    const result = await client.executePayment('order-102', {
+      pay_type: 'Card',
+      access_id: 'acc-102',
+      method: '1',
+      token: 'card_token_xxx',
+      tds2_ret_url: 'http://webapp/3ds-callback',
+      tds2_type: '2',
+    });
+
+    expect(result.status).toBe('AUTHENTICATED');
+    expect(result.acs_url).toBe('https://acs.example/3ds?token=xyz');
+  });
+
+  it('HTTP 402 + errors 応答時に FincodeAuthorizationError を throw', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments/order-103': {
+          status: 402,
+          body: {
+            errors: [
+              {
+                error_code: 'CARD_DECLINED',
+                error_message: 'card declined by issuer',
+              },
+            ],
+          },
+        },
+      }),
+    });
+
+    await expect(
+      client.executePayment('order-103', {
+        pay_type: 'Card',
+        access_id: 'acc-103',
+        method: '1',
+        token: 'card_token_declined',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FincodeAuthorizationError',
+      errorCode: 'CARD_DECLINED',
+    });
+  });
+});
+
+describe('FincodeClient.authorize (register + execute 統合)', () => {
+  it('register + execute 順次呼出し AuthorizationResult を返す', async () => {
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: makeFetchStub({
+        '/v1/payments/order-201': {
+          body: {
+            id: 'order-201',
+            access_id: 'acc-201',
+            status: 'AUTHORIZED',
+            job_code: 'AUTH',
+            amount: '25000',
+            approve: '9876543',
+            transaction_id: 'tx-201',
+          },
+        },
+        '/v1/payments': {
+          body: {
+            id: 'order-201',
+            access_id: 'acc-201',
+            status: 'CHECKED',
+            job_code: 'AUTH',
+            amount: '25000',
+          },
+        },
+      }),
+    });
+
+    const result = await client.authorize({
+      orderId: 'order-201',
+      amount: 25000,
+      cardToken: 'card_token_xxx',
+    });
+
+    expect(result).toMatchObject({
+      authId: 'acc-201',
+      accessId: 'acc-201',
+      orderId: 'order-201',
+      status: 'AUTHORIZED',
+      approve: '9876543',
+      transactionId: 'tx-201',
+    });
+  });
+
+  it('register fail 時に execute 呼ばず即 throw', async () => {
+    const executeStub = vi.fn();
+    const fetchStub = vi.fn(async (input: string | URL | Request) => {
+      const url = resolveUrl(input);
+      if (url.endsWith('/v1/payments')) {
+        return new Response(
+          JSON.stringify({
+            errors: [{ error_code: 'E10001', error_message: 'amount over limit' }],
+          }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      executeStub();
+      return new Response('{}', { status: 200 });
+    });
+
+    const client = new FincodeClient({
+      endpoint: 'http://test-fincode',
+      apiKeySecret: 'm_test_dummy',
+      fetch: fetchStub,
+    });
+
+    await expect(
+      client.authorize({
+        orderId: 'order-202',
+        amount: 10_000_000,
+        cardToken: 'card_token_xxx',
+      }),
+    ).rejects.toMatchObject({
+      name: 'FincodeAuthorizationError',
+      errorCode: 'E10001',
+    });
+    expect(executeStub).not.toHaveBeenCalled();
+  });
+});
+
+describe('FincodeClient endpoint 解決', () => {
+  let restoreEnv: () => void = () => {};
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('USE_FINCODE_MOCK=true 時に FINCODE_MOCK_ENDPOINT を使う', async () => {
+    restoreEnv = withEnv({
+      USE_FINCODE_MOCK: 'true',
+      FINCODE_MOCK_ENDPOINT: 'http://mock-server:2427',
+    });
+    const fetchStub = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          id: 'order-301',
+          access_id: 'acc-301',
+          status: 'CHECKED',
+          job_code: 'AUTH',
+          amount: '25000',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    const client = new FincodeClient({ apiKeySecret: 'm_test_dummy', fetch: fetchStub });
+
+    await client.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: '25000',
+      id: 'order-301',
+    });
+
+    const call = fetchStub.mock.calls[0];
+    if (call === undefined) throw new Error('fetch not called');
+    expect(resolveUrl(call[0] as string | URL | Request)).toContain('mock-server:2427');
+  });
+
+  it('USE_FINCODE_MOCK=false + live=false 時に test endpoint を使う', async () => {
+    restoreEnv = withEnv({
+      USE_FINCODE_MOCK: 'false',
+      FINCODE_IS_LIVE_MODE: 'false',
+    });
+    const fetchStub = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          id: 'order-302',
+          access_id: 'acc-302',
+          status: 'CHECKED',
+          job_code: 'AUTH',
+          amount: '25000',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    const client = new FincodeClient({ apiKeySecret: 'm_test_dummy', fetch: fetchStub });
+
+    await client.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: '25000',
+      id: 'order-302',
+    });
+
+    const call = fetchStub.mock.calls[0];
+    if (call === undefined) throw new Error('fetch not called');
+    expect(resolveUrl(call[0] as string | URL | Request)).toContain('api.test.fincode.jp');
+  });
+
+  it('USE_FINCODE_MOCK=false + live=true 時に production endpoint を使う', async () => {
+    restoreEnv = withEnv({
+      USE_FINCODE_MOCK: 'false',
+      FINCODE_IS_LIVE_MODE: 'true',
+    });
+    const fetchStub = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({
+          id: 'order-303',
+          access_id: 'acc-303',
+          status: 'CHECKED',
+          job_code: 'AUTH',
+          amount: '25000',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    });
+    const client = new FincodeClient({ apiKeySecret: 'm_test_dummy', fetch: fetchStub });
+
+    await client.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: '25000',
+      id: 'order-303',
+    });
+
+    const call = fetchStub.mock.calls[0];
+    if (call === undefined) throw new Error('fetch not called');
+    expect(resolveUrl(call[0] as string | URL | Request)).toContain('api.fincode.jp');
+  });
+});

--- a/packages/niji-api/src/services/fincode/client.test.ts
+++ b/packages/niji-api/src/services/fincode/client.test.ts
@@ -16,7 +16,7 @@
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { FincodeClient } from './client.js';
+import { FincodeClient, type FetchLike } from './client.js';
 
 /**
  * fetch stub を作る helper
@@ -183,7 +183,7 @@ describe('FincodeClient.registerPayment', () => {
   });
 
   it('Authorization header に Bearer + secret を送信', async () => {
-    const fetchStub = vi.fn(async () => {
+    const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
         JSON.stringify({
           id: 'order-005',
@@ -219,7 +219,7 @@ describe('FincodeClient.registerPayment', () => {
   });
 
   it('Tenant-Shop-Id を設定時のみ header に付与', async () => {
-    const fetchStub = vi.fn(async () => {
+    const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
         JSON.stringify({
           id: 'order-006',
@@ -444,7 +444,7 @@ describe('FincodeClient endpoint 解決', () => {
       USE_FINCODE_MOCK: 'true',
       FINCODE_MOCK_ENDPOINT: 'http://mock-server:2427',
     });
-    const fetchStub = vi.fn(async () => {
+    const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
         JSON.stringify({
           id: 'order-301',
@@ -475,7 +475,7 @@ describe('FincodeClient endpoint 解決', () => {
       USE_FINCODE_MOCK: 'false',
       FINCODE_IS_LIVE_MODE: 'false',
     });
-    const fetchStub = vi.fn(async () => {
+    const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
         JSON.stringify({
           id: 'order-302',
@@ -506,7 +506,7 @@ describe('FincodeClient endpoint 解決', () => {
       USE_FINCODE_MOCK: 'false',
       FINCODE_IS_LIVE_MODE: 'true',
     });
-    const fetchStub = vi.fn(async () => {
+    const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
         JSON.stringify({
           id: 'order-303',

--- a/packages/niji-api/src/services/fincode/client.ts
+++ b/packages/niji-api/src/services/fincode/client.ts
@@ -1,0 +1,295 @@
+/**
+ * fincode byGMO API client (Phase 2 backend 統合、 Issue #3115)
+ *
+ * fincode 公式仕様 —
+ * - Content-Type = application/json (request / response 双方)
+ * - Authorization = Bearer <FINCODE_API_KEY_SECRET> (secret key、 backend 専用、 browser 露出禁止)
+ * - Tenant-Shop-Id header = <FINCODE_TENANT_SHOP_ID> (テナント運用時のみ、 単一店舗契約時は空 OK)
+ * - error は HTTP 4xx / 5xx で { errors: [{ error_code, error_message }] } を JSON body に返す
+ *
+ * env 切替 —
+ * - `USE_FINCODE_MOCK=true` (dev / test) → `FINCODE_MOCK_ENDPOINT` (default `http://127.0.0.1:2427`) を叩く
+ * - `USE_FINCODE_MOCK=false` (本番 / 実 test env verify) → `FINCODE_IS_LIVE_MODE` で prod / test 切替
+ *   - live=true → https://api.fincode.jp
+ *   - live=false → https://api.test.fincode.jp
+ *
+ * SSOT — packages/niji-api/src/services/gmo/client.ts (GMO 世代の対比 pattern)、
+ *        packages/niji-api/src/services/fincode/types.ts
+ */
+
+import type {
+  FincodeAuthorizationResult,
+  FincodeErrorResponse,
+  FincodePaymentExecuteRequest,
+  FincodePaymentExecuteSuccess,
+  FincodePaymentRegisterRequest,
+  FincodePaymentRegisterSuccess,
+} from './types.js';
+
+/** DI 用の fetch signature (test で mock 差替可能、 GMO と同 pattern) */
+export type FetchLike = typeof globalThis.fetch;
+
+export type FincodeClientOptions = {
+  /**
+   * fincode API base URL (default = env `FINCODE_ENDPOINT` 経由、 mock / live 自動切替)
+   */
+  endpoint?: string;
+  /** API secret key (default = env `FINCODE_API_KEY_SECRET`) */
+  apiKeySecret?: string;
+  /** テナント shop ID (default = env `FINCODE_TENANT_SHOP_ID`、 空 OK) */
+  tenantShopId?: string;
+  /** request timeout (ms、 default = env `FINCODE_REQUEST_TIMEOUT_MS` or 30000) */
+  timeoutMs?: number;
+  /** fetch 実装差替 (test 用、 default = globalThis.fetch) */
+  fetch?: FetchLike;
+};
+
+/**
+ * fincode API 障害 (network fail / HTTP error / errors 返却) を統合した error
+ * authorize handler は本 error を catch して 5xx FincodeAuthorizationFailed に変換する
+ */
+export class FincodeAuthorizationError extends Error {
+  public readonly errorCode?: string;
+  public readonly errorMessage?: string;
+  constructor(
+    message: string,
+    options: { errorCode?: string; errorMessage?: string; cause?: unknown } = {},
+  ) {
+    super(message);
+    this.name = 'FincodeAuthorizationError';
+    if (options.errorCode !== undefined) {
+      this.errorCode = options.errorCode;
+    }
+    if (options.errorMessage !== undefined) {
+      this.errorMessage = options.errorMessage;
+    }
+    if (options.cause !== undefined) {
+      (this as { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+/**
+ * env / options から endpoint を決定
+ * USE_FINCODE_MOCK truthy → FINCODE_MOCK_ENDPOINT
+ * それ以外は FINCODE_IS_LIVE_MODE で live / test 切替
+ */
+const resolveEndpoint = (option: string | undefined): string => {
+  if (option !== undefined && option.trim() !== '') {
+    return option;
+  }
+  const useMock = (process.env['USE_FINCODE_MOCK'] ?? 'true').trim().toLowerCase();
+  const isMock = useMock === 'true' || useMock === '1' || useMock === 'yes';
+  if (isMock) {
+    return process.env['FINCODE_MOCK_ENDPOINT'] ?? 'http://127.0.0.1:2427';
+  }
+  const isLive = (process.env['FINCODE_IS_LIVE_MODE'] ?? 'false').trim().toLowerCase() === 'true';
+  if (isLive) {
+    return process.env['FINCODE_LIVE_ENDPOINT'] ?? 'https://api.fincode.jp';
+  }
+  return process.env['FINCODE_TEST_ENDPOINT'] ?? 'https://api.test.fincode.jp';
+};
+
+const readStringConfig = (option: string | undefined, envKey: string, fallback: string): string => {
+  if (option !== undefined && option.trim() !== '') {
+    return option;
+  }
+  const raw = process.env[envKey];
+  if (raw !== undefined && raw.trim() !== '') {
+    return raw;
+  }
+  return fallback;
+};
+
+const readNumberConfig = (
+  optionValue: number | undefined,
+  envKey: string,
+  defaultValue: number,
+): number => {
+  if (typeof optionValue === 'number' && Number.isFinite(optionValue) && optionValue > 0) {
+    return optionValue;
+  }
+  const raw = process.env[envKey];
+  if (raw !== undefined && raw.trim() !== '') {
+    const parsed = Number.parseFloat(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return defaultValue;
+};
+
+/** timeout 付き fetch (AbortController で abort 時 signal) */
+const fetchWithTimeout = async (
+  fetchImpl: FetchLike,
+  url: string,
+  init: RequestInit,
+  timeoutMs: number,
+): Promise<Response> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+/** fincode error response 判定 (HTTP status 4xx/5xx or body.errors 存在) */
+const extractFincodeError = (
+  status: number,
+  body: unknown,
+): { code: string; message: string } | undefined => {
+  if (status >= 200 && status < 300) {
+    return undefined;
+  }
+  if (body === null || typeof body !== 'object') {
+    return { code: `HTTP_${status}`, message: `HTTP ${status} with non-JSON body` };
+  }
+  const errors = (body as FincodeErrorResponse).errors;
+  if (Array.isArray(errors) && errors.length > 0 && errors[0] !== undefined) {
+    return {
+      code: errors[0].error_code ?? `HTTP_${status}`,
+      message: errors[0].error_message ?? `HTTP ${status}`,
+    };
+  }
+  return { code: `HTTP_${status}`, message: `HTTP ${status}` };
+};
+
+export class FincodeClient {
+  private readonly endpoint: string;
+  private readonly apiKeySecret: string;
+  private readonly tenantShopId: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: FetchLike;
+
+  constructor(options: FincodeClientOptions = {}) {
+    this.endpoint = resolveEndpoint(options.endpoint);
+    this.apiKeySecret = readStringConfig(options.apiKeySecret, 'FINCODE_API_KEY_SECRET', '');
+    this.tenantShopId = readStringConfig(options.tenantShopId, 'FINCODE_TENANT_SHOP_ID', '');
+    this.timeoutMs = readNumberConfig(options.timeoutMs, 'FINCODE_REQUEST_TIMEOUT_MS', 30000);
+    this.fetchImpl = options.fetch ?? globalThis.fetch;
+  }
+
+  /**
+   * POST /v1/payments — 決済登録 (access_id 発行、 status = CHECKED)
+   * amount は fincode 仕様上 string で送信 (JSON body でも文字列型)
+   */
+  async registerPayment(
+    req: FincodePaymentRegisterRequest,
+  ): Promise<FincodePaymentRegisterSuccess> {
+    const body = await this.post<FincodePaymentRegisterSuccess>('/v1/payments', req);
+    if (body.access_id === undefined || body.access_id === '') {
+      throw new FincodeAuthorizationError('fincode registerPayment missing access_id');
+    }
+    return body;
+  }
+
+  /**
+   * PUT /v1/payments/{id} — 決済実行 (与信 authorization + 3DS 2.0 判定)
+   * token = webapp が fincode.js iframe tokenize で受領した card_id
+   */
+  async executePayment(
+    orderId: string,
+    req: FincodePaymentExecuteRequest,
+  ): Promise<FincodePaymentExecuteSuccess> {
+    const path = `/v1/payments/${encodeURIComponent(orderId)}`;
+    const body = await this.put<FincodePaymentExecuteSuccess>(path, req);
+    if (body.status === undefined) {
+      throw new FincodeAuthorizationError('fincode executePayment missing status');
+    }
+    return body;
+  }
+
+  /**
+   * register + execute を順次呼出、 authorize handler が使う統合 method
+   * どちらか fail 時に FincodeAuthorizationError を throw (handler で 5xx 変換)
+   */
+  async authorize(input: {
+    orderId: string;
+    amount: number;
+    cardToken: string;
+    tds2RetUrl?: string;
+  }): Promise<FincodeAuthorizationResult> {
+    const registered = await this.registerPayment({
+      pay_type: 'Card',
+      job_code: 'AUTH',
+      amount: String(input.amount),
+      id: input.orderId,
+    });
+
+    const executeReq: FincodePaymentExecuteRequest = {
+      pay_type: 'Card',
+      access_id: registered.access_id,
+      method: '1',
+      token: input.cardToken,
+    };
+    if (input.tds2RetUrl !== undefined) {
+      executeReq.tds2_ret_url = input.tds2RetUrl;
+      executeReq.tds2_type = '2';
+    }
+    const executed = await this.executePayment(input.orderId, executeReq);
+
+    return {
+      authId: executed.access_id,
+      accessId: executed.access_id,
+      tds2Url: executed.acs_url,
+      orderId: executed.id,
+      status: executed.status,
+      approve: executed.approve,
+      transactionId: executed.transaction_id,
+    };
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>('POST', path, body);
+  }
+
+  private async put<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>('PUT', path, body);
+  }
+
+  private async request<T>(method: 'POST' | 'PUT', path: string, body: unknown): Promise<T> {
+    const url = `${this.endpoint.replace(/\/$/, '')}${path}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKeySecret}`,
+    };
+    if (this.tenantShopId !== '') {
+      headers['Tenant-Shop-Id'] = this.tenantShopId;
+    }
+    let response: Response;
+    try {
+      response = await fetchWithTimeout(
+        this.fetchImpl,
+        url,
+        {
+          method,
+          headers,
+          body: JSON.stringify(body),
+        },
+        this.timeoutMs,
+      );
+    } catch (err) {
+      throw new FincodeAuthorizationError(`fincode ${method} ${path} network error`, {
+        cause: err,
+      });
+    }
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch (err) {
+      throw new FincodeAuthorizationError(`fincode ${method} ${path} invalid JSON body`, {
+        cause: err,
+      });
+    }
+    const err = extractFincodeError(response.status, parsed);
+    if (err !== undefined) {
+      throw new FincodeAuthorizationError(`fincode ${method} ${path} failed (${err.code})`, {
+        errorCode: err.code,
+        errorMessage: err.message,
+      });
+    }
+    return parsed as T;
+  }
+}

--- a/packages/niji-api/src/services/fincode/types.ts
+++ b/packages/niji-api/src/services/fincode/types.ts
@@ -1,0 +1,101 @@
+/**
+ * fincode byGMO API request / response 型定義 (Phase 2 backend 統合、 Issue #3115)
+ *
+ * fincode 公式仕様 (JSON) の shape を TypeScript 型として集約する。
+ * client.ts はここで定義した型を build / parse する責務のみを持つ。
+ *
+ * 決済 flow (card token 経路) —
+ * (1) webapp が fincode.js iframe で card tokenize、 card_id を受領 (Phase 1c 完了)
+ * (2) webapp が backend POST /api/v1/fiat-bid/authorize-fincode に card_id + amount + orderId 送信
+ * (3) backend が fincode POST /v1/payments で payment 登録 (job_code=AUTH、 status=CHECKED)
+ * (4) backend が fincode PUT /v1/payments/{id} で payment 実行 (method=1、 token=card_id、 status=AUTHORIZED)
+ * (5) backend が webapp に authId + status 応答 (3DS 必要時は acs_url 併記)
+ *
+ * SSOT — https://docs.fincode.jp/api (公式 API リファレンス)、
+ *        packages/niji-api/src/services/gmo/types.ts (GMO 世代の対比 pattern)
+ */
+
+/** POST /v1/payments (payment 登録) request body */
+export type FincodePaymentRegisterRequest = {
+  /** 決済手段 (Card / Konbini / Paypay / 等)、 Phase 2 は Card 固定 */
+  pay_type: 'Card';
+  /** 決済処理区分 (AUTH = 与信のみ / CAPTURE = 与信 + 売上確定 / CHECK) */
+  job_code: 'AUTH' | 'CAPTURE' | 'CHECK';
+  /** 決済額 (円単位、 fincode は文字列で送受信) */
+  amount: string;
+  /** 加盟店側 order ID (fiat_bid.authId PK に一致させて後段 lookup 可能に) */
+  id: string;
+  /** 通貨 (default JPY、 fincode 現状 JPY のみ) */
+  client_field_1?: string;
+};
+
+/** POST /v1/payments 成功応答 */
+export type FincodePaymentRegisterSuccess = {
+  /** 加盟店側 order ID (request の id と同値) */
+  id: string;
+  /** 決済 access ID (fincode 側の一意識別子、 PUT /payments/{id} で使用) */
+  access_id: string;
+  /** 決済 status (登録直後は CHECKED) */
+  status: 'CHECKED';
+  /** 決済処理区分 */
+  job_code: string;
+  /** 決済額 */
+  amount: string;
+};
+
+/** PUT /v1/payments/{id} (payment 実行) request body */
+export type FincodePaymentExecuteRequest = {
+  pay_type: 'Card';
+  /** POST /payments で発行された access_id */
+  access_id: string;
+  /** 実行方法 (1 = 一回払い、 2 = 分割払い、 3 = リボ払い)、 Phase 2 は 1 固定 */
+  method: '1';
+  /** fincode card token (webapp iframe tokenize 経由取得) */
+  token: string;
+  /** 3DS 2.0 認証後の webapp 側 return URL (Phase 3 で使用) */
+  tds2_ret_url?: string;
+  /** 3DS 認証タイプ (2 = 3DS 2.0)、 Phase 3 で使用 */
+  tds2_type?: '2';
+};
+
+/** PUT /v1/payments/{id} 成功応答 */
+export type FincodePaymentExecuteSuccess = {
+  id: string;
+  access_id: string;
+  /** 決済 status (AUTHORIZED = 与信成功 / CAPTURED = 売上確定成功 / AUTHENTICATED = 3DS 認証必要) */
+  status: 'AUTHORIZED' | 'CAPTURED' | 'AUTHENTICATED';
+  job_code: string;
+  amount: string;
+  /** 3DS 認証 redirect URL (status = AUTHENTICATED 時のみ返却) */
+  acs_url?: string;
+  /** fincode 側 transaction ID (経緯 audit 用) */
+  transaction_id?: string;
+  /** authorization 承認番号 (伝票印字用) */
+  approve?: string;
+};
+
+/** fincode error 応答 shape (HTTP 4xx / 5xx 時に返却) */
+export type FincodeErrorResponse = {
+  errors: Array<{
+    error_code: string;
+    error_message: string;
+  }>;
+};
+
+/** authorize 統合結果 (register + execute 順次呼出後の返却型、 handler が使う) */
+export type FincodeAuthorizationResult = {
+  /** fincode auth ID (fiat_bid.authId PK に一致、 access_id を採用) */
+  authId: string;
+  /** fincode access_id (subsequent PUT /payments/{id} で使用) */
+  accessId: string;
+  /** 3DS 認証 redirect URL (3DS 不要時は undefined) */
+  tds2Url: string | undefined;
+  /** 加盟店側 order ID */
+  orderId: string;
+  /** 決済 status (AUTHORIZED / CAPTURED / AUTHENTICATED) */
+  status: FincodePaymentExecuteSuccess['status'];
+  /** authorization 承認番号 */
+  approve: string | undefined;
+  /** fincode transaction ID */
+  transactionId: string | undefined;
+};

--- a/packages/niji-contracts/.env.example
+++ b/packages/niji-contracts/.env.example
@@ -1,3 +1,10 @@
+# ================================================================
+# [SECURITY] 本 file (.env.example) は template のみ、 実 secret 含まず。
+# コピー先の .env は KMS / 1Password / hardware wallet 経由で管理し、
+# chat / PR / GitHub Issue / Slack / paste bin に絶対貼付禁止。
+# 特に WALLET_PRIVATE_KEY / MNEMONIC の実値貼付は資産流出に直結。
+# ================================================================
+
 INFURA_PROJECT_ID=
 ETHERSCAN_API_KEY=
 

--- a/packages/niji-sdk/.env.example
+++ b/packages/niji-sdk/.env.example
@@ -1,3 +1,9 @@
+# ================================================================
+# [SECURITY] 本 file (.env.example) は template のみ、 実 secret 含まず。
+# コピー先の .env は KMS / 1Password 経由で管理し、
+# chat / PR / GitHub Issue / Slack / paste bin に絶対貼付禁止。
+# ================================================================
+
 # used by wagmi cli
 ETHERSCAN_API_KEY=
 

--- a/packages/niji-webapp/.env.base-sepolia.example
+++ b/packages/niji-webapp/.env.base-sepolia.example
@@ -1,3 +1,9 @@
+# ================================================================
+# [SECURITY] 本 file (.env.base-sepolia.example) は template のみ、 実 secret 含まず。
+# コピー先の .env.base-sepolia は KMS / 1Password 経由で管理し、
+# chat / PR / GitHub Issue / Slack / paste bin に絶対貼付禁止。
+# ================================================================
+
 # Niji webapp — Base Sepolia (84532) 用 env
 # 使い方 ... cp .env.base-sepolia.example .env.base-sepolia → pnpm dev:base-sepolia
 

--- a/packages/niji-webapp/.env.example
+++ b/packages/niji-webapp/.env.example
@@ -1,3 +1,9 @@
+# ================================================================
+# [SECURITY] 本 file (.env.example) は template のみ、 実 secret 含まず。
+# コピー先の .env は KMS / 1Password 経由で管理し、
+# chat / PR / GitHub Issue / Slack / paste bin に絶対貼付禁止。
+# ================================================================
+
 # Active Chain ID: Specifies the Ethereum network (1 for Mainnet, 11155111 for Sepolia)
 VITE_CHAIN_ID=1
 

--- a/packages/niji-webapp/.env.example.local
+++ b/packages/niji-webapp/.env.example.local
@@ -1,3 +1,9 @@
+# ================================================================
+# [SECURITY] 本 file (.env.example.local) は template のみ、 実 secret 含まず。
+# コピー先の .env は KMS / 1Password / hardware wallet 経由で管理し、
+# chat / PR / GitHub Issue / Slack / paste bin に絶対貼付禁止。
+# ================================================================
+
 # Active Chain ID: Specifies the Ethereum network (1 for Mainnet, 11155111 for Sepolia, 31337 for Hardhat/Anvil)
 VITE_CHAIN_ID=31337
 
@@ -33,8 +39,11 @@ VITE_ENABLE_TANSTACK_QUERY_DEVTOOLS=false
 # VITE_BASE_SEPOLIA_DEPLOY_BLOCK=
 
 # ------------------------------------------------------------------
-# GMO fiat bid (Phase 1 MVP)
+# fiat bid endpoint (niji-api base URL、 fincode 移行後も継続使用、 provider 非依存)
 # 用途詳細 = docs/operations/gmo-fiat-bid.md § env 変数 SSOT
+# ⚠️ 変数名 VITE_GMO_* は歴史的経緯の名残 (旧 GMO PGマルチペイメント前提の命名)、
+# fincode byGMO 移行完了後に VITE_FIAT_* へ rename 予定 (別 PR で計画)。
+# 実体は niji-api endpoint で決済 product 名に依存しない、 rename までは名前保持。
 # ------------------------------------------------------------------
 
 # niji-api (Ponder + Hono) の base URL、 fiat bid endpoint (authorize / capture / topup 等) 呼出に使用
@@ -52,19 +61,24 @@ VITE_GMO_API_ENDPOINT_SPOT_RATE=http://127.0.0.1:42070
 VITE_ENABLE_FIAT_BID=false
 
 # ------------------------------------------------------------------
-# fincode byGMO (Phase 1 実 test env 移行、 Issue #3115)
+# fincode byGMO (GMO Payment Gateway, Inc. 提供の新決済 product、
+# 同社の旧 product = GMO PGマルチペイメントから移行中、 Issue #3115)
+# Phase 1c = SDK iframe 描画完了 (PR #3127 merge 済、 e2e 2/2 pass 実測)、
+# Phase 2 = backend fincode SDK Node 統合予定。
+# card tokenize は browser 側 fincode.js iframe で完結 (PCI DSS SAQ-A-EP)、
+# 自 site JS は生 card info に一切触れない。
 # ------------------------------------------------------------------
 
-# fincode public key (公開 OK、 browser 側 fincode.js に埋込)。
-# test env = dashboard.test.fincode.jp で発行される p_test_XXXX、
-# 本番 env = dashboard.fincode.jp で発行される p_live_XXXX (別 key、 互換なし)。
+# fincode public key (公開 OK、 browser 側 fincode.js に埋込)
+# test env = dashboard.test.fincode.jp で発行される p_test_XXXX
+# 本番 env = dashboard.fincode.jp で発行される p_live_XXXX (別 key、 互換なし)
 VITE_FINCODE_PUBLIC_KEY=
 
 # fincode API base URL、 SDK 内部で isLiveMode: false 指定時は test env に自動 route するため
 # 通常は明示不要、 override 必要時のみ設定。 test = https://api.test.fincode.jp、 本番 = https://api.fincode.jp
 # VITE_FINCODE_API_BASE=
 
-# fincode.js iframe UI 使用 flag (true / false、 default = false で従来 mock 経路継続)。
-# true 時に CardInputFincode component が render され、 card 情報は fincode 側 iframe で入力 + tokenize、
-# 自 site JS は生 card info に一切触れない (PCI DSS SAQ-A-EP)。 dev 検証後に本番 default 化を検討。
+# fincode.js iframe UI 使用 flag (true / false、 default = false で従来 mock 経路継続)
+# true 時に CardInputFincode component が render され、 card 情報は fincode 側 iframe で入力 + tokenize
+# 自 site JS は生 card info に一切触れない (PCI DSS SAQ-A-EP)。 dev 検証後に本番 default 化を検討
 VITE_USE_FINCODE_UI=false

--- a/packages/niji-webapp/src/hooks/useFiatBid.test.ts
+++ b/packages/niji-webapp/src/hooks/useFiatBid.test.ts
@@ -9,7 +9,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useFiatBid } from './useFiatBid';
+import { resolveAuthorizePath, useFiatBid } from './useFiatBid';
 
 describe('useFiatBid.authorize', () => {
   it('authorize 成功で step = "three-ds"、 saveState + redirect が呼ばれる', async () => {
@@ -90,6 +90,109 @@ describe('useFiatBid.authorize', () => {
     expect(result.current.errorMessage).toBe('BidLimitExceeded');
     expect(saveState).not.toHaveBeenCalled();
     expect(redirect).not.toHaveBeenCalled();
+  });
+});
+
+describe('useFiatBid.authorize — fincode 経路 (Issue #3115)', () => {
+  it('tds2Url undefined + status=AUTHORIZED で step="placing" 遷移、 redirect 呼ばず', async () => {
+    const authorize = vi.fn().mockResolvedValue({
+      authId: 'fincode-auth-1',
+      // tds2Url 未返却 (fincode AUTHORIZED = 3DS 不要 pattern)
+      jpyAmount: 50_000,
+      ethAmount: '100000000000000000',
+      spotRate: 500_000,
+      spotRateSource: 'gmo-coin' as const,
+      status: 'AUTHORIZED' as const,
+    });
+    const placeBid = vi.fn();
+    const saveState = vi.fn();
+    const redirect = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFiatBid({
+        fetchers: { authorize, placeBid },
+        saveState,
+        redirect,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.authorize({
+        auctionId: '42',
+        bidderWallet: '0xUSER',
+        ethAmount: '100000000000000000',
+        spotRate: 500_000,
+        jpyAmount: 50_000,
+        cardToken: 'card_token_fincode_xxx',
+      });
+    });
+
+    // status=AUTHORIZED は 3DS skip → placing 直遷移
+    expect(result.current.step).toBe('placing');
+    expect(saveState).toHaveBeenCalledOnce();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it('tds2Url 有り + status=AUTHENTICATED で step="three-ds" 遷移、 redirect 呼出', async () => {
+    const authorize = vi.fn().mockResolvedValue({
+      authId: 'fincode-auth-2',
+      tds2Url: 'https://acs.example/3ds?token=xyz',
+      jpyAmount: 50_000,
+      ethAmount: '100000000000000000',
+      spotRate: 500_000,
+      spotRateSource: 'gmo-coin' as const,
+      status: 'AUTHENTICATED' as const,
+    });
+    const placeBid = vi.fn();
+    const saveState = vi.fn();
+    const redirect = vi.fn();
+
+    const { result } = renderHook(() =>
+      useFiatBid({
+        fetchers: { authorize, placeBid },
+        saveState,
+        redirect,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.authorize({
+        auctionId: '42',
+        bidderWallet: '0xUSER',
+        ethAmount: '100000000000000000',
+        spotRate: 500_000,
+        jpyAmount: 50_000,
+        cardToken: 'card_token_fincode_xxx',
+      });
+    });
+
+    // status=AUTHENTICATED は 3DS 必要で redirect
+    expect(result.current.step).toBe('three-ds');
+    expect(redirect).toHaveBeenCalledWith('https://acs.example/3ds?token=xyz');
+  });
+});
+
+describe('resolveAuthorizePath (Issue #3115)', () => {
+  it('VITE_USE_FINCODE_UI 未設定時は GMO endpoint (/authorize) を返す', () => {
+    expect(resolveAuthorizePath({})).toBe('/api/v1/fiat-bid/authorize');
+  });
+
+  it('VITE_USE_FINCODE_UI=true で fincode endpoint (/authorize-fincode) を返す', () => {
+    expect(resolveAuthorizePath({ VITE_USE_FINCODE_UI: 'true' })).toBe(
+      '/api/v1/fiat-bid/authorize-fincode',
+    );
+  });
+
+  it('VITE_USE_FINCODE_UI=false で GMO endpoint を返す', () => {
+    expect(resolveAuthorizePath({ VITE_USE_FINCODE_UI: 'false' })).toBe(
+      '/api/v1/fiat-bid/authorize',
+    );
+  });
+
+  it('VITE_USE_FINCODE_UI=TRUE (大文字) で fincode endpoint (case-insensitive)', () => {
+    expect(resolveAuthorizePath({ VITE_USE_FINCODE_UI: 'TRUE' })).toBe(
+      '/api/v1/fiat-bid/authorize-fincode',
+    );
   });
 });
 

--- a/packages/niji-webapp/src/hooks/useFiatBid.ts
+++ b/packages/niji-webapp/src/hooks/useFiatBid.ts
@@ -52,14 +52,21 @@ export type FiatTopupPhase =
  *
  * spotRateSource は backend `SpotRateSource` (`packages/niji-api/src/services/spotRate/index.ts` SSOT) と
  * 一致させる。 Issue #3061 で `mock` union を追加、 `gmo` legacy label は既存 mock fixture 互換で残置。
+ *
+ * Phase 2 fincode (Issue #3115) で以下 2 field を追加。
+ * - tds2Url = optional 化 (fincode status=AUTHORIZED 時は 3DS 不要で undefined)
+ * - status  = 追加 (fincode AUTHORIZED / AUTHENTICATED / CAPTURED、 GMO 経路では undefined)
  */
 export type AuthorizeResponse = {
   authId: string;
-  tds2Url: string;
+  /** 3DS 認証 URL、 GMO 経路は必ず string、 fincode 経路は status=AUTHENTICATED 時のみ返却 */
+  tds2Url?: string;
   jpyAmount: number;
   ethAmount: string;
   spotRate: number;
   spotRateSource: 'gmo' | 'gmo-coin' | 'coingecko' | 'mock';
+  /** 決済 status (fincode 経路のみ、 GMO 経路では undefined、 Issue #3115) */
+  status?: 'AUTHORIZED' | 'AUTHENTICATED' | 'CAPTURED';
 };
 
 /** place-bid endpoint 応答 shape */
@@ -150,8 +157,34 @@ const buildEndpoint = (path: string): string => {
   return `${readApiBase().replace(/\/$/, '')}${path}`;
 };
 
+/**
+ * fincode UI flag 検出 (Issue #3115)
+ * VITE_USE_FINCODE_UI=true 時は fincode 経路 endpoint (authorize-fincode) を叩き、
+ * false / 未設定時は GMO 経路 endpoint (authorize) を叩く。
+ * FiatBidForm 側の card 入力 UI 切替 (fincode.js iframe vs GMO Token 方式 mock) と同 env flag で連動。
+ *
+ * 引数 envSource は test で差替可能に、 default は `import.meta.env` (useSpotRate と同 pattern)。
+ */
+export const isFincodeBackendEnabled = (
+  envSource: Record<string, string | undefined> = ((): Record<string, string | undefined> => {
+    return typeof import.meta !== 'undefined'
+      ? ((import.meta as { env?: Record<string, string> }).env ?? {})
+      : {};
+  })(),
+): boolean => {
+  const envValue = envSource['VITE_USE_FINCODE_UI'];
+  return typeof envValue === 'string' && envValue.trim().toLowerCase() === 'true';
+};
+
+/** authorize endpoint path 決定 (fincode / GMO 切替、 Issue #3115) */
+export const resolveAuthorizePath = (envSource?: Record<string, string | undefined>): string => {
+  return isFincodeBackendEnabled(envSource)
+    ? '/api/v1/fiat-bid/authorize-fincode'
+    : '/api/v1/fiat-bid/authorize';
+};
+
 export const defaultAuthorizeFetch = async (body: AuthorizeRequest): Promise<AuthorizeResponse> => {
-  const response = await fetch(buildEndpoint('/api/v1/fiat-bid/authorize'), {
+  const response = await fetch(buildEndpoint(resolveAuthorizePath()), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
@@ -276,6 +309,13 @@ export const useFiatBid = (options: UseFiatBidOptions = {}) => {
         };
         saveState(pending);
 
+        // fincode 経路で status=AUTHORIZED / CAPTURED (3DS 不要) の場合は tds2Url が undefined、
+        // 3DS redirect skip + placing step 移行で直接 bid tx 発火経路に繋ぐ (Issue #3115)。
+        // GMO 経路は必ず tds2Url を返すため fall-through で従来通り 3DS redirect する。
+        if (result.tds2Url === undefined) {
+          setStep('placing');
+          return result;
+        }
         setStep('three-ds');
         redirect(result.tds2Url);
         return result;


### PR DESCRIPTION
## 概要

GMO fincode byGMO クレカ決済の Phase 2 backend 統合。 Phase 1c (PR #3127) の webapp fincode.js iframe 描画達成に続き、 backend fincode API 呼出経路 + webapp endpoint routing を実装。

決済 vendor = GMO Payment Gateway, Inc. 継続、 product 差替 = GMO PGマルチペイメント → fincode byGMO (同社の新 product) の Phase 2 段。 GMO 経路と fincode 経路を並列共存させ、 webapp 側 `VITE_USE_FINCODE_UI` env flag で切替。

## 変更内容

### env template 整理 (commit ebf13cde1)
- FINCODE_ 5 変数追加 (API_KEY_SECRET / IS_LIVE_MODE / TENANT_SHOP_ID / WEBHOOK_SECRET / USE_FINCODE_MOCK)
- GMO_ 系 5 変数に「Phase 2 完了後削除予定」 note 付き活性残置 (backend src 50+ 参照 active)
- 全 6 file 先頭に日本語 4 行 chat 禁止 warning block 統一挿入
- GMO 系 3 社関係 (Payment Gateway = 決済 vendor / GMO コイン = 暗号通貨取引所 / fincode = 決済 vendor 新 product) 明確化

### backend fincode client 実装 (commit 5315fa064)
- services/fincode/{types.ts, client.ts, client.test.ts} 新規、 GMO Client と同 pattern (factory + DI + env config + custom error)
- @fincode/node SDK 不使用、 直接 fetch 経路 (GMO 経路と統一 pattern、 dep 最小化)
- endpoint 3 段切替 (mock / test / live)、 Authorization Bearer + Tenant-Shop-Id header
- 14 unit test pass 実測 (registerPayment 5 / executePayment 3 / authorize 2 / endpoint 解決 3 / header 検証 1)

### backend fincode handler + mock + route (commit fd53d992d)
- handlers/fiat-bid/authorize-fincode.ts 新規、 authorize.ts の parseAuthorizeBody / FiatBidStore を re-use (DRY)
- mocks/fincode-server.ts 新規、 MSW で fincode API 2 endpoint intercept (POST /v1/payments + PUT /v1/payments/{id})、 error 5 種 + 3DS 経路 cover
- mocks/index.ts に startFincodeMockIfEnabled / stopFincodeMock 追加、 GMO aggregator と対称 pattern
- api/index.ts に FincodeClient singleton + /api/v1/fiat-bid/authorize-fincode route 登録
- 7 handler unit test pass 実測 (AUTHORIZED / AUTHENTICATED / BidLimit / FincodeError / InvalidRequest 2 種 / SpotRateUnavailable)

### webapp endpoint routing + 3DS skip (commit f7ebd5baa)
- hooks/useFiatBid.ts の AuthorizeResponse を fincode 対応 (tds2Url optional + status field)
- isFincodeBackendEnabled + resolveAuthorizePath 新規、 VITE_USE_FINCODE_UI=true で /authorize-fincode routing
- envSource 引数注入 pattern (useSpotRate と同、 test 経路統一)
- authorize action で tds2Url undefined 分岐 = fincode AUTHORIZED (3DS 不要) 経路で step='placing' 直遷移
- 4 unit test 追加 (fincode 2 + resolveAuthorizePath 4 の内訳、 useFiatBid.test.ts 12/12 pass)

## 実装方針

- backend GMO_ 経路 = 活性残置 (mock server + fetcher + reauthorize worker、 backend src 50+ 参照)、 fincode 並列追加のみで regression 0
- webapp VITE_GMO_* 変数名 = rename 別 PR (実体は provider 非依存 endpoint、 本 PR scope 外)
- webhook receive + signature verify = 別 Issue defer (webhook secret 未発行、 Phase 3 scope)
- @fincode/node SDK = 不使用、 直接 fetch (GMO client と統一 pattern + dep 最小化)
- e2e = 既存 fincode-iframe-verify.spec.ts (PR #3127、 2/2 pass 実測) で iframe render + tokenize prep 経路 cover、 backend authorize-fincode 含む full flow e2e は follow-up Issue で組込

## 動作証明

```
niji-api:   20 test file / 252 test 全 pass (Duration 849ms、 21 test 新規)
niji-webapp: 123 test file / 9872 test 全 pass (Duration 21.21s、 4 test 新規)
typecheck:  fincode 関連 file 0 error (ponder.config.ts の 4 件 pre-existing error は本 branch 変更外)
regression: 0 (既存 GMO 経路 test + webapp UI test 全 pass 維持)
```

## Test plan

- [x] pnpm --filter @niji/api vitest run = 252/252 pass
- [x] pnpm --filter niji-webapp vitest run = 9872/9872 pass
- [x] pnpm --filter @niji/api typecheck = fincode 関連 0 error
- [x] fincode client 14 test pass
- [x] fincode authorize handler 7 test pass
- [x] webapp useFiatBid 12 test pass (fincode 4 test 新規)
- [x] regression = 0 (既存 GMO 経路 88 test + webapp 全 test 破壊なし)
- [ ] backend authorize-fincode 実 test env 疎通 verify (follow-up、 Phase 3 で組込)
- [ ] webhook receive + signature verify (follow-up、 Phase 3 で webhook secret 発行後実施)

## Refs

Refs #3115 (fincode 移行 Phase 2 backend 統合)
Refs #3127 (Phase 1c webapp fincode iframe 描画達成、 merge 済)

## Follow-up

- webhook receive endpoint + FINCODE_WEBHOOK_SECRET 検証 logic (Phase 3、 webhook secret 発行後)
- backend authorize-fincode の real fincode test env 疎通 e2e (Phase 3、 CI 経路と切り離した local verify)
- VITE_GMO_* rename → VITE_FIAT_* (別 PR、 source 参照 10+ 件、 provider 非依存命名に統一)
- GMO_ 系 5 変数 + Reauthorization worker + reauthorize API 呼出経路の cleanup (Phase 2 完全移行時、 code + env まとめて撤去)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWpuhkFoEse2Yo9Xb5QsvF