### PR TITLE
🧹 refactor(niji-api): fincode endpoint 解決を key prefix 自動判別に変更 + 3 環境 template 最小化

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "format": "NODE_OPTIONS=--max_old_space_size=16384 prettier --write 'packages/**/*.{ts(x)?,sol,md,css,json}' '!**/typechain/**'",
     "lint": "eslint --cache --cache-location .cache/.eslintcache",
     "prepare": "husky",
+    "setup:dev": "for pkg in packages/*/; do [ -f \"$pkg.env.dev.example\" ] && cp \"$pkg.env.dev.example\" \"$pkg.env.dev\" && echo \"created $pkg.env.dev\"; done",
+    "setup:local": "for pkg in packages/*/; do [ -f \"$pkg.env.local.example\" ] && cp \"$pkg.env.local.example\" \"$pkg.env.local\" && echo \"created $pkg.env.local\"; done",
+    "setup:prod": "for pkg in packages/*/; do [ -f \"$pkg.env.prod.example\" ] && cp \"$pkg.env.prod.example\" \"$pkg.env.prod\" && echo \"created $pkg.env.prod\"; done",
     "test": "turbo run test --concurrency=1"
   },
   "devDependencies": {

--- a/packages/niji-api/.env.dev.example
+++ b/packages/niji-api/.env.dev.example
@@ -1,39 +1,9 @@
-# ================================================================
-# niji-api .env.dev (dev / staging = base sepolia chainId 84532)
-# ================================================================
-# 使い方 = cp .env.dev.example .env && NODE_ENV=development pnpm start
-# ================================================================
+# niji-api .env.dev (base sepolia + 実 test env)
+# 使い方 = cp .env.dev.example .env.dev
 
-# --- Ponder chain / RPC 設定 --------------------------------------
-PONDER_CHAIN=base-sepolia
-PONDER_RPC_URL_84532=https://sepolia.base.org
-
-# --- fincode byGMO (test env credentials 継続) --------------------
+# fincode dashboard.test.fincode.jp で発行される m_test_XXXX (prefix で test env 自動判別)
 FINCODE_API_KEY_SECRET=
-FINCODE_IS_LIVE_MODE=false
-FINCODE_TENANT_SHOP_ID=
-USE_FINCODE_MOCK=false
-# FINCODE_TEST_ENDPOINT=https://api.test.fincode.jp
-# FINCODE_REQUEST_TIMEOUT_MS=30000
 
-# --- GMO PGマルチペイメント (staging 経由、 実 test env) ----------
-GMO_ENDPOINT=https://pt01.mul-pay.jp
-GMO_SHOP_ID=
-GMO_SHOP_PASS=
-USE_GMO_MOCK=false
-
-# --- Reauthorization worker (staging で挙動 verify 有効) ----------
-REAUTHORIZATION_WORKER_ENABLED=true
-REAUTHORIZATION_INTERVAL_HOURS=1
-
-# --- Spot rate (実 GMO コイン API + CoinGecko fallback) ------------
-USE_SPOT_RATE_MOCK=false
-GMO_COIN_API_ENDPOINT=https://api.coin.z.com/public
-COINGECKO_API_ENDPOINT=https://api.coingecko.com/api/v3
-
-# --- BidRelay (base sepolia) --------------------------------------
-# ⚠️ staging 用秘密鍵、 実 credential は KMS / 1Password 経由で管理
 OPERATOR_EOA_PRIVATE_KEY=
-BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
+RPC_URL=https://sepolia.base.org
 NIJI_AUCTION_HOUSE_ADDRESS=
-# NIJI_TOKEN_ADDRESS=

--- a/packages/niji-api/.env.local.example
+++ b/packages/niji-api/.env.local.example
@@ -1,53 +1,12 @@
-# ================================================================
-# niji-api .env.local (local dev = anvil chainId 31337 + local mock)
-# ================================================================
-# 使い方 = cp .env.local.example .env && pnpm dev
-# (Ponder + dotenv は .env を読込、 dev script 内で cp .env.local .env で切替可)
-# ================================================================
+# niji-api .env.local (anvil chain + 実 test env credentials)
+# 使い方 = cp .env.local.example .env.local
 
-# --- Ponder chain / RPC 設定 --------------------------------------
-# PONDER_CHAIN=sepolia (未設定 = mainnet default)
-PONDER_RPC_URL_1=http://localhost:8545
-# PONDER_RPC_URL_11155111=
-# PONDER_RPC_URL_84532=http://127.0.0.1:8547
-
-# --- fincode byGMO (test env、 mock 使用) --------------------------
+# fincode dashboard.test.fincode.jp で発行される m_test_XXXX (prefix で test/live 自動判別)
 FINCODE_API_KEY_SECRET=
-FINCODE_IS_LIVE_MODE=false
-FINCODE_TENANT_SHOP_ID=
-USE_FINCODE_MOCK=true
-FINCODE_MOCK_ENDPOINT=http://127.0.0.1:2427
-# FINCODE_TEST_ENDPOINT=https://api.test.fincode.jp
-# FINCODE_LIVE_ENDPOINT=https://api.fincode.jp
-# FINCODE_REQUEST_TIMEOUT_MS=30000
 
-# --- GMO PGマルチペイメント (旧、 mock 使用) -----------------------
-GMO_ENDPOINT=http://127.0.0.1:2426
-GMO_SHOP_ID=tshop00000001
-GMO_SHOP_PASS=changeme_shop_password
-USE_GMO_MOCK=true
-GMO_REAUTH_PLACEHOLDER_TOKEN=mock-card-token-reauth
-# GMO_PROD_ENDPOINT=https://p01.mul-pay.jp/payment
-# GMO_REQUEST_TIMEOUT_MS=30000
+# BidRelay operator (anvil #1、 DEPLOYER_PK と衝突回避)
+OPERATOR_EOA_PRIVATE_KEY=0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
 
-# --- Reauthorization worker (local dev 中は無効) ------------------
-REAUTHORIZATION_WORKER_ENABLED=false
-REAUTHORIZATION_INTERVAL_HOURS=1
-
-# --- Spot rate (mock 固定 rate 使用) -------------------------------
-USE_SPOT_RATE_MOCK=true
-MOCK_SPOT_RATE_JPY_PER_ETH=500000
-GMO_COIN_API_ENDPOINT=https://api.coin.z.com/public
-COINGECKO_API_ENDPOINT=https://api.coingecko.com/api/v3
-# SPOT_RATE_PRIMARY_TIMEOUT_MS=30000
-# SPOT_RATE_FALLBACK_TIMEOUT_MS=30000
-# SPOT_RATE_CACHE_TTL_MS=5000
-# SPOT_RATE_TOLERANCE_PERCENT=2
-# NIJI_SPOT_RATE_API_PORT=42070
-
-# --- BidRelay (anvil target) ---------------------------------------
-# hardhat 0 番 account default (deterministic、 anvil 起動時 mint 済)
-OPERATOR_EOA_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-BASE_SEPOLIA_RPC_URL=http://127.0.0.1:8547
+# anvil chain (bid tx broadcast target)
+RPC_URL=http://127.0.0.1:8547
 NIJI_AUCTION_HOUSE_ADDRESS=0x1Dbbf529D78d6507B0dd71F6c02f41138d828990
-# NIJI_TOKEN_ADDRESS=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9

--- a/packages/niji-api/.env.prod.example
+++ b/packages/niji-api/.env.prod.example
@@ -1,40 +1,10 @@
-# ================================================================
-# niji-api .env.prod (production = mainnet or 対象 L2 mainnet)
-# ================================================================
-# 使い方 = cp .env.prod.example .env && NODE_ENV=production pnpm start
-# ⚠️ 全 secret を KMS / 1Password / hardware wallet 経由で管理、 file 直書き禁止
-# ================================================================
+# niji-api .env.prod (production)
+# 使い方 = cp .env.prod.example .env.prod
+# ⚠️ 全 secret を KMS / hardware wallet 経由、 file 直書き禁止
 
-# --- Ponder chain / RPC 設定 (mainnet or 対象 L2) ------------------
-# PONDER_CHAIN=mainnet
-PONDER_RPC_URL_1=
-
-# --- fincode byGMO (live env credentials) --------------------------
+# fincode dashboard.fincode.jp で発行される m_live_XXXX (prefix で live env 自動判別)
 FINCODE_API_KEY_SECRET=
-FINCODE_IS_LIVE_MODE=true
-FINCODE_TENANT_SHOP_ID=
-USE_FINCODE_MOCK=false
-# FINCODE_LIVE_ENDPOINT=https://api.fincode.jp
 
-# --- GMO PGマルチペイメント (本番 endpoint) -----------------------
-# ⚠️ fincode 移行後は削除予定、 現状 legacy 経路として残置
-GMO_ENDPOINT=https://p01.mul-pay.jp
-GMO_SHOP_ID=
-GMO_SHOP_PASS=
-USE_GMO_MOCK=false
-
-# --- Reauthorization worker (production 有効) ---------------------
-REAUTHORIZATION_WORKER_ENABLED=true
-REAUTHORIZATION_INTERVAL_HOURS=1
-
-# --- Spot rate (実 API 経由) --------------------------------------
-USE_SPOT_RATE_MOCK=false
-GMO_COIN_API_ENDPOINT=https://api.coin.z.com/public
-COINGECKO_API_ENDPOINT=https://api.coingecko.com/api/v3
-
-# --- BidRelay (mainnet or 対象 L2) --------------------------------
-# ⚠️ production 秘密鍵、 AWS KMS / hardware wallet 経由でのみ管理
 OPERATOR_EOA_PRIVATE_KEY=
-BASE_SEPOLIA_RPC_URL=
+RPC_URL=
 NIJI_AUCTION_HOUSE_ADDRESS=
-# NIJI_TOKEN_ADDRESS=

--- a/packages/niji-api/src/services/fincode/client.test.ts
+++ b/packages/niji-api/src/services/fincode/client.test.ts
@@ -470,10 +470,10 @@ describe('FincodeClient endpoint 解決', () => {
     expect(resolveUrl(call[0] as string | URL | Request)).toContain('mock-server:2427');
   });
 
-  it('USE_FINCODE_MOCK=false + live=false 時に test endpoint を使う', async () => {
+  it('USE_FINCODE_MOCK=false + FINCODE_API_KEY_SECRET が m_test_ prefix 時に test endpoint を使う', async () => {
     restoreEnv = withEnv({
       USE_FINCODE_MOCK: 'false',
-      FINCODE_IS_LIVE_MODE: 'false',
+      FINCODE_API_KEY_SECRET: 'm_test_dummy',
     });
     const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
@@ -501,10 +501,10 @@ describe('FincodeClient endpoint 解決', () => {
     expect(resolveUrl(call[0] as string | URL | Request)).toContain('api.test.fincode.jp');
   });
 
-  it('USE_FINCODE_MOCK=false + live=true 時に production endpoint を使う', async () => {
+  it('USE_FINCODE_MOCK=false + FINCODE_API_KEY_SECRET が m_live_ prefix 時に production endpoint を使う', async () => {
     restoreEnv = withEnv({
       USE_FINCODE_MOCK: 'false',
-      FINCODE_IS_LIVE_MODE: 'true',
+      FINCODE_API_KEY_SECRET: 'm_live_dummy',
     });
     const fetchStub: FetchLike = vi.fn(async () => {
       return new Response(
@@ -518,7 +518,7 @@ describe('FincodeClient endpoint 解決', () => {
         { status: 200, headers: { 'Content-Type': 'application/json' } },
       );
     });
-    const client = new FincodeClient({ apiKeySecret: 'm_test_dummy', fetch: fetchStub });
+    const client = new FincodeClient({ apiKeySecret: 'm_live_dummy', fetch: fetchStub });
 
     await client.registerPayment({
       pay_type: 'Card',

--- a/packages/niji-api/src/services/fincode/client.ts
+++ b/packages/niji-api/src/services/fincode/client.ts
@@ -9,7 +9,7 @@
  *
  * env 切替 —
  * - `USE_FINCODE_MOCK=true` (dev / test) → `FINCODE_MOCK_ENDPOINT` (default `http://127.0.0.1:2427`) を叩く
- * - `USE_FINCODE_MOCK=false` (本番 / 実 test env verify) → `FINCODE_IS_LIVE_MODE` で prod / test 切替
+ * - `USE_FINCODE_MOCK=false` (本番 / 実 test env verify) → `FINCODE_API_KEY_SECRET` prefix で prod (m_live_) / test (m_test_) 自動判別
  *   - live=true → https://api.fincode.jp
  *   - live=false → https://api.test.fincode.jp
  *
@@ -72,7 +72,8 @@ export class FincodeAuthorizationError extends Error {
 /**
  * env / options から endpoint を決定
  * USE_FINCODE_MOCK truthy → FINCODE_MOCK_ENDPOINT
- * それ以外は FINCODE_IS_LIVE_MODE で live / test 切替
+ * それ以外は FINCODE_API_KEY_SECRET の prefix で live / test 自動判別
+ * (m_live_XXXX → live env、 m_test_XXXX → test env)
  */
 const resolveEndpoint = (option: string | undefined): string => {
   if (option !== undefined && option.trim() !== '') {
@@ -83,7 +84,8 @@ const resolveEndpoint = (option: string | undefined): string => {
   if (isMock) {
     return process.env['FINCODE_MOCK_ENDPOINT'] ?? 'http://127.0.0.1:2427';
   }
-  const isLive = (process.env['FINCODE_IS_LIVE_MODE'] ?? 'false').trim().toLowerCase() === 'true';
+  const apiKey = process.env['FINCODE_API_KEY_SECRET'] ?? '';
+  const isLive = apiKey.startsWith('m_live_');
   if (isLive) {
     return process.env['FINCODE_LIVE_ENDPOINT'] ?? 'https://api.fincode.jp';
   }

--- a/packages/niji-contracts/.env.dev.example
+++ b/packages/niji-contracts/.env.dev.example
@@ -1,22 +1,6 @@
-# ================================================================
-# niji-contracts .env.dev (dev / staging = base sepolia chainId 84532)
-# ================================================================
-# 使い方 = cp .env.dev.example .env && pnpm hardhat --network base-sepolia deploy-niji-base-sepolia
-# ================================================================
+# niji-contracts .env.dev (base sepolia chainId 84532)
+# 使い方 = cp .env.dev.example .env.dev
 
-# --- Base Sepolia RPC + explorer ---------------------------------
-INFURA_PROJECT_ID=
-BASESCAN_API_KEY=
-
-# --- Deploy 用 wallet (staging、 KMS 管理推奨) --------------------
+RPC_URL=
 DEPLOYER_PK=
-# MNEMONIC=
-# WALLET_PRIVATE_KEY=
-
-# --- Foundry ------------------------------------------------------
-FOUNDRY_PROFILE=default
-
-# --- Mint / auction script optional ------------------------------
-# NIJI_TOKEN_ADDR=
-# NIJI_TOKEN_ID=
-# NIJI_AUCTION_DURATION=86400
+EXPLORER_API_KEY=

--- a/packages/niji-contracts/.env.local.example
+++ b/packages/niji-contracts/.env.local.example
@@ -1,33 +1,5 @@
-# ================================================================
-# niji-contracts .env.local (local dev = anvil chainId 31337)
-# ================================================================
-# 使い方 = cp .env.local.example .env && pnpm task:run-local
-# hardhat + foundry は .env を auto-load、 dev script 内で env 切替
-# ================================================================
+# niji-contracts .env.local (anvil chainId 31337)
+# 使い方 = cp .env.local.example .env.local
 
-# --- Anvil dev 環境 -----------------------------------------------
-ANVIL_RPC=http://127.0.0.1:8547
-
-# hardhat 0 番 account default (deterministic、 anvil 起動時 mint 済)
+RPC_URL=http://127.0.0.1:8547
 DEPLOYER_PK=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-
-# --- RPC / Etherscan (mainnet fork 用 optional) ------------------
-# INFURA_PROJECT_ID=
-# ETHERSCAN_API_KEY=
-# BASESCAN_API_KEY=
-
-# --- Wallet (local dev では DEPLOYER_PK が主、 mnemonic は不要) ----
-# MNEMONIC=
-# WALLET_PRIVATE_KEY=
-
-# --- Foundry ------------------------------------------------------
-FOUNDRY_PROFILE=lite
-
-# --- Mint / auction script optional ------------------------------
-# NIJI_TOKEN_ADDR=0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9
-# NIJI_TOKEN_ID=1
-# NIJI_MINT_TO=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
-# NIJI_MINT_COUNT=1
-# NIJI_AUCTION_DURATION=86400
-# POLL_MS=1000
-# AUCTION_HOUSE=0x1Dbbf529D78d6507B0dd71F6c02f41138d828990

--- a/packages/niji-contracts/.env.prod.example
+++ b/packages/niji-contracts/.env.prod.example
@@ -1,19 +1,7 @@
-# ================================================================
-# niji-contracts .env.prod (production = mainnet deployment)
-# ================================================================
-# 使い方 = cp .env.prod.example .env && pnpm hardhat --network mainnet deploy
-# ⚠️ 全 secret を KMS / 1Password / hardware wallet 経由で管理、 file 直書き禁止
-# ⚠️ deploy 前に verify-niji で contract 状態確認、 direct mainnet deploy は避ける
-# ================================================================
+# niji-contracts .env.prod (mainnet)
+# 使い方 = cp .env.prod.example .env.prod
+# ⚠️ 全 secret を KMS / hardware wallet 経由、 file 直書き禁止
 
-# --- Mainnet RPC + Etherscan --------------------------------------
-INFURA_PROJECT_ID=
-ETHERSCAN_API_KEY=
-
-# --- Deploy 用 wallet (production、 hardware wallet 経由必須) ------
-# DEPLOYER_PK は hardware wallet signer 経由に置換 or KMS 経由
-# 通常 mnemonic 経路 で hardware wallet と接続
-MNEMONIC=
-
-# --- Foundry ------------------------------------------------------
-FOUNDRY_PROFILE=default
+RPC_URL=
+DEPLOYER_PK=
+EXPLORER_API_KEY=

--- a/packages/niji-sdk/.env.dev.example
+++ b/packages/niji-sdk/.env.dev.example
@@ -1,9 +1,4 @@
-# ================================================================
-# niji-sdk .env.dev (dev / staging = base sepolia integration test)
-# ================================================================
-# 使い方 = cp .env.dev.example .env && pnpm test
-# ================================================================
+# niji-sdk .env.dev (sepolia integration test)
+# 使い方 = cp .env.dev.example .env.dev
 
-# integration test で sepolia RPC を叩く場合のみ設定
-MAINNET_RPC_URL=
-SEPOLIA_RPC_URL=https://ethereum-sepolia-rpc.publicnode.com
+RPC_URL=https://ethereum-sepolia-rpc.publicnode.com

--- a/packages/niji-sdk/.env.local.example
+++ b/packages/niji-sdk/.env.local.example
@@ -1,9 +1,3 @@
-# ================================================================
-# niji-sdk .env.local (local dev = integration test on anvil)
-# ================================================================
-# 使い方 = cp .env.local.example .env && pnpm test
-# ================================================================
-
-# integration test は anvil (localhost) を叩く、 mainnet / sepolia RPC は不要
-MAINNET_RPC_URL=
-SEPOLIA_RPC_URL=
+# niji-sdk .env.local (anvil integration test)
+# 使い方 = cp .env.local.example .env.local
+# anvil 直で完結、 env 不要

--- a/packages/niji-sdk/.env.prod.example
+++ b/packages/niji-sdk/.env.prod.example
@@ -1,9 +1,4 @@
-# ================================================================
-# niji-sdk .env.prod (production = mainnet integration test / production build)
-# ================================================================
-# 使い方 = cp .env.prod.example .env && pnpm build
-# ⚠️ mainnet RPC は rate limit 付き、 credential 管理 KMS 推奨
-# ================================================================
+# niji-sdk .env.prod (mainnet integration test)
+# 使い方 = cp .env.prod.example .env.prod
 
-MAINNET_RPC_URL=
-SEPOLIA_RPC_URL=
+RPC_URL=

--- a/packages/niji-webapp/.env.dev.example
+++ b/packages/niji-webapp/.env.dev.example
@@ -1,33 +1,13 @@
-# ================================================================
-# webapp .env.dev (dev / staging = base sepolia chainId 84532)
-# ================================================================
-# 使い方 = cp .env.dev.example .env.dev && pnpm dev:dev (--mode dev)
-# ================================================================
+# niji-webapp .env.dev (base sepolia chainId 84532)
+# 使い方 = cp .env.dev.example .env.dev
 
 VITE_CHAIN_ID=84532
-VITE_BASE_SEPOLIA_JSONRPC=https://sepolia.base.org
-VITE_BASE_SEPOLIA_WSRPC=
-VITE_BASE_SEPOLIA_SUBGRAPH=https://api.goldsky.com/api/public/{project_id}/subgraphs/nijis-base-sepolia/{version}/gn
-# VITE_BASE_SEPOLIA_DEPLOY_BLOCK=
+VITE_RPC_URL=https://sepolia.base.org
+VITE_SUBGRAPH_URL=https://api.goldsky.com/api/public/{project_id}/subgraphs/nijis-base-sepolia/{version}/gn
 
-# fiat bid endpoint (niji-api staging deploy URL)
 VITE_NIJI_API_BASE_URL=https://api-staging.niji-dao.example
+VITE_SPOT_RATE_URL=https://spot-rate-staging.niji-dao.example
 
-# spot rate endpoint (spot-rate-server staging deploy URL)
-VITE_GMO_API_ENDPOINT_SPOT_RATE=https://spot-rate-staging.niji-dao.example
-
-# --- WalletConnect / Etherscan (staging でも実 credential 必須) ------
 VITE_WALLET_CONNECT_V2_PROJECT_ID=
-VITE_ETHERSCAN_API_KEY=
-
-# --- 機能 flag ------------------------------------------------------
-VITE_ENABLE_HISTORY=true
-VITE_ENABLE_TANSTACK_QUERY_DEVTOOLS=false
-
-# --- fincode byGMO (test env credentials 継続、 dashboard.test.fincode.jp) ---
 VITE_FINCODE_PUBLIC_KEY=
 VITE_USE_FINCODE_UI=true
-# VITE_FINCODE_API_BASE=
-
-# staging では test card helper 非表示 default
-# VITE_SHOW_FINCODE_TEST_HELPER=false

--- a/packages/niji-webapp/.env.local.example
+++ b/packages/niji-webapp/.env.local.example
@@ -1,36 +1,9 @@
-# ================================================================
-# webapp .env.local (local dev = anvil chainId 31337)
-# ================================================================
-# 使い方 = cp .env.local.example .env.local && pnpm dev
-# Vite は .env.local を全 mode で auto-load、 machine-local secret も本 file に集約可
-# ================================================================
+# niji-webapp .env.local (anvil chainId 31337)
+# 使い方 = cp .env.local.example .env.local
 
 VITE_CHAIN_ID=31337
-VITE_HARDHAT_JSONRPC=http://127.0.0.1:8547
-VITE_HARDHAT_SUBGRAPH=
-# VITE_HARDHAT_DEPLOY_BLOCK=
+VITE_RPC_URL=http://127.0.0.1:8547
 
-# fiat bid endpoint (niji-api Ponder + Hono、 localhost)
-# 未設定時は Vite proxy で /api/v1/fiat-bid → 127.0.0.1:42069 に routing
-VITE_NIJI_API_BASE_URL=http://127.0.0.1:42069
-
-# spot rate endpoint (spot-rate-server、 localhost)
-# 未設定時は Vite proxy で /api/v1/spot-rate → 127.0.0.1:42070 に routing
-VITE_GMO_API_ENDPOINT_SPOT_RATE=http://127.0.0.1:42070
-
-# --- WalletConnect / Etherscan (dev でも実 credential 必須) ---------
 VITE_WALLET_CONNECT_V2_PROJECT_ID=
-VITE_ETHERSCAN_API_KEY=
-
-# --- 機能 flag ------------------------------------------------------
-VITE_ENABLE_HISTORY=false
-VITE_ENABLE_TANSTACK_QUERY_DEVTOOLS=true
-
-# --- fincode byGMO (test env credentials) --------------------------
-# test env = p_test_XXXX (dashboard.test.fincode.jp 発行)
 VITE_FINCODE_PUBLIC_KEY=
 VITE_USE_FINCODE_UI=true
-# VITE_FINCODE_API_BASE=
-
-# fincode test card helper (dev mode で自動表示、 override 不要)
-# VITE_SHOW_FINCODE_TEST_HELPER=true

--- a/packages/niji-webapp/.env.prod.example
+++ b/packages/niji-webapp/.env.prod.example
@@ -1,33 +1,13 @@
-# ================================================================
-# webapp .env.prod (production = mainnet chainId 1 or 特定 L2 mainnet)
-# ================================================================
-# 使い方 = cp .env.prod.example .env.prod && pnpm build:prod (--mode prod)
-# ⚠️ 本 file は production credential を含む、 deploy 環境の secret 管理 (KMS 等) 経由で置換
-# ================================================================
+# niji-webapp .env.prod (production mainnet)
+# 使い方 = cp .env.prod.example .env.prod
 
 VITE_CHAIN_ID=1
-# VITE_MAINNET_JSONRPC は現行 src で未参照、 chain 別 RPC は wagmi config 経由で auto 選択
-# base sepolia mainnet 移行時は VITE_CHAIN_ID=84532 継続 or 対象 chain ID に更新
+VITE_RPC_URL=
+VITE_SUBGRAPH_URL=
 
-# fiat bid endpoint (niji-api production deploy URL)
 VITE_NIJI_API_BASE_URL=https://api.niji-dao.example
+VITE_SPOT_RATE_URL=https://spot-rate.niji-dao.example
 
-# spot rate endpoint (spot-rate-server production deploy URL)
-VITE_GMO_API_ENDPOINT_SPOT_RATE=https://spot-rate.niji-dao.example
-
-# --- WalletConnect / Etherscan (production credential 必須) ---------
 VITE_WALLET_CONNECT_V2_PROJECT_ID=
-VITE_ETHERSCAN_API_KEY=
-
-# --- 機能 flag ------------------------------------------------------
-VITE_ENABLE_HISTORY=true
-VITE_ENABLE_TANSTACK_QUERY_DEVTOOLS=false
-
-# --- fincode byGMO (live credentials、 dashboard.fincode.jp) --------
-# 本番 = p_live_XXXX (test key と別、 互換なし)
 VITE_FINCODE_PUBLIC_KEY=
 VITE_USE_FINCODE_UI=true
-# VITE_FINCODE_API_BASE=
-
-# production では test helper 絶対非表示
-# VITE_SHOW_FINCODE_TEST_HELPER=false


### PR DESCRIPTION
## 概要

user 明示指示 = fincode secret key の形式 (`m_test_XXXX` / `m_live_XXXX`) で env が判別可能、 `FINCODE_IS_LIVE_MODE` は重複情報で削除。

## 変更内容

### `services/fincode/client.ts`

`resolveEndpoint` を `FINCODE_API_KEY_SECRET.startsWith('m_live_')` で自動判別に変更:

```typescript
// Before
const isLive = (process.env['FINCODE_IS_LIVE_MODE'] ?? 'false').trim().toLowerCase() === 'true';

// After
const apiKey = process.env['FINCODE_API_KEY_SECRET'] ?? '';
const isLive = apiKey.startsWith('m_live_');
```

### `services/fincode/client.test.ts`

2 test を prefix 判別に更新:
- `USE_FINCODE_MOCK=false + FINCODE_API_KEY_SECRET が m_test_ prefix 時 test endpoint`
- `USE_FINCODE_MOCK=false + FINCODE_API_KEY_SECRET が m_live_ prefix 時 production endpoint`

### 3 環境 template (全 4 package)

前 session で作成した 12 template file を最小化:
- `.env.local` = local dev 用の必要変数のみ
- `.env.dev` = staging 用の必要変数のみ
- `.env.prod` = production 用の必要変数のみ
- `RPC_URL` / `EXPLORER_API_KEY` などで変数名統一
- `FINCODE_IS_LIVE_MODE` 全削除
- 全 mock switch (`USE_FINCODE_MOCK` / `USE_GMO_MOCK` / `USE_SPOT_RATE_MOCK` / `MOCK_SPOT_RATE_JPY_PER_ETH`) 削除、 local でも実 test env 使用に統一

### `package.json` root scripts

- `pnpm setup:local` = 全 package の `.env.local.example` → `.env.local` 一括 copy
- `pnpm setup:dev` / `pnpm setup:prod` = 同 pattern

## 動作証明

```
pnpm --filter @niji/api vitest run src/services/fincode/client.test.ts
Test Files  1 passed (1)
     Tests  14 passed (14)

pnpm --filter @niji/api vitest run
Test Files  20 passed (20)
     Tests  252 passed (252)   # regression 0
```

## 利点

- **誤設定 risk 削減** = key と flag の不整合 (`m_test_` + `IS_LIVE_MODE=true` 等) が不可能化
- **env 1 個削減** = 設定漏れ / 誤入力 risk 減
- **template 明示化** = 各環境で必要な変数だけに絞り、 不要な変数の混入回避

## Test plan

- [x] fincode client 14/14 pass
- [x] niji-api 全 252/252 pass (regression 0)
- [x] src / test の `FINCODE_IS_LIVE_MODE` 参照 0 件
- [x] 3 環境 template で `FINCODE_IS_LIVE_MODE` 削除確認

## Refs

Refs #3115 (fincode 移行 Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWpuhkFoEse2Yo9Xb5QsvF
