### PR TITLE
🧹 chore(niji-contracts): abi/ 配下を gitignore 一括 ignore (hardhat 出力 pattern 漏れ解消)

### DIFF
--- a/packages/niji-contracts/.gitignore
+++ b/packages/niji-contracts/.gitignore
@@ -14,13 +14,9 @@ logs
 coverage/
 coverage.json
 
-abi/@openzeppelin
-abi/contracts/base
-abi/contracts/external
-abi/contracts/governance
-abi/contracts/interfaces
-abi/contracts/proxies
-abi/contracts/test
+# hardhat compile 出力 ABI JSON (再生成可能、 sdk 側は wagmi cli / typechain 経路で別途生成)
+# tracked file 0 件で全て build artifact なので abi/ 配下全体を ignore する。
+abi/
 
 # Foundry
 foundry-out


### PR DESCRIPTION
## 概要

user 明示指示 = 「packages から不要なもの削除したい」 の一環。 Tier 1 (build artifact 513M 削除) 完了後の Tier 3 対応 = `packages/niji-contracts/.gitignore` の abi 関連 pattern 拡張。

現行 gitignore は sub-dir 個別列挙で top-level `abi/contracts/*.json` (実 pattern は nested `{SolName}.sol/{Name}.json`) が漏れて 14 file 相当 untracked 残置していた。 hardhat compile 出力なので再生成可能で tracked file 0 件、 `abi/` 一括 ignore に統合。

## 変更内容

`packages/niji-contracts/.gitignore` 7 pattern → 1 pattern に統合。

```diff
-abi/@openzeppelin
-abi/contracts/base
-abi/contracts/external
-abi/contracts/governance
-abi/contracts/interfaces
-abi/contracts/proxies
-abi/contracts/test
+# hardhat compile 出力 ABI JSON (再生成可能、 sdk 側は wagmi cli / typechain 経路で別途生成)
+# tracked file 0 件で全て build artifact なので abi/ 配下全体を ignore する。
+abi/
```

## 動作証明

```
$ cd packages/niji-contracts
$ git ls-files abi/ | wc -l
0   # 変更前 tracked 0 件 = 誤削除 risk 0

$ git ls-files --others --exclude-standard abi/ | wc -l
0   # 変更後 untracked 0 件 = 全て ignore 対象化

$ git check-ignore -v abi/contracts/governance/data/NijiDAODataEvents.sol/NijiDAODataEvents.json
packages/niji-contracts/.gitignore:19:abi/	abi/contracts/governance/data/NijiDAODataEvents.sol/NijiDAODataEvents.json
```

## 影響範囲

- **sdk 参照経路**: @niji/sdk は wagmi cli / typechain 経由で type 生成、 `abi/contracts/*.json` 直接参照なし → 影響 0
- **tracked file**: 変更前 `git ls-files abi/` = 0 実測、 誤削除 risk 0
- **hardhat workflow**: compile 時 `abi/` 再生成 = 常時 dirty 化しない workflow に統一

## Test plan

- [x] git ls-files abi/ = 0 (変更前 tracked 0 確認)
- [x] git ls-files --others --exclude-standard abi/ = 0 (変更後 untracked 0 確認)
- [x] git check-ignore で hardhat 実 ABI file path match 確認
- [x] `.gitignore` 1 file のみ変更、 他 file 影響 0

## Follow-up

- Tier 1 build artifact 削除 (`.next` / `dist` / `artifacts` / `.ponder` 等 513M) は本 PR とは別に local 実行済 (user 環境の disk space 解放)
- 他 package の gitignore 見直し (niji-webapp / niji-api 等) は必要に応じて別 PR で対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWpuhkFoEse2Yo9Xb5QsvF
