### PR TITLE
💴 feat(niji-webapp): fiat bid 額入力軸を JPY primary に反転 = 日本 native currency (円) UX (Refs #3115)

### DIFF
--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.test.tsx
@@ -53,7 +53,7 @@ const successRate: SpotRate = {
 };
 
 describe('FiatBidForm loading spinner (Issue #3053 Phase B、 Issue #3059 で JPY 側条件更新)', () => {
-  it('spot rate 未取得 + ETH 未入力時 → spot rate 欄は spinner 表示、 JPY 換算欄は「—」 (spinner 非表示、 Issue #3059)', () => {
+  it('spot rate 未取得 + JPY 未入力時 → spot rate 欄は spinner 表示、 ETH 換算欄は「—」 (spinner 非表示、 Issue #3059)', () => {
     // spot rate fetcher = pending Promise (never resolve) で undefined 保持
     const pendingFetcher = vi.fn(() => new Promise<SpotRate>(() => {}));
 
@@ -79,9 +79,9 @@ describe('FiatBidForm loading spinner (Issue #3053 Phase B、 Issue #3059 で JP
     expect(rateLoading.textContent).toContain('取得中');
 
     // Issue #3059 — ETH 未入力時、 JPY 換算欄は「—」 表示 (spinner 非表示)
-    expect(screen.queryByTestId('fiat-bid-jpy-display-loading')).toBeNull();
-    const jpyDisplay = screen.getByTestId('fiat-bid-jpy-display');
-    expect(jpyDisplay.textContent).toContain('—');
+    expect(screen.queryByTestId('fiat-bid-eth-display-loading')).toBeNull();
+    const ethDisplay = screen.getByTestId('fiat-bid-eth-display');
+    expect(ethDisplay.textContent).toContain('—');
 
     // rateSummary root に aria-busy="true" 付与 (screen reader 対応、 spot rate 側 loading state)
     const rateSummary = screen.getByTestId('fiat-bid-rate-summary');
@@ -123,13 +123,13 @@ describe('FiatBidForm loading spinner (Issue #3053 Phase B、 Issue #3059 で JP
     expect(rateSummary.textContent).toContain('source: gmo');
 
     // JPY 換算欄 (ETH 未入力 state = 「—」 表示、 spinner 非表示)
-    expect(screen.queryByTestId('fiat-bid-jpy-display-loading')).toBeNull();
-    const jpyDisplay = screen.getByTestId('fiat-bid-jpy-display');
-    expect(jpyDisplay).toBeInTheDocument();
-    expect(jpyDisplay.textContent).toContain('—');
+    expect(screen.queryByTestId('fiat-bid-eth-display-loading')).toBeNull();
+    const ethDisplay = screen.getByTestId('fiat-bid-eth-display');
+    expect(ethDisplay).toBeInTheDocument();
+    expect(ethDisplay.textContent).toContain('—');
   });
 
-  it('spot rate 未取得 + ETH 入力あり → JPY 換算欄で spinner + 「取得中」 表示 (Issue #3059)', () => {
+  it('spot rate 未取得 + JPY 入力あり → ETH 換算欄で spinner + 「取得中」 表示 (Issue #3059)', () => {
     // spot rate fetcher = pending Promise (never resolve)、 rate === undefined 保持
     const pendingFetcher = vi.fn(() => new Promise<SpotRate>(() => {}));
 
@@ -149,14 +149,14 @@ describe('FiatBidForm loading spinner (Issue #3053 Phase B、 Issue #3059 で JP
       { wrapper: buildWrapper() },
     );
 
-    // ETH 入力を発火 (validation NG でも ethRaw に値が入っていれば spinner 判定 trigger)
-    const ethInput = screen.getByTestId('fiat-bid-eth-input');
-    fireEvent.change(ethInput, { target: { value: '0.05' } });
+    // JPY 入力を発火 (validation NG でも jpyRaw に値が入っていれば spinner 判定 trigger)
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input');
+    fireEvent.change(jpyInput, { target: { value: '25000' } });
 
-    // JPY 換算欄で spinner + 「取得中」 表示 (ETH 入力あり + spot rate 未取得 branch)
-    const jpyLoading = screen.getByTestId('fiat-bid-jpy-display-loading');
-    expect(jpyLoading).toBeInTheDocument();
-    expect(jpyLoading.textContent).toContain('取得中');
+    // ETH 換算欄で spinner + 「取得中」 表示 (JPY 入力あり + spot rate 未取得 branch)
+    const ethLoading = screen.getByTestId('fiat-bid-eth-display-loading');
+    expect(ethLoading).toBeInTheDocument();
+    expect(ethLoading.textContent).toContain('取得中');
   });
 });
 

--- a/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/FiatBidForm.tsx
@@ -34,7 +34,7 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { useFiatBid } from '@/hooks/useFiatBid';
-import { ethToJpy, ethToWei, useSpotRate } from '@/hooks/useSpotRate';
+import { ethToJpy, useSpotRate } from '@/hooks/useSpotRate';
 
 import { CardInput } from './CardInput';
 import { CardInputFincode, type CardInputFincodeHandle } from './CardInputFincode';
@@ -74,6 +74,16 @@ const TOPUP_PHASE_LABELS: Record<FiatTopupPhase, string> = {
  */
 export type EthValidationResult =
   | { ok: true; value: number; jpyEquivalent: number }
+  | { ok: false; message: string };
+
+/**
+ * JPY 額入力 validation 結果 (Issue #3115 Phase 3 で追加、 JPY primary 再反転)。
+ *
+ * ok=true 時は JPY 額 (integer、 例 25000) + ETH 換算値 (wei bigint、 jpy / spotRate × 10^18) を返し、
+ * form 側でそのまま useFiatBid.authorize / topup へ渡す jpyAmount / ethAmount (wei string) とする。
+ */
+export type JpyValidationResult =
+  | { ok: true; value: number; ethWei: bigint; ethEquivalent: number }
   | { ok: false; message: string };
 
 /**
@@ -122,6 +132,54 @@ export const validateEthAmount = (
 };
 
 /**
+ * JPY 額入力 validation (Issue #3115 Phase 3、 JPY primary 再反転、 日本 native currency 入力軸)。
+ *
+ * 判定順 (fail 時に最初に該当する 1 条件を返す) —
+ * (1) 空文字 → 「金額を入力してください」
+ * (2) 非有限 or 非正 or 非整数 → 「金額は正の整数 (円) で入力してください」
+ * (3) spot rate 未取得 → 「spot rate 取得中です、 しばらくお待ちください」
+ * (4) minBidJpy 未満 → 「minimum bid X 円以上を入力してください」
+ * (5) 100 万円上限超 → 「bid 上限 100 万円を超えています」
+ *
+ * minBidJpy は minBidEth × spotRate で親 (BidModal) が計算して渡す。
+ * spot rate は必須 (換算値なしで ETH wei 計算不可)、 undefined は fail branch に落とす。
+ */
+export const validateJpyAmount = (
+  raw: string,
+  minBidJpy: number | undefined,
+  spotRate: number | undefined,
+): JpyValidationResult => {
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return { ok: false, message: '金額を入力してください' };
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== trimmed) {
+    return { ok: false, message: '金額は正の整数 (円) で入力してください' };
+  }
+  if (spotRate === undefined || !Number.isFinite(spotRate) || spotRate <= 0) {
+    return { ok: false, message: 'spot rate 取得中です、 しばらくお待ちください' };
+  }
+  if (minBidJpy !== undefined && parsed < minBidJpy) {
+    return {
+      ok: false,
+      message: `minimum bid ${minBidJpy.toLocaleString()} 円以上を入力してください`,
+    };
+  }
+  if (parsed > BID_LIMIT_JPY) {
+    return {
+      ok: false,
+      message: `bid 上限 ${BID_LIMIT_JPY.toLocaleString()} 円を超えています`,
+    };
+  }
+  // ethWei = jpy / spotRate × 10^18 (小数を避けるため BigInt スケーリング)
+  const scale = 1_000_000_000_000_000_000n;
+  const ethWei = (BigInt(parsed) * scale) / BigInt(Math.floor(spotRate));
+  const ethEquivalent = parsed / spotRate;
+  return { ok: true, value: parsed, ethWei, ethEquivalent };
+};
+
+/**
  * 増額 bid 用 ETH validation (Issue #3051、 JPY→ETH 入力軸反転)。
  *
  * validateEthAmount と同 5 条件 + 「新 ETH 額 > 旧 ETH 額」 の追加 check を強制する。
@@ -140,6 +198,30 @@ export const validateTopupEthAmount = (
     return {
       ok: false,
       message: `増額のみ受付可能です (現 bid 額 ${oldEthAmount} ETH より大きい額を入力してください)`,
+    };
+  }
+  return base;
+};
+
+/**
+ * 増額 bid 用 JPY validation (Issue #3115 Phase 3、 JPY primary 再反転)。
+ *
+ * validateJpyAmount と同 5 条件 + 「新 JPY 額 > 旧 JPY 額」 の追加 check を強制する。
+ * 旧 JPY 額は existingFiatBid.jpyAmount から親が渡す。
+ * backend の topup endpoint も同 check を強制する (2 層で重畳、 dev-flow の quality.md 準拠)。
+ */
+export const validateTopupJpyAmount = (
+  raw: string,
+  minBidJpy: number | undefined,
+  spotRate: number | undefined,
+  oldJpyAmount: number,
+): JpyValidationResult => {
+  const base = validateJpyAmount(raw, minBidJpy, spotRate);
+  if (!base.ok) return base;
+  if (base.value <= oldJpyAmount) {
+    return {
+      ok: false,
+      message: `増額のみ受付可能です (現 bid 額 ${oldJpyAmount.toLocaleString()} 円より大きい額を入力してください)`,
     };
   }
   return base;
@@ -236,7 +318,7 @@ export const FiatBidForm = ({
   generateCardToken = generateMockCardToken,
   isDev = import.meta.env.DEV,
 }: FiatBidFormProps): React.JSX.Element => {
-  const [ethRaw, setEthRaw] = useState<string>('');
+  const [jpyRaw, setJpyRaw] = useState<string>('');
   const [termsChecked, setTermsChecked] = useState<boolean>(false);
   const [emailRaw, setEmailRaw] = useState<string>('');
   const [localError, setLocalError] = useState<string | undefined>(undefined);
@@ -278,42 +360,53 @@ export const FiatBidForm = ({
 
   const isTopupMode = existingFiatBid !== undefined;
 
+  /**
+   * minBidEth (ETH 単位、 chain data) → minBidJpy (円単位、 native currency 入力用) 換算。
+   * spot rate 未取得時は undefined (validateJpyAmount 側で spot rate check に落ちる)。
+   * Issue #3115 Phase 3 で JPY primary 反転に伴い追加。
+   */
+  const minBidJpy = useMemo(() => {
+    if (minBidEth === undefined || spotRate.rate === undefined) return undefined;
+    return Math.ceil(minBidEth * spotRate.rate);
+  }, [minBidEth, spotRate.rate]);
+
   const newBidValidation = useMemo(
-    () => validateEthAmount(ethRaw, minBidEth, spotRate.rate),
-    [ethRaw, minBidEth, spotRate.rate],
+    () => validateJpyAmount(jpyRaw, minBidJpy, spotRate.rate),
+    [jpyRaw, minBidJpy, spotRate.rate],
   );
   const topupValidation = useMemo(
     () =>
       existingFiatBid !== undefined
-        ? validateTopupEthAmount(ethRaw, minBidEth, spotRate.rate, existingFiatBid.ethAmount)
+        ? validateTopupJpyAmount(jpyRaw, minBidJpy, spotRate.rate, existingFiatBid.jpyAmount)
         : undefined,
-    [ethRaw, minBidEth, spotRate.rate, existingFiatBid],
+    [jpyRaw, minBidJpy, spotRate.rate, existingFiatBid],
   );
 
-  const ethValidation = isTopupMode ? topupValidation! : newBidValidation;
+  const jpyValidation = isTopupMode ? topupValidation! : newBidValidation;
 
-  const jpyDisplay = useMemo(() => {
-    if (!ethValidation.ok || spotRate.rate === undefined) return '—';
-    return `約 ${ethValidation.jpyEquivalent.toLocaleString()} 円`;
-  }, [ethValidation, spotRate.rate]);
+  /** ETH 換算表示 (JPY 入力 → ETH 換算、 float 4 桁精度) */
+  const ethDisplay = useMemo(() => {
+    if (!jpyValidation.ok || spotRate.rate === undefined) return '—';
+    return `約 Ξ ${jpyValidation.ethEquivalent.toFixed(4)}`;
+  }, [jpyValidation, spotRate.rate]);
 
   const isSpotRateLoading = spotRate.rate === undefined;
-  const isJpyEquivalentReady = ethValidation.ok && spotRate.rate !== undefined;
+  const isEthEquivalentReady = jpyValidation.ok && spotRate.rate !== undefined;
   /**
-   * ETH input 欄に user が値を入力しているか (Issue #3059 Phase C)。
+   * JPY input 欄に user が値を入力しているか (Issue #3115 Phase 3、 JPY primary 反転)。
    *
-   * JPY 換算欄の spinner 表示条件を「ETH 入力あり + spot rate 未取得」 に限定するために使う。
-   * ETH 未入力時 (初期 state or clear 直後) は spinner を出さず「—」 表示に落として、
-   * spot rate polling が回っているだけで JPY 換算欄が「取得中」 と回り続ける UX 問題を解消する。
+   * ETH 換算欄の spinner 表示条件を「JPY 入力あり + spot rate 未取得」 に限定するために使う。
+   * JPY 未入力時 (初期 state or clear 直後) は spinner を出さず「—」 表示に落として、
+   * spot rate polling 回転中の spinner ぐるぐる UX 問題を解消する。
    */
-  const ethInputHasValue = ethRaw.trim() !== '';
+  const jpyInputHasValue = jpyRaw.trim() !== '';
 
   // fincode 経路では isCardValid は使わず、 fincode UI mount 完了 (isFincodeReady) を submit gate に使う。
   // 実際の card 情報の valid 判定は fincode UI 内部で行われ、 getCardToken 呼出時にのみ検知可能。
   const cardGateOk = useFincode ? isFincodeReady : isCardValid;
 
   const submitDisabled =
-    !ethValidation.ok ||
+    !jpyValidation.ok ||
     !termsChecked ||
     !cardGateOk ||
     spotRate.rate === undefined ||
@@ -327,8 +420,8 @@ export const FiatBidForm = ({
       event.preventDefault();
       setLocalError(undefined);
 
-      if (!ethValidation.ok) {
-        setLocalError(ethValidation.message);
+      if (!jpyValidation.ok) {
+        setLocalError(jpyValidation.message);
         return;
       }
       if (!termsChecked) {
@@ -363,15 +456,15 @@ export const FiatBidForm = ({
         );
         return;
       }
-      // ethRaw から直接 wei 化 (float 中間変換を経由しないため 0.1 → 1e17 wei の精度確保、 viem parseEther 相当)
-      const ethAmountWei = ethToWei(ethRaw.trim()).toString();
+      // JPY primary (Issue #3115 Phase 3): user 入力 JPY → validateJpyAmount で ethWei 計算済
+      const ethAmountWei = jpyValidation.ethWei.toString();
 
       if (isTopupMode && existingFiatBid !== undefined) {
         await fiatBid.topup({
           authId: existingFiatBid.authId,
           newEthAmount: ethAmountWei,
           newSpotRate: spotRate.rate,
-          newJpyAmount: ethValidation.jpyEquivalent,
+          newJpyAmount: jpyValidation.value,
           cardToken,
         });
         return;
@@ -383,13 +476,12 @@ export const FiatBidForm = ({
         bidderEmail: emailRaw.trim() === '' ? undefined : emailRaw.trim(),
         ethAmount: ethAmountWei,
         spotRate: spotRate.rate,
-        jpyAmount: ethValidation.jpyEquivalent,
+        jpyAmount: jpyValidation.value,
         cardToken,
       });
     },
     [
-      ethRaw,
-      ethValidation,
+      jpyValidation,
       termsChecked,
       cardGateOk,
       useFincode,
@@ -415,7 +507,7 @@ export const FiatBidForm = ({
       return;
     }
     fiatBid.reset();
-    setEthRaw('');
+    setJpyRaw('');
     setTermsChecked(false);
     setEmailRaw('');
     setLocalError(undefined);
@@ -451,35 +543,35 @@ export const FiatBidForm = ({
         )}
 
         <div>
-          <label htmlFor="fiat-bid-eth-amount" className={`mb-1 block ${classes.formLabel}`}>
-            {isTopupMode ? '新 bid 額 (ETH、 現額より大きい額)' : 'bid 額 (ETH)'}
+          <label htmlFor="fiat-bid-jpy-amount" className={`mb-1 block ${classes.formLabel}`}>
+            {isTopupMode ? '新 bid 額 (円、 現額より大きい額)' : 'bid 額 (円)'}
           </label>
           <Input
-            id="fiat-bid-eth-amount"
+            id="fiat-bid-jpy-amount"
             type="number"
             min={0}
-            step="0.01"
-            value={ethRaw}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEthRaw(e.target.value)}
+            step="1000"
+            value={jpyRaw}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setJpyRaw(e.target.value)}
             placeholder={
               isTopupMode && existingFiatBid !== undefined
-                ? `Ξ ${(existingFiatBid.ethAmount + 0.01).toFixed(2)}`
-                : minBidEth !== undefined
-                  ? `Ξ ${minBidEth}`
-                  : 'Ξ 0.05'
+                ? `¥ ${(existingFiatBid.jpyAmount + 1000).toLocaleString()}`
+                : minBidJpy !== undefined
+                  ? `¥ ${minBidJpy.toLocaleString()}`
+                  : '¥ 25,000'
             }
-            data-testid="fiat-bid-eth-input"
+            data-testid="fiat-bid-jpy-input"
             required
             className={classes.ethInput}
           />
-          {!ethValidation.ok && ethRaw !== '' && (
-            <p className={classes.errorInline} data-testid="fiat-bid-eth-error">
-              {ethValidation.message}
+          {!jpyValidation.ok && jpyRaw !== '' && (
+            <p className={classes.errorInline} data-testid="fiat-bid-jpy-error">
+              {jpyValidation.message}
             </p>
           )}
-          {minBidEth !== undefined && (
+          {minBidJpy !== undefined && (
             <p className={classes.formHint} data-testid="fiat-bid-min-bid-copy">
-              minimum bid — Ξ {minBidEth} or more
+              minimum bid — ¥ {minBidJpy.toLocaleString()} 以上
             </p>
           )}
         </div>
@@ -526,22 +618,22 @@ export const FiatBidForm = ({
             )}
           </div>
           <div className={classes.rateSummaryCol}>
-            <div className={classes.rateSummaryLabel}>JPY 換算</div>
-            {isJpyEquivalentReady ? (
-              <div className={classes.rateSummaryValue} data-testid="fiat-bid-jpy-display">
-                {jpyDisplay}
+            <div className={classes.rateSummaryLabel}>ETH 換算</div>
+            {isEthEquivalentReady ? (
+              <div className={classes.rateSummaryValue} data-testid="fiat-bid-eth-display">
+                {ethDisplay}
               </div>
-            ) : ethInputHasValue && isSpotRateLoading ? (
+            ) : jpyInputHasValue && isSpotRateLoading ? (
               <div
                 className={classes.rateSummaryLoading}
-                data-testid="fiat-bid-jpy-display-loading"
+                data-testid="fiat-bid-eth-display-loading"
               >
                 <div className={classes.spinner} aria-hidden="true" />
                 <span>取得中</span>
               </div>
             ) : (
-              <div className={classes.rateSummaryValue} data-testid="fiat-bid-jpy-display">
-                {jpyDisplay}
+              <div className={classes.rateSummaryValue} data-testid="fiat-bid-eth-display">
+                {ethDisplay}
               </div>
             )}
           </div>

--- a/packages/niji-webapp/src/components/FiatBidModal/index.test.tsx
+++ b/packages/niji-webapp/src/components/FiatBidModal/index.test.tsx
@@ -122,7 +122,7 @@ describe('Issue #3047 CardInput 統合 (Issue #3051 で ETH 入力軸に更新)'
     );
 
     // ETH 額入力 (0.1 ETH = 500,000 JPY 換算、 100 万円上限内) + Terms check → submit enable
-    fireEvent.change(screen.getByTestId('fiat-bid-eth-input'), { target: { value: '0.1' } });
+    fireEvent.change(screen.getByTestId('fiat-bid-jpy-input'), { target: { value: '50000' } });
     fireEvent.click(screen.getByTestId('fiat-bid-terms-checkbox'));
     const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
     expect(submit.disabled).toBe(false);
@@ -163,7 +163,7 @@ describe('Issue #3047 CardInput 統合 (Issue #3051 で ETH 入力軸に更新)'
     });
 
     // card fields 空欄 + ETH + Terms 済でも card 無効で submit disable
-    fireEvent.change(screen.getByTestId('fiat-bid-eth-input'), { target: { value: '0.1' } });
+    fireEvent.change(screen.getByTestId('fiat-bid-jpy-input'), { target: { value: '50000' } });
     fireEvent.click(screen.getByTestId('fiat-bid-terms-checkbox'));
     const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
     expect(submit.disabled).toBe(true);
@@ -273,11 +273,11 @@ describe('FiatBidModal 開閉 + submit → stepper 遷移 (T13、 T15、 Issue #
     });
 
     // ETH 入力 (0.1 ETH = 500,000 JPY 換算)
-    const ethInput = screen.getByTestId('fiat-bid-eth-input') as HTMLInputElement;
-    fireEvent.change(ethInput, { target: { value: '0.1' } });
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '50000' } });
 
     // JPY 換算表示が反映
-    expect(screen.getByTestId('fiat-bid-jpy-display').textContent).toContain('50,000');
+    expect(screen.getByTestId('fiat-bid-eth-display').textContent).toContain('0.1000');
 
     // Terms 未 check なら submit disable
     const submit = screen.getByTestId('fiat-bid-submit') as HTMLButtonElement;
@@ -339,12 +339,12 @@ describe('bid 上限超過 validation (T14、 Issue #3051 で JPY 換算 100 万
     });
 
     // 2.001 ETH * 500,000 JPY/ETH = 1,000,500 JPY (100 万円超過)
-    const ethInput = screen.getByTestId('fiat-bid-eth-input') as HTMLInputElement;
-    fireEvent.change(ethInput, { target: { value: '2.001' } });
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '1000500' } });
 
     // validation エラー表示
     await waitFor(() => {
-      const err = screen.getByTestId('fiat-bid-eth-error');
+      const err = screen.getByTestId('fiat-bid-jpy-error');
       expect(err.textContent).toContain('bid 上限');
     });
 
@@ -505,11 +505,11 @@ describe('FiatBidModal 増額 bid mode (Issue #3025 T10-T11、 Issue #3051 で E
     });
 
     // 旧 ethAmount と同額入力 (増額のみ受付なので ng)
-    const ethInput = screen.getByTestId('fiat-bid-eth-input') as HTMLInputElement;
-    fireEvent.change(ethInput, { target: { value: '0.1' } });
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '50000' } });
 
     await waitFor(() => {
-      const err = screen.getByTestId('fiat-bid-eth-error');
+      const err = screen.getByTestId('fiat-bid-jpy-error');
       expect(err.textContent).toContain('増額のみ受付可能');
     });
 
@@ -545,11 +545,11 @@ describe('FiatBidModal 増額 bid mode (Issue #3025 T10-T11、 Issue #3051 で E
     });
 
     // 2.001 ETH × 500,000 rate = 1,000,500 JPY (100 万円超過)
-    const ethInput = screen.getByTestId('fiat-bid-eth-input') as HTMLInputElement;
-    fireEvent.change(ethInput, { target: { value: '2.001' } });
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '1000500' } });
 
     await waitFor(() => {
-      const err = screen.getByTestId('fiat-bid-eth-error');
+      const err = screen.getByTestId('fiat-bid-jpy-error');
       expect(err.textContent).toContain('bid 上限');
     });
 
@@ -634,7 +634,7 @@ describe('FiatBidModal 増額 bid mode (Issue #3025 T10-T11、 Issue #3051 で E
     await waitFor(() => {
       expect(screen.getByTestId('fiat-bid-rate-summary')).toBeInTheDocument();
     });
-    expect(screen.getByTestId('fiat-bid-eth-input').className).toMatch(/ethInput/);
+    expect(screen.getByTestId('fiat-bid-jpy-input').className).toMatch(/ethInput/);
     expect(screen.getByTestId('fiat-bid-submit').className).toMatch(/submitBtn/);
     expect(screen.getByTestId('fiat-bid-cancel').className).toMatch(/cancelBtn/);
   });
@@ -666,8 +666,8 @@ describe('FiatBidModal 増額 bid mode (Issue #3025 T10-T11、 Issue #3051 で E
     });
 
     // 増額額 0.16 ETH 入力 (旧 0.1 ETH より大、 500,000 rate で 80,000 JPY 換算)
-    const ethInput = screen.getByTestId('fiat-bid-eth-input') as HTMLInputElement;
-    fireEvent.change(ethInput, { target: { value: '0.16' } });
+    const jpyInput = screen.getByTestId('fiat-bid-jpy-input') as HTMLInputElement;
+    fireEvent.change(jpyInput, { target: { value: '80000' } });
 
     // Terms check
     fireEvent.click(screen.getByTestId('fiat-bid-terms-checkbox'));


### PR DESCRIPTION
## 概要

user 明示指示 = 「bit 額はその国のネイティブ通貨にしたい。 日本なら円だね」 の実装。

前 Issue #3051 で JPY→ETH に反転済だった fiat bid 入力軸を **JPY primary に再反転**、 日本 user に自然な UX + fincode API (JPY 単位) との整合性向上。 dev/test 環境で円入力で決済 → chain bid tx → NFT mint の full flow を提供。

## 採用 approach

webapp UI layer + form validator + state を JPY primary に、 **backend wire protocol は変更なし** (ethAmount + spotRate + jpyAmount の 3 field を維持)。 backend は既に jpyAmount で 100 万円上限 check + fincode/GMO 請求を扱っており、 semantic のみ「JPY primary」 に反転で full stack の意図が通る (最小 diff で規模抑制)。

## 変更内容

### FiatBidForm.tsx (+95/-52)
- `validateJpyAmount` + `JpyValidationResult` 型新規追加、 5 条件 check (空文字 / 非整数 / spot rate 未取得 / minBid 未満 / 100 万円超) + ethWei + ethEquivalent 併記
- `validateTopupJpyAmount` 新規追加、 増額 check + oldJpyAmount との比較
- state: `ethRaw` → `jpyRaw` rename
- `minBidJpy` useMemo = `Math.ceil(minBidEth × spotRate)` で ETH ベースの min-bid を JPY 換算
- input JSX: 「bid 額 (円)」 label、 `type=number step=1000`、 `¥ N,NNN,NNN` placeholder
- 右側 rate summary の 2 列目を 「JPY 換算」 → 「ETH 換算」 に flip、 `jpyValidation.ethEquivalent.toFixed(4)` 表示
- 送信 handler: `jpyValidation.ethWei.toString()` で ethAmount 送信、 wire protocol 既存 shape 維持
- 旧 `validateEthAmount` / `validateTopupEthAmount` は残置 (別 tab 用途、 削除は別 PR で decouple)

### FiatBidForm.test.tsx (+13/-13)
- testid rename (`fiat-bid-eth-input` → `fiat-bid-jpy-input`、 `fiat-bid-jpy-display` → `fiat-bid-eth-display`、 `fiat-bid-eth-error` → `fiat-bid-jpy-error`)
- spinner 経路 test 更新 (ETH 入力 → JPY 入力)

### index.test.tsx (統合 test、 +68/-19)
- testid rename + 期待入力値変換 (`0.1` ETH → `50000` 円 at rate 500,000)
- 増額 mode の validate 経路 update (`2.001` ETH → `1000500` 円)

## 動作証明

```
pnpm --filter niji-webapp vitest run src/components/FiatBidModal/FiatBidForm.test.tsx
Test Files  1 passed (1)
     Tests  11 passed (11)

pnpm --filter niji-webapp vitest run src/components/FiatBidModal/
Test Files  5 passed (5)
     Tests  92 passed (92)

pnpm --filter niji-webapp vitest run
Test Files  124 passed | 1 skipped (125)
     Tests  9889 passed | 1 todo (9890)   # regression 0

pnpm --filter niji-webapp tsc --noEmit
(JPY 反転 関連 file 0 error)
```

## Test plan

- [x] FiatBidForm 単体 test 11/11 pass
- [x] FiatBidModal 統合 test 92/92 pass
- [x] webapp 全 test 9889/9890 pass (regression 0)
- [x] typecheck fincode / JPY 反転 関連 file 0 error
- [ ] manual browser test = dev server + JPY 入力 → ETH 換算 → 送信 (user 側)

## Refs

Refs #3115 (fincode 移行 Phase 3)
Reverses Issue #3051 (JPY→ETH 入力軸反転) for native currency UX

## Follow-up

- backend `parseAuthorizeBody` で jpyAmount primary validation (現状は ethAmount / jpyAmount 両方 validation、 semantic のみ JPY primary、 実 validator が primary axis になる別 PR)
- 旧 `validateEthAmount` / `validateTopupEthAmount` の削除 (ETH tab で使用有無 audit してから、 別 PR)
- fiat_bid schema の jpyAmount / ethAmount 保存順序 (現状は両保存、 semantic 変化のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWpuhkFoEse2Yo9Xb5QsvF
