### PR TITLE
🐛 fix(niji-webapp): Vite dev proxy fallback = spot rate 取得中 症状の構造的 fix (Refs #3115)

### DIFF
--- a/packages/niji-webapp/vite.config.ts
+++ b/packages/niji-webapp/vite.config.ts
@@ -67,6 +67,19 @@ export default defineConfig({
     hmr: {
       overlay: true,
     },
+    // dev 環境で VITE_GMO_API_ENDPOINT_SPOT_RATE / VITE_GMO_API_ENDPOINT が .env に未設定の場合の
+    // fallback 経路として、 相対 URL /api/v1/... を Ponder (42069) + spot-rate-server (42070) に proxy する。
+    // env 明示設定時は resolveSpotRateEndpoint が絶対 URL を返し fetch は proxy を経由しない (優先度低)。
+    proxy: {
+      '/api/v1/spot-rate': {
+        target: 'http://127.0.0.1:42070',
+        changeOrigin: true,
+      },
+      '/api/v1/fiat-bid': {
+        target: 'http://127.0.0.1:42069',
+        changeOrigin: true,
+      },
+    },
   },
   // build 時のみ 30MB niji-data-rle.json を JSON.parse で lazy 展開 (dev では逆効果のため無効)。
   json: {


### PR DESCRIPTION
## 概要

user 症状 = 「spot rate ずっと取得中」 の Playwright headless 実測診断で root cause 特定 → Vite dev proxy fallback で構造的 fix。

## 検出した root cause (Playwright 実測診断)

webapp を実 browser 上で load + `resolveSpotRateEndpoint()` + `fetch()` を browser context で実行:

- webapp `.env` に `VITE_GMO_API_ENDPOINT_SPOT_RATE` (推奨経路) も `VITE_GMO_API_ENDPOINT` (fallback) も未設定
- `resolveSpotRateEndpoint()` = 空文字列 return
- fetch URL = 相対 `/api/v1/spot-rate/eth-jpy` = `http://localhost:2424/api/v1/spot-rate/eth-jpy` (webapp origin)
- webapp Vite dev server = HTTP 404 return (routing なし)
- useSpotRate query = error 状態 → UI「取得中」 spinner 継続 = user 症状

## 修正内容

`packages/niji-webapp/vite.config.ts` server.proxy 追加 (2 経路):

```typescript
proxy: {
  '/api/v1/spot-rate': {
    target: 'http://127.0.0.1:42070',
    changeOrigin: true,
  },
  '/api/v1/fiat-bid': {
    target: 'http://127.0.0.1:42069',
    changeOrigin: true,
  },
},
```

- `/api/v1/spot-rate` → `127.0.0.1:42070` (spot-rate-server、 Ponder 非依存)
- `/api/v1/fiat-bid` → `127.0.0.1:42069` (Ponder + Hono、 fincode / GMO 経路)

user が `.env` 設定を忘れても dev 環境で相対 URL 経路で backend 到達、 「取得中」 spinner 症状を構造的解消。 env 明示設定時は resolveSpotRateEndpoint が absolute URL 返して proxy 迂回 = 従来経路互換。

## 動作証明

### 修正前 (fix 前の症状)

```
resolveSpotRateEndpoint() → ""
fetch('/api/v1/spot-rate/eth-jpy') → HTTP 404 (webapp 2424 origin ヒット)
useSpotRate: error 状態 → UI 「取得中」 spinner
```

### 修正後 (Vite proxy 経由)

```
curl http://localhost:2424/api/v1/spot-rate/eth-jpy
→ {"rate":309819,"source":"gmo-coin","cachedAt":...,"expiresAt":...}

Playwright browser fetch:
{ok: true, status: 200, body: {rate: 309819, source: "gmo-coin"}}
```

## 影響範囲

- **production build 影響 0** = `server` は Vite dev server 専用 config、 production build (dist/) には含まれない
- **security 面**: proxy target は localhost port 42070 / 42069 (dev-only backend)、 external 経路露出なし
- **env 明示設定時の挙動**: `resolveSpotRateEndpoint()` が absolute URL 返す時、 fetch は proxy 経由せず直接 backend を叩く = 従来経路互換
- **test regression risk 0**: unit test は fetcher option で mock 差替 (proxy 経路を通らない)、 e2e test も page.route intercept で proxy 経路 bypass

## Test plan

- [x] curl 経由 spot rate 応答実測 (`{"rate":309819,...}`)
- [x] Playwright headless browser fetch 実測 (`ok: true, status: 200`)
- [x] production build 影響なし (Vite dev server 専用 config)
- [x] env 明示設定時の absolute URL 経路互換

## Refs

Refs #3115 (fincode 移行 Phase 3)
Complements Issue #3065 (spot-rate-server 独立化) with dev proxy fallback

## Follow-up

- webapp `.env.example.local` に `VITE_GMO_API_ENDPOINT_SPOT_RATE` の推奨値記載強化 (別 PR、 docs polish)
- 全 dev env の setup script 化 (別 PR、 `pnpm setup:test-env` 経路整備)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWpuhkFoEse2Yo9Xb5QsvF
