### PR TITLE
🧹 refactor(niji-webapp): WalletConnect connector を project ID set 時のみ有効化、 local dev は MetaMask のみ

### DIFF
--- a/packages/niji-webapp/.env.local.example
+++ b/packages/niji-webapp/.env.local.example
@@ -1,8 +1,8 @@
 # niji-webapp .env.local (anvil chainId 31337)
 # 使い方 = cp .env.local.example .env.local
+# local dev は MetaMask (injected) のみ、 WalletConnect は不要
 
 VITE_CHAIN_ID=31337
 VITE_RPC_URL=http://127.0.0.1:8547
 
-VITE_WALLET_CONNECT_V2_PROJECT_ID=
 VITE_FINCODE_PUBLIC_KEY=

--- a/packages/niji-webapp/src/wagmi.ts
+++ b/packages/niji-webapp/src/wagmi.ts
@@ -53,23 +53,26 @@ const wagmiStorage =
       })
     : undefined;
 
+// WalletConnect connector は project ID 設定時のみ有効化。 local dev (anvil + MetaMask) では
+// reown 発行不要、 空文字で walletConnect connector を connectors 配列から除外する。
+// Base Sepolia / production では project ID 必須 (mobile wallet / QR 経路のため)。
+const connectors = [
+  // Coinbase Wallet connector は Analytics SDK が cca-lite.coinbase.com/metrics に
+  // 常時 telemetry POST (BLOCKED_BY_CLIENT で ad blocker との衝突多発)、 かつ SDK bundle
+  // が 100-200KB 追加される割に本 webapp の主 wallet ユースケースが MetaMask / WalletConnect
+  // 経由で完結するため除去 (Issue #3101、 サイト重い audit の Phase A)。
+  injected(),
+  ...(WALLET_CONNECT_V2_PROJECT_ID !== ''
+    ? [walletConnect({ projectId: WALLET_CONNECT_V2_PROJECT_ID, showQrModal: false })]
+    : []),
+];
+
 export const config = createConfig({
   chains: SUPPORTED_CHAINS,
   transports,
   storage: wagmiStorage,
   multiInjectedProviderDiscovery: true,
-  connectors: [
-    // Coinbase Wallet connector は Analytics SDK が cca-lite.coinbase.com/metrics に
-    // 常時 telemetry POST (BLOCKED_BY_CLIENT で ad blocker との衝突多発)、 かつ SDK bundle
-    // が 100-200KB 追加される割に本 webapp の主 wallet ユースケースが MetaMask / WalletConnect
-    // 経由で完結するため除去 (Issue #3101、 サイト重い audit の Phase A)。
-    // 将来 Coinbase Wallet native 対応要件が出た場合は個別 Issue で再検討。
-    injected(),
-    walletConnect({
-      projectId: WALLET_CONNECT_V2_PROJECT_ID,
-      showQrModal: false,
-    }),
-  ],
+  connectors,
 });
 
 export const defaultChain = activeChain;


### PR DESCRIPTION
## 概要

user 明示指示 = 「ローカルの時はreown使いませんよ。 というか使えないから」。 wagmi config の `walletConnect` connector を `VITE_WALLET_CONNECT_V2_PROJECT_ID` 設定時のみ conditional 有効化、 anvil ローカルは `injected` (MetaMask) のみで完結。

## 変更内容

### `wagmi.ts`

connectors 配列を条件付き構築:

```typescript
const connectors = [
  injected(),
  ...(WALLET_CONNECT_V2_PROJECT_ID !== ''
    ? [walletConnect({ projectId: WALLET_CONNECT_V2_PROJECT_ID, showQrModal: false })]
    : []),
];
```

### `.env.local.example`

`VITE_WALLET_CONNECT_V2_PROJECT_ID` line 削除、 comment で「local dev は MetaMask のみ、 WalletConnect 不要」 明示。

dev / prod template は変更なし (mobile wallet / QR 経路のため継続必要)。

## 動作証明

```
pnpm --filter niji-webapp vitest run
Test Files  123 passed | 2 skipped (125)
     Tests  9850 passed | 1 skipped | 1 todo (9852)   # regression 0

pnpm --filter niji-webapp tsc --noEmit
(0 error)
```

## 影響範囲

- **local dev**: WalletConnect 依存除去、 MetaMask (injected) のみで anvil 接続可能
- **dev / prod**: env 設定時 walletConnect 有効、 従来通り
- **UI**: wallet 接続 modal で local のみ「WalletConnect」 option 非表示

## Refs

Refs #3115 (fincode 移行 Phase 3、 local dev 摩擦削減)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWpuhkFoEse2Yo9Xb5QsvF
